### PR TITLE
[DO NOT MERGE!] Source MSSQL: Add Debezium heartbeat logging for troubleshooting

### DIFF
--- a/airbyte-integrations/connectors/source-mssql/build.gradle
+++ b/airbyte-integrations/connectors/source-mssql/build.gradle
@@ -7,7 +7,7 @@ plugins {
 airbyteJavaConnector {
     cdkVersionRequired = '0.48.18'
     features = ['db-sources']
-    useLocalCdk = false
+    useLocalCdk = true
 }
 
 java {


### PR DESCRIPTION
### This PR is not intended to be merged! It is created solely for troubleshooting purposes.

## What
Added temporary logging to investigate why the connector is not reaching the `HEARTBEAT_REACHED_TARGET_POSITION` state for a specific sync.

## How
- Added logs in the `computeNext()` method to trace heartbeat progress.
- Related to [9931](https://github.com/airbytehq/oncall/issues/9931)

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
