### PR TITLE
fix gradle warning

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,3 @@
-import com.gradle.scan.plugin.PublishedBuildScan
-
 pluginManagement {
     repositories {
         // # Gradle looks for dependency artifacts in repositories listed in 'repositories' blocks in descending order.
@@ -119,7 +117,7 @@ develocity {
         termsOfUseUrl = "https://gradle.com/terms-of-service"
         termsOfUseAgree = "yes"
         uploadInBackground = !isCI // Disable in CI or scan URLs may not work.
-        buildScanPublished { PublishedBuildScan scan ->
+        buildScanPublished { scan ->
             file("scan-journal.log") << "${new Date()} - ${scan.buildScanId} - ${scan.buildScanUri}\n"
         }
     }


### PR DESCRIPTION
fix warning
```
WARNING: Error invoking build scan buildScanPublished action
        The closure 'settings_eiovfyqcnpx3uwknkft4bozav$_run_closure2$_closure24$_closure25@5cbb40b2' is not valid as an action for
argument 'com.gradle.scan.plugin.internal.service.PluginServiceFactory$1@6a26c0e'. It should accept no parameters, or one compatible with
type 'com.gradle.scan.plugin.internal.service.PluginServiceFactory$1'. It accepts (com.gradle.scan.plugin.PublishedBuildScan).
```
I think this started happening after the enterprise plugin -> develocity upgrade and I just didn't notice until now?