### PR TITLE
Support multiple ts precision decoding

### DIFF
--- a/airbyte-cdk/bulk/changelog.md
+++ b/airbyte-cdk/bulk/changelog.md
@@ -1,3 +1,9 @@
+## Version 0.1.79
+
+**Extract CDK**
+
+* Support multiple ts precision patterns for ts decoding. Expose `columnMetadataFromResultSet` function in `JdbcMetadataQuerier`.
+
 ## Version 0.1.78
 
 load cdk: add basic schema evolution test cases

--- a/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/data/JsonCodec.kt
+++ b/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/data/JsonCodec.kt
@@ -260,14 +260,19 @@ data object LocalTimeCodec : JsonCodec<LocalTime> {
     override fun decode(encoded: JsonNode): LocalTime {
         val str: String = TextCodec.decode(encoded)
         try {
-            return LocalTime.parse(str, formatter)
+            return LocalTime.parse(str, flexibleFormatter)
         } catch (e: DateTimeParseException) {
-            throw IllegalArgumentException("invalid value $str for pattern '$PATTERN'", e)
+            throw IllegalArgumentException("invalid value $str for flexible time pattern", e)
         }
     }
 
     const val PATTERN = "HH:mm:ss.SSSSSS"
     val formatter: DateTimeFormatter = DateTimeFormatter.ofPattern(PATTERN)
+    // Flexible formatter accepts 0-9 decimal places for fractional seconds
+    private val flexibleFormatter: DateTimeFormatter =
+        DateTimeFormatter.ofPattern(
+            "HH:mm:ss[.SSSSSSSSS][.SSSSSSSS][.SSSSSSS][.SSSSSS][.SSSSS][.SSSS][.SSS][.SS][.S]"
+        )
 }
 
 data object LocalDateTimeCodec : JsonCodec<LocalDateTime> {
@@ -277,14 +282,20 @@ data object LocalDateTimeCodec : JsonCodec<LocalDateTime> {
     override fun decode(encoded: JsonNode): LocalDateTime {
         val str: String = TextCodec.decode(encoded)
         try {
-            return LocalDateTime.parse(str, formatter)
+            return LocalDateTime.parse(str, flexibleFormatter)
         } catch (e: DateTimeParseException) {
-            throw IllegalArgumentException("invalid value $str for pattern '$PATTERN'", e)
+            throw IllegalArgumentException("invalid value $str for flexible datetime pattern", e)
         }
     }
 
     const val PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSSSSS"
     val formatter: DateTimeFormatter = DateTimeFormatter.ofPattern(PATTERN)
+    // Flexible formatter accepts 0-9 decimal places for fractional seconds (needed for MSSQL
+    // datetime2)
+    private val flexibleFormatter: DateTimeFormatter =
+        DateTimeFormatter.ofPattern(
+            "yyyy-MM-dd'T'HH:mm:ss[.SSSSSSSSS][.SSSSSSSS][.SSSSSSS][.SSSSSS][.SSSSS][.SSSS][.SSS][.SS][.S]"
+        )
 }
 
 data object OffsetTimeCodec : JsonCodec<OffsetTime> {
@@ -293,14 +304,22 @@ data object OffsetTimeCodec : JsonCodec<OffsetTime> {
     override fun decode(encoded: JsonNode): OffsetTime {
         val str: String = TextCodec.decode(encoded)
         try {
-            return OffsetTime.parse(str, formatter)
+            return OffsetTime.parse(str, flexibleFormatter)
         } catch (e: DateTimeParseException) {
-            throw IllegalArgumentException("invalid value $str for pattern '$PATTERN'", e)
+            throw IllegalArgumentException(
+                "invalid value $str for flexible time with offset pattern",
+                e
+            )
         }
     }
 
     const val PATTERN = "HH:mm:ss.SSSSSSXXX"
     val formatter: DateTimeFormatter = DateTimeFormatter.ofPattern(PATTERN)
+    // Flexible formatter accepts 0-9 decimal places for fractional seconds
+    private val flexibleFormatter: DateTimeFormatter =
+        DateTimeFormatter.ofPattern(
+            "HH:mm:ss[.SSSSSSSSS][.SSSSSSSS][.SSSSSSS][.SSSSSS][.SSSSS][.SSSS][.SSS][.SS][.S]XXX"
+        )
 }
 
 data object OffsetDateTimeCodec : JsonCodec<OffsetDateTime> {
@@ -310,14 +329,22 @@ data object OffsetDateTimeCodec : JsonCodec<OffsetDateTime> {
     override fun decode(encoded: JsonNode): OffsetDateTime {
         val str: String = TextCodec.decode(encoded)
         try {
-            return OffsetDateTime.parse(str, formatter)
+            return OffsetDateTime.parse(str, flexibleFormatter)
         } catch (e: DateTimeParseException) {
-            throw IllegalArgumentException("invalid value $str for pattern '$PATTERN'", e)
+            throw IllegalArgumentException(
+                "invalid value $str for flexible datetime with offset pattern",
+                e
+            )
         }
     }
 
     const val PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSSSSSXXX"
     val formatter: DateTimeFormatter = DateTimeFormatter.ofPattern(PATTERN)
+    // Flexible formatter accepts 0-9 decimal places for fractional seconds
+    private val flexibleFormatter: DateTimeFormatter =
+        DateTimeFormatter.ofPattern(
+            "yyyy-MM-dd'T'HH:mm:ss[.SSSSSSSSS][.SSSSSSSS][.SSSSSSS][.SSSSSS][.SSSSS][.SSSS][.SSS][.SS][.S]XXX"
+        )
 }
 
 // We need a specialized CDC OffsetDateTimeCodec to support CDC metafield that are string

--- a/airbyte-cdk/bulk/core/base/src/test/kotlin/io/airbyte/cdk/data/JsonCodecTest.kt
+++ b/airbyte-cdk/bulk/core/base/src/test/kotlin/io/airbyte/cdk/data/JsonCodecTest.kt
@@ -241,7 +241,15 @@ class JsonCodecTest {
         LocalTimeCodec.run {
             testValueRoundTrip(LocalTime.now().truncatedTo(ChronoUnit.MICROS))
             testJsonRoundTrip(Jsons.textNode("01:02:03.456789"))
-            testBadEncoding(Jsons.textNode("01:02:03.4"))
+            // Test variable precision support (1-9 decimal places)
+            Assertions.assertEquals(
+                LocalTime.of(1, 2, 3, 400000000),
+                decode(Jsons.textNode("01:02:03.4"))
+            )
+            Assertions.assertEquals(
+                LocalTime.of(1, 2, 3, 123456789),
+                decode(Jsons.textNode("01:02:03.123456789"))
+            )
             testBadEncoding(Jsons.textNode("foo"))
             testBadEncoding(Jsons.nullNode())
         }
@@ -252,6 +260,15 @@ class JsonCodecTest {
         LocalDateTimeCodec.run {
             testValueRoundTrip(LocalDateTime.now().truncatedTo(ChronoUnit.MICROS))
             testJsonRoundTrip(Jsons.textNode("2024-03-01T01:02:03.456789"))
+            // Test variable precision support (1-9 decimal places) - for MSSQL datetime2
+            Assertions.assertEquals(
+                LocalDateTime.of(2024, 2, 20, 1, 52, 4, 353333300),
+                decode(Jsons.textNode("2024-02-20T01:52:04.353333300"))
+            )
+            Assertions.assertEquals(
+                LocalDateTime.of(2024, 3, 1, 1, 2, 3, 400000000),
+                decode(Jsons.textNode("2024-03-01T01:02:03.4"))
+            )
             testBadEncoding(Jsons.textNode("2024-03-01 01:02:03.4"))
             testBadEncoding(Jsons.numberNode(LocalDateTime.now().toEpochSecond(ZoneOffset.UTC)))
             testBadEncoding(Jsons.textNode("foo"))

--- a/airbyte-cdk/bulk/toolkits/extract-jdbc/src/main/kotlin/io/airbyte/cdk/discover/JdbcMetadataQuerier.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-jdbc/src/main/kotlin/io/airbyte/cdk/discover/JdbcMetadataQuerier.kt
@@ -182,7 +182,7 @@ class JdbcMetadataQuerier(
         }
     }
 
-    private fun columnMetadataFromResultSet(
+    fun columnMetadataFromResultSet(
         rs: ResultSet,
         isPseudoColumn: Boolean,
     ): Pair<TableName, ColumnMetadata> {

--- a/airbyte-cdk/bulk/version.properties
+++ b/airbyte-cdk/bulk/version.properties
@@ -1,1 +1,1 @@
-version=0.1.78
+version=0.1.79


### PR DESCRIPTION
## What
1. we have user connection that stored ts cursor with 7 digits precision and we failed to decode it
2. make `columnMetadataFromResultSet ` public to be used by other metadata querier

## How
update JsonCodec with multiple precision pattern

## Review guide
<!--
1. `x.py`
3. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
