### PR TITLE
Destination Bigquery: Correctly handle timestamps getting nulled out

### DIFF
--- a/airbyte-integrations/connectors/destination-bigquery/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-bigquery/metadata.yaml
@@ -6,7 +6,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 22f6c74f-5699-40ff-833c-4a879ea40133
-  dockerImageTag: 3.0.14
+  dockerImageTag: 3.0.15
   dockerRepository: airbyte/destination-bigquery
   documentationUrl: https://docs.airbyte.com/integrations/destinations/bigquery
   githubIssueLabel: destination-bigquery

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/formatter/BigQueryRecordFormatter.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/formatter/BigQueryRecordFormatter.kt
@@ -93,23 +93,26 @@ class BigQueryRecordFormatter(
                         if (value.abValue != NullValue) {
                             // first, validate the value.
                             validateAirbyteValue(value)
-                            // then, populate the record.
-                            // Bigquery has some strict requirements for datetime / time formatting,
-                            // so handle that here.
-                            when (value.type) {
-                                TimestampTypeWithTimezone ->
-                                    outputRecord[columnNameMapping[key]!!] =
-                                        formatTimestampWithTimezone(value)
-                                TimestampTypeWithoutTimezone ->
-                                    outputRecord[columnNameMapping[key]!!] =
-                                        formatTimestampWithoutTimezone(value)
-                                TimeTypeWithoutTimezone ->
-                                    outputRecord[columnNameMapping[key]!!] =
-                                        formatTimeWithoutTimezone(value)
-                                TimeTypeWithTimezone ->
-                                    outputRecord[columnNameMapping[key]!!] =
-                                        formatTimeWithTimezone(value)
-                                else -> outputRecord[columnNameMapping[key]!!] = value.abValue
+                            // Recheck nullness, since validateAirbyteValue might have nulled it out
+                            if (value.abValue != NullValue) {
+                                // then, populate the record.
+                                // Bigquery has some strict requirements for datetime / time
+                                // formatting, so handle that here.
+                                when (value.type) {
+                                    TimestampTypeWithTimezone ->
+                                        outputRecord[columnNameMapping[key]!!] =
+                                            formatTimestampWithTimezone(value)
+                                    TimestampTypeWithoutTimezone ->
+                                        outputRecord[columnNameMapping[key]!!] =
+                                            formatTimestampWithoutTimezone(value)
+                                    TimeTypeWithoutTimezone ->
+                                        outputRecord[columnNameMapping[key]!!] =
+                                            formatTimeWithoutTimezone(value)
+                                    TimeTypeWithTimezone ->
+                                        outputRecord[columnNameMapping[key]!!] =
+                                            formatTimeWithTimezone(value)
+                                    else -> outputRecord[columnNameMapping[key]!!] = value.abValue
+                                }
                             }
                         }
                     }

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/bulk_loader/BigQueryCSVRowGenerator.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/bulk_loader/BigQueryCSVRowGenerator.kt
@@ -33,13 +33,8 @@ class BigQueryCSVRowGenerator {
             )
 
         enrichedRecord.declaredFields.values.forEach { value ->
-            if (value.abValue is NullValue) {
-                return@forEach
-            }
             validateAirbyteValue(value)
-
             val actualValue = value.abValue
-            // validateAirbyteValue might have nulled us out, so recheck nullness
             if (actualValue is NullValue) {
                 return@forEach
             }

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/bulk_loader/BigQueryCSVRowGenerator.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/bulk_loader/BigQueryCSVRowGenerator.kt
@@ -39,6 +39,10 @@ class BigQueryCSVRowGenerator {
             validateAirbyteValue(value)
 
             val actualValue = value.abValue
+            // validateAirbyteValue might have nulled us out, so recheck nullness
+            if (actualValue is NullValue) {
+                return@forEach
+            }
             when (value.type) {
                 is TimestampTypeWithTimezone ->
                     value.abValue = StringValue(formatTimestampWithTimezone(value))

--- a/airbyte-integrations/connectors/destination-bigquery/src/test/kotlin/io/airbyte/integrations/destination/bigquery/formatter/BigQueryRecordFormatterTest.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test/kotlin/io/airbyte/integrations/destination/bigquery/formatter/BigQueryRecordFormatterTest.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.bigquery.formatter
+
+import io.airbyte.cdk.load.command.Append
+import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.command.NamespaceMapper
+import io.airbyte.cdk.load.data.FieldType
+import io.airbyte.cdk.load.data.ObjectType
+import io.airbyte.cdk.load.data.TimestampTypeWithTimezone
+import io.airbyte.cdk.load.message.DestinationRecordJsonSource
+import io.airbyte.cdk.load.message.DestinationRecordRaw
+import io.airbyte.cdk.load.table.ColumnNameMapping
+import io.airbyte.cdk.load.util.Jsons
+import io.airbyte.protocol.models.v0.AirbyteMessage
+import io.airbyte.protocol.models.v0.AirbyteRecordMessage
+import java.util.UUID
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class BigQueryRecordFormatterTest {
+    @Test
+    fun testNulledTimestamp() {
+        val formatter =
+            BigQueryRecordFormatter(
+                ColumnNameMapping(mapOf("test" to "test")),
+                legacyRawTablesOnly = false,
+            )
+        val formatted =
+            formatter.formatRecord(
+                DestinationRecordRaw(
+                    DestinationStream(
+                        unmappedNamespace = "namespace",
+                        unmappedName = "name",
+                        Append,
+                        ObjectType(
+                            linkedMapOf("test" to FieldType(TimestampTypeWithTimezone, true))
+                        ),
+                        generationId = 42,
+                        minimumGenerationId = 0,
+                        syncId = 42,
+                        namespaceMapper = NamespaceMapper(),
+                    ),
+                    DestinationRecordJsonSource(
+                        AirbyteMessage()
+                            .withRecord(
+                                AirbyteRecordMessage()
+                                    .withEmittedAt(1234)
+                                    .withData(
+                                        Jsons.readTree(
+                                            // Somewhat ridiculous test setup.
+                                            // Our timestamp parser only recognizes years between
+                                            // 0001 - 9999,
+                                            // and bigquery supports anything in that range.
+                                            // So we set our offset to a negative number, because
+                                            // bigquery translates everything to UTC >.>
+                                            """{"test": "9999-12-31T23:59:59.999999-08"}"""
+                                        )
+                                    )
+                            )
+                    ),
+                    serializedSizeBytes = 42,
+                    airbyteRawId = UUID.fromString("129b0dc6-826a-4e86-a50f-33250cbf63c2"),
+                )
+            )
+        assertEquals(
+            """{"_airbyte_raw_id":"129b0dc6-826a-4e86-a50f-33250cbf63c2","_airbyte_extracted_at":"1970-01-01 00:00:01.234000+00:00","_airbyte_generation_id":42,"_airbyte_meta":{"sync_id":42,"changes":[{"field":"test","change":"NULLED","reason":"DESTINATION_FIELD_SIZE_LIMITATION"}]}}""",
+            formatted
+        )
+    }
+}

--- a/docs/integrations/destinations/bigquery.md
+++ b/docs/integrations/destinations/bigquery.md
@@ -210,6 +210,7 @@ tutorials:
 
 | Version     | Date       | Pull Request                                               | Subject                                                                                                                                                                           |
 |:------------|:-----------|:-----------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 3.0.15 | 2025-11-12 | [69307](https://github.com/airbytehq/airbyte/pull/69307) | Handle out-of-range timestamps/times. |
 | 3.0.14 | 2025-11-11 | [69231](https://github.com/airbytehq/airbyte/pull/69231) | Upgrade to Bulk CDK 0.1.74. |
 | 3.0.13 | 2025-11-01 | [69126](https://github.com/airbytehq/airbyte/pull/69126) | Upgrade to Bulk CDK 0.1.61. |
 | 3.0.12      | 2025-10-29 | [69083](https://github.com/airbytehq/airbyte/pull/69083) | Fail loudly if Bigquery detects bad records. |


### PR DESCRIPTION
see https://airbytehq.sentry.io/issues/7022366260/?notification_uuid=d262e417-e5f3-4772-a054-504ebb3cff1d&project=6527718&referrer=assigned_activity-email

there's probably more elegant ways to handle this, but :shrug: this presumably works