### PR TITLE
Fix(Source-Google-Drive): Skip Mismatched Filetypes

### DIFF
--- a/airbyte-integrations/connectors/source-google-drive/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-drive/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: file
   connectorType: source
   definitionId: 9f8dda77-1048-4368-815b-269bf54ee9b8
-  dockerImageTag: 0.5.3
+  dockerImageTag: 0.5.4-rc.1
   dockerRepository: airbyte/source-google-drive
   githubIssueLabel: source-google-drive
   icon: google-drive.svg
@@ -29,7 +29,7 @@ data:
   releaseStage: alpha
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
   documentationUrl: https://docs.airbyte.com/integrations/sources/google-drive
   tags:
     - language:python

--- a/airbyte-integrations/connectors/source-google-drive/pyproject.toml
+++ b/airbyte-integrations/connectors/source-google-drive/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "0.5.3"
+version = "0.5.4-rc.1"
 name = "source-google-drive"
 description = "Source implementation for Google Drive."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-google-drive/source_google_drive/source.py
+++ b/airbyte-integrations/connectors/source-google-drive/source_google_drive/source.py
@@ -7,13 +7,13 @@ from typing import Any, Mapping, Optional
 
 from airbyte_cdk import AdvancedAuth, ConfiguredAirbyteCatalog, ConnectorSpecification, OAuthConfigSpecification, TState
 from airbyte_cdk.models import AuthFlowType, OauthConnectorInputSpecification
-from airbyte_cdk.sources.file_based.file_based_source import FileBasedSource
 from airbyte_cdk.sources.file_based.config.abstract_file_based_spec import AbstractFileBasedSpec
 from airbyte_cdk.sources.file_based.config.file_based_stream_config import FileBasedStreamConfig
 from airbyte_cdk.sources.file_based.config.validate_config_transfer_modes import preserve_directory_structure, use_file_transfer
-from airbyte_cdk.sources.file_based.stream.cursor.default_file_based_cursor import DefaultFileBasedCursor
-from airbyte_cdk.sources.file_based.stream.cursor import AbstractFileBasedCursor
+from airbyte_cdk.sources.file_based.file_based_source import FileBasedSource
 from airbyte_cdk.sources.file_based.stream import AbstractFileBasedStream
+from airbyte_cdk.sources.file_based.stream.cursor import AbstractFileBasedCursor
+from airbyte_cdk.sources.file_based.stream.cursor.default_file_based_cursor import DefaultFileBasedCursor
 from source_google_drive.spec import SourceGoogleDriveSpec
 from source_google_drive.stream import GoogleDriveFileBasedStream
 from source_google_drive.stream_permissions_reader import SourceGoogleDriveStreamPermissionsReader

--- a/airbyte-integrations/connectors/source-google-drive/source_google_drive/stream.py
+++ b/airbyte-integrations/connectors/source-google-drive/source_google_drive/stream.py
@@ -79,11 +79,7 @@ class GoogleDriveFileBasedStream(DefaultFileBasedStream):
             return True
 
         extension = self._get_extension(remote_file.uri)
-        mime_candidates = {
-            value.lower()
-            for value in [remote_file.mime_type, getattr(remote_file, "original_mime_type", None)]
-            if value
-        }
+        mime_candidates = {value.lower() for value in [remote_file.mime_type, getattr(remote_file, "original_mime_type", None)] if value}
 
         if extension and extension in self._FILETYPE_EXTENSIONS[configured_filetype]:
             return True

--- a/airbyte-integrations/connectors/source-google-drive/source_google_drive/stream.py
+++ b/airbyte-integrations/connectors/source-google-drive/source_google_drive/stream.py
@@ -1,0 +1,125 @@
+#
+# Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+#
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, Optional, Set
+
+from airbyte_cdk.sources.file_based.remote_file import RemoteFile
+from airbyte_cdk.sources.file_based.stream import DefaultFileBasedStream
+
+
+class GoogleDriveFileBasedStream(DefaultFileBasedStream):
+    """Stream implementation that filters files whose type does not align with the configured format."""
+
+    _FILETYPE_EXTENSIONS: Dict[str, Set[str]] = {
+        "csv": {".csv"},
+        "jsonl": {".jsonl", ".ndjson"},
+        "parquet": {".parquet"},
+        "avro": {".avro"},
+        "excel": {".xls", ".xlsx", ".xlsm", ".xlsb", ".ods"},
+        "unstructured": {".pdf", ".docx", ".pptx", ".md", ".txt"},
+    }
+
+    _FILETYPE_MIME_TYPES: Dict[str, Set[str]] = {
+        "csv": {"text/csv"},
+        "jsonl": {"application/json", "application/x-ndjson", "application/jsonl"},
+        "parquet": {"application/x-parquet", "application/vnd.apache.parquet"},
+        "avro": {"application/avro"},
+        "excel": {
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            "application/vnd.ms-excel",
+            "application/vnd.ms-excel.sheet.macroenabled.12",
+            "application/vnd.ms-excel.sheet.binary.macroenabled.12",
+            "application/vnd.oasis.opendocument.spreadsheet",
+        },
+        "unstructured": {
+            "application/pdf",
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+            "text/markdown",
+            "text/plain",
+        },
+    }
+
+    _FILETYPE_ORIGINAL_MIME_TYPES: Dict[str, Set[str]] = {
+        "excel": {"application/vnd.google-apps.spreadsheet"},
+        "unstructured": {
+            "application/vnd.google-apps.document",
+            "application/vnd.google-apps.presentation",
+            "application/vnd.google-apps.drawing",
+        },
+    }
+
+    def get_files(self) -> Iterable[RemoteFile]:  # noqa: D401
+        for remote_file in self.stream_reader.get_matching_files(
+            self.config.globs or [],
+            self.config.legacy_prefix,
+            self.logger,
+        ):
+            if self._file_matches_configured_type(remote_file):
+                yield remote_file
+            else:
+                configured_filetype = self._configured_filetype() or "unknown"
+                self.logger.info(
+                    "Skipping file %s because it does not match the configured file type '%s' (%s). Modify the stream's glob pattern, adjust the file type, or move the file outside the matched path and try again.",
+                    remote_file.uri,
+                    configured_filetype,
+                    self._describe_file(remote_file),
+                )
+
+    def _file_matches_configured_type(self, remote_file: RemoteFile) -> bool:
+        configured_filetype = self._configured_filetype()
+        if not configured_filetype:
+            return True
+
+        if configured_filetype not in self._FILETYPE_EXTENSIONS:
+            # Unknown configuration, do not filter
+            return True
+
+        extension = self._get_extension(remote_file.uri)
+        mime_candidates = {
+            value.lower()
+            for value in [remote_file.mime_type, getattr(remote_file, "original_mime_type", None)]
+            if value
+        }
+
+        if extension and extension in self._FILETYPE_EXTENSIONS[configured_filetype]:
+            return True
+
+        if mime_candidates.intersection(self._FILETYPE_MIME_TYPES.get(configured_filetype, set())):
+            return True
+
+        if mime_candidates.intersection(self._FILETYPE_ORIGINAL_MIME_TYPES.get(configured_filetype, set())):
+            return True
+
+        return False
+
+    def _configured_filetype(self) -> Optional[str]:
+        filetype = getattr(self.config.format, "filetype", None)
+        if isinstance(filetype, str):
+            return filetype.lower()
+        return None
+
+    @staticmethod
+    def _get_extension(uri: str) -> Optional[str]:
+        filename = uri.rsplit("/", 1)[-1]
+        if "." not in filename:
+            return None
+        extension = "." + filename.lower().split(".")[-1]
+        return extension
+
+    @staticmethod
+    def _describe_file(remote_file: RemoteFile) -> str:
+        parts = []
+        extension = GoogleDriveFileBasedStream._get_extension(remote_file.uri)
+        if extension:
+            parts.append(f"extension {extension}")
+        original_mime = getattr(remote_file, "original_mime_type", None)
+        if original_mime:
+            parts.append(f"original mime type {original_mime}")
+        mime_type = remote_file.mime_type
+        if mime_type and mime_type != original_mime:
+            parts.append(f"mime type {mime_type}")
+        return ", ".join(parts) if parts else "type unknown"

--- a/airbyte-integrations/connectors/source-google-drive/unit_tests/test_stream.py
+++ b/airbyte-integrations/connectors/source-google-drive/unit_tests/test_stream.py
@@ -8,6 +8,8 @@ from typing import Callable, Dict, Optional
 from unittest.mock import MagicMock
 
 import pytest  # type: ignore[import-not-found]
+from source_google_drive.stream import GoogleDriveFileBasedStream
+from source_google_drive.stream_reader import GoogleDriveRemoteFile
 
 from airbyte_cdk.sources.file_based.config.avro_format import AvroFormat
 from airbyte_cdk.sources.file_based.config.csv_format import CsvFormat
@@ -16,9 +18,6 @@ from airbyte_cdk.sources.file_based.config.file_based_stream_config import FileB
 from airbyte_cdk.sources.file_based.config.jsonl_format import JsonlFormat
 from airbyte_cdk.sources.file_based.config.parquet_format import ParquetFormat
 from airbyte_cdk.sources.file_based.config.unstructured_format import UnstructuredFormat
-
-from source_google_drive.stream import GoogleDriveFileBasedStream
-from source_google_drive.stream_reader import GoogleDriveRemoteFile
 
 
 def _make_remote_file(

--- a/airbyte-integrations/connectors/source-google-drive/unit_tests/test_stream.py
+++ b/airbyte-integrations/connectors/source-google-drive/unit_tests/test_stream.py
@@ -1,0 +1,150 @@
+#
+# Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+#
+
+import datetime
+import logging
+from typing import Callable, Dict, Optional
+from unittest.mock import MagicMock
+
+import pytest  # type: ignore[import-not-found]
+
+from airbyte_cdk.sources.file_based.config.avro_format import AvroFormat
+from airbyte_cdk.sources.file_based.config.csv_format import CsvFormat
+from airbyte_cdk.sources.file_based.config.excel_format import ExcelFormat
+from airbyte_cdk.sources.file_based.config.file_based_stream_config import FileBasedStreamConfig
+from airbyte_cdk.sources.file_based.config.jsonl_format import JsonlFormat
+from airbyte_cdk.sources.file_based.config.parquet_format import ParquetFormat
+from airbyte_cdk.sources.file_based.config.unstructured_format import UnstructuredFormat
+
+from source_google_drive.stream import GoogleDriveFileBasedStream
+from source_google_drive.stream_reader import GoogleDriveRemoteFile
+
+
+def _make_remote_file(
+    uri: str,
+    mime_type: str,
+    original_mime_type: Optional[str] = None,
+) -> GoogleDriveRemoteFile:
+    now = datetime.datetime.utcnow()
+    return GoogleDriveRemoteFile(
+        uri=uri,
+        id=f"id-{uri}",
+        mime_type=mime_type,
+        original_mime_type=original_mime_type or mime_type,
+        last_modified=now,
+        created_at=now,
+        view_link=f"https://example.com/{uri}",
+    )
+
+
+@pytest.mark.parametrize(
+    "format_factory, matching_kwargs, mismatched_kwargs",
+    [
+        pytest.param(
+            CsvFormat,
+            {"uri": "valid.csv", "mime_type": "text/csv"},
+            {"uri": "invalid.pdf", "mime_type": "application/pdf"},
+            id="csv",
+        ),
+        pytest.param(
+            JsonlFormat,
+            {"uri": "valid.jsonl", "mime_type": "application/json"},
+            {"uri": "invalid.csv", "mime_type": "text/csv"},
+            id="jsonl",
+        ),
+        pytest.param(
+            ParquetFormat,
+            {"uri": "valid.parquet", "mime_type": "application/x-parquet"},
+            {"uri": "invalid.csv", "mime_type": "text/csv"},
+            id="parquet",
+        ),
+        pytest.param(
+            AvroFormat,
+            {"uri": "valid.avro", "mime_type": "application/avro"},
+            {"uri": "invalid.csv", "mime_type": "text/csv"},
+            id="avro",
+        ),
+        pytest.param(
+            ExcelFormat,
+            {
+                "uri": "valid.xlsx",
+                "mime_type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            },
+            {"uri": "invalid.csv", "mime_type": "text/csv"},
+            id="excel",
+        ),
+        pytest.param(
+            UnstructuredFormat,
+            {
+                "uri": "Meeting Notes",
+                "mime_type": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                "original_mime_type": "application/vnd.google-apps.document",
+            },
+            {"uri": "invalid.csv", "mime_type": "text/csv"},
+            id="unstructured",
+        ),
+    ],
+)
+def test_google_drive_stream_filters_mismatched_files(
+    format_factory: Callable[[], object],
+    matching_kwargs: Dict[str, str],
+    mismatched_kwargs: Dict[str, str],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    format_config = format_factory()
+    matching_file = _make_remote_file(**matching_kwargs)
+    mismatched_file = _make_remote_file(**mismatched_kwargs)
+
+    stream_reader = MagicMock()
+    stream_reader.get_matching_files.return_value = [matching_file, mismatched_file]
+
+    stream = GoogleDriveFileBasedStream(
+        config=FileBasedStreamConfig(name="drive_stream", format=format_config, globs=["**"]),
+        catalog_schema=None,
+        stream_reader=stream_reader,
+        availability_strategy=MagicMock(),
+        discovery_policy=MagicMock(),
+        parsers={type(format_config): MagicMock()},
+        validation_policy=MagicMock(),
+        errors_collector=MagicMock(),
+        cursor=MagicMock(),
+    )
+
+    with caplog.at_level(logging.INFO):
+        files = list(stream.get_files())
+
+    assert [f.uri for f in files] == [matching_file.uri]
+    assert mismatched_file.uri in caplog.text
+    assert "Skipping file" in caplog.text
+    assert "Modify the stream's glob pattern" in caplog.text
+    assert format_config.filetype in caplog.text
+
+
+def test_google_drive_stream_accepts_google_docs_when_configured(caplog: pytest.LogCaptureFixture) -> None:
+    format_config = UnstructuredFormat()
+    google_doc = _make_remote_file(
+        uri="Project Plan",
+        mime_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        original_mime_type="application/vnd.google-apps.document",
+    )
+    stream_reader = MagicMock()
+    stream_reader.get_matching_files.return_value = [google_doc]
+
+    stream = GoogleDriveFileBasedStream(
+        config=FileBasedStreamConfig(name="unstructured_stream", format=format_config, globs=["**"]),
+        catalog_schema=None,
+        stream_reader=stream_reader,
+        availability_strategy=MagicMock(),
+        discovery_policy=MagicMock(),
+        parsers={type(format_config): MagicMock()},
+        validation_policy=MagicMock(),
+        errors_collector=MagicMock(),
+        cursor=MagicMock(),
+    )
+
+    with caplog.at_level(logging.INFO):
+        files = list(stream.get_files())
+
+    assert [f.uri for f in files] == [google_doc.uri]
+    assert caplog.text == ""

--- a/docs/integrations/sources/google-drive.md
+++ b/docs/integrations/sources/google-drive.md
@@ -320,7 +320,7 @@ By default, this stream is enabled and retrieves information about **users and g
 
 | Version | Date       | Pull Request                                             | Subject                                                                                      |
 |---------|------------|----------------------------------------------------------|----------------------------------------------------------------------------------------------|
-| 0.5.4-rc.1 | 2025-11-11 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) |Skip Mismatched File Types in Glob Patterns |
+| 0.5.4-rc.1 | 2025-11-13 | [69287](https://github.com/airbytehq/airbyte/pull/69287) |Skip Mismatched File Types in Glob Patterns |
 | 0.5.3 | 2025-11-11 | [69272](https://github.com/airbytehq/airbyte/pull/69272) | Update dependencies |
 | 0.5.2 | 2025-11-04 | [69158](https://github.com/airbytehq/airbyte/pull/69158) | Update dependencies |
 | 0.5.1 | 2025-10-29 | [69053](https://github.com/airbytehq/airbyte/pull/69053) | Update dependencies |

--- a/docs/integrations/sources/google-drive.md
+++ b/docs/integrations/sources/google-drive.md
@@ -320,6 +320,7 @@ By default, this stream is enabled and retrieves information about **users and g
 
 | Version | Date       | Pull Request                                             | Subject                                                                                      |
 |---------|------------|----------------------------------------------------------|----------------------------------------------------------------------------------------------|
+| 0.5.4-rc.1 | 2025-11-11 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) |Skip Mismatched File Types in Glob Patterns |
 | 0.5.3 | 2025-11-11 | [69272](https://github.com/airbytehq/airbyte/pull/69272) | Update dependencies |
 | 0.5.2 | 2025-11-04 | [69158](https://github.com/airbytehq/airbyte/pull/69158) | Update dependencies |
 | 0.5.1 | 2025-10-29 | [69053](https://github.com/airbytehq/airbyte/pull/69053) | Update dependencies |


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->
OC Issue: https://github.com/airbytehq/oncall/issues/9976 (non-blocker)
While working on the OC issue above, we discovered that that there is no validation on file types prior to processing file.

For example, if the user has a glob set to `**` to match eveything and has the file type set to CSV, but there is a PDF file in the GDrive, then we will attempt to parse the PDF as a CSV which will cause errors.




Ideally, for each stream defined, we would take the user entered file-type and check the globs specified for that defined stream. If there are files that do not match, we should throw an info warning log saying the filename does not match the file type specified and skip over that file. The info log should inform users to either modify the glob pattern (to only match the desired file types), change the file-type format, or move the file in the source directory outside of the glob pattern and then try again.



## How
<!--
* Describe how code changes achieve the solution.
-->
We override `_make_default_stream` so that we can return our own `GoogleDriveFileBasedStream`, which injects the extension/MIME validation and logging in `streams.py`.

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
