### PR TITLE
feat(destination-snowflake-cortex): Add keypair authentication support

### DIFF
--- a/airbyte-integrations/connectors/destination-snowflake-cortex/README.md
+++ b/airbyte-integrations/connectors/destination-snowflake-cortex/README.md
@@ -25,6 +25,19 @@ See `integration_tests/sample_config.json` for a sample config file.
 **If you are an Airbyte core member**, copy the credentials in Lastpass under the secret name `destination snowflake-cortex test creds`
 and place them into `secrets/config.json`.
 
+#### Authentication Methods
+This connector supports two authentication methods:
+
+1. **Username and Password**: Traditional authentication using a username and password.
+2. **Key Pair Authentication**: RSA key-pair authentication for enhanced security. This method is recommended for production environments and is required by organizations that have deprecated password-based authentication.
+
+To use key pair authentication, you need to:
+- Generate an RSA key pair
+- Assign the public key to your Snowflake user
+- Provide the private key (and optional passphrase) in the connector configuration
+
+For detailed instructions on setting up key pair authentication, see the [Snowflake documentation](https://docs.snowflake.com/en/user-guide/key-pair-auth).
+
 ### Locally running the connector
 ```
 poetry run python main.py spec

--- a/airbyte-integrations/connectors/destination-snowflake-cortex/destination_snowflake_cortex/config.py
+++ b/airbyte-integrations/connectors/destination-snowflake-cortex/destination_snowflake_cortex/config.py
@@ -5,9 +5,14 @@
 
 from airbyte_cdk.destinations.vector_db_based.config import VectorDBConfigModel
 from pydantic import BaseModel, Field
+from typing import Literal, Union
 
 
 class PasswordBasedAuthorizationModel(BaseModel):
+    auth_type: Literal["password"] = Field(
+        default="password",
+        const=True,
+    )
     password: str = Field(
         ...,
         title="Password",
@@ -18,7 +23,30 @@ class PasswordBasedAuthorizationModel(BaseModel):
     )
 
     class Config:
-        title = "Credentials"
+        title = "Username and Password"
+
+
+class KeyPairAuthorizationModel(BaseModel):
+    auth_type: Literal["key_pair"] = Field(
+        default="key_pair",
+        const=True,
+    )
+    private_key: str = Field(
+        ...,
+        title="Private Key",
+        airbyte_secret=True,
+        description="RSA Private key to use for key pair authentication. Enter the private key as a string.",
+        multiline=True,
+    )
+    private_key_passphrase: str | None = Field(
+        default=None,
+        title="Private Key Passphrase",
+        airbyte_secret=True,
+        description="Passphrase for private key if the key is encrypted. Leave empty if the key is not encrypted.",
+    )
+
+    class Config:
+        title = "Key Pair Authentication"
 
 
 # to-do - https://github.com/airbytehq/airbyte/issues/38007 - add Snowflake supported models to embedding options
@@ -66,7 +94,17 @@ class SnowflakeCortexIndexingModel(BaseModel):
         examples=["AIRBYTE_USER"],
     )
 
-    credentials: PasswordBasedAuthorizationModel
+    credentials: Union[PasswordBasedAuthorizationModel, KeyPairAuthorizationModel] = Field(
+        ...,
+        title="Authorization Method",
+        description="Choose the authorization method for the Snowflake connection",
+        discriminator="auth_type",
+        type="object",
+        oneOf=[
+            {"title": "Username and Password", "required": ["password"], "properties": {"auth_type": {"type": "string", "const": "password"}}},
+            {"title": "Key Pair Authentication", "required": ["private_key"], "properties": {"auth_type": {"type": "string", "const": "key_pair"}}},
+        ],
+    )
 
     class Config:
         title = "Snowflake Connection"

--- a/airbyte-integrations/connectors/destination-snowflake-cortex/destination_snowflake_cortex/config.py
+++ b/airbyte-integrations/connectors/destination-snowflake-cortex/destination_snowflake_cortex/config.py
@@ -3,9 +3,10 @@
 #
 
 
+from typing import Literal, Union
+
 from airbyte_cdk.destinations.vector_db_based.config import VectorDBConfigModel
 from pydantic import BaseModel, Field
-from typing import Literal, Union
 
 
 class PasswordBasedAuthorizationModel(BaseModel):
@@ -101,8 +102,16 @@ class SnowflakeCortexIndexingModel(BaseModel):
         discriminator="auth_type",
         type="object",
         oneOf=[
-            {"title": "Username and Password", "required": ["password"], "properties": {"auth_type": {"type": "string", "const": "password"}}},
-            {"title": "Key Pair Authentication", "required": ["private_key"], "properties": {"auth_type": {"type": "string", "const": "key_pair"}}},
+            {
+                "title": "Username and Password",
+                "required": ["password"],
+                "properties": {"auth_type": {"type": "string", "const": "password"}},
+            },
+            {
+                "title": "Key Pair Authentication",
+                "required": ["private_key"],
+                "properties": {"auth_type": {"type": "string", "const": "key_pair"}},
+            },
         ],
     )
 

--- a/airbyte-integrations/connectors/destination-snowflake-cortex/destination_snowflake_cortex/destination.py
+++ b/airbyte-integrations/connectors/destination-snowflake-cortex/destination_snowflake_cortex/destination.py
@@ -22,7 +22,11 @@ from airbyte_cdk.models import (
 
 from destination_snowflake_cortex import cortex_processor
 from destination_snowflake_cortex.common.catalog.catalog_providers import CatalogProvider
-from destination_snowflake_cortex.config import ConfigModel, PasswordBasedAuthorizationModel, KeyPairAuthorizationModel
+from destination_snowflake_cortex.config import (
+    ConfigModel,
+    KeyPairAuthorizationModel,
+    PasswordBasedAuthorizationModel,
+)
 
 BATCH_SIZE = 150
 


### PR DESCRIPTION
## What

Adds RSA key-pair authentication support to destination-snowflake-cortex to address customer requirements where password-based authentication is deprecated or prohibited by security policies.

Related to Slack thread: https://airbytehq-team.slack.com/archives/C03AS1GAQV6/p1762986270408869

## How

1. **Config Model Changes** (`config.py`):
   - Added `KeyPairAuthorizationModel` with `private_key` and optional `private_key_passphrase` fields
   - Updated `PasswordBasedAuthorizationModel` to include `auth_type` discriminator
   - Modified `SnowflakeCortexIndexingModel.credentials` to accept a union of both auth models using discriminated union pattern

2. **Processor Changes** (`cortex_processor.py`):
   - Updated `SnowflakeCortexConfig` to support optional `password`, `private_key`, and `private_key_passphrase` fields
   - Added `_validate_authentication_config()` to ensure only one auth method is provided
   - Added `_get_private_key_bytes()` to load and deserialize PEM-encoded private keys using the cryptography library
   - Updated `get_sql_alchemy_url()` to conditionally include password based on auth method
   - Added `get_sql_alchemy_connect_args()` to pass private key bytes to SQLAlchemy
   - Updated `get_vendor_client()` to use JWT authenticator when using keypair auth

3. **Destination Changes** (`destination.py`):
   - Modified `_init_sql_processor()` to dynamically build config params based on auth type
   - Added type checking to determine which credentials model is being used

4. **Documentation** (`README.md`):
   - Added "Authentication Methods" section explaining both password and keypair options
   - Linked to Snowflake's official key-pair auth documentation

## Review guide

**Critical files to review:**
1. `destination_snowflake_cortex/cortex_processor.py` - Review the private key handling logic, especially `_get_private_key_bytes()` and `_validate_authentication_config()`
2. `destination_snowflake_cortex/config.py` - Verify the discriminated union setup is correct for the UI
3. `destination_snowflake_cortex/destination.py` - Check the credential mapping logic handles both auth types correctly

**Key areas to validate:**
- Private key deserialization uses proper cryptography library patterns (matches PyAirbyte implementation)
- Validation logic prevents invalid auth configurations (e.g., both password and private_key provided)
- Backward compatibility: existing password-based configs should continue to work without changes
- Error messages are clear and actionable

**Testing notes:**
- ⚠️ This code has NOT been tested with actual Snowflake credentials yet
- Local lint checks (ruff, mypy) pass
- Cryptography library is available as a transitive dependency (verified via `poetry show`)

## User Impact

**Positive:**
- Users can now authenticate to Snowflake using RSA key-pair authentication
- Enables usage for organizations that have deprecated password-based authentication
- More secure authentication method for production environments

**Potential issues:**
- Private keys must be in PEM format (other formats not supported)
- Users need to properly configure their Snowflake user with the public key before using this feature

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

This is a purely additive change. Existing password-based authentication continues to work unchanged. Reverting would only remove the new keypair auth option.

---

**Link to Devin run:** https://app.devin.ai/sessions/ef8be40a93984d29af4f3ad46c1b90ba  
**Requested by:** AJ Steers (aj@airbyte.io) / @aaronsteers