### PR TITLE
fix: Handle comma-separated version ranges in pre-release CDK check

### DIFF
--- a/poe-tasks/detect-python-cdk.py
+++ b/poe-tasks/detect-python-cdk.py
@@ -97,30 +97,30 @@ def parse_cdk_dependency(pyproject_path) -> dict:
 
 def is_prerelease_version(version_str) -> bool:
     """Check if version string represents a standard published version.
-    
+
     Handles comma-separated version ranges like ">=6.61.6,<7.0" by validating
     each constraint separately. Returns True if any constraint is invalid or
     contains prerelease markers.
     """
     if not version_str:
         return True
-    
+
     parts = [p.strip() for p in version_str.split(",") if p.strip()]
-    
+
     constraint_pattern = re.compile(r"^(?:\^|~|~=|==|!=|<=|>=|<|>)?\s*\d+(?:\.\d+){0,2}\s*$")
-    
+
     prerelease_pattern = re.compile(r"(?:a|alpha|b|beta|c|rc|pre|preview|dev)\d*$", re.IGNORECASE)
-    
+
     for part in parts:
         if "*" in part or "x" in part.lower():
             return True
-        
+
         if prerelease_pattern.search(part):
             return True
-        
+
         if not constraint_pattern.match(part):
             return True
-    
+
     return False
 
 

--- a/poe-tasks/detect-python-cdk.py
+++ b/poe-tasks/detect-python-cdk.py
@@ -96,13 +96,32 @@ def parse_cdk_dependency(pyproject_path) -> dict:
 
 
 def is_prerelease_version(version_str) -> bool:
-    """Check if version string represents a standard published version."""
+    """Check if version string represents a standard published version.
+    
+    Handles comma-separated version ranges like ">=6.61.6,<7.0" by validating
+    each constraint separately. Returns True if any constraint is invalid or
+    contains prerelease markers.
+    """
     if not version_str:
         return True
-
-    version_pattern = r"^[~^>=<]*\d+\.\d+\.\d+([a-zA-Z0-9\-\.]*)?$"
-    is_prod_version = bool(re.match(version_pattern, version_str.strip()))
-    return not is_prod_version
+    
+    parts = [p.strip() for p in version_str.split(",") if p.strip()]
+    
+    constraint_pattern = re.compile(r"^(?:\^|~|~=|==|!=|<=|>=|<|>)?\s*\d+(?:\.\d+){0,2}\s*$")
+    
+    prerelease_pattern = re.compile(r"(?:a|alpha|b|beta|c|rc|pre|preview|dev)\d*$", re.IGNORECASE)
+    
+    for part in parts:
+        if "*" in part or "x" in part.lower():
+            return True
+        
+        if prerelease_pattern.search(part):
+            return True
+        
+        if not constraint_pattern.match(part):
+            return True
+    
+    return False
 
 
 def format_extras_for_poetry(extras) -> str:


### PR DESCRIPTION
## What

Fixes the pre-release CDK version check that was incorrectly flagging valid production version ranges as pre-releases.

The `is_prerelease_version()` function in `poe-tasks/detect-python-cdk.py` was failing on comma-separated version ranges like `>=6.61.6,<7.0` because the regex pattern only matched single version constraints.

**Failing CI run:** https://github.com/airbytehq/airbyte/actions/runs/19284696841/job/55142891644#step:7:1

## How

Replaced the single regex match with a split-and-validate approach:

1. **Split on commas** to handle version ranges with multiple constraints
2. **Validate each constraint separately** using a more flexible regex that:
   - Accepts 1-3 version segments (e.g., `7`, `7.0`, `7.0.1`) instead of requiring exactly 3
   - Supports all Poetry operators: `^`, `~`, `~=`, `==`, `!=`, `<=`, `>=`, `<`, `>`
3. **Explicitly check for pre-release markers**: `a`, `alpha`, `b`, `beta`, `c`, `rc`, `pre`, `preview`, `dev`
4. **Reject wildcards**: `*` and `x` patterns

## Review guide

1. **`poe-tasks/detect-python-cdk.py`** - Focus on the `is_prerelease_version()` function:
   - **Line 110**: Does the `constraint_pattern` regex correctly match all valid Poetry version constraints?
   - **Line 112**: Does the `prerelease_pattern` regex catch all pre-release markers?
   - **Lines 114-122**: Is the validation logic sound? Any edge cases missed?
   - Consider: Should we add unit tests for this function to prevent future regressions?

**Tested locally with 28 test cases** covering:
- Single and multi-constraint ranges (`>=6.61.6,<7.0`, `>=6.61.6,!=6.62.0,<7`)
- All operators and version formats
- Pre-release markers (rc, alpha, beta, dev, etc.)
- Edge cases (wildcards, empty strings, invalid formats)

## User Impact

**Positive:**
- CI checks will no longer fail on valid production version ranges
- Connectors using version ranges like `>=6.61.6,<7.0` will pass pre-release checks

**Potential concerns:**
- The function now accepts 1-2 segment versions (e.g., `<7`, `~6.61`) which the old regex rejected. This is correct per Poetry spec, but represents a behavior change.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

This is a pure bug fix with no dependencies. Reverting would restore the buggy behavior but wouldn't break anything else.

---

**Link to Devin run:** https://app.devin.ai/sessions/69ab280891284c7198ae94769625f503  
**Requested by:** AJ Steers (@aaronsteers)