### PR TITLE
Fix duplicate metadata key in JdbcMetadataQuerier

### DIFF
--- a/airbyte-cdk/bulk/changelog.md
+++ b/airbyte-cdk/bulk/changelog.md
@@ -1,3 +1,9 @@
+## Version 0.1.77
+
+**Extract CDK**
+
+* Fix duplicate metadata key in JdbcMetadataQuerier.
+
 ## Version 0.1.76
 
 **Load CDK**

--- a/airbyte-cdk/bulk/toolkits/extract-jdbc/src/main/kotlin/io/airbyte/cdk/discover/JdbcMetadataQuerier.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-jdbc/src/main/kotlin/io/airbyte/cdk/discover/JdbcMetadataQuerier.kt
@@ -174,8 +174,11 @@ class JdbcMetadataQuerier(
         }
         return@lazy results.groupBy({ it.first }, { it.second }).mapValues {
             (_, columnMetadataByTable: List<ColumnMetadata>) ->
-            columnMetadataByTable.filter { it.ordinal == null } +
-                columnMetadataByTable.filter { it.ordinal != null }.sortedBy { it.ordinal }
+            // Deduplicate columns by name to handle case-insensitive databases
+            // where uppercase/lowercase namespace queries return duplicate columns
+            val deduplicatedColumns = columnMetadataByTable.distinctBy { it.name }
+            deduplicatedColumns.filter { it.ordinal == null } +
+                deduplicatedColumns.filter { it.ordinal != null }.sortedBy { it.ordinal }
         }
     }
 

--- a/airbyte-cdk/bulk/version.properties
+++ b/airbyte-cdk/bulk/version.properties
@@ -1,1 +1,1 @@
-version=0.1.76
+version=0.1.77


### PR DESCRIPTION
## What
We introduce a bug when optimizing the perf of metadata query. Previous we dedup metadata from the table name but after the optimization we got metadata twice (one for original namespace name, one for upper cased namespace name). This introduced duplicated key in metadata map.

## How
We fix this by dedup the metadata map.

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
