### PR TITLE
Bulk CDK: check that we aren't republishing _any_ version

### DIFF
--- a/airbyte-cdk/bulk/build.gradle
+++ b/airbyte-cdk/bulk/build.gradle
@@ -105,11 +105,16 @@ tasks.register('checkBuildNumber') {
 
             XPath xpath = XPathFactory.newInstance().newXPath()
 
-            String expression = "/metadata/versioning/latest"
+            String expression = "/metadata/versioning/versions/version"
 
-            String latestVersion = (String) xpath.compile(expression).evaluate(doc, XPathConstants.STRING)
-            if (version.toString() == latestVersion) {
-                throw new GradleException("Version already exist")
+            var versionNodes = xpath.compile(expression).evaluate(doc, XPathConstants.NODESET)
+            var allVersions = []
+            for (int i = 0; i < versionNodes.length; i++) {
+                allVersions.add(versionNodes.item(i).textContent)
+            }
+
+            if (allVersions.contains(version.toString())) {
+                throw new GradleException("Version ${version} already exists in the repository")
             }
         } finally {
             connection.disconnect()


### PR DESCRIPTION
currently the check only validates that we're not republishing the _latest_ version. This means that if your PR was branched from CDK version 1.2.3, and master has advanced to 1.2.4 - the PR check would pass, even though it _should_ force you to bump the version to 1.2.5.

code is claude-generated, but I tested it locally and it works correctly. Prompt:
> In `airbyte-cdk/bulk/build.gradle`, the `checkBuildNumber` currently queries a maven-metadata.xml URL and checks whether the latest version matches our current version. Change this so that it instead checks whether _any_ version matches our current version.