### PR TITLE
feat: Add external documentation URLs to all destination connectors (Group A)

### DIFF
--- a/airbyte-ci/connectors/metadata_service/docs/external_documentation_urls.md
+++ b/airbyte-ci/connectors/metadata_service/docs/external_documentation_urls.md
@@ -1,0 +1,554 @@
+# External Documentation URLs Guide
+
+## Overview
+
+This guide explains how to identify, scrape, and maintain `externalDocumentationUrls` in connector `metadata.yaml` files. These URLs point to official vendor documentation that helps users understand API changes, authentication requirements, rate limits, and other critical information.
+
+### Purpose
+
+External documentation URLs serve several key purposes:
+- Surface vendor changelogs and release notes for tracking breaking changes
+- Provide quick access to authentication and permissions documentation
+- Link to rate limits and quota information
+- Direct users to official API references and data model documentation
+- Connect users with vendor status pages and developer communities
+
+### Schema Location
+
+The schema is defined in `airbyte-ci/connectors/metadata_service/lib/metadata_service/models/src/ConnectorMetadataDefinitionV0.yaml`.
+
+The `externalDocumentationUrls` field is an optional array where each entry contains:
+- `title` (required): Display title for the documentation link
+- `url` (required): URL to the external documentation
+- `type` (optional): Category of documentation (see taxonomy below)
+- `requiresLogin` (optional, default: false): Whether the URL requires authentication to access
+
+## Documentation Type Taxonomy
+
+### api_release_history
+**Description:** Changelogs, release notes, API version history, and out-of-cycle changes.
+
+**Typical URL patterns:**
+- `*/changelog*`
+- `*/release-notes*`
+- `*/api/versions*`
+- `*/whats-new*`
+
+**Examples:**
+- Airtable: `https://airtable.com/developers/web/api/changelog`
+- Google Ads: `https://developers.google.com/google-ads/api/docs/release-notes`
+- Salesforce: `https://help.salesforce.com/s/articleView?id=release-notes.salesforce_release_notes.htm`
+- Facebook Marketing: `https://developers.facebook.com/docs/marketing-api/marketing-api-changelog`
+
+### api_reference
+**Description:** API documentation, versioning docs, technical references, and API specifications.
+
+**Typical URL patterns:**
+- `*/api/reference*`
+- `*/api/docs*`
+- `*/developers/api*`
+- `*/api-reference*`
+
+**Examples:**
+- GitLab: `https://docs.gitlab.com/ee/api/rest/`
+- Chargebee: `https://apidocs.chargebee.com/docs/api/versioning`
+- Azure Blob Storage: `https://learn.microsoft.com/en-us/rest/api/storageservices/`
+- Pinecone: `https://docs.pinecone.io/reference/api/introduction`
+
+### api_deprecations
+**Description:** Deprecation notices, future breaking changes, and migration timelines.
+
+**Typical URL patterns:**
+- `*/deprecations*`
+- `*/breaking-changes*`
+- `*/sunset*`
+- `*/migration*`
+
+**Examples:**
+- GitLab: `https://docs.gitlab.com/ee/api/rest/deprecations.html`
+- Facebook Marketing: `https://developers.facebook.com/docs/marketing-api/out-of-cycle-changes/`
+- Stripe: `https://stripe.com/docs/upgrades#api-versions`
+
+### authentication_guide
+**Description:** Official OAuth/API key setup, consent flows, and authentication methods.
+
+**Typical URL patterns:**
+- `*/oauth*`
+- `*/authentication*`
+- `*/auth*`
+- `*/api-keys*`
+- `*/credentials*`
+
+**Examples:**
+- Airtable: `https://airtable.com/developers/web/api/oauth-reference`
+- Google Cloud: `https://cloud.google.com/iam/docs/service-accounts`
+- Salesforce: `https://help.salesforce.com/s/articleView?id=sf.connected_app_create.htm`
+- Snowflake: `https://docs.snowflake.com/en/user-guide/key-pair-auth`
+
+### permissions_scopes
+**Description:** Required roles, permissions, OAuth scopes, or database GRANTs.
+
+**Typical URL patterns:**
+- `*/permissions*`
+- `*/scopes*`
+- `*/roles*`
+- `*/access-control*`
+- `*/grants*`
+
+**Examples:**
+- BigQuery: `https://cloud.google.com/bigquery/docs/access-control`
+- Salesforce: `https://help.salesforce.com/s/articleView?id=sf.connected_app_create_api_integration.htm`
+- Google Ads: `https://developers.google.com/google-ads/api/docs/oauth/overview`
+- Postgres: `https://www.postgresql.org/docs/current/sql-grant.html`
+
+### rate_limits
+**Description:** Rate limits, quotas, throttling behavior, and concurrency limits.
+
+**Typical URL patterns:**
+- `*/rate-limits*`
+- `*/quotas*`
+- `*/limits*`
+- `*/throttling*`
+
+**Examples:**
+- BigQuery: `https://cloud.google.com/bigquery/quotas`
+- GitHub: `https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting`
+- Salesforce: `https://developer.salesforce.com/docs/atlas.en-us.salesforce_app_limits_cheatsheet.meta/salesforce_app_limits_cheatsheet/`
+- Stripe: `https://stripe.com/docs/rate-limits`
+
+### status_page
+**Description:** Vendor status/uptime pages for incident tracking.
+
+**Typical URL patterns:**
+- `status.*`
+- `*/status*`
+- `*/system-status*`
+
+**Examples:**
+- Snowflake: `https://status.snowflake.com/`
+- Google Cloud: `https://status.cloud.google.com/`
+- Salesforce: `https://status.salesforce.com/`
+- GitHub: `https://www.githubstatus.com/`
+
+### data_model_reference
+**Description:** Object/field/endpoint reference for SaaS APIs (what tables/fields exist).
+
+**Typical URL patterns:**
+- `*/object-reference*`
+- `*/data-model*`
+- `*/schema*`
+- `*/objects*`
+
+**Examples:**
+- Salesforce: `https://developer.salesforce.com/docs/atlas.en-us.object_reference.meta/object_reference/`
+- HubSpot: `https://developers.hubspot.com/docs/api/crm/understanding-the-crm`
+- GitHub: `https://docs.github.com/en/rest/overview/resources-in-the-rest-api`
+
+### sql_reference
+**Description:** SQL dialect/reference docs for databases and warehouses.
+
+**Typical URL patterns:**
+- `*/sql-reference*`
+- `*/sql/reference*`
+- `*/language-reference*`
+
+**Examples:**
+- BigQuery: `https://cloud.google.com/bigquery/docs/reference/standard-sql`
+- Snowflake: `https://docs.snowflake.com/en/sql-reference`
+- Postgres: `https://www.postgresql.org/docs/current/sql.html`
+- Redshift: `https://docs.aws.amazon.com/redshift/latest/dg/c_SQL_reference.html`
+
+### migration_guide
+**Description:** Vendor migration/breaking-change guides between versions.
+
+**Typical URL patterns:**
+- `*/migration*`
+- `*/upgrade*`
+- `*/version-migration*`
+
+**Examples:**
+- Stripe: `https://stripe.com/docs/upgrades`
+- Elasticsearch: `https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes.html`
+
+### developer_community
+**Description:** Official forums/communities for vendor Q&A and technical discussions.
+
+**Typical URL patterns:**
+- `community.*`
+- `*/community*`
+- `*/forum*`
+- `*/discussions*`
+
+**Examples:**
+- Airtable: `https://community.airtable.com/development-apis-11`
+- Salesforce: `https://developer.salesforce.com/forums`
+- Snowflake: `https://community.snowflake.com/`
+
+### other
+**Description:** Catch-all for documentation that doesn't fit other categories. Use sparingly.
+
+**Note:** Since `type` is optional, prefer omitting the type field rather than using "other" when a link doesn't fit neatly into a category.
+
+## How to Find Documentation URLs
+
+### Preferred Sources (in order of priority)
+1. **Official vendor documentation** (e.g., `docs.vendor.com`, `developers.vendor.com`)
+2. **Official vendor blogs** (e.g., `blog.vendor.com`, `developers.vendor.com/blog`)
+3. **Official community forums** (e.g., `community.vendor.com`)
+
+### Search Query Templates
+
+Use these search patterns to find appropriate documentation:
+
+```
+# Release notes / changelogs
+site:<vendor-domain> "release notes"
+site:<vendor-domain> "changelog"
+site:<vendor-domain> "API changelog"
+
+# API reference
+site:<vendor-domain> "API reference"
+site:<vendor-domain> "API documentation"
+
+# Authentication
+site:<vendor-domain> "OAuth"
+site:<vendor-domain> "authentication"
+site:<vendor-domain> "API key"
+
+# Permissions
+site:<vendor-domain> "permissions"
+site:<vendor-domain> "scopes"
+site:<vendor-domain> "access control"
+
+# Rate limits
+site:<vendor-domain> "rate limits"
+site:<vendor-domain> "quotas"
+site:<vendor-domain> "API limits"
+
+# Status page
+site:status.<vendor-domain>
+"<vendor>" status page
+
+# SQL reference (for databases/warehouses)
+site:<vendor-domain> "SQL reference"
+site:<vendor-domain> "language reference"
+```
+
+### URL Selection Heuristics
+
+1. **Prefer canonical, version-agnostic URLs** that are updated over time rather than version-specific pages
+   - ✅ Good: `https://docs.vendor.com/api/changelog`
+   - ❌ Avoid: `https://docs.vendor.com/v2.3/api/changelog`
+
+2. **Avoid locale-specific paths** when generic URLs exist
+   - ✅ Good: `https://docs.vendor.com/api/reference`
+   - ❌ Avoid: `https://docs.vendor.com/en-us/api/reference`
+
+3. **Prefer stable root pages** over deep-linked anchors that may change
+   - ✅ Good: `https://docs.vendor.com/rate-limits`
+   - ⚠️ Use with caution: `https://docs.vendor.com/api#rate-limits-section`
+
+4. **Always use official vendor domains** - never third-party mirrors or documentation aggregators
+
+5. **Set `requiresLogin: true`** when the URL requires authentication to access
+
+## Connector Family-Specific Guidance
+
+### Data Warehouses (BigQuery, Snowflake, Redshift, Databricks)
+
+**Priority types to include:**
+- `sql_reference` (required) - SQL dialect documentation
+- `authentication_guide` - Service account, key pair, or IAM auth
+- `permissions_scopes` - Required roles and grants
+- `api_release_history` - Release notes for API/driver changes
+- `status_page` - Service status monitoring
+- `rate_limits` - Query limits, concurrency limits (if applicable)
+
+**Example (BigQuery):**
+```yaml
+externalDocumentationUrls:
+  - title: Release notes
+    url: https://cloud.google.com/bigquery/docs/release-notes
+    type: api_release_history
+  - title: Standard SQL reference
+    url: https://cloud.google.com/bigquery/docs/reference/standard-sql
+    type: sql_reference
+  - title: Service account authentication
+    url: https://cloud.google.com/iam/docs/service-accounts
+    type: authentication_guide
+  - title: Access control and permissions
+    url: https://cloud.google.com/bigquery/docs/access-control
+    type: permissions_scopes
+  - title: Quotas and limits
+    url: https://cloud.google.com/bigquery/quotas
+    type: rate_limits
+  - title: Google Cloud Status
+    url: https://status.cloud.google.com/
+    type: status_page
+```
+
+### Databases (Postgres, MySQL, MSSQL, MongoDB)
+
+**Priority types to include:**
+- `sql_reference` (for SQL databases) - SQL dialect documentation
+- `authentication_guide` - Connection and authentication methods
+- `permissions_scopes` - User permissions and grants
+- `api_release_history` - Version release notes (if applicable)
+
+**Example (Postgres):**
+```yaml
+externalDocumentationUrls:
+  - title: PostgreSQL documentation
+    url: https://www.postgresql.org/docs/current/
+    type: api_reference
+  - title: SQL reference
+    url: https://www.postgresql.org/docs/current/sql.html
+    type: sql_reference
+  - title: Authentication methods
+    url: https://www.postgresql.org/docs/current/auth-methods.html
+    type: authentication_guide
+  - title: GRANT permissions
+    url: https://www.postgresql.org/docs/current/sql-grant.html
+    type: permissions_scopes
+```
+
+### SaaS APIs (Salesforce, HubSpot, GitHub, Stripe)
+
+**Priority types to include:**
+- `api_release_history` (required) - Changelogs and release notes
+- `api_reference` - API documentation
+- `api_deprecations` - Deprecation schedules (if available)
+- `authentication_guide` - OAuth or API key setup
+- `permissions_scopes` - Required scopes or permissions
+- `rate_limits` - API rate limits
+- `data_model_reference` - Object/field reference
+- `developer_community` - Developer forums
+- `status_page` - Service status
+
+**Example (Salesforce):**
+```yaml
+externalDocumentationUrls:
+  - title: API release notes
+    url: https://help.salesforce.com/s/articleView?id=release-notes.salesforce_release_notes.htm
+    type: api_release_history
+  - title: REST API reference
+    url: https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/
+    type: api_reference
+  - title: Connected app OAuth
+    url: https://help.salesforce.com/s/articleView?id=sf.connected_app_create.htm
+    type: authentication_guide
+  - title: OAuth scopes
+    url: https://help.salesforce.com/s/articleView?id=sf.remoteaccess_oauth_tokens_scopes.htm
+    type: permissions_scopes
+  - title: API rate limits
+    url: https://developer.salesforce.com/docs/atlas.en-us.salesforce_app_limits_cheatsheet.meta/salesforce_app_limits_cheatsheet/
+    type: rate_limits
+  - title: Object reference
+    url: https://developer.salesforce.com/docs/atlas.en-us.object_reference.meta/object_reference/
+    type: data_model_reference
+  - title: Salesforce Status
+    url: https://status.salesforce.com/
+    type: status_page
+```
+
+### Vector Stores (Pinecone, Weaviate, Qdrant, Chroma)
+
+**Priority types to include:**
+- `api_reference` (required) - API documentation
+- `rate_limits` - Request limits and quotas
+- `authentication_guide` - API key or authentication setup
+- `api_release_history` - Release notes (if available)
+- `status_page` - Service status (if available)
+- `migration_guide` - Version migration guides (if versions differ significantly)
+
+**Example (Pinecone):**
+```yaml
+externalDocumentationUrls:
+  - title: API reference
+    url: https://docs.pinecone.io/reference/api/introduction
+    type: api_reference
+  - title: Authentication
+    url: https://docs.pinecone.io/guides/get-started/authentication
+    type: authentication_guide
+  - title: Rate limits
+    url: https://docs.pinecone.io/troubleshooting/rate-limits
+    type: rate_limits
+  - title: Release notes
+    url: https://docs.pinecone.io/release-notes
+    type: api_release_history
+```
+
+## Maintenance Guidelines
+
+### Link Stability Checks
+
+Periodically validate that external documentation URLs are still accessible:
+
+1. **HTTP status validation** - Check that URLs return 200 or 3xx status codes
+2. **Flag 4xx/5xx errors** - Document broken links for replacement
+3. **Set `requiresLogin: true`** when appropriate to avoid false positives
+
+**Simple validation script:**
+```bash
+# Check a single URL
+curl -I -L -s -o /dev/null -w "%{http_code}" "https://docs.vendor.com/api/changelog"
+
+# Expected: 200, 301, 302
+# Action needed: 404, 403, 500
+```
+
+### Update Cadence
+
+- **Quarterly sweep** - Review all external documentation URLs for broken links
+- **On vendor announcements** - Update when vendors announce major documentation restructuring
+- **On deprecation notices** - Add `api_deprecations` links when vendors announce breaking changes
+
+### Replacement Rules
+
+When updating broken or outdated links:
+
+1. **Prefer same domain** - Look for the new location on the same vendor domain
+2. **Check vendor consolidation** - Vendors may consolidate multiple doc sites into one
+3. **Update to canonical** - If vendor provides a redirect, update to the final destination
+4. **Document in PR** - Note why the link was changed in the PR description
+
+### PR Review Practices
+
+When reviewing PRs that add or modify external documentation URLs:
+
+1. **Spot-check 2-3 links** per connector to verify they're accessible and relevant
+2. **Verify type categorization** - Ensure the `type` field matches the content
+3. **Check for duplicates** - Avoid adding the same URL twice with different titles
+4. **Validate requiresLogin** - Confirm whether authentication is actually required
+
+## YAML Template
+
+Here's a canonical example showing multiple types:
+
+```yaml
+externalDocumentationUrls:
+  - title: Release notes
+    url: https://cloud.google.com/bigquery/docs/release-notes
+    type: api_release_history
+  - title: Standard SQL reference
+    url: https://cloud.google.com/bigquery/docs/reference/standard-sql
+    type: sql_reference
+  - title: Service account authentication
+    url: https://cloud.google.com/iam/docs/service-accounts
+    type: authentication_guide
+  - title: Access control and permissions
+    url: https://cloud.google.com/bigquery/docs/access-control
+    type: permissions_scopes
+  - title: Quotas and limits
+    url: https://cloud.google.com/bigquery/quotas
+    type: rate_limits
+  - title: Google Cloud Status
+    url: https://status.cloud.google.com/
+    type: status_page
+    requiresLogin: false
+```
+
+## Validation Checklist
+
+Before submitting a PR with external documentation URLs:
+
+- [ ] Schema validation passes (run `poetry run metadata_service validate <metadata.yaml> <doc.md>`)
+- [ ] All URLs return HTTP 200 or 3xx status codes
+- [ ] No paywalls or login requirements (unless `requiresLogin: true` is set)
+- [ ] URLs are canonical and version-agnostic when possible
+- [ ] Type categorization is accurate
+- [ ] No duplicate URLs with different titles
+- [ ] Official vendor domains only (no third-party mirrors)
+- [ ] Titles are descriptive and consistent with vendor terminology
+
+## Common Pitfalls to Avoid
+
+1. **Don't over-categorize** - If a link doesn't fit neatly, omit the `type` field rather than forcing it
+2. **Avoid version-specific URLs** - Prefer evergreen URLs that are updated over time
+3. **Don't link to third-party docs** - Always use official vendor documentation
+4. **Watch for locale redirects** - Some URLs may redirect based on browser locale
+5. **Don't assume status pages exist** - Not all vendors have public status pages
+6. **Avoid deep anchors** - Deep-linked sections may change; prefer stable root pages
+7. **Don't duplicate content** - If a single page covers multiple topics, link it once with the most specific type
+
+## Examples by Connector Type
+
+### Example: Snowflake (Data Warehouse)
+```yaml
+externalDocumentationUrls:
+  - title: Release notes
+    url: https://docs.snowflake.com/en/release-notes
+    type: api_release_history
+  - title: SQL reference
+    url: https://docs.snowflake.com/en/sql-reference
+    type: sql_reference
+  - title: Key pair authentication
+    url: https://docs.snowflake.com/en/user-guide/key-pair-auth
+    type: authentication_guide
+  - title: Access control
+    url: https://docs.snowflake.com/en/user-guide/security-access-control
+    type: permissions_scopes
+  - title: Snowflake Status
+    url: https://status.snowflake.com/
+    type: status_page
+```
+
+### Example: Stripe (SaaS API)
+```yaml
+externalDocumentationUrls:
+  - title: API changelog
+    url: https://stripe.com/docs/upgrades#api-changelog
+    type: api_release_history
+  - title: API reference
+    url: https://stripe.com/docs/api
+    type: api_reference
+  - title: API versioning and upgrades
+    url: https://stripe.com/docs/upgrades
+    type: migration_guide
+  - title: Authentication
+    url: https://stripe.com/docs/keys
+    type: authentication_guide
+  - title: Rate limits
+    url: https://stripe.com/docs/rate-limits
+    type: rate_limits
+  - title: Stripe Status
+    url: https://status.stripe.com/
+    type: status_page
+```
+
+### Example: Postgres (Database)
+```yaml
+externalDocumentationUrls:
+  - title: PostgreSQL documentation
+    url: https://www.postgresql.org/docs/current/
+    type: api_reference
+  - title: SQL commands
+    url: https://www.postgresql.org/docs/current/sql-commands.html
+    type: sql_reference
+  - title: Client authentication
+    url: https://www.postgresql.org/docs/current/client-authentication.html
+    type: authentication_guide
+  - title: Database roles and privileges
+    url: https://www.postgresql.org/docs/current/user-manag.html
+    type: permissions_scopes
+```
+
+## Regenerating Schema After Changes
+
+If you modify the schema enum in `ConnectorMetadataDefinitionV0.yaml`, regenerate the generated models:
+
+```bash
+cd airbyte-ci/connectors/metadata_service/lib
+poetry install
+poetry run poe generate-models
+```
+
+This will update:
+- `metadata_service/models/generated/ConnectorMetadataDefinitionV0.json`
+- `metadata_service/models/generated/ConnectorMetadataDefinitionV0.py`
+
+## Additional Resources
+
+- [Connector Metadata Schema](../lib/metadata_service/models/src/ConnectorMetadataDefinitionV0.yaml)
+- [Metadata Service README](../lib/README.md)
+- [Connector Development Guide](https://docs.airbyte.com/connector-development/)

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorMetadataDefinitionV0.json
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorMetadataDefinitionV0.json
@@ -199,11 +199,19 @@
               },
               "type": {
                 "type": "string",
-                "description": "Category of documentation (api_release_history, api_reference, api_deprecations, or other)",
+                "description": "Category of documentation",
                 "enum": [
                   "api_release_history",
                   "api_reference",
                   "api_deprecations",
+                  "authentication_guide",
+                  "permissions_scopes",
+                  "rate_limits",
+                  "status_page",
+                  "data_model_reference",
+                  "sql_reference",
+                  "migration_guide",
+                  "developer_community",
                   "other"
                 ]
               },

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorMetadataDefinitionV0.json
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorMetadataDefinitionV0.json
@@ -201,18 +201,18 @@
                 "type": "string",
                 "description": "Category of documentation",
                 "enum": [
-                  "api_release_history",
-                  "api_reference",
                   "api_deprecations",
+                  "api_reference",
+                  "api_release_history",
                   "authentication_guide",
+                  "data_model_reference",
+                  "developer_community",
+                  "migration_guide",
+                  "other",
                   "permissions_scopes",
                   "rate_limits",
-                  "status_page",
-                  "data_model_reference",
                   "sql_reference",
-                  "migration_guide",
-                  "developer_community",
-                  "other"
+                  "status_page"
                 ]
               },
               "requiresLogin": {

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorMetadataDefinitionV0.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorMetadataDefinitionV0.py
@@ -19,18 +19,18 @@ class ExternalDocumentationUrl(BaseModel):
     url: AnyUrl = Field(..., description="URL to the external documentation")
     type: Optional[
         Literal[
-            "api_release_history",
-            "api_reference",
             "api_deprecations",
+            "api_reference",
+            "api_release_history",
             "authentication_guide",
+            "data_model_reference",
+            "developer_community",
+            "migration_guide",
+            "other",
             "permissions_scopes",
             "rate_limits",
-            "status_page",
-            "data_model_reference",
             "sql_reference",
-            "migration_guide",
-            "developer_community",
-            "other",
+            "status_page",
         ]
     ] = Field(None, description="Category of documentation")
     requiresLogin: Optional[bool] = Field(

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorMetadataDefinitionV0.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorMetadataDefinitionV0.py
@@ -18,11 +18,21 @@ class ExternalDocumentationUrl(BaseModel):
     title: str = Field(..., description="Display title for the documentation link")
     url: AnyUrl = Field(..., description="URL to the external documentation")
     type: Optional[
-        Literal["api_release_history", "api_reference", "api_deprecations", "other"]
-    ] = Field(
-        None,
-        description="Category of documentation (api_release_history, api_reference, api_deprecations, or other)",
-    )
+        Literal[
+            "api_release_history",
+            "api_reference",
+            "api_deprecations",
+            "authentication_guide",
+            "permissions_scopes",
+            "rate_limits",
+            "status_page",
+            "data_model_reference",
+            "sql_reference",
+            "migration_guide",
+            "developer_community",
+            "other",
+        ]
+    ] = Field(None, description="Category of documentation")
     requiresLogin: Optional[bool] = Field(
         False, description="Whether the URL requires authentication to access"
     )

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/src/ConnectorMetadataDefinitionV0.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/src/ConnectorMetadataDefinitionV0.yaml
@@ -77,11 +77,19 @@ properties:
               description: "URL to the external documentation"
             type:
               type: string
-              description: "Category of documentation (api_release_history, api_reference, api_deprecations, or other)"
+              description: "Category of documentation"
               enum:
                 - api_release_history
                 - api_reference
                 - api_deprecations
+                - authentication_guide
+                - permissions_scopes
+                - rate_limits
+                - status_page
+                - data_model_reference
+                - sql_reference
+                - migration_guide
+                - developer_community
                 - other
             requiresLogin:
               type: boolean

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/src/ConnectorMetadataDefinitionV0.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/src/ConnectorMetadataDefinitionV0.yaml
@@ -79,18 +79,18 @@ properties:
               type: string
               description: "Category of documentation"
               enum:
-                - api_release_history
-                - api_reference
                 - api_deprecations
+                - api_reference
+                - api_release_history
                 - authentication_guide
+                - data_model_reference
+                - developer_community
+                - migration_guide
+                - other
                 - permissions_scopes
                 - rate_limits
-                - status_page
-                - data_model_reference
                 - sql_reference
-                - migration_guide
-                - developer_community
-                - other
+                - status_page
             requiresLogin:
               type: boolean
               description: "Whether the URL requires authentication to access"

--- a/airbyte-integrations/connectors/destination-amazon-sqs/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-amazon-sqs/metadata.yaml
@@ -16,36 +16,36 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/amazon-sqs
   tags:
-  - language:python
-  - cdk:python
+    - language:python
+    - cdk:python
   ab_internal:
     sl: 100
     ql: 200
   supportLevel: community
   connectorTestSuitesOptions:
-  - suite: integrationTests
-    testSecrets:
-    - name: SECRET_DESTINATION-AMAZON-SQS
-      fileName: config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION-AMAZON-SQS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
   connectorBuildOptions:
     baseImage: docker.io/airbyte/python-connector-base:2.0.0@sha256:c44839ba84406116e8ba68722a0f30e8f6e7056c726f447681bb9e9ece8bd916
   externalDocumentationUrls:
-  - title: Amazon SQS documentation
-    url: https://docs.aws.amazon.com/sqs/
-    type: api_reference
-  - title: IAM authentication
-    url: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html
-    type: authentication_guide
-  - title: IAM policies
-    url: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-authentication-and-access-control.html
-    type: permissions_scopes
-  - title: Quotas and limits
-    url: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-quotas.html
-    type: rate_limits
-  - title: AWS Service Health Dashboard
-    url: https://health.aws.amazon.com/health/status
-    type: status_page
-metadataSpecVersion: '1.0'
+    - title: Amazon SQS documentation
+      url: https://docs.aws.amazon.com/sqs/
+      type: api_reference
+    - title: IAM authentication
+      url: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html
+      type: authentication_guide
+    - title: IAM policies
+      url: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-authentication-and-access-control.html
+      type: permissions_scopes
+    - title: Quotas and limits
+      url: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-quotas.html
+      type: rate_limits
+    - title: AWS Service Health Dashboard
+      url: https://health.aws.amazon.com/health/status
+      type: status_page
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-amazon-sqs/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-amazon-sqs/metadata.yaml
@@ -16,24 +16,36 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/amazon-sqs
   tags:
-    - language:python
-    - cdk:python
+  - language:python
+  - cdk:python
   ab_internal:
     sl: 100
     ql: 200
   supportLevel: community
   connectorTestSuitesOptions:
-    # Disable unit tests for now
-    # They are not passing
-    # No Airbyte Cloud usage
-    #- suite: unitTests
-    - suite: integrationTests
-      testSecrets:
-        - name: SECRET_DESTINATION-AMAZON-SQS
-          fileName: config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
+  - suite: integrationTests
+    testSecrets:
+    - name: SECRET_DESTINATION-AMAZON-SQS
+      fileName: config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
   connectorBuildOptions:
     baseImage: docker.io/airbyte/python-connector-base:2.0.0@sha256:c44839ba84406116e8ba68722a0f30e8f6e7056c726f447681bb9e9ece8bd916
-metadataSpecVersion: "1.0"
+  externalDocumentationUrls:
+  - title: Amazon SQS documentation
+    url: https://docs.aws.amazon.com/sqs/
+    type: api_reference
+  - title: IAM authentication
+    url: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html
+    type: authentication_guide
+  - title: IAM policies
+    url: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-authentication-and-access-control.html
+    type: permissions_scopes
+  - title: Quotas and limits
+    url: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-quotas.html
+    type: rate_limits
+  - title: AWS Service Health Dashboard
+    url: https://health.aws.amazon.com/health/status
+    type: status_page
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-amazon-sqs/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-amazon-sqs/metadata.yaml
@@ -23,6 +23,10 @@ data:
     ql: 200
   supportLevel: community
   connectorTestSuitesOptions:
+    # Disable unit tests for now
+    # They are not passing
+    # No Airbyte Cloud usage
+    #- suite: unitTests
     - suite: integrationTests
       testSecrets:
         - name: SECRET_DESTINATION-AMAZON-SQS

--- a/airbyte-integrations/connectors/destination-astra/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-astra/metadata.yaml
@@ -1,7 +1,7 @@
 data:
   allowedHosts:
     hosts:
-    - '*.apps.astra.datastax.com'
+      - "*.apps.astra.datastax.com"
   registryOverrides:
     oss:
       enabled: true
@@ -23,32 +23,32 @@ data:
   supportLevel: community
   documentationUrl: https://docs.airbyte.com/integrations/destinations/astra
   tags:
-  - language:python
-  - cdk:python
+    - language:python
+    - cdk:python
   connectorTestSuitesOptions:
-  - suite: unitTests
-  - suite: integrationTests
-    testSecrets:
-    - name: SECRET_DESTINATION-ASTRA__CREDS
-      fileName: config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
-  - suite: acceptanceTests
-    testSecrets:
-    - name: SECRET_DESTINATION-ASTRA__CREDS
-      fileName: config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION-ASTRA__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_DESTINATION-ASTRA__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
   externalDocumentationUrls:
-  - title: DataStax Astra documentation
-    url: https://docs.datastax.com/en/astra-serverless/docs/
-    type: api_reference
-  - title: CQL reference
-    url: https://docs.datastax.com/en/cql-oss/3.x/cql/cql_reference/cqlReferenceTOC.html
-    type: sql_reference
-  - title: Authentication
-    url: https://docs.datastax.com/en/astra-serverless/docs/manage/org/manage-tokens.html
-    type: authentication_guide
-metadataSpecVersion: '1.0'
+    - title: DataStax Astra documentation
+      url: https://docs.datastax.com/en/astra-serverless/docs/
+      type: api_reference
+    - title: CQL reference
+      url: https://docs.datastax.com/en/cql-oss/3.x/cql/cql_reference/cqlReferenceTOC.html
+      type: sql_reference
+    - title: Authentication
+      url: https://docs.datastax.com/en/astra-serverless/docs/manage/org/manage-tokens.html
+      type: authentication_guide
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-astra/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-astra/metadata.yaml
@@ -8,6 +8,9 @@ data:
     cloud:
       enabled: true
   connectorBuildOptions:
+    # Please update to the latest version of the connector base image.
+    # Please use the full address with sha256 hash to guarantee build reproducibility.
+    # https://hub.docker.com/r/airbyte/python-connector-base
     baseImage: docker.io/airbyte/python-connector-base:4.0.0@sha256:d9894b6895923b379f3006fa251147806919c62b7d9021b5cd125bb67d7bbe22
   connectorSubtype: database
   connectorType: destination

--- a/airbyte-integrations/connectors/destination-astra/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-astra/metadata.yaml
@@ -1,16 +1,13 @@
 data:
   allowedHosts:
     hosts:
-      - "*.apps.astra.datastax.com"
+    - '*.apps.astra.datastax.com'
   registryOverrides:
     oss:
       enabled: true
     cloud:
       enabled: true
   connectorBuildOptions:
-    # Please update to the latest version of the connector base image.
-    # Please use the full address with sha256 hash to guarantee build reproducibility.
-    # https://hub.docker.com/r/airbyte/python-connector-base
     baseImage: docker.io/airbyte/python-connector-base:4.0.0@sha256:d9894b6895923b379f3006fa251147806919c62b7d9021b5cd125bb67d7bbe22
   connectorSubtype: database
   connectorType: destination
@@ -26,22 +23,32 @@ data:
   supportLevel: community
   documentationUrl: https://docs.airbyte.com/integrations/destinations/astra
   tags:
-    - language:python
-    - cdk:python
+  - language:python
+  - cdk:python
   connectorTestSuitesOptions:
-    - suite: unitTests
-    - suite: integrationTests
-      testSecrets:
-        - name: SECRET_DESTINATION-ASTRA__CREDS
-          fileName: config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-    - suite: acceptanceTests
-      testSecrets:
-        - name: SECRET_DESTINATION-ASTRA__CREDS
-          fileName: config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-metadataSpecVersion: "1.0"
+  - suite: unitTests
+  - suite: integrationTests
+    testSecrets:
+    - name: SECRET_DESTINATION-ASTRA__CREDS
+      fileName: config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+  - suite: acceptanceTests
+    testSecrets:
+    - name: SECRET_DESTINATION-ASTRA__CREDS
+      fileName: config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+  - title: DataStax Astra documentation
+    url: https://docs.datastax.com/en/astra-serverless/docs/
+    type: api_reference
+  - title: CQL reference
+    url: https://docs.datastax.com/en/cql-oss/3.x/cql/cql_reference/cqlReferenceTOC.html
+    type: sql_reference
+  - title: Authentication
+    url: https://docs.datastax.com/en/astra-serverless/docs/manage/org/manage-tokens.html
+    type: authentication_guide
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-aws-datalake/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-aws-datalake/metadata.yaml
@@ -18,29 +18,29 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/aws-datalake
   tags:
-  - language:python
-  - cdk:python
+    - language:python
+    - cdk:python
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
-  - suite: unitTests
-  - suite: integrationTests
-    testSecrets:
-    - name: SECRET_DESTINATION-AWS-DATALAKE_CREDS
-      fileName: config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION-AWS-DATALAKE_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
   externalDocumentationUrls:
-  - title: AWS Lake Formation documentation
-    url: https://docs.aws.amazon.com/lake-formation/
-    type: api_reference
-  - title: IAM authentication
-    url: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html
-    type: authentication_guide
-  - title: Permissions
-    url: https://docs.aws.amazon.com/lake-formation/latest/dg/lake-formation-permissions.html
-    type: permissions_scopes
-metadataSpecVersion: '1.0'
+    - title: AWS Lake Formation documentation
+      url: https://docs.aws.amazon.com/lake-formation/
+      type: api_reference
+    - title: IAM authentication
+      url: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html
+      type: authentication_guide
+    - title: Permissions
+      url: https://docs.aws.amazon.com/lake-formation/latest/dg/lake-formation-permissions.html
+      type: permissions_scopes
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-aws-datalake/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-aws-datalake/metadata.yaml
@@ -18,19 +18,29 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/aws-datalake
   tags:
-    - language:python
-    - cdk:python
+  - language:python
+  - cdk:python
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
-    - suite: unitTests
-    - suite: integrationTests
-      testSecrets:
-        - name: SECRET_DESTINATION-AWS-DATALAKE_CREDS
-          fileName: config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-metadataSpecVersion: "1.0"
+  - suite: unitTests
+  - suite: integrationTests
+    testSecrets:
+    - name: SECRET_DESTINATION-AWS-DATALAKE_CREDS
+      fileName: config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+  - title: AWS Lake Formation documentation
+    url: https://docs.aws.amazon.com/lake-formation/
+    type: api_reference
+  - title: IAM authentication
+    url: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html
+    type: authentication_guide
+  - title: Permissions
+    url: https://docs.aws.amazon.com/lake-formation/latest/dg/lake-formation-permissions.html
+    type: permissions_scopes
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-azure-blob-storage/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage/metadata.yaml
@@ -49,22 +49,20 @@ data:
       enableProgressiveRollout: false
     breakingChanges:
       1.0.0:
-        message:
-          '''This version updates the connector''s behavior to match other
-          certified destinations'' behavior. In particular, the `_airbyte_*` columns
-          have been renamed, and files are now placed in `<container>/<stream namespace>/<stream
-          name>/**` (previously, stream namespace was not used in the path).
+        message: >
+          'This version updates the connector's behavior to match other certified destinations' behavior.
+          In particular, the `_airbyte_*` columns have been renamed, and files are now placed in
+          `<container>/<stream namespace>/<stream name>/**` (previously, stream namespace was not used
+          in the path).
 
-          Some options have been renamed for clarity. Notably, the "spill size" option
-          is now named "file split size"; additionally, this option is now correctly
-          applied to CSV files (previously it only applied to JSONL files).
+          Some options have been renamed for clarity. Notably, the "spill size" option is now named
+          "file split size"; additionally, this option is now correctly applied to CSV files (previously
+          it only applied to JSONL files).
 
-          This connector now writes "block" blobs, instead of "append" blobs. This
-          means that you may assume that as soon as a blob shows up in your Azure
-          blob container, it is ready for consumption. (Previously, with append blobs,
-          the connector would first write an empty blob, and fill it gradually.)
-
-          ''
+          This connector now writes "block" blobs, instead of "append" blobs. This means that you may
+          assume that as soon as a blob shows up in your Azure blob container, it is ready for consumption.
+          (Previously, with append blobs, the connector would first write an empty blob, and fill it
+          gradually.)
 
           '
         upgradeDeadline: "2026-03-31"

--- a/airbyte-integrations/connectors/destination-azure-blob-storage/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage/metadata.yaml
@@ -7,19 +7,19 @@ data:
     baseImage: docker.io/airbyte/java-connector-base:2.0.1@sha256:ec89bd1a89e825514dd2fc8730ba299a3ae1544580a078df0e35c5202c2085b3
   connectorSubtype: file
   connectorTestSuitesOptions:
-  - suite: unitTests
-  - suite: integrationTests
-    testSecrets:
-    - fileName: config.json
-      name: SECRET_DESTINATION-AZURE-BLOB-STORAGE__CREDS
-      secretStore:
-        alias: airbyte-connector-testing-secret-store
-        type: GSM
-    - fileName: config_sas.json
-      name: SECRET_DESTINATION-AZURE-BLOB-STORAGE-SAS__CREDS
-      secretStore:
-        alias: airbyte-connector-testing-secret-store
-        type: GSM
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - fileName: config.json
+          name: SECRET_DESTINATION-AZURE-BLOB-STORAGE__CREDS
+          secretStore:
+            alias: airbyte-connector-testing-secret-store
+            type: GSM
+        - fileName: config_sas.json
+          name: SECRET_DESTINATION-AZURE-BLOB-STORAGE-SAS__CREDS
+          secretStore:
+            alias: airbyte-connector-testing-secret-store
+            type: GSM
   connectorType: destination
   definitionId: b4c5d105-31fd-4817-96b6-cb923bfc04cb
   dockerImageTag: 1.1.4
@@ -33,11 +33,11 @@ data:
     dataChannel:
       version: 0.0.2
       supportedSerialization:
-      - JSONL
-      - PROTOBUF
+        - JSONL
+        - PROTOBUF
       supportedTransport:
-      - SOCKET
-      - STDIO
+        - SOCKET
+        - STDIO
   registryOverrides:
     cloud:
       enabled: true
@@ -49,7 +49,8 @@ data:
       enableProgressiveRollout: false
     breakingChanges:
       1.0.0:
-        message: '''This version updates the connector''s behavior to match other
+        message:
+          '''This version updates the connector''s behavior to match other
           certified destinations'' behavior. In particular, the `_airbyte_*` columns
           have been renamed, and files are now placed in `<container>/<stream namespace>/<stream
           name>/**` (previously, stream namespace was not used in the path).
@@ -66,31 +67,31 @@ data:
           ''
 
           '
-        upgradeDeadline: '2026-03-31'
+        upgradeDeadline: "2026-03-31"
   resourceRequirements:
     jobSpecific:
-    - jobType: sync
-      resourceRequirements:
-        memory_request: 1Gi
+      - jobType: sync
+        resourceRequirements:
+          memory_request: 1Gi
   supportLevel: certified
   tags:
-  - language:java
+    - language:java
   supportsFileTransfer: true
   supportsRefreshes: true
   externalDocumentationUrls:
-  - title: Azure Blob Storage documentation
-    url: https://learn.microsoft.com/en-us/azure/storage/blobs/
-    type: api_reference
-  - title: Authorize access
-    url: https://learn.microsoft.com/en-us/azure/storage/common/authorize-data-access
-    type: authentication_guide
-  - title: Access control
-    url: https://learn.microsoft.com/en-us/azure/storage/blobs/data-lake-storage-access-control
-    type: permissions_scopes
-  - title: Scalability and performance
-    url: https://learn.microsoft.com/en-us/azure/storage/blobs/scalability-targets
-    type: rate_limits
-  - title: Azure Status
-    url: https://status.azure.com/
-    type: status_page
-metadataSpecVersion: '1.0'
+    - title: Azure Blob Storage documentation
+      url: https://learn.microsoft.com/en-us/azure/storage/blobs/
+      type: api_reference
+    - title: Authorize access
+      url: https://learn.microsoft.com/en-us/azure/storage/common/authorize-data-access
+      type: authentication_guide
+    - title: Access control
+      url: https://learn.microsoft.com/en-us/azure/storage/blobs/data-lake-storage-access-control
+      type: permissions_scopes
+    - title: Scalability and performance
+      url: https://learn.microsoft.com/en-us/azure/storage/blobs/scalability-targets
+      type: rate_limits
+    - title: Azure Status
+      url: https://status.azure.com/
+      type: status_page
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-azure-blob-storage/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage/metadata.yaml
@@ -7,19 +7,19 @@ data:
     baseImage: docker.io/airbyte/java-connector-base:2.0.1@sha256:ec89bd1a89e825514dd2fc8730ba299a3ae1544580a078df0e35c5202c2085b3
   connectorSubtype: file
   connectorTestSuitesOptions:
-    - suite: unitTests
-    - suite: integrationTests
-      testSecrets:
-        - fileName: config.json
-          name: SECRET_DESTINATION-AZURE-BLOB-STORAGE__CREDS
-          secretStore:
-            alias: airbyte-connector-testing-secret-store
-            type: GSM
-        - fileName: config_sas.json
-          name: SECRET_DESTINATION-AZURE-BLOB-STORAGE-SAS__CREDS
-          secretStore:
-            alias: airbyte-connector-testing-secret-store
-            type: GSM
+  - suite: unitTests
+  - suite: integrationTests
+    testSecrets:
+    - fileName: config.json
+      name: SECRET_DESTINATION-AZURE-BLOB-STORAGE__CREDS
+      secretStore:
+        alias: airbyte-connector-testing-secret-store
+        type: GSM
+    - fileName: config_sas.json
+      name: SECRET_DESTINATION-AZURE-BLOB-STORAGE-SAS__CREDS
+      secretStore:
+        alias: airbyte-connector-testing-secret-store
+        type: GSM
   connectorType: destination
   definitionId: b4c5d105-31fd-4817-96b6-cb923bfc04cb
   dockerImageTag: 1.1.4
@@ -31,9 +31,13 @@ data:
   name: Azure Blob Storage
   connectorIPCOptions:
     dataChannel:
-      version: "0.0.2"
-      supportedSerialization: ["JSONL", "PROTOBUF"]
-      supportedTransport: ["SOCKET", "STDIO"]
+      version: 0.0.2
+      supportedSerialization:
+      - JSONL
+      - PROTOBUF
+      supportedTransport:
+      - SOCKET
+      - STDIO
   registryOverrides:
     cloud:
       enabled: true
@@ -45,31 +49,48 @@ data:
       enableProgressiveRollout: false
     breakingChanges:
       1.0.0:
-        message: >
-          'This version updates the connector's behavior to match other certified destinations' behavior.
-          In particular, the `_airbyte_*` columns have been renamed, and files are now placed in
-          `<container>/<stream namespace>/<stream name>/**` (previously, stream namespace was not used
-          in the path).
+        message: '''This version updates the connector''s behavior to match other
+          certified destinations'' behavior. In particular, the `_airbyte_*` columns
+          have been renamed, and files are now placed in `<container>/<stream namespace>/<stream
+          name>/**` (previously, stream namespace was not used in the path).
 
-          Some options have been renamed for clarity. Notably, the "spill size" option is now named
-          "file split size"; additionally, this option is now correctly applied to CSV files (previously
-          it only applied to JSONL files).
+          Some options have been renamed for clarity. Notably, the "spill size" option
+          is now named "file split size"; additionally, this option is now correctly
+          applied to CSV files (previously it only applied to JSONL files).
 
-          This connector now writes "block" blobs, instead of "append" blobs. This means that you may
-          assume that as soon as a blob shows up in your Azure blob container, it is ready for consumption.
-          (Previously, with append blobs, the connector would first write an empty blob, and fill it
-          gradually.)
+          This connector now writes "block" blobs, instead of "append" blobs. This
+          means that you may assume that as soon as a blob shows up in your Azure
+          blob container, it is ready for consumption. (Previously, with append blobs,
+          the connector would first write an empty blob, and fill it gradually.)
+
+          ''
 
           '
-        upgradeDeadline: "2026-03-31"
+        upgradeDeadline: '2026-03-31'
   resourceRequirements:
     jobSpecific:
-      - jobType: sync
-        resourceRequirements:
-          memory_request: 1Gi
+    - jobType: sync
+      resourceRequirements:
+        memory_request: 1Gi
   supportLevel: certified
   tags:
-    - language:java
+  - language:java
   supportsFileTransfer: true
   supportsRefreshes: true
-metadataSpecVersion: "1.0"
+  externalDocumentationUrls:
+  - title: Azure Blob Storage documentation
+    url: https://learn.microsoft.com/en-us/azure/storage/blobs/
+    type: api_reference
+  - title: Authorize access
+    url: https://learn.microsoft.com/en-us/azure/storage/common/authorize-data-access
+    type: authentication_guide
+  - title: Access control
+    url: https://learn.microsoft.com/en-us/azure/storage/blobs/data-lake-storage-access-control
+    type: permissions_scopes
+  - title: Scalability and performance
+    url: https://learn.microsoft.com/en-us/azure/storage/blobs/scalability-targets
+    type: rate_limits
+  - title: Azure Status
+    url: https://status.azure.com/
+    type: status_page
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-bigquery-denormalized/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-bigquery-denormalized/metadata.yaml
@@ -16,11 +16,7 @@ data:
   releases:
     breakingChanges:
       2.0.0:
-        message:
-          "`destination-bigquery-denormalized` is being retired in favor of
-          `destination-bigquery`, and is no longer maintained. Please switch to destination-bigquery,
-          which will produce similar tables and contains many improvements.  Learn
-          more [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/)."
+        message: "`destination-bigquery-denormalized` is being retired in favor of `destination-bigquery`, and is no longer maintained. Please switch to destination-bigquery, which will produce similar tables and contains many improvements.  Learn more [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/)."
         upgradeDeadline: "2023-11-01"
   releaseStage: alpha
   resourceRequirements:

--- a/airbyte-integrations/connectors/destination-bigquery-denormalized/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-bigquery-denormalized/metadata.yaml
@@ -16,33 +16,34 @@ data:
   releases:
     breakingChanges:
       2.0.0:
-        message: '`destination-bigquery-denormalized` is being retired in favor of
+        message:
+          "`destination-bigquery-denormalized` is being retired in favor of
           `destination-bigquery`, and is no longer maintained. Please switch to destination-bigquery,
           which will produce similar tables and contains many improvements.  Learn
-          more [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/).'
-        upgradeDeadline: '2023-11-01'
+          more [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/)."
+        upgradeDeadline: "2023-11-01"
   releaseStage: alpha
   resourceRequirements:
     jobSpecific:
-    - jobType: sync
-      resourceRequirements:
-        memory_limit: 1Gi
-        memory_request: 1Gi
+      - jobType: sync
+        resourceRequirements:
+          memory_limit: 1Gi
+          memory_request: 1Gi
   documentationUrl: https://docs.airbyte.com/integrations/destinations/bigquery
   tags:
-  - language:java
+    - language:java
   ab_internal:
     sl: 100
     ql: 300
   supportLevel: archived
   externalDocumentationUrls:
-  - title: BigQuery documentation
-    url: https://cloud.google.com/bigquery/docs
-    type: api_reference
-  - title: Standard SQL reference
-    url: https://cloud.google.com/bigquery/docs/reference/standard-sql
-    type: sql_reference
-  - title: Service account authentication
-    url: https://cloud.google.com/iam/docs/service-accounts
-    type: authentication_guide
-metadataSpecVersion: '1.0'
+    - title: BigQuery documentation
+      url: https://cloud.google.com/bigquery/docs
+      type: api_reference
+    - title: Standard SQL reference
+      url: https://cloud.google.com/bigquery/docs/reference/standard-sql
+      type: sql_reference
+    - title: Service account authentication
+      url: https://cloud.google.com/iam/docs/service-accounts
+      type: authentication_guide
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-bigquery-denormalized/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-bigquery-denormalized/metadata.yaml
@@ -16,20 +16,33 @@ data:
   releases:
     breakingChanges:
       2.0.0:
-        message: "`destination-bigquery-denormalized` is being retired in favor of `destination-bigquery`, and is no longer maintained. Please switch to destination-bigquery, which will produce similar tables and contains many improvements.  Learn more [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/)."
-        upgradeDeadline: "2023-11-01"
+        message: '`destination-bigquery-denormalized` is being retired in favor of
+          `destination-bigquery`, and is no longer maintained. Please switch to destination-bigquery,
+          which will produce similar tables and contains many improvements.  Learn
+          more [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/).'
+        upgradeDeadline: '2023-11-01'
   releaseStage: alpha
   resourceRequirements:
     jobSpecific:
-      - jobType: sync
-        resourceRequirements:
-          memory_limit: 1Gi
-          memory_request: 1Gi
+    - jobType: sync
+      resourceRequirements:
+        memory_limit: 1Gi
+        memory_request: 1Gi
   documentationUrl: https://docs.airbyte.com/integrations/destinations/bigquery
   tags:
-    - language:java
+  - language:java
   ab_internal:
     sl: 100
     ql: 300
   supportLevel: archived
-metadataSpecVersion: "1.0"
+  externalDocumentationUrls:
+  - title: BigQuery documentation
+    url: https://cloud.google.com/bigquery/docs
+    type: api_reference
+  - title: Standard SQL reference
+    url: https://cloud.google.com/bigquery/docs/reference/standard-sql
+    type: sql_reference
+  - title: Service account authentication
+    url: https://cloud.google.com/iam/docs/service-accounts
+    type: authentication_guide
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-bigquery/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-bigquery/metadata.yaml
@@ -33,27 +33,10 @@ data:
   releases:
     breakingChanges:
       2.0.0:
-        message:
-          "**Do not upgrade until you have run a test upgrade as outlined [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#testing-destinations-v2-for-a-single-connection)**.
-
-          This version introduces [Destinations V2](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#what-is-destinations-v2),
-          which provides better error handling, incremental delivery of data for large
-          syncs, and improved final table structures. To review the breaking changes,
-          and how to upgrade, see [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#quick-start-to-upgrading).
-          These changes will likely require updates to downstream dbt / SQL models,
-          which we walk through [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#updating-downstream-transformations).
-
-          Selecting `Upgrade` will upgrade **all** connections using this destination
-          at their next sync. You can manually sync existing connections prior to
-          the next scheduled sync to start the upgrade early.
-
-          "
+        message: "**Do not upgrade until you have run a test upgrade as outlined [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#testing-destinations-v2-for-a-single-connection)**.\nThis version introduces [Destinations V2](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#what-is-destinations-v2), which provides better error handling, incremental delivery of data for large syncs, and improved final table structures. To review the breaking changes, and how to upgrade, see [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#quick-start-to-upgrading). These changes will likely require updates to downstream dbt / SQL models, which we walk through [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#updating-downstream-transformations).\nSelecting `Upgrade` will upgrade **all** connections using this destination at their next sync. You can manually sync existing connections prior to the next scheduled sync to start the upgrade early.\n"
         upgradeDeadline: "2023-11-07"
       3.0.0:
-        message:
-          If you never interact with the raw tables, you can upgrade without
-          taking any action. Otherwise, make sure to read the migration guide for
-          more details.
+        message: "If you never interact with the raw tables, you can upgrade without taking any action. Otherwise, make sure to read the migration guide for more details."
         upgradeDeadline: "2026-07-31"
     rolloutConfiguration:
       enableProgressiveRollout: false

--- a/airbyte-integrations/connectors/destination-bigquery/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-bigquery/metadata.yaml
@@ -17,9 +17,13 @@ data:
     baseImage: docker.io/airbyte/java-connector-base:2.0.1@sha256:ec89bd1a89e825514dd2fc8730ba299a3ae1544580a078df0e35c5202c2085b3
   connectorIPCOptions:
     dataChannel:
-      version: "0.0.2"
-      supportedSerialization: ["JSONL", "PROTOBUF"]
-      supportedTransport: ["SOCKET", "STDIO"]
+      version: 0.0.2
+      supportedSerialization:
+      - JSONL
+      - PROTOBUF
+      supportedTransport:
+      - SOCKET
+      - STDIO
   registryOverrides:
     cloud:
       enabled: true
@@ -29,55 +33,89 @@ data:
   releases:
     breakingChanges:
       2.0.0:
-        message: "**Do not upgrade until you have run a test upgrade as outlined [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#testing-destinations-v2-for-a-single-connection)**.\nThis version introduces [Destinations V2](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#what-is-destinations-v2), which provides better error handling, incremental delivery of data for large syncs, and improved final table structures. To review the breaking changes, and how to upgrade, see [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#quick-start-to-upgrading). These changes will likely require updates to downstream dbt / SQL models, which we walk through [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#updating-downstream-transformations).\nSelecting `Upgrade` will upgrade **all** connections using this destination at their next sync. You can manually sync existing connections prior to the next scheduled sync to start the upgrade early.\n"
-        upgradeDeadline: "2023-11-07"
+        message: '**Do not upgrade until you have run a test upgrade as outlined [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#testing-destinations-v2-for-a-single-connection)**.
+
+          This version introduces [Destinations V2](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#what-is-destinations-v2),
+          which provides better error handling, incremental delivery of data for large
+          syncs, and improved final table structures. To review the breaking changes,
+          and how to upgrade, see [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#quick-start-to-upgrading).
+          These changes will likely require updates to downstream dbt / SQL models,
+          which we walk through [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#updating-downstream-transformations).
+
+          Selecting `Upgrade` will upgrade **all** connections using this destination
+          at their next sync. You can manually sync existing connections prior to
+          the next scheduled sync to start the upgrade early.
+
+          '
+        upgradeDeadline: '2023-11-07'
       3.0.0:
-        message: "If you never interact with the raw tables, you can upgrade without taking any action. Otherwise, make sure to read the migration guide for more details."
-        upgradeDeadline: "2026-07-31"
+        message: If you never interact with the raw tables, you can upgrade without
+          taking any action. Otherwise, make sure to read the migration guide for
+          more details.
+        upgradeDeadline: '2026-07-31'
     rolloutConfiguration:
       enableProgressiveRollout: false
   resourceRequirements:
     jobSpecific:
-      - jobType: sync
-        resourceRequirements:
-          memory_request: 1Gi
+    - jobType: sync
+      resourceRequirements:
+        memory_request: 1Gi
   supportLevel: certified
   supportsDbt: true
   supportsRefreshes: true
   tags:
-    - language:java
+  - language:java
   connectorTestSuitesOptions:
-    - suite: unitTests
-    - suite: integrationTests
-      testSecrets:
-        - name: SECRET_DESTINATION-BIGQUERY_CREDENTIALS_1S1T_GCS
-          fileName: credentials-1s1t-gcs.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-        - name: SECRET_DESTINATION-BIGQUERY_CREDENTIALS_1S1T_STANDARD
-          fileName: credentials-1s1t-standard.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-        - name: SECRET_DESTINATION-BIGQUERY_CREDENTIALS_BAD_PROJECT_CREDS
-          fileName: credentials-badproject.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-        - name: SECRET_DESTINATION-BIGQUERY_CREDENTIALS_NO_PUBLIC_SCHEMA_EDIT_ROLE
-          fileName: credentials-no-edit-public-schema-role.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-        - name: SECRET_DESTINATION-BIGQUERY_STANDARD-NO-DATASET-CREATION__CREDS
-          fileName: credentials-standard-no-dataset-creation.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-        - name: SECRET_DESTINATION-BIGQUERY_CREDENTIALS_1S1T_GCS_BAD_COPY
-          fileName: credentials-1s1t-gcs-bad-copy-permission.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-metadataSpecVersion: "1.0"
+  - suite: unitTests
+  - suite: integrationTests
+    testSecrets:
+    - name: SECRET_DESTINATION-BIGQUERY_CREDENTIALS_1S1T_GCS
+      fileName: credentials-1s1t-gcs.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+    - name: SECRET_DESTINATION-BIGQUERY_CREDENTIALS_1S1T_STANDARD
+      fileName: credentials-1s1t-standard.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+    - name: SECRET_DESTINATION-BIGQUERY_CREDENTIALS_BAD_PROJECT_CREDS
+      fileName: credentials-badproject.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+    - name: SECRET_DESTINATION-BIGQUERY_CREDENTIALS_NO_PUBLIC_SCHEMA_EDIT_ROLE
+      fileName: credentials-no-edit-public-schema-role.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+    - name: SECRET_DESTINATION-BIGQUERY_STANDARD-NO-DATASET-CREATION__CREDS
+      fileName: credentials-standard-no-dataset-creation.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+    - name: SECRET_DESTINATION-BIGQUERY_CREDENTIALS_1S1T_GCS_BAD_COPY
+      fileName: credentials-1s1t-gcs-bad-copy-permission.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+  - title: Release notes
+    url: https://cloud.google.com/bigquery/docs/release-notes
+    type: api_release_history
+  - title: Standard SQL reference
+    url: https://cloud.google.com/bigquery/docs/reference/standard-sql
+    type: sql_reference
+  - title: Service account authentication
+    url: https://cloud.google.com/iam/docs/service-accounts
+    type: authentication_guide
+  - title: Access control and permissions
+    url: https://cloud.google.com/bigquery/docs/access-control
+    type: permissions_scopes
+  - title: Quotas and limits
+    url: https://cloud.google.com/bigquery/quotas
+    type: rate_limits
+  - title: Google Cloud Status
+    url: https://status.cloud.google.com/
+    type: status_page
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-bigquery/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-bigquery/metadata.yaml
@@ -19,11 +19,11 @@ data:
     dataChannel:
       version: 0.0.2
       supportedSerialization:
-      - JSONL
-      - PROTOBUF
+        - JSONL
+        - PROTOBUF
       supportedTransport:
-      - SOCKET
-      - STDIO
+        - SOCKET
+        - STDIO
   registryOverrides:
     cloud:
       enabled: true
@@ -33,7 +33,8 @@ data:
   releases:
     breakingChanges:
       2.0.0:
-        message: '**Do not upgrade until you have run a test upgrade as outlined [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#testing-destinations-v2-for-a-single-connection)**.
+        message:
+          "**Do not upgrade until you have run a test upgrade as outlined [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#testing-destinations-v2-for-a-single-connection)**.
 
           This version introduces [Destinations V2](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#what-is-destinations-v2),
           which provides better error handling, incremental delivery of data for large
@@ -46,76 +47,77 @@ data:
           at their next sync. You can manually sync existing connections prior to
           the next scheduled sync to start the upgrade early.
 
-          '
-        upgradeDeadline: '2023-11-07'
+          "
+        upgradeDeadline: "2023-11-07"
       3.0.0:
-        message: If you never interact with the raw tables, you can upgrade without
+        message:
+          If you never interact with the raw tables, you can upgrade without
           taking any action. Otherwise, make sure to read the migration guide for
           more details.
-        upgradeDeadline: '2026-07-31'
+        upgradeDeadline: "2026-07-31"
     rolloutConfiguration:
       enableProgressiveRollout: false
   resourceRequirements:
     jobSpecific:
-    - jobType: sync
-      resourceRequirements:
-        memory_request: 1Gi
+      - jobType: sync
+        resourceRequirements:
+          memory_request: 1Gi
   supportLevel: certified
   supportsDbt: true
   supportsRefreshes: true
   tags:
-  - language:java
+    - language:java
   connectorTestSuitesOptions:
-  - suite: unitTests
-  - suite: integrationTests
-    testSecrets:
-    - name: SECRET_DESTINATION-BIGQUERY_CREDENTIALS_1S1T_GCS
-      fileName: credentials-1s1t-gcs.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
-    - name: SECRET_DESTINATION-BIGQUERY_CREDENTIALS_1S1T_STANDARD
-      fileName: credentials-1s1t-standard.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
-    - name: SECRET_DESTINATION-BIGQUERY_CREDENTIALS_BAD_PROJECT_CREDS
-      fileName: credentials-badproject.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
-    - name: SECRET_DESTINATION-BIGQUERY_CREDENTIALS_NO_PUBLIC_SCHEMA_EDIT_ROLE
-      fileName: credentials-no-edit-public-schema-role.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
-    - name: SECRET_DESTINATION-BIGQUERY_STANDARD-NO-DATASET-CREATION__CREDS
-      fileName: credentials-standard-no-dataset-creation.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
-    - name: SECRET_DESTINATION-BIGQUERY_CREDENTIALS_1S1T_GCS_BAD_COPY
-      fileName: credentials-1s1t-gcs-bad-copy-permission.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION-BIGQUERY_CREDENTIALS_1S1T_GCS
+          fileName: credentials-1s1t-gcs.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-BIGQUERY_CREDENTIALS_1S1T_STANDARD
+          fileName: credentials-1s1t-standard.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-BIGQUERY_CREDENTIALS_BAD_PROJECT_CREDS
+          fileName: credentials-badproject.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-BIGQUERY_CREDENTIALS_NO_PUBLIC_SCHEMA_EDIT_ROLE
+          fileName: credentials-no-edit-public-schema-role.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-BIGQUERY_STANDARD-NO-DATASET-CREATION__CREDS
+          fileName: credentials-standard-no-dataset-creation.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-BIGQUERY_CREDENTIALS_1S1T_GCS_BAD_COPY
+          fileName: credentials-1s1t-gcs-bad-copy-permission.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
   externalDocumentationUrls:
-  - title: Release notes
-    url: https://cloud.google.com/bigquery/docs/release-notes
-    type: api_release_history
-  - title: Standard SQL reference
-    url: https://cloud.google.com/bigquery/docs/reference/standard-sql
-    type: sql_reference
-  - title: Service account authentication
-    url: https://cloud.google.com/iam/docs/service-accounts
-    type: authentication_guide
-  - title: Access control and permissions
-    url: https://cloud.google.com/bigquery/docs/access-control
-    type: permissions_scopes
-  - title: Quotas and limits
-    url: https://cloud.google.com/bigquery/quotas
-    type: rate_limits
-  - title: Google Cloud Status
-    url: https://status.cloud.google.com/
-    type: status_page
-metadataSpecVersion: '1.0'
+    - title: Release notes
+      url: https://cloud.google.com/bigquery/docs/release-notes
+      type: api_release_history
+    - title: Standard SQL reference
+      url: https://cloud.google.com/bigquery/docs/reference/standard-sql
+      type: sql_reference
+    - title: Service account authentication
+      url: https://cloud.google.com/iam/docs/service-accounts
+      type: authentication_guide
+    - title: Access control and permissions
+      url: https://cloud.google.com/bigquery/docs/access-control
+      type: permissions_scopes
+    - title: Quotas and limits
+      url: https://cloud.google.com/bigquery/quotas
+      type: rate_limits
+    - title: Google Cloud Status
+      url: https://status.cloud.google.com/
+      type: status_page
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-cassandra/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-cassandra/metadata.yaml
@@ -16,19 +16,19 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/cassandra
   tags:
-  - language:java
+    - language:java
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: community
   externalDocumentationUrls:
-  - title: Cassandra documentation
-    url: https://cassandra.apache.org/doc/latest/
-    type: api_reference
-  - title: CQL reference
-    url: https://cassandra.apache.org/doc/latest/cassandra/cql/
-    type: sql_reference
-  - title: Authentication
-    url: https://cassandra.apache.org/doc/latest/cassandra/configuration/cass_yaml_file.html#authenticator
-    type: authentication_guide
-metadataSpecVersion: '1.0'
+    - title: Cassandra documentation
+      url: https://cassandra.apache.org/doc/latest/
+      type: api_reference
+    - title: CQL reference
+      url: https://cassandra.apache.org/doc/latest/cassandra/cql/
+      type: sql_reference
+    - title: Authentication
+      url: https://cassandra.apache.org/doc/latest/cassandra/configuration/cass_yaml_file.html#authenticator
+      type: authentication_guide
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-cassandra/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-cassandra/metadata.yaml
@@ -16,9 +16,19 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/cassandra
   tags:
-    - language:java
+  - language:java
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: community
-metadataSpecVersion: "1.0"
+  externalDocumentationUrls:
+  - title: Cassandra documentation
+    url: https://cassandra.apache.org/doc/latest/
+    type: api_reference
+  - title: CQL reference
+    url: https://cassandra.apache.org/doc/latest/cassandra/cql/
+    type: sql_reference
+  - title: Authentication
+    url: https://cassandra.apache.org/doc/latest/cassandra/configuration/cass_yaml_file.html#authenticator
+    type: authentication_guide
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-chroma/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-chroma/metadata.yaml
@@ -15,21 +15,21 @@ data:
   icon: chroma.svg
   license: ELv2
   name: Chroma
-  releaseDate: '2023-09-13'
+  releaseDate: "2023-09-13"
   releaseStage: alpha
   supportLevel: community
   documentationUrl: https://docs.airbyte.com/integrations/destinations/chroma
   tags:
-  - language:python
-  - cdk:python
+    - language:python
+    - cdk:python
   connectorTestSuitesOptions:
-  - suite: unitTests
-  - suite: integrationTests
+    - suite: unitTests
+    - suite: integrationTests
   externalDocumentationUrls:
-  - title: Chroma documentation
-    url: https://docs.trychroma.com/
-    type: api_reference
-  - title: Authentication
-    url: https://docs.trychroma.com/deployment/auth
-    type: authentication_guide
-metadataSpecVersion: '1.0'
+    - title: Chroma documentation
+      url: https://docs.trychroma.com/
+      type: api_reference
+    - title: Authentication
+      url: https://docs.trychroma.com/deployment/auth
+      type: authentication_guide
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-chroma/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-chroma/metadata.yaml
@@ -15,14 +15,21 @@ data:
   icon: chroma.svg
   license: ELv2
   name: Chroma
-  releaseDate: "2023-09-13"
+  releaseDate: '2023-09-13'
   releaseStage: alpha
   supportLevel: community
   documentationUrl: https://docs.airbyte.com/integrations/destinations/chroma
   tags:
-    - language:python
-    - cdk:python
+  - language:python
+  - cdk:python
   connectorTestSuitesOptions:
-    - suite: unitTests
-    - suite: integrationTests
-metadataSpecVersion: "1.0"
+  - suite: unitTests
+  - suite: integrationTests
+  externalDocumentationUrls:
+  - title: Chroma documentation
+    url: https://docs.trychroma.com/
+    type: api_reference
+  - title: Authentication
+    url: https://docs.trychroma.com/deployment/auth
+    type: authentication_guide
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
@@ -14,11 +14,11 @@ data:
     dataChannel:
       version: 0.0.2
       supportedSerialization:
-      - JSONL
-      - PROTOBUF
+        - JSONL
+        - PROTOBUF
       supportedTransport:
-      - SOCKET
-      - STDIO
+        - SOCKET
+        - STDIO
   registryOverrides:
     cloud:
       enabled: true
@@ -30,37 +30,38 @@ data:
       enableProgressiveRollout: false
     breakingChanges:
       2.0.0:
-        message: 'This connector has been re-written from scratch. Data will now be
+        message:
+          "This connector has been re-written from scratch. Data will now be
           typed and stored in final (non-raw) tables. The connector may require changes
           to its configuration to function properly and downstream pipelines may be
-          affected. Warning: SSH tunneling is in Beta.'
-        upgradeDeadline: '2025-08-19'
+          affected. Warning: SSH tunneling is in Beta."
+        upgradeDeadline: "2025-08-19"
   documentationUrl: https://docs.airbyte.com/integrations/destinations/clickhouse
   tags:
-  - language:java
+    - language:java
   ab_internal:
     sl: 300
     ql: 300
     requireVersionIncrementsInPullRequests: false
   supportLevel: certified
   connectorTestSuitesOptions:
-  - suite: unitTests
-  - suite: integrationTests
-    testSecrets:
-    - name: destination_clickhouse_component_test_instance
-      fileName: test-instance.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: destination_clickhouse_component_test_instance
+          fileName: test-instance.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
   supportsRefreshes: true
   externalDocumentationUrls:
-  - title: ClickHouse documentation
-    url: https://clickhouse.com/docs
-    type: api_reference
-  - title: SQL reference
-    url: https://clickhouse.com/docs/en/sql-reference
-    type: sql_reference
-  - title: User authentication
-    url: https://clickhouse.com/docs/en/operations/access-rights
-    type: authentication_guide
-metadataSpecVersion: '1.0'
+    - title: ClickHouse documentation
+      url: https://clickhouse.com/docs
+      type: api_reference
+    - title: SQL reference
+      url: https://clickhouse.com/docs/en/sql-reference
+      type: sql_reference
+    - title: User authentication
+      url: https://clickhouse.com/docs/en/operations/access-rights
+      type: authentication_guide
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
@@ -12,9 +12,13 @@ data:
     baseImage: docker.io/airbyte/java-connector-base:2.0.1@sha256:ec89bd1a89e825514dd2fc8730ba299a3ae1544580a078df0e35c5202c2085b3
   connectorIPCOptions:
     dataChannel:
-      version: "0.0.2"
-      supportedSerialization: ["JSONL", "PROTOBUF"]
-      supportedTransport: ["SOCKET", "STDIO"]
+      version: 0.0.2
+      supportedSerialization:
+      - JSONL
+      - PROTOBUF
+      supportedTransport:
+      - SOCKET
+      - STDIO
   registryOverrides:
     cloud:
       enabled: true
@@ -26,24 +30,37 @@ data:
       enableProgressiveRollout: false
     breakingChanges:
       2.0.0:
-        message: "This connector has been re-written from scratch. Data will now be typed and stored in final (non-raw) tables. The connector may require changes to its configuration to function properly and downstream pipelines may be affected. Warning: SSH tunneling is in Beta."
-        upgradeDeadline: "2025-08-19"
+        message: 'This connector has been re-written from scratch. Data will now be
+          typed and stored in final (non-raw) tables. The connector may require changes
+          to its configuration to function properly and downstream pipelines may be
+          affected. Warning: SSH tunneling is in Beta.'
+        upgradeDeadline: '2025-08-19'
   documentationUrl: https://docs.airbyte.com/integrations/destinations/clickhouse
   tags:
-    - language:java
+  - language:java
   ab_internal:
     sl: 300
     ql: 300
     requireVersionIncrementsInPullRequests: false
   supportLevel: certified
   connectorTestSuitesOptions:
-    - suite: unitTests
-    - suite: integrationTests
-      testSecrets:
-        - name: destination_clickhouse_component_test_instance
-          fileName: test-instance.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
+  - suite: unitTests
+  - suite: integrationTests
+    testSecrets:
+    - name: destination_clickhouse_component_test_instance
+      fileName: test-instance.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
   supportsRefreshes: true
-metadataSpecVersion: "1.0"
+  externalDocumentationUrls:
+  - title: ClickHouse documentation
+    url: https://clickhouse.com/docs
+    type: api_reference
+  - title: SQL reference
+    url: https://clickhouse.com/docs/en/sql-reference
+    type: sql_reference
+  - title: User authentication
+    url: https://clickhouse.com/docs/en/operations/access-rights
+    type: authentication_guide
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
@@ -30,11 +30,7 @@ data:
       enableProgressiveRollout: false
     breakingChanges:
       2.0.0:
-        message:
-          "This connector has been re-written from scratch. Data will now be
-          typed and stored in final (non-raw) tables. The connector may require changes
-          to its configuration to function properly and downstream pipelines may be
-          affected. Warning: SSH tunneling is in Beta."
+        message: "This connector has been re-written from scratch. Data will now be typed and stored in final (non-raw) tables. The connector may require changes to its configuration to function properly and downstream pipelines may be affected. Warning: SSH tunneling is in Beta."
         upgradeDeadline: "2025-08-19"
   documentationUrl: https://docs.airbyte.com/integrations/destinations/clickhouse
   tags:

--- a/airbyte-integrations/connectors/destination-convex/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-convex/metadata.yaml
@@ -16,15 +16,25 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/convex
   tags:
-    - language:python
-    - cdk:python
+  - language:python
+  - cdk:python
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
-    - suite: unitTests
-    - suite: integrationTests
+  - suite: unitTests
+  - suite: integrationTests
   connectorBuildOptions:
     baseImage: docker.io/airbyte/python-connector-base:4.0.0@sha256:d9894b6895923b379f3006fa251147806919c62b7d9021b5cd125bb67d7bbe22
-metadataSpecVersion: "1.0"
+  externalDocumentationUrls:
+  - title: Convex documentation
+    url: https://docs.convex.dev/
+    type: api_reference
+  - title: Authentication
+    url: https://docs.convex.dev/auth
+    type: authentication_guide
+  - title: Convex Status
+    url: https://status.convex.dev/
+    type: status_page
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-convex/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-convex/metadata.yaml
@@ -16,25 +16,25 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/convex
   tags:
-  - language:python
-  - cdk:python
+    - language:python
+    - cdk:python
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
-  - suite: unitTests
-  - suite: integrationTests
+    - suite: unitTests
+    - suite: integrationTests
   connectorBuildOptions:
     baseImage: docker.io/airbyte/python-connector-base:4.0.0@sha256:d9894b6895923b379f3006fa251147806919c62b7d9021b5cd125bb67d7bbe22
   externalDocumentationUrls:
-  - title: Convex documentation
-    url: https://docs.convex.dev/
-    type: api_reference
-  - title: Authentication
-    url: https://docs.convex.dev/auth
-    type: authentication_guide
-  - title: Convex Status
-    url: https://status.convex.dev/
-    type: status_page
-metadataSpecVersion: '1.0'
+    - title: Convex documentation
+      url: https://docs.convex.dev/
+      type: api_reference
+    - title: Authentication
+      url: https://docs.convex.dev/auth
+      type: authentication_guide
+    - title: Convex Status
+      url: https://status.convex.dev/
+      type: status_page
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-couchbase/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-couchbase/metadata.yaml
@@ -1,8 +1,11 @@
 data:
   allowedHosts:
     hosts:
-      - "*"
+      - "*" # Couchbase can be hosted anywhere
   connectorBuildOptions:
+    # Please update to the latest version of the connector base image.
+    # Please use the full address with sha256 hash to guarantee build reproducibility.
+    # https://hub.docker.com/r/airbyte/python-connector-base
     baseImage: docker.io/airbyte/python-connector-base:4.0.0@sha256:d9894b6895923b379f3006fa251147806919c62b7d9021b5cd125bb67d7bbe22
   connectorSubtype: database
   connectorType: destination

--- a/airbyte-integrations/connectors/destination-couchbase/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-couchbase/metadata.yaml
@@ -1,7 +1,7 @@
 data:
   allowedHosts:
     hosts:
-    - '*'
+      - "*"
   connectorBuildOptions:
     baseImage: docker.io/airbyte/python-connector-base:4.0.0@sha256:d9894b6895923b379f3006fa251147806919c62b7d9021b5cd125bb67d7bbe22
   connectorSubtype: database
@@ -13,18 +13,18 @@ data:
   icon: couchbase.svg
   license: ELv2
   name: Couchbase
-  releaseDate: '2024-10-30'
+  releaseDate: "2024-10-30"
   releaseStage: alpha
   supportLevel: community
   documentationUrl: https://docs.airbyte.com/integrations/destinations/couchbase
   tags:
-  - language:python
-  - cdk:python
+    - language:python
+    - cdk:python
   externalDocumentationUrls:
-  - title: Couchbase documentation
-    url: https://docs.couchbase.com/
-    type: api_reference
-  - title: Authentication
-    url: https://docs.couchbase.com/server/current/learn/security/authentication.html
-    type: authentication_guide
-metadataSpecVersion: '1.0'
+    - title: Couchbase documentation
+      url: https://docs.couchbase.com/
+      type: api_reference
+    - title: Authentication
+      url: https://docs.couchbase.com/server/current/learn/security/authentication.html
+      type: authentication_guide
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-couchbase/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-couchbase/metadata.yaml
@@ -1,11 +1,8 @@
 data:
   allowedHosts:
     hosts:
-      - "*" # Couchbase can be hosted anywhere
+    - '*'
   connectorBuildOptions:
-    # Please update to the latest version of the connector base image.
-    # Please use the full address with sha256 hash to guarantee build reproducibility.
-    # https://hub.docker.com/r/airbyte/python-connector-base
     baseImage: docker.io/airbyte/python-connector-base:4.0.0@sha256:d9894b6895923b379f3006fa251147806919c62b7d9021b5cd125bb67d7bbe22
   connectorSubtype: database
   connectorType: destination
@@ -16,11 +13,18 @@ data:
   icon: couchbase.svg
   license: ELv2
   name: Couchbase
-  releaseDate: "2024-10-30"
+  releaseDate: '2024-10-30'
   releaseStage: alpha
   supportLevel: community
   documentationUrl: https://docs.airbyte.com/integrations/destinations/couchbase
   tags:
-    - language:python
-    - cdk:python
-metadataSpecVersion: "1.0"
+  - language:python
+  - cdk:python
+  externalDocumentationUrls:
+  - title: Couchbase documentation
+    url: https://docs.couchbase.com/
+    type: api_reference
+  - title: Authentication
+    url: https://docs.couchbase.com/server/current/learn/security/authentication.html
+    type: authentication_guide
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-csv/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-csv/metadata.yaml
@@ -7,8 +7,8 @@ data:
     baseImage: docker.io/airbyte/java-connector-base:2.0.1@sha256:ec89bd1a89e825514dd2fc8730ba299a3ae1544580a078df0e35c5202c2085b3
   connectorSubtype: file
   connectorTestSuitesOptions:
-    - suite: unitTests
-    - suite: integrationTests
+  - suite: unitTests
+  - suite: integrationTests
   connectorType: destination
   definitionId: 8be1cf83-fde1-477f-a4ad-318d23c9f3c6
   dockerImageTag: 1.0.2
@@ -26,5 +26,9 @@ data:
   releaseStage: alpha
   supportLevel: community
   tags:
-    - language:java
-metadataSpecVersion: "1.0"
+  - language:java
+  externalDocumentationUrls:
+  - title: CSV specification
+    url: https://datatracker.ietf.org/doc/html/rfc4180
+    type: api_reference
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-csv/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-csv/metadata.yaml
@@ -7,8 +7,8 @@ data:
     baseImage: docker.io/airbyte/java-connector-base:2.0.1@sha256:ec89bd1a89e825514dd2fc8730ba299a3ae1544580a078df0e35c5202c2085b3
   connectorSubtype: file
   connectorTestSuitesOptions:
-  - suite: unitTests
-  - suite: integrationTests
+    - suite: unitTests
+    - suite: integrationTests
   connectorType: destination
   definitionId: 8be1cf83-fde1-477f-a4ad-318d23c9f3c6
   dockerImageTag: 1.0.2
@@ -26,9 +26,9 @@ data:
   releaseStage: alpha
   supportLevel: community
   tags:
-  - language:java
+    - language:java
   externalDocumentationUrls:
-  - title: CSV specification
-    url: https://datatracker.ietf.org/doc/html/rfc4180
-    type: api_reference
-metadataSpecVersion: '1.0'
+    - title: CSV specification
+      url: https://datatracker.ietf.org/doc/html/rfc4180
+      type: api_reference
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-cumulio/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-cumulio/metadata.yaml
@@ -16,28 +16,28 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/cumulio
   tags:
-  - language:python
-  - cdk:python
+    - language:python
+    - cdk:python
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
-  - suite: unitTests
-  - suite: integrationTests
-    testSecrets:
-    - name: SECRET_DESTINATION-CUMULIO_CREDENTIALS__CREDS
-      fileName: config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION-CUMULIO_CREDENTIALS__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
   connectorBuildOptions:
     baseImage: docker.io/airbyte/python-connector-base:4.0.0@sha256:d9894b6895923b379f3006fa251147806919c62b7d9021b5cd125bb67d7bbe22
   externalDocumentationUrls:
-  - title: Cumul.io documentation
-    url: https://developer.cumul.io/
-    type: api_reference
-  - title: Authentication
-    url: https://developer.cumul.io/#authentication
-    type: authentication_guide
-metadataSpecVersion: '1.0'
+    - title: Cumul.io documentation
+      url: https://developer.cumul.io/
+      type: api_reference
+    - title: Authentication
+      url: https://developer.cumul.io/#authentication
+      type: authentication_guide
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-cumulio/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-cumulio/metadata.yaml
@@ -16,21 +16,28 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/cumulio
   tags:
-    - language:python
-    - cdk:python
+  - language:python
+  - cdk:python
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
-    - suite: unitTests
-    - suite: integrationTests
-      testSecrets:
-        - name: SECRET_DESTINATION-CUMULIO_CREDENTIALS__CREDS
-          fileName: config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
+  - suite: unitTests
+  - suite: integrationTests
+    testSecrets:
+    - name: SECRET_DESTINATION-CUMULIO_CREDENTIALS__CREDS
+      fileName: config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
   connectorBuildOptions:
     baseImage: docker.io/airbyte/python-connector-base:4.0.0@sha256:d9894b6895923b379f3006fa251147806919c62b7d9021b5cd125bb67d7bbe22
-metadataSpecVersion: "1.0"
+  externalDocumentationUrls:
+  - title: Cumul.io documentation
+    url: https://developer.cumul.io/
+    type: api_reference
+  - title: Authentication
+    url: https://developer.cumul.io/#authentication
+    type: authentication_guide
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-customer-io/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-customer-io/metadata.yaml
@@ -1,7 +1,7 @@
 data:
   allowedHosts:
     hosts:
-      - "track.customer.io"
+    - track.customer.io
   registryOverrides:
     cloud:
       enabled: true
@@ -21,12 +21,25 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/customer-io
   tags:
-    - language:java
+  - language:java
   ab_internal:
     sl: 100
     ql: 100
     requireVersionIncrementsInPullRequests: false
   supportLevel: certified
   supportsDataActivation: true
-  supportsRefreshes: true # needed for the CDK to work as it relies on the generation/sync ids to work
-metadataSpecVersion: "1.0"
+  supportsRefreshes: true
+  externalDocumentationUrls:
+  - title: Customer.io API documentation
+    url: https://customer.io/docs/api/
+    type: api_reference
+  - title: Authentication
+    url: https://customer.io/docs/api/app/#tag/Authentication
+    type: authentication_guide
+  - title: Rate limits
+    url: https://customer.io/docs/api/app/#tag/Rate-Limits
+    type: rate_limits
+  - title: Customer.io Status
+    url: https://status.customer.io/
+    type: status_page
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-customer-io/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-customer-io/metadata.yaml
@@ -1,7 +1,7 @@
 data:
   allowedHosts:
     hosts:
-    - track.customer.io
+      - track.customer.io
   registryOverrides:
     cloud:
       enabled: true
@@ -21,7 +21,7 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/customer-io
   tags:
-  - language:java
+    - language:java
   ab_internal:
     sl: 100
     ql: 100
@@ -30,16 +30,16 @@ data:
   supportsDataActivation: true
   supportsRefreshes: true
   externalDocumentationUrls:
-  - title: Customer.io API documentation
-    url: https://customer.io/docs/api/
-    type: api_reference
-  - title: Authentication
-    url: https://customer.io/docs/api/app/#tag/Authentication
-    type: authentication_guide
-  - title: Rate limits
-    url: https://customer.io/docs/api/app/#tag/Rate-Limits
-    type: rate_limits
-  - title: Customer.io Status
-    url: https://status.customer.io/
-    type: status_page
-metadataSpecVersion: '1.0'
+    - title: Customer.io API documentation
+      url: https://customer.io/docs/api/
+      type: api_reference
+    - title: Authentication
+      url: https://customer.io/docs/api/app/#tag/Authentication
+      type: authentication_guide
+    - title: Rate limits
+      url: https://customer.io/docs/api/app/#tag/Rate-Limits
+      type: rate_limits
+    - title: Customer.io Status
+      url: https://status.customer.io/
+      type: status_page
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-customer-io/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-customer-io/metadata.yaml
@@ -28,7 +28,7 @@ data:
     requireVersionIncrementsInPullRequests: false
   supportLevel: certified
   supportsDataActivation: true
-  supportsRefreshes: true
+  supportsRefreshes: true # needed for the CDK to work as it relies on the generation/sync ids to work
   externalDocumentationUrls:
     - title: Customer.io API documentation
       url: https://customer.io/docs/api/

--- a/airbyte-integrations/connectors/destination-databend/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-databend/metadata.yaml
@@ -16,21 +16,21 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/databend
   tags:
-  - language:python
-  - cdk:python
+    - language:python
+    - cdk:python
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
-  - suite: unitTests
+    - suite: unitTests
   connectorBuildOptions:
     baseImage: docker.io/airbyte/python-connector-base:4.0.0@sha256:d9894b6895923b379f3006fa251147806919c62b7d9021b5cd125bb67d7bbe22
   externalDocumentationUrls:
-  - title: Databend documentation
-    url: https://databend.rs/doc/
-    type: api_reference
-  - title: SQL reference
-    url: https://databend.rs/doc/sql-reference
-    type: sql_reference
-metadataSpecVersion: '1.0'
+    - title: Databend documentation
+      url: https://databend.rs/doc/
+      type: api_reference
+    - title: SQL reference
+      url: https://databend.rs/doc/sql-reference
+      type: sql_reference
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-databend/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-databend/metadata.yaml
@@ -16,24 +16,21 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/databend
   tags:
-    - language:python
-    - cdk:python
+  - language:python
+  - cdk:python
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
-    - suite: unitTests
-    # Disable integration tests for now
-    # They are not passing
-    # No Airbyte Cloud usage
-    # - suite: integrationTests
-    #   testSecrets:
-    #     - name: SECRET_DESTINATION_DATABEND_CLOUD_CREDS
-    #       fileName: config.json
-    #       secretStore:
-    #         type: GSM
-    #         alias: airbyte-connector-testing-secret-store
+  - suite: unitTests
   connectorBuildOptions:
     baseImage: docker.io/airbyte/python-connector-base:4.0.0@sha256:d9894b6895923b379f3006fa251147806919c62b7d9021b5cd125bb67d7bbe22
-metadataSpecVersion: "1.0"
+  externalDocumentationUrls:
+  - title: Databend documentation
+    url: https://databend.rs/doc/
+    type: api_reference
+  - title: SQL reference
+    url: https://databend.rs/doc/sql-reference
+    type: sql_reference
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-databend/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-databend/metadata.yaml
@@ -24,6 +24,16 @@ data:
   supportLevel: community
   connectorTestSuitesOptions:
     - suite: unitTests
+    # Disable integration tests for now
+    # They are not passing
+    # No Airbyte Cloud usage
+    # - suite: integrationTests
+    #   testSecrets:
+    #     - name: SECRET_DESTINATION_DATABEND_CLOUD_CREDS
+    #       fileName: config.json
+    #       secretStore:
+    #         type: GSM
+    #         alias: airbyte-connector-testing-secret-store
   connectorBuildOptions:
     baseImage: docker.io/airbyte/python-connector-base:4.0.0@sha256:d9894b6895923b379f3006fa251147806919c62b7d9021b5cd125bb67d7bbe22
   externalDocumentationUrls:

--- a/airbyte-integrations/connectors/destination-databricks/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-databricks/metadata.yaml
@@ -19,7 +19,8 @@ data:
   releases:
     breakingChanges:
       2.0.0:
-        message: '**This is a private preview version, Do not upgrade until you review
+        message:
+          '**This is a private preview version, Do not upgrade until you review
           the changes**.\n This version is a rewrite of the community connector with
           support for Unity catalog, and staging files using Unity catalog volumes.
           This version also introduces [Destinations V2](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#what-is-destinations-v2),
@@ -28,72 +29,73 @@ data:
           see [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#quick-start-to-upgrading).
 
           '
-        upgradeDeadline: '2025-01-31'
+        upgradeDeadline: "2025-01-31"
       3.0.0:
-        message: 'This version adds an `_airbyte_generation_id` column to the raw
+        message:
+          "This version adds an `_airbyte_generation_id` column to the raw
           and final tables. If you ran a sync using 2.0.0, you MUST manually drop
           the raw and final tables and then clear (reset) your connection; this release
           will not automatically upgrade your tables.
 
-          '
-        upgradeDeadline: '2025-01-31'
+          "
+        upgradeDeadline: "2025-01-31"
   documentationUrl: https://docs.airbyte.com/integrations/destinations/databricks
   resourceRequirements:
     jobSpecific:
-    - jobType: check_connection
-      resourceRequirements:
-        memory_limit: 600Mi
-        memory_request: 600Mi
+      - jobType: check_connection
+        resourceRequirements:
+          memory_limit: 600Mi
+          memory_request: 600Mi
   tags:
-  - language:java
+    - language:java
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: certified
   supportsRefreshes: true
   connectorTestSuitesOptions:
-  - suite: unitTests
-  - suite: integrationTests
-    testSecrets:
-    - name: SECRET_DESTINATION-DATABRICKS_AZURE__CREDS
-      fileName: azure_config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
-    - name: SECRET_DESTINATION-DATABRICKS__CREDS
-      fileName: config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
-    - name: SECRET_DESTINATION-DATABRICKS__STAGING_CREDS
-      fileName: staging_config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
-    - name: SECRET_DESTINATION_DATABRICKS_OAUTH_CONFIG
-      fileName: oauth_config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
-    - name: SECRET_DESTINATION_DATABRICKS_PERSONAL_ACCESS_TOKEN_CONFIG
-      fileName: pat_config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION-DATABRICKS_AZURE__CREDS
+          fileName: azure_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-DATABRICKS__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-DATABRICKS__STAGING_CREDS
+          fileName: staging_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION_DATABRICKS_OAUTH_CONFIG
+          fileName: oauth_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION_DATABRICKS_PERSONAL_ACCESS_TOKEN_CONFIG
+          fileName: pat_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
   externalDocumentationUrls:
-  - title: Release notes
-    url: https://docs.databricks.com/release-notes/index.html
-    type: api_release_history
-  - title: SQL reference
-    url: https://docs.databricks.com/sql/language-manual/index.html
-    type: sql_reference
-  - title: Authentication
-    url: https://docs.databricks.com/dev-tools/auth.html
-    type: authentication_guide
-  - title: Access control
-    url: https://docs.databricks.com/security/access-control/index.html
-    type: permissions_scopes
-  - title: Databricks Status
-    url: https://status.databricks.com/
-    type: status_page
-metadataSpecVersion: '1.0'
+    - title: Release notes
+      url: https://docs.databricks.com/release-notes/index.html
+      type: api_release_history
+    - title: SQL reference
+      url: https://docs.databricks.com/sql/language-manual/index.html
+      type: sql_reference
+    - title: Authentication
+      url: https://docs.databricks.com/dev-tools/auth.html
+      type: authentication_guide
+    - title: Access control
+      url: https://docs.databricks.com/security/access-control/index.html
+      type: permissions_scopes
+    - title: Databricks Status
+      url: https://status.databricks.com/
+      type: status_page
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-databricks/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-databricks/metadata.yaml
@@ -19,25 +19,17 @@ data:
   releases:
     breakingChanges:
       2.0.0:
-        message:
-          '**This is a private preview version, Do not upgrade until you review
-          the changes**.\n This version is a rewrite of the community connector with
-          support for Unity catalog, and staging files using Unity catalog volumes.
+        message: >
+          **This is a private preview version, Do not upgrade until you review the changes**.\n
+          This version is a rewrite of the community connector with support for Unity catalog, and staging files using Unity catalog volumes.
           This version also introduces [Destinations V2](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#what-is-destinations-v2),
-          which provides better error handling, incremental delivery of data for large
-          syncs, and improved final table structures. To review the breaking changes,
-          see [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#quick-start-to-upgrading).
-
-          '
+          which provides better error handling, incremental delivery of data for large syncs, and improved final table structures.
+          To review the breaking changes, see [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#quick-start-to-upgrading).
         upgradeDeadline: "2025-01-31"
       3.0.0:
-        message:
-          "This version adds an `_airbyte_generation_id` column to the raw
-          and final tables. If you ran a sync using 2.0.0, you MUST manually drop
-          the raw and final tables and then clear (reset) your connection; this release
-          will not automatically upgrade your tables.
-
-          "
+        message: >
+          This version adds an `_airbyte_generation_id` column to the raw and final tables. If you ran a sync using 2.0.0, you MUST manually drop the
+          raw and final tables and then clear (reset) your connection; this release will not automatically upgrade your tables.
         upgradeDeadline: "2025-01-31"
   documentationUrl: https://docs.airbyte.com/integrations/destinations/databricks
   resourceRequirements:

--- a/airbyte-integrations/connectors/destination-databricks/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-databricks/metadata.yaml
@@ -19,59 +19,81 @@ data:
   releases:
     breakingChanges:
       2.0.0:
-        message: >
-          **This is a private preview version, Do not upgrade until you review the changes**.\n
-          This version is a rewrite of the community connector with support for Unity catalog, and staging files using Unity catalog volumes.
+        message: '**This is a private preview version, Do not upgrade until you review
+          the changes**.\n This version is a rewrite of the community connector with
+          support for Unity catalog, and staging files using Unity catalog volumes.
           This version also introduces [Destinations V2](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#what-is-destinations-v2),
-          which provides better error handling, incremental delivery of data for large syncs, and improved final table structures.
-          To review the breaking changes, see [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#quick-start-to-upgrading).
-        upgradeDeadline: "2025-01-31"
+          which provides better error handling, incremental delivery of data for large
+          syncs, and improved final table structures. To review the breaking changes,
+          see [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#quick-start-to-upgrading).
+
+          '
+        upgradeDeadline: '2025-01-31'
       3.0.0:
-        message: >
-          This version adds an `_airbyte_generation_id` column to the raw and final tables. If you ran a sync using 2.0.0, you MUST manually drop the
-          raw and final tables and then clear (reset) your connection; this release will not automatically upgrade your tables.
-        upgradeDeadline: "2025-01-31"
+        message: 'This version adds an `_airbyte_generation_id` column to the raw
+          and final tables. If you ran a sync using 2.0.0, you MUST manually drop
+          the raw and final tables and then clear (reset) your connection; this release
+          will not automatically upgrade your tables.
+
+          '
+        upgradeDeadline: '2025-01-31'
   documentationUrl: https://docs.airbyte.com/integrations/destinations/databricks
   resourceRequirements:
     jobSpecific:
-      - jobType: check_connection
-        resourceRequirements:
-          memory_limit: 600Mi
-          memory_request: 600Mi
+    - jobType: check_connection
+      resourceRequirements:
+        memory_limit: 600Mi
+        memory_request: 600Mi
   tags:
-    - language:java
+  - language:java
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: certified
   supportsRefreshes: true
   connectorTestSuitesOptions:
-    - suite: unitTests
-    - suite: integrationTests
-      testSecrets:
-        - name: SECRET_DESTINATION-DATABRICKS_AZURE__CREDS
-          fileName: azure_config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-        - name: SECRET_DESTINATION-DATABRICKS__CREDS
-          fileName: config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-        - name: SECRET_DESTINATION-DATABRICKS__STAGING_CREDS
-          fileName: staging_config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-        - name: SECRET_DESTINATION_DATABRICKS_OAUTH_CONFIG
-          fileName: oauth_config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-        - name: SECRET_DESTINATION_DATABRICKS_PERSONAL_ACCESS_TOKEN_CONFIG
-          fileName: pat_config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-metadataSpecVersion: "1.0"
+  - suite: unitTests
+  - suite: integrationTests
+    testSecrets:
+    - name: SECRET_DESTINATION-DATABRICKS_AZURE__CREDS
+      fileName: azure_config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+    - name: SECRET_DESTINATION-DATABRICKS__CREDS
+      fileName: config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+    - name: SECRET_DESTINATION-DATABRICKS__STAGING_CREDS
+      fileName: staging_config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+    - name: SECRET_DESTINATION_DATABRICKS_OAUTH_CONFIG
+      fileName: oauth_config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+    - name: SECRET_DESTINATION_DATABRICKS_PERSONAL_ACCESS_TOKEN_CONFIG
+      fileName: pat_config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+  - title: Release notes
+    url: https://docs.databricks.com/release-notes/index.html
+    type: api_release_history
+  - title: SQL reference
+    url: https://docs.databricks.com/sql/language-manual/index.html
+    type: sql_reference
+  - title: Authentication
+    url: https://docs.databricks.com/dev-tools/auth.html
+    type: authentication_guide
+  - title: Access control
+    url: https://docs.databricks.com/security/access-control/index.html
+    type: permissions_scopes
+  - title: Databricks Status
+    url: https://status.databricks.com/
+    type: status_page
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-deepset/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-deepset/metadata.yaml
@@ -1,17 +1,14 @@
-metadataSpecVersion: "1.0"
+metadataSpecVersion: '1.0'
 data:
   name: Deepset
   icon: deepset.svg
   definitionId: a6fe9a28-7377-4d2d-aa39-15bcf9578e17
   connectorBuildOptions:
-    # Please update to the latest version of the connector base image.
-    # Please use the full address with sha256 hash to guarantee build reproducibility.
-    # https://hub.docker.com/r/airbyte/python-connector-base
     baseImage: docker.io/airbyte/python-connector-base:4.0.0@sha256:d9894b6895923b379f3006fa251147806919c62b7d9021b5cd125bb67d7bbe22
   connectorTestSuitesOptions:
-    - suite: unitTests
-    - suite: integrationTests
-    - suite: acceptanceTests
+  - suite: unitTests
+  - suite: integrationTests
+  - suite: acceptanceTests
   connectorType: destination
   dockerRepository: airbyte/destination-deepset
   dockerImageTag: 0.1.8
@@ -23,9 +20,9 @@ data:
   releaseStage: alpha
   supportLevel: community
   tags:
-    - language:python
-    - cdk:python
-    - keyword:ai
+  - language:python
+  - cdk:python
+  - keyword:ai
   registryOverrides:
     oss:
       enabled: true
@@ -33,9 +30,16 @@ data:
       enabled: true
   allowedHosts:
     hosts:
-      - "*.us.deepset.ai"
-      - "*.cloud.deepset.ai"
+    - '*.us.deepset.ai'
+    - '*.cloud.deepset.ai'
   ab_internal:
     sl: 100
     ql: 100
   supportsFileTransfer: true
+  externalDocumentationUrls:
+  - title: Deepset Cloud documentation
+    url: https://docs.cloud.deepset.ai/
+    type: api_reference
+  - title: Authentication
+    url: https://docs.cloud.deepset.ai/docs/authentication
+    type: authentication_guide

--- a/airbyte-integrations/connectors/destination-deepset/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-deepset/metadata.yaml
@@ -1,4 +1,4 @@
-metadataSpecVersion: '1.0'
+metadataSpecVersion: "1.0"
 data:
   name: Deepset
   icon: deepset.svg
@@ -6,9 +6,9 @@ data:
   connectorBuildOptions:
     baseImage: docker.io/airbyte/python-connector-base:4.0.0@sha256:d9894b6895923b379f3006fa251147806919c62b7d9021b5cd125bb67d7bbe22
   connectorTestSuitesOptions:
-  - suite: unitTests
-  - suite: integrationTests
-  - suite: acceptanceTests
+    - suite: unitTests
+    - suite: integrationTests
+    - suite: acceptanceTests
   connectorType: destination
   dockerRepository: airbyte/destination-deepset
   dockerImageTag: 0.1.8
@@ -20,9 +20,9 @@ data:
   releaseStage: alpha
   supportLevel: community
   tags:
-  - language:python
-  - cdk:python
-  - keyword:ai
+    - language:python
+    - cdk:python
+    - keyword:ai
   registryOverrides:
     oss:
       enabled: true
@@ -30,16 +30,16 @@ data:
       enabled: true
   allowedHosts:
     hosts:
-    - '*.us.deepset.ai'
-    - '*.cloud.deepset.ai'
+      - "*.us.deepset.ai"
+      - "*.cloud.deepset.ai"
   ab_internal:
     sl: 100
     ql: 100
   supportsFileTransfer: true
   externalDocumentationUrls:
-  - title: Deepset Cloud documentation
-    url: https://docs.cloud.deepset.ai/
-    type: api_reference
-  - title: Authentication
-    url: https://docs.cloud.deepset.ai/docs/authentication
-    type: authentication_guide
+    - title: Deepset Cloud documentation
+      url: https://docs.cloud.deepset.ai/
+      type: api_reference
+    - title: Authentication
+      url: https://docs.cloud.deepset.ai/docs/authentication
+      type: authentication_guide

--- a/airbyte-integrations/connectors/destination-deepset/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-deepset/metadata.yaml
@@ -4,6 +4,9 @@ data:
   icon: deepset.svg
   definitionId: a6fe9a28-7377-4d2d-aa39-15bcf9578e17
   connectorBuildOptions:
+    # Please update to the latest version of the connector base image.
+    # Please use the full address with sha256 hash to guarantee build reproducibility.
+    # https://hub.docker.com/r/airbyte/python-connector-base
     baseImage: docker.io/airbyte/python-connector-base:4.0.0@sha256:d9894b6895923b379f3006fa251147806919c62b7d9021b5cd125bb67d7bbe22
   connectorTestSuitesOptions:
     - suite: unitTests

--- a/airbyte-integrations/connectors/destination-doris/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-doris/metadata.yaml
@@ -16,16 +16,16 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/doris
   tags:
-  - language:java
+    - language:java
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: archived
   externalDocumentationUrls:
-  - title: Apache Doris documentation
-    url: https://doris.apache.org/docs/dev/
-    type: api_reference
-  - title: SQL reference
-    url: https://doris.apache.org/docs/dev/sql-manual/sql-reference/
-    type: sql_reference
-metadataSpecVersion: '1.0'
+    - title: Apache Doris documentation
+      url: https://doris.apache.org/docs/dev/
+      type: api_reference
+    - title: SQL reference
+      url: https://doris.apache.org/docs/dev/sql-manual/sql-reference/
+      type: sql_reference
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-doris/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-doris/metadata.yaml
@@ -16,9 +16,16 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/doris
   tags:
-    - language:java
+  - language:java
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: archived
-metadataSpecVersion: "1.0"
+  externalDocumentationUrls:
+  - title: Apache Doris documentation
+    url: https://doris.apache.org/docs/dev/
+    type: api_reference
+  - title: SQL reference
+    url: https://doris.apache.org/docs/dev/sql-manual/sql-reference/
+    type: sql_reference
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-duckdb/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-duckdb/metadata.yaml
@@ -19,24 +19,27 @@ data:
   releases:
     breakingChanges:
       0.3.0:
-        message: 'This version uses the DuckDB 0.9.1 database driver, which is not
+        message:
+          "This version uses the DuckDB 0.9.1 database driver, which is not
           backwards compatible with prior versions. MotherDuck users can upgrade their
           database by visiting https://app.motherduck.com/ and accepting the upgrade.
           For more information, see the connector migration guide.
 
-          '
-        upgradeDeadline: '2023-10-31'
+          "
+        upgradeDeadline: "2023-10-31"
       0.4.0:
-        message: 'This version uses the DuckDB 0.10.3 database driver, which in not
+        message:
+          "This version uses the DuckDB 0.10.3 database driver, which in not
           backwards compatible with databases created using the 0.9.x versions of
           DuckDB. MotherDuck users can upgrade their database by visiting https://app.motherduck.com/
           and accepting the upgrade. For more information, see the connector migration
           guide.
 
-          '
-        upgradeDeadline: '2024-06-30'
+          "
+        upgradeDeadline: "2024-06-30"
       0.5.0:
-        message: 'This version uses the DuckDB 1.2.1 database driver, which is backwards
+        message:
+          "This version uses the DuckDB 1.2.1 database driver, which is backwards
           compatible with databases created using versions 0.10.x or higher of DuckDB.
           If your databases were created using an older version, you may need to manually
           upgrade your database file. Note that forward compatibility is provided
@@ -44,47 +47,47 @@ data:
           be readable in prior versions of DuckDB. You can read more about the DuckDB
           storage format here: https://duckdb.org/docs/stable/internals/storage.html.
 
-          '
-        upgradeDeadline: '2025-05-07'
+          "
+        upgradeDeadline: "2025-05-07"
   resourceRequirements:
     jobSpecific:
-    - jobType: check_connection
-      resourceRequirements:
-        memory_limit: 800Mi
-        memory_request: 800Mi
-    - jobType: sync
-      resourceRequirements:
-        memory_limit: 2Gi
-        memory_request: 2Gi
+      - jobType: check_connection
+        resourceRequirements:
+          memory_limit: 800Mi
+          memory_request: 800Mi
+      - jobType: sync
+        resourceRequirements:
+          memory_limit: 2Gi
+          memory_request: 2Gi
   documentationUrl: https://docs.airbyte.com/integrations/destinations/duckdb
   tags:
-  - language:python
-  - cdk:python
+    - language:python
+    - cdk:python
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
-  - suite: unitTests
-  - suite: integrationTests
-    testSecrets:
-    - name: SECRET_DESTINATION_DUCKDB__MOTHERDUCK__CREDS
-      fileName: config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
-  - suite: acceptanceTests
-    testSecrets:
-    - name: SECRET_DESTINATION_DUCKDB__MOTHERDUCK__CREDS
-      fileName: config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION_DUCKDB__MOTHERDUCK__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_DESTINATION_DUCKDB__MOTHERDUCK__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
   externalDocumentationUrls:
-  - title: DuckDB documentation
-    url: https://duckdb.org/docs/
-    type: api_reference
-  - title: SQL reference
-    url: https://duckdb.org/docs/sql/introduction
-    type: sql_reference
-metadataSpecVersion: '1.0'
+    - title: DuckDB documentation
+      url: https://duckdb.org/docs/
+      type: api_reference
+    - title: SQL reference
+      url: https://duckdb.org/docs/sql/introduction
+      type: sql_reference
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-duckdb/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-duckdb/metadata.yaml
@@ -19,53 +19,72 @@ data:
   releases:
     breakingChanges:
       0.3.0:
-        message: >
-          This version uses the DuckDB 0.9.1 database driver, which is not
-          backwards compatible with prior versions. MotherDuck users can
-          upgrade their database by visiting https://app.motherduck.com/ and
-          accepting the upgrade. For more information, see the connector
-          migration guide.
-        upgradeDeadline: "2023-10-31"
+        message: 'This version uses the DuckDB 0.9.1 database driver, which is not
+          backwards compatible with prior versions. MotherDuck users can upgrade their
+          database by visiting https://app.motherduck.com/ and accepting the upgrade.
+          For more information, see the connector migration guide.
+
+          '
+        upgradeDeadline: '2023-10-31'
       0.4.0:
-        message: >
-          This version uses the DuckDB 0.10.3 database driver, which in not backwards compatible with databases created using the 0.9.x versions of DuckDB. MotherDuck users can upgrade their database by visiting https://app.motherduck.com/ and accepting the upgrade. For more information, see the connector migration guide.
-        upgradeDeadline: "2024-06-30"
+        message: 'This version uses the DuckDB 0.10.3 database driver, which in not
+          backwards compatible with databases created using the 0.9.x versions of
+          DuckDB. MotherDuck users can upgrade their database by visiting https://app.motherduck.com/
+          and accepting the upgrade. For more information, see the connector migration
+          guide.
+
+          '
+        upgradeDeadline: '2024-06-30'
       0.5.0:
-        message: >
-          This version uses the DuckDB 1.2.1 database driver, which is backwards compatible with databases created using versions 0.10.x or higher of DuckDB. If your databases were created using an older version, you may need to manually upgrade your database file. Note that forward compatibility is provided on a best effort basis, so upgrading may cause your databases to no longer be readable in prior versions of DuckDB. You can read more about the DuckDB storage format here: https://duckdb.org/docs/stable/internals/storage.html.
-        upgradeDeadline: "2025-05-07"
+        message: 'This version uses the DuckDB 1.2.1 database driver, which is backwards
+          compatible with databases created using versions 0.10.x or higher of DuckDB.
+          If your databases were created using an older version, you may need to manually
+          upgrade your database file. Note that forward compatibility is provided
+          on a best effort basis, so upgrading may cause your databases to no longer
+          be readable in prior versions of DuckDB. You can read more about the DuckDB
+          storage format here: https://duckdb.org/docs/stable/internals/storage.html.
+
+          '
+        upgradeDeadline: '2025-05-07'
   resourceRequirements:
     jobSpecific:
-      - jobType: check_connection
-        resourceRequirements:
-          memory_limit: 800Mi
-          memory_request: 800Mi
-      - jobType: sync
-        resourceRequirements:
-          memory_limit: 2Gi
-          memory_request: 2Gi
+    - jobType: check_connection
+      resourceRequirements:
+        memory_limit: 800Mi
+        memory_request: 800Mi
+    - jobType: sync
+      resourceRequirements:
+        memory_limit: 2Gi
+        memory_request: 2Gi
   documentationUrl: https://docs.airbyte.com/integrations/destinations/duckdb
   tags:
-    - language:python
-    - cdk:python
+  - language:python
+  - cdk:python
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
-    - suite: unitTests
-    - suite: integrationTests
-      testSecrets:
-        - name: SECRET_DESTINATION_DUCKDB__MOTHERDUCK__CREDS
-          fileName: config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-    - suite: acceptanceTests
-      testSecrets:
-        - name: SECRET_DESTINATION_DUCKDB__MOTHERDUCK__CREDS
-          fileName: config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-metadataSpecVersion: "1.0"
+  - suite: unitTests
+  - suite: integrationTests
+    testSecrets:
+    - name: SECRET_DESTINATION_DUCKDB__MOTHERDUCK__CREDS
+      fileName: config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+  - suite: acceptanceTests
+    testSecrets:
+    - name: SECRET_DESTINATION_DUCKDB__MOTHERDUCK__CREDS
+      fileName: config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+  - title: DuckDB documentation
+    url: https://duckdb.org/docs/
+    type: api_reference
+  - title: SQL reference
+    url: https://duckdb.org/docs/sql/introduction
+    type: sql_reference
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-duckdb/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-duckdb/metadata.yaml
@@ -19,35 +19,20 @@ data:
   releases:
     breakingChanges:
       0.3.0:
-        message:
-          "This version uses the DuckDB 0.9.1 database driver, which is not
-          backwards compatible with prior versions. MotherDuck users can upgrade their
-          database by visiting https://app.motherduck.com/ and accepting the upgrade.
-          For more information, see the connector migration guide.
-
-          "
+        message: >
+          This version uses the DuckDB 0.9.1 database driver, which is not
+          backwards compatible with prior versions. MotherDuck users can
+          upgrade their database by visiting https://app.motherduck.com/ and
+          accepting the upgrade. For more information, see the connector
+          migration guide.
         upgradeDeadline: "2023-10-31"
       0.4.0:
-        message:
-          "This version uses the DuckDB 0.10.3 database driver, which in not
-          backwards compatible with databases created using the 0.9.x versions of
-          DuckDB. MotherDuck users can upgrade their database by visiting https://app.motherduck.com/
-          and accepting the upgrade. For more information, see the connector migration
-          guide.
-
-          "
+        message: >
+          This version uses the DuckDB 0.10.3 database driver, which in not backwards compatible with databases created using the 0.9.x versions of DuckDB. MotherDuck users can upgrade their database by visiting https://app.motherduck.com/ and accepting the upgrade. For more information, see the connector migration guide.
         upgradeDeadline: "2024-06-30"
       0.5.0:
-        message:
-          "This version uses the DuckDB 1.2.1 database driver, which is backwards
-          compatible with databases created using versions 0.10.x or higher of DuckDB.
-          If your databases were created using an older version, you may need to manually
-          upgrade your database file. Note that forward compatibility is provided
-          on a best effort basis, so upgrading may cause your databases to no longer
-          be readable in prior versions of DuckDB. You can read more about the DuckDB
-          storage format here: https://duckdb.org/docs/stable/internals/storage.html.
-
-          "
+        message: >
+          This version uses the DuckDB 1.2.1 database driver, which is backwards compatible with databases created using versions 0.10.x or higher of DuckDB. If your databases were created using an older version, you may need to manually upgrade your database file. Note that forward compatibility is provided on a best effort basis, so upgrading may cause your databases to no longer be readable in prior versions of DuckDB. You can read more about the DuckDB storage format here: https://duckdb.org/docs/stable/internals/storage.html.
         upgradeDeadline: "2025-05-07"
   resourceRequirements:
     jobSpecific:

--- a/airbyte-integrations/connectors/destination-dynamodb/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-dynamodb/metadata.yaml
@@ -18,19 +18,35 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/dynamodb
   tags:
-    - language:java
+  - language:java
   ab_internal:
     sl: 100
     ql: 200
     requireVersionIncrementsInPullRequests: false
   supportLevel: community
   connectorTestSuitesOptions:
-    - suite: unitTests
-    - suite: integrationTests
-      testSecrets:
-        - name: SECRET_DESTINATION-DYNAMODB__CREDS
-          fileName: config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-metadataSpecVersion: "1.0"
+  - suite: unitTests
+  - suite: integrationTests
+    testSecrets:
+    - name: SECRET_DESTINATION-DYNAMODB__CREDS
+      fileName: config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+  - title: DynamoDB documentation
+    url: https://docs.aws.amazon.com/dynamodb/
+    type: api_reference
+  - title: IAM authentication
+    url: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html
+    type: authentication_guide
+  - title: IAM policies
+    url: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/iam-policy-structure.html
+    type: permissions_scopes
+  - title: Service quotas
+    url: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ServiceQuotas.html
+    type: rate_limits
+  - title: AWS Service Health Dashboard
+    url: https://health.aws.amazon.com/health/status
+    type: status_page
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-dynamodb/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-dynamodb/metadata.yaml
@@ -18,35 +18,35 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/dynamodb
   tags:
-  - language:java
+    - language:java
   ab_internal:
     sl: 100
     ql: 200
     requireVersionIncrementsInPullRequests: false
   supportLevel: community
   connectorTestSuitesOptions:
-  - suite: unitTests
-  - suite: integrationTests
-    testSecrets:
-    - name: SECRET_DESTINATION-DYNAMODB__CREDS
-      fileName: config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION-DYNAMODB__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
   externalDocumentationUrls:
-  - title: DynamoDB documentation
-    url: https://docs.aws.amazon.com/dynamodb/
-    type: api_reference
-  - title: IAM authentication
-    url: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html
-    type: authentication_guide
-  - title: IAM policies
-    url: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/iam-policy-structure.html
-    type: permissions_scopes
-  - title: Service quotas
-    url: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ServiceQuotas.html
-    type: rate_limits
-  - title: AWS Service Health Dashboard
-    url: https://health.aws.amazon.com/health/status
-    type: status_page
-metadataSpecVersion: '1.0'
+    - title: DynamoDB documentation
+      url: https://docs.aws.amazon.com/dynamodb/
+      type: api_reference
+    - title: IAM authentication
+      url: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html
+      type: authentication_guide
+    - title: IAM policies
+      url: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/iam-policy-structure.html
+      type: permissions_scopes
+    - title: Service quotas
+      url: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ServiceQuotas.html
+      type: rate_limits
+    - title: AWS Service Health Dashboard
+      url: https://health.aws.amazon.com/health/status
+      type: status_page
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-elasticsearch-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-elasticsearch-strict-encrypt/metadata.yaml
@@ -18,24 +18,24 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/elasticsearch
   tags:
-  - language:java
+    - language:java
   connectorTestSuitesOptions:
-  - suite: unitTests
-  - suite: integrationTests
+    - suite: unitTests
+    - suite: integrationTests
   externalDocumentationUrls:
-  - title: Elasticsearch documentation
-    url: https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html
-    type: api_reference
-  - title: Release notes
-    url: https://www.elastic.co/guide/en/elasticsearch/reference/current/es-release-notes.html
-    type: api_release_history
-  - title: Authentication
-    url: https://www.elastic.co/guide/en/elasticsearch/reference/current/setting-up-authentication.html
-    type: authentication_guide
-  - title: Security privileges
-    url: https://www.elastic.co/guide/en/elasticsearch/reference/current/security-privileges.html
-    type: permissions_scopes
-  - title: Elastic Cloud Status
-    url: https://status.elastic.co/
-    type: status_page
-metadataSpecVersion: '1.0'
+    - title: Elasticsearch documentation
+      url: https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html
+      type: api_reference
+    - title: Release notes
+      url: https://www.elastic.co/guide/en/elasticsearch/reference/current/es-release-notes.html
+      type: api_release_history
+    - title: Authentication
+      url: https://www.elastic.co/guide/en/elasticsearch/reference/current/setting-up-authentication.html
+      type: authentication_guide
+    - title: Security privileges
+      url: https://www.elastic.co/guide/en/elasticsearch/reference/current/security-privileges.html
+      type: permissions_scopes
+    - title: Elastic Cloud Status
+      url: https://status.elastic.co/
+      type: status_page
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-elasticsearch-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-elasticsearch-strict-encrypt/metadata.yaml
@@ -3,9 +3,9 @@ data:
     baseImage: docker.io/airbyte/java-connector-base:2.0.2@sha256:f8e47304842a2c4d75ac223cf4b3c4117aa1c5c9207149369d296616815fe5b0
   registryOverrides:
     cloud:
-      enabled: false
+      enabled: false # strict encrypt connectors are deployed to Cloud by their non strict encrypt sibling.
     oss:
-      enabled: false
+      enabled: false # strict encrypt connectors are not used on OSS.
   connectorSubtype: api
   connectorType: destination
   definitionId: 68f351a7-2745-4bef-ad7f-996b8e51bb8c

--- a/airbyte-integrations/connectors/destination-elasticsearch-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-elasticsearch-strict-encrypt/metadata.yaml
@@ -3,9 +3,9 @@ data:
     baseImage: docker.io/airbyte/java-connector-base:2.0.2@sha256:f8e47304842a2c4d75ac223cf4b3c4117aa1c5c9207149369d296616815fe5b0
   registryOverrides:
     cloud:
-      enabled: false # strict encrypt connectors are deployed to Cloud by their non strict encrypt sibling.
+      enabled: false
     oss:
-      enabled: false # strict encrypt connectors are not used on OSS.
+      enabled: false
   connectorSubtype: api
   connectorType: destination
   definitionId: 68f351a7-2745-4bef-ad7f-996b8e51bb8c
@@ -18,8 +18,24 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/elasticsearch
   tags:
-    - language:java
+  - language:java
   connectorTestSuitesOptions:
-    - suite: unitTests
-    - suite: integrationTests
-metadataSpecVersion: "1.0"
+  - suite: unitTests
+  - suite: integrationTests
+  externalDocumentationUrls:
+  - title: Elasticsearch documentation
+    url: https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html
+    type: api_reference
+  - title: Release notes
+    url: https://www.elastic.co/guide/en/elasticsearch/reference/current/es-release-notes.html
+    type: api_release_history
+  - title: Authentication
+    url: https://www.elastic.co/guide/en/elasticsearch/reference/current/setting-up-authentication.html
+    type: authentication_guide
+  - title: Security privileges
+    url: https://www.elastic.co/guide/en/elasticsearch/reference/current/security-privileges.html
+    type: permissions_scopes
+  - title: Elastic Cloud Status
+    url: https://status.elastic.co/
+    type: status_page
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-elasticsearch/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-elasticsearch/metadata.yaml
@@ -19,12 +19,28 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/elasticsearch
   tags:
-    - language:java
+  - language:java
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
-    - suite: unitTests
-    - suite: integrationTests
-metadataSpecVersion: "1.0"
+  - suite: unitTests
+  - suite: integrationTests
+  externalDocumentationUrls:
+  - title: Elasticsearch documentation
+    url: https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html
+    type: api_reference
+  - title: Release notes
+    url: https://www.elastic.co/guide/en/elasticsearch/reference/current/es-release-notes.html
+    type: api_release_history
+  - title: Authentication
+    url: https://www.elastic.co/guide/en/elasticsearch/reference/current/setting-up-authentication.html
+    type: authentication_guide
+  - title: Security privileges
+    url: https://www.elastic.co/guide/en/elasticsearch/reference/current/security-privileges.html
+    type: permissions_scopes
+  - title: Elastic Cloud Status
+    url: https://status.elastic.co/
+    type: status_page
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-elasticsearch/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-elasticsearch/metadata.yaml
@@ -19,28 +19,28 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/elasticsearch
   tags:
-  - language:java
+    - language:java
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
-  - suite: unitTests
-  - suite: integrationTests
+    - suite: unitTests
+    - suite: integrationTests
   externalDocumentationUrls:
-  - title: Elasticsearch documentation
-    url: https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html
-    type: api_reference
-  - title: Release notes
-    url: https://www.elastic.co/guide/en/elasticsearch/reference/current/es-release-notes.html
-    type: api_release_history
-  - title: Authentication
-    url: https://www.elastic.co/guide/en/elasticsearch/reference/current/setting-up-authentication.html
-    type: authentication_guide
-  - title: Security privileges
-    url: https://www.elastic.co/guide/en/elasticsearch/reference/current/security-privileges.html
-    type: permissions_scopes
-  - title: Elastic Cloud Status
-    url: https://status.elastic.co/
-    type: status_page
-metadataSpecVersion: '1.0'
+    - title: Elasticsearch documentation
+      url: https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html
+      type: api_reference
+    - title: Release notes
+      url: https://www.elastic.co/guide/en/elasticsearch/reference/current/es-release-notes.html
+      type: api_release_history
+    - title: Authentication
+      url: https://www.elastic.co/guide/en/elasticsearch/reference/current/setting-up-authentication.html
+      type: authentication_guide
+    - title: Security privileges
+      url: https://www.elastic.co/guide/en/elasticsearch/reference/current/security-privileges.html
+      type: permissions_scopes
+    - title: Elastic Cloud Status
+      url: https://status.elastic.co/
+      type: status_page
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-exasol/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-exasol/metadata.yaml
@@ -15,9 +15,16 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/exasol
   tags:
-    - language:java
+  - language:java
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: archived
-metadataSpecVersion: "1.0"
+  externalDocumentationUrls:
+  - title: Exasol documentation
+    url: https://docs.exasol.com/
+    type: api_reference
+  - title: SQL reference
+    url: https://docs.exasol.com/db/latest/sql_references/sqlreferencesoverview.htm
+    type: sql_reference
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-exasol/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-exasol/metadata.yaml
@@ -15,16 +15,16 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/exasol
   tags:
-  - language:java
+    - language:java
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: archived
   externalDocumentationUrls:
-  - title: Exasol documentation
-    url: https://docs.exasol.com/
-    type: api_reference
-  - title: SQL reference
-    url: https://docs.exasol.com/db/latest/sql_references/sqlreferencesoverview.htm
-    type: sql_reference
-metadataSpecVersion: '1.0'
+    - title: Exasol documentation
+      url: https://docs.exasol.com/
+      type: api_reference
+    - title: SQL reference
+      url: https://docs.exasol.com/db/latest/sql_references/sqlreferencesoverview.htm
+      type: sql_reference
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-firebolt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-firebolt/metadata.yaml
@@ -19,29 +19,29 @@ data:
   documentationUrl: https://docs.airbyte.com/integrations/destinations/firebolt
   supportsDbt: true
   tags:
-  - language:python
-  - cdk:python
+    - language:python
+    - cdk:python
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
-  - suite: unitTests
-  - suite: integrationTests
-    testSecrets:
-    - name: SECRET_DESTINATION-FIREBOLT_CREDS
-      fileName: config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION-FIREBOLT_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
   externalDocumentationUrls:
-  - title: Firebolt documentation
-    url: https://docs.firebolt.io/
-    type: api_reference
-  - title: SQL reference
-    url: https://docs.firebolt.io/sql_reference/
-    type: sql_reference
-  - title: Authentication
-    url: https://docs.firebolt.io/godocs/Overview/managing-your-organization/service-accounts.html
-    type: authentication_guide
-metadataSpecVersion: '1.0'
+    - title: Firebolt documentation
+      url: https://docs.firebolt.io/
+      type: api_reference
+    - title: SQL reference
+      url: https://docs.firebolt.io/sql_reference/
+      type: sql_reference
+    - title: Authentication
+      url: https://docs.firebolt.io/godocs/Overview/managing-your-organization/service-accounts.html
+      type: authentication_guide
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-firebolt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-firebolt/metadata.yaml
@@ -19,19 +19,29 @@ data:
   documentationUrl: https://docs.airbyte.com/integrations/destinations/firebolt
   supportsDbt: true
   tags:
-    - language:python
-    - cdk:python
+  - language:python
+  - cdk:python
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
-    - suite: unitTests
-    - suite: integrationTests
-      testSecrets:
-        - name: SECRET_DESTINATION-FIREBOLT_CREDS
-          fileName: config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-metadataSpecVersion: "1.0"
+  - suite: unitTests
+  - suite: integrationTests
+    testSecrets:
+    - name: SECRET_DESTINATION-FIREBOLT_CREDS
+      fileName: config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+  - title: Firebolt documentation
+    url: https://docs.firebolt.io/
+    type: api_reference
+  - title: SQL reference
+    url: https://docs.firebolt.io/sql_reference/
+    type: sql_reference
+  - title: Authentication
+    url: https://docs.firebolt.io/godocs/Overview/managing-your-organization/service-accounts.html
+    type: authentication_guide
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-firestore/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-firestore/metadata.yaml
@@ -16,21 +16,37 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/firestore
   tags:
-    - language:python
-    - cdk:python
+  - language:python
+  - cdk:python
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
-    - suite: unitTests
-    - suite: integrationTests
-      testSecrets:
-        - name: SECRET_DESTINATION-FIRESTORE
-          fileName: config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
+  - suite: unitTests
+  - suite: integrationTests
+    testSecrets:
+    - name: SECRET_DESTINATION-FIRESTORE
+      fileName: config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
   connectorBuildOptions:
     baseImage: docker.io/airbyte/python-connector-base:4.0.0@sha256:d9894b6895923b379f3006fa251147806919c62b7d9021b5cd125bb67d7bbe22
-metadataSpecVersion: "1.0"
+  externalDocumentationUrls:
+  - title: Firestore documentation
+    url: https://firebase.google.com/docs/firestore
+    type: api_reference
+  - title: Authentication
+    url: https://firebase.google.com/docs/firestore/security/get-started
+    type: authentication_guide
+  - title: Security rules
+    url: https://firebase.google.com/docs/firestore/security/rules-structure
+    type: permissions_scopes
+  - title: Quotas and limits
+    url: https://firebase.google.com/docs/firestore/quotas
+    type: rate_limits
+  - title: Firebase Status
+    url: https://status.firebase.google.com/
+    type: status_page
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-firestore/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-firestore/metadata.yaml
@@ -16,37 +16,37 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/firestore
   tags:
-  - language:python
-  - cdk:python
+    - language:python
+    - cdk:python
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
-  - suite: unitTests
-  - suite: integrationTests
-    testSecrets:
-    - name: SECRET_DESTINATION-FIRESTORE
-      fileName: config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION-FIRESTORE
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
   connectorBuildOptions:
     baseImage: docker.io/airbyte/python-connector-base:4.0.0@sha256:d9894b6895923b379f3006fa251147806919c62b7d9021b5cd125bb67d7bbe22
   externalDocumentationUrls:
-  - title: Firestore documentation
-    url: https://firebase.google.com/docs/firestore
-    type: api_reference
-  - title: Authentication
-    url: https://firebase.google.com/docs/firestore/security/get-started
-    type: authentication_guide
-  - title: Security rules
-    url: https://firebase.google.com/docs/firestore/security/rules-structure
-    type: permissions_scopes
-  - title: Quotas and limits
-    url: https://firebase.google.com/docs/firestore/quotas
-    type: rate_limits
-  - title: Firebase Status
-    url: https://status.firebase.google.com/
-    type: status_page
-metadataSpecVersion: '1.0'
+    - title: Firestore documentation
+      url: https://firebase.google.com/docs/firestore
+      type: api_reference
+    - title: Authentication
+      url: https://firebase.google.com/docs/firestore/security/get-started
+      type: authentication_guide
+    - title: Security rules
+      url: https://firebase.google.com/docs/firestore/security/rules-structure
+      type: permissions_scopes
+    - title: Quotas and limits
+      url: https://firebase.google.com/docs/firestore/quotas
+      type: rate_limits
+    - title: Firebase Status
+      url: https://status.firebase.google.com/
+      type: status_page
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-gcs-data-lake/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/metadata.yaml
@@ -11,14 +11,14 @@ data:
       enabled: true
   connectorSubtype: file
   connectorTestSuitesOptions:
-  - suite: unitTests
-  - suite: integrationTests
-    testSecrets:
-    - name: SECRET_DESTINATION_GCS_DATA_LAKE_BIGLAKE
-      fileName: biglake.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION_GCS_DATA_LAKE_BIGLAKE
+          fileName: biglake.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
   connectorType: destination
   definitionId: 8c8a2d3e-1b4f-4a9c-9e7d-6f5a4b3c2d1e
   dockerImageTag: 1.0.2
@@ -32,15 +32,15 @@ data:
   supportLevel: certified
   supportsRefreshes: true
   tags:
-  - language:java
+    - language:java
   externalDocumentationUrls:
-  - title: Cloud Storage documentation
-    url: https://cloud.google.com/storage/docs
-    type: api_reference
-  - title: Service account authentication
-    url: https://cloud.google.com/iam/docs/service-accounts
-    type: authentication_guide
-  - title: Access control
-    url: https://cloud.google.com/storage/docs/access-control
-    type: permissions_scopes
-metadataSpecVersion: '1.0'
+    - title: Cloud Storage documentation
+      url: https://cloud.google.com/storage/docs
+      type: api_reference
+    - title: Service account authentication
+      url: https://cloud.google.com/iam/docs/service-accounts
+      type: authentication_guide
+    - title: Access control
+      url: https://cloud.google.com/storage/docs/access-control
+      type: permissions_scopes
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-gcs-data-lake/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/metadata.yaml
@@ -11,14 +11,14 @@ data:
       enabled: true
   connectorSubtype: file
   connectorTestSuitesOptions:
-    - suite: unitTests
-    - suite: integrationTests
-      testSecrets:
-        - name: SECRET_DESTINATION_GCS_DATA_LAKE_BIGLAKE
-          fileName: biglake.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
+  - suite: unitTests
+  - suite: integrationTests
+    testSecrets:
+    - name: SECRET_DESTINATION_GCS_DATA_LAKE_BIGLAKE
+      fileName: biglake.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
   connectorType: destination
   definitionId: 8c8a2d3e-1b4f-4a9c-9e7d-6f5a4b3c2d1e
   dockerImageTag: 1.0.2
@@ -32,5 +32,15 @@ data:
   supportLevel: certified
   supportsRefreshes: true
   tags:
-    - language:java
-metadataSpecVersion: "1.0"
+  - language:java
+  externalDocumentationUrls:
+  - title: Cloud Storage documentation
+    url: https://cloud.google.com/storage/docs
+    type: api_reference
+  - title: Service account authentication
+    url: https://cloud.google.com/iam/docs/service-accounts
+    type: authentication_guide
+  - title: Access control
+    url: https://cloud.google.com/storage/docs/access-control
+    type: permissions_scopes
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-gcs/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-gcs/metadata.yaml
@@ -7,18 +7,18 @@ data:
     baseImage: docker.io/airbyte/java-connector-base:2.0.1@sha256:ec89bd1a89e825514dd2fc8730ba299a3ae1544580a078df0e35c5202c2085b3
   connectorSubtype: file
   connectorTestSuitesOptions:
-    - suite: integrationTests
-      testSecrets:
-        - fileName: insufficient_roles_config.json
-          name: SECRET_DESTINATION-GCS_NO_MULTIPART_ROLE_CREDS
-          secretStore:
-            alias: airbyte-connector-testing-secret-store
-            type: GSM
-        - fileName: config.json
-          name: SECRET_DESTINATION-GCS__CREDS
-          secretStore:
-            alias: airbyte-connector-testing-secret-store
-            type: GSM
+  - suite: integrationTests
+    testSecrets:
+    - fileName: insufficient_roles_config.json
+      name: SECRET_DESTINATION-GCS_NO_MULTIPART_ROLE_CREDS
+      secretStore:
+        alias: airbyte-connector-testing-secret-store
+        type: GSM
+    - fileName: config.json
+      name: SECRET_DESTINATION-GCS__CREDS
+      secretStore:
+        alias: airbyte-connector-testing-secret-store
+        type: GSM
   connectorType: destination
   definitionId: ca8f6566-e555-4b40-943a-545bf123117a
   dockerImageTag: 0.4.9
@@ -36,11 +36,27 @@ data:
   releaseStage: beta
   resourceRequirements:
     jobSpecific:
-      - jobType: sync
-        resourceRequirements:
-          memory_limit: 1Gi
-          memory_request: 1Gi
+    - jobType: sync
+      resourceRequirements:
+        memory_limit: 1Gi
+        memory_request: 1Gi
   supportLevel: community
   tags:
-    - language:java
-metadataSpecVersion: "1.0"
+  - language:java
+  externalDocumentationUrls:
+  - title: Cloud Storage documentation
+    url: https://cloud.google.com/storage/docs
+    type: api_reference
+  - title: Service account authentication
+    url: https://cloud.google.com/iam/docs/service-accounts
+    type: authentication_guide
+  - title: Access control
+    url: https://cloud.google.com/storage/docs/access-control
+    type: permissions_scopes
+  - title: Quotas and limits
+    url: https://cloud.google.com/storage/quotas
+    type: rate_limits
+  - title: Google Cloud Status
+    url: https://status.cloud.google.com/
+    type: status_page
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-gcs/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-gcs/metadata.yaml
@@ -7,18 +7,18 @@ data:
     baseImage: docker.io/airbyte/java-connector-base:2.0.1@sha256:ec89bd1a89e825514dd2fc8730ba299a3ae1544580a078df0e35c5202c2085b3
   connectorSubtype: file
   connectorTestSuitesOptions:
-  - suite: integrationTests
-    testSecrets:
-    - fileName: insufficient_roles_config.json
-      name: SECRET_DESTINATION-GCS_NO_MULTIPART_ROLE_CREDS
-      secretStore:
-        alias: airbyte-connector-testing-secret-store
-        type: GSM
-    - fileName: config.json
-      name: SECRET_DESTINATION-GCS__CREDS
-      secretStore:
-        alias: airbyte-connector-testing-secret-store
-        type: GSM
+    - suite: integrationTests
+      testSecrets:
+        - fileName: insufficient_roles_config.json
+          name: SECRET_DESTINATION-GCS_NO_MULTIPART_ROLE_CREDS
+          secretStore:
+            alias: airbyte-connector-testing-secret-store
+            type: GSM
+        - fileName: config.json
+          name: SECRET_DESTINATION-GCS__CREDS
+          secretStore:
+            alias: airbyte-connector-testing-secret-store
+            type: GSM
   connectorType: destination
   definitionId: ca8f6566-e555-4b40-943a-545bf123117a
   dockerImageTag: 0.4.9
@@ -36,27 +36,27 @@ data:
   releaseStage: beta
   resourceRequirements:
     jobSpecific:
-    - jobType: sync
-      resourceRequirements:
-        memory_limit: 1Gi
-        memory_request: 1Gi
+      - jobType: sync
+        resourceRequirements:
+          memory_limit: 1Gi
+          memory_request: 1Gi
   supportLevel: community
   tags:
-  - language:java
+    - language:java
   externalDocumentationUrls:
-  - title: Cloud Storage documentation
-    url: https://cloud.google.com/storage/docs
-    type: api_reference
-  - title: Service account authentication
-    url: https://cloud.google.com/iam/docs/service-accounts
-    type: authentication_guide
-  - title: Access control
-    url: https://cloud.google.com/storage/docs/access-control
-    type: permissions_scopes
-  - title: Quotas and limits
-    url: https://cloud.google.com/storage/quotas
-    type: rate_limits
-  - title: Google Cloud Status
-    url: https://status.cloud.google.com/
-    type: status_page
-metadataSpecVersion: '1.0'
+    - title: Cloud Storage documentation
+      url: https://cloud.google.com/storage/docs
+      type: api_reference
+    - title: Service account authentication
+      url: https://cloud.google.com/iam/docs/service-accounts
+      type: authentication_guide
+    - title: Access control
+      url: https://cloud.google.com/storage/docs/access-control
+      type: permissions_scopes
+    - title: Quotas and limits
+      url: https://cloud.google.com/storage/quotas
+      type: rate_limits
+    - title: Google Cloud Status
+      url: https://status.cloud.google.com/
+      type: status_page
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-glassflow/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-glassflow/metadata.yaml
@@ -9,11 +9,11 @@ data:
   license: ELv2
   name: GlassFlow
   tags:
-    - language:python
-    - cdk:python
+  - language:python
+  - cdk:python
   allowedHosts:
     hosts:
-      - api.glassflow.dev
+    - api.glassflow.dev
   remoteRegistries:
     pypi:
       enabled: true
@@ -28,20 +28,24 @@ data:
   connectorBuildOptions:
     baseImage: docker.io/airbyte/python-connector-base:4.0.0@sha256:d9894b6895923b379f3006fa251147806919c62b7d9021b5cd125bb67d7bbe22
   connectorTestSuitesOptions:
-    - suite: unitTests
-    - suite: integrationTests
-      testSecrets:
-        - name: SECRET_DESTINATION-GLASSFLOW__CREDS
-          fileName: config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-    - suite: acceptanceTests
-      testSecrets:
-        - name: SECRET_DESTINATION-GLASSFLOW__CREDS
-          fileName: config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
+  - suite: unitTests
+  - suite: integrationTests
+    testSecrets:
+    - name: SECRET_DESTINATION-GLASSFLOW__CREDS
+      fileName: config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+  - suite: acceptanceTests
+    testSecrets:
+    - name: SECRET_DESTINATION-GLASSFLOW__CREDS
+      fileName: config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
   releaseStage: alpha
-metadataSpecVersion: "1.0"
+  externalDocumentationUrls:
+  - title: Glassflow documentation
+    url: https://docs.glassflow.dev/
+    type: api_reference
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-glassflow/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-glassflow/metadata.yaml
@@ -9,11 +9,11 @@ data:
   license: ELv2
   name: GlassFlow
   tags:
-  - language:python
-  - cdk:python
+    - language:python
+    - cdk:python
   allowedHosts:
     hosts:
-    - api.glassflow.dev
+      - api.glassflow.dev
   remoteRegistries:
     pypi:
       enabled: true
@@ -28,24 +28,24 @@ data:
   connectorBuildOptions:
     baseImage: docker.io/airbyte/python-connector-base:4.0.0@sha256:d9894b6895923b379f3006fa251147806919c62b7d9021b5cd125bb67d7bbe22
   connectorTestSuitesOptions:
-  - suite: unitTests
-  - suite: integrationTests
-    testSecrets:
-    - name: SECRET_DESTINATION-GLASSFLOW__CREDS
-      fileName: config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
-  - suite: acceptanceTests
-    testSecrets:
-    - name: SECRET_DESTINATION-GLASSFLOW__CREDS
-      fileName: config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION-GLASSFLOW__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_DESTINATION-GLASSFLOW__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
   releaseStage: alpha
   externalDocumentationUrls:
-  - title: Glassflow documentation
-    url: https://docs.glassflow.dev/
-    type: api_reference
-metadataSpecVersion: '1.0'
+    - title: Glassflow documentation
+      url: https://docs.glassflow.dev/
+      type: api_reference
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-google-sheets/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-google-sheets/metadata.yaml
@@ -16,26 +16,39 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/google-sheets
   tags:
-    - language:python
-    - cdk:python
+  - language:python
+  - cdk:python
   ab_internal:
     sl: 100
     ql: 200
   supportLevel: community
   connectorTestSuitesOptions:
-    - suite: unitTests
-    - suite: integrationTests
-      testSecrets:
-        - name: SECRET_DESTINATION-GOOGLE_SHEETS_OAUTH_CREDS
-          fileName: config_oauth.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-        - name: SECRET_DESTINATION-GOOGLE_SHEETS_SA_CREDS
-          fileName: config_service.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
+  - suite: unitTests
+  - suite: integrationTests
+    testSecrets:
+    - name: SECRET_DESTINATION-GOOGLE_SHEETS_OAUTH_CREDS
+      fileName: config_oauth.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+    - name: SECRET_DESTINATION-GOOGLE_SHEETS_SA_CREDS
+      fileName: config_service.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
   connectorBuildOptions:
     baseImage: docker.io/airbyte/python-connector-base:4.0.0@sha256:d9894b6895923b379f3006fa251147806919c62b7d9021b5cd125bb67d7bbe22
-metadataSpecVersion: "1.0"
+  externalDocumentationUrls:
+  - title: Google Sheets API documentation
+    url: https://developers.google.com/sheets/api
+    type: api_reference
+  - title: OAuth 2.0
+    url: https://developers.google.com/identity/protocols/oauth2
+    type: authentication_guide
+  - title: Usage limits
+    url: https://developers.google.com/sheets/api/limits
+    type: rate_limits
+  - title: Google Workspace Status
+    url: https://www.google.com/appsstatus/
+    type: status_page
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-google-sheets/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-google-sheets/metadata.yaml
@@ -16,39 +16,39 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/google-sheets
   tags:
-  - language:python
-  - cdk:python
+    - language:python
+    - cdk:python
   ab_internal:
     sl: 100
     ql: 200
   supportLevel: community
   connectorTestSuitesOptions:
-  - suite: unitTests
-  - suite: integrationTests
-    testSecrets:
-    - name: SECRET_DESTINATION-GOOGLE_SHEETS_OAUTH_CREDS
-      fileName: config_oauth.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
-    - name: SECRET_DESTINATION-GOOGLE_SHEETS_SA_CREDS
-      fileName: config_service.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION-GOOGLE_SHEETS_OAUTH_CREDS
+          fileName: config_oauth.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-GOOGLE_SHEETS_SA_CREDS
+          fileName: config_service.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
   connectorBuildOptions:
     baseImage: docker.io/airbyte/python-connector-base:4.0.0@sha256:d9894b6895923b379f3006fa251147806919c62b7d9021b5cd125bb67d7bbe22
   externalDocumentationUrls:
-  - title: Google Sheets API documentation
-    url: https://developers.google.com/sheets/api
-    type: api_reference
-  - title: OAuth 2.0
-    url: https://developers.google.com/identity/protocols/oauth2
-    type: authentication_guide
-  - title: Usage limits
-    url: https://developers.google.com/sheets/api/limits
-    type: rate_limits
-  - title: Google Workspace Status
-    url: https://www.google.com/appsstatus/
-    type: status_page
-metadataSpecVersion: '1.0'
+    - title: Google Sheets API documentation
+      url: https://developers.google.com/sheets/api
+      type: api_reference
+    - title: OAuth 2.0
+      url: https://developers.google.com/identity/protocols/oauth2
+      type: authentication_guide
+    - title: Usage limits
+      url: https://developers.google.com/sheets/api/limits
+      type: rate_limits
+    - title: Google Workspace Status
+      url: https://www.google.com/appsstatus/
+      type: status_page
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-hubspot/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-hubspot/metadata.yaml
@@ -28,7 +28,7 @@ data:
     isEnterprise: false
   supportLevel: certified
   supportsDataActivation: true
-  supportsRefreshes: true
+  supportsRefreshes: true # needed for the CDK to work as it relies on the generation/sync ids to work
   externalDocumentationUrls:
     - title: HubSpot API documentation
       url: https://developers.hubspot.com/docs/api/overview

--- a/airbyte-integrations/connectors/destination-hubspot/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-hubspot/metadata.yaml
@@ -1,7 +1,7 @@
 data:
   allowedHosts:
     hosts:
-    - api.hubapi.com
+      - api.hubapi.com
   registryOverrides:
     cloud:
       enabled: true
@@ -21,7 +21,7 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/hubspot
   tags:
-  - language:java
+    - language:java
   ab_internal:
     sl: 100
     ql: 100
@@ -30,16 +30,16 @@ data:
   supportsDataActivation: true
   supportsRefreshes: true
   externalDocumentationUrls:
-  - title: HubSpot API documentation
-    url: https://developers.hubspot.com/docs/api/overview
-    type: api_reference
-  - title: OAuth
-    url: https://developers.hubspot.com/docs/api/oauth-quickstart-guide
-    type: authentication_guide
-  - title: Rate limits
-    url: https://developers.hubspot.com/docs/api/usage-details
-    type: rate_limits
-  - title: HubSpot Status
-    url: https://status.hubspot.com/
-    type: status_page
-metadataSpecVersion: '1.0'
+    - title: HubSpot API documentation
+      url: https://developers.hubspot.com/docs/api/overview
+      type: api_reference
+    - title: OAuth
+      url: https://developers.hubspot.com/docs/api/oauth-quickstart-guide
+      type: authentication_guide
+    - title: Rate limits
+      url: https://developers.hubspot.com/docs/api/usage-details
+      type: rate_limits
+    - title: HubSpot Status
+      url: https://status.hubspot.com/
+      type: status_page
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-hubspot/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-hubspot/metadata.yaml
@@ -1,7 +1,7 @@
 data:
   allowedHosts:
     hosts:
-      - api.hubapi.com
+    - api.hubapi.com
   registryOverrides:
     cloud:
       enabled: true
@@ -21,12 +21,25 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/hubspot
   tags:
-    - language:java
+  - language:java
   ab_internal:
     sl: 100
     ql: 100
     isEnterprise: false
   supportLevel: certified
   supportsDataActivation: true
-  supportsRefreshes: true # needed for the CDK to work as it relies on the generation/sync ids to work
-metadataSpecVersion: "1.0"
+  supportsRefreshes: true
+  externalDocumentationUrls:
+  - title: HubSpot API documentation
+    url: https://developers.hubspot.com/docs/api/overview
+    type: api_reference
+  - title: OAuth
+    url: https://developers.hubspot.com/docs/api/oauth-quickstart-guide
+    type: authentication_guide
+  - title: Rate limits
+    url: https://developers.hubspot.com/docs/api/usage-details
+    type: rate_limits
+  - title: HubSpot Status
+    url: https://status.hubspot.com/
+    type: status_page
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-iceberg/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-iceberg/metadata.yaml
@@ -16,7 +16,7 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/iceberg
   tags:
-    - language:java
+  - language:java
   ab_internal:
     sl: 100
     ql: 100
@@ -24,12 +24,19 @@ data:
   connectorBuildOptions:
     baseImage: docker.io/airbyte/java-connector-base:2.0.0@sha256:5a1a21c75c5e1282606de9fa539ba136520abe2fbd013058e988bb0297a9f454
   connectorTestSuitesOptions:
-    - suite: unitTests
-    - suite: integrationTests
-      testSecrets:
-        - name: SECRET_DESTINATION-ICEBERG_S3_GLUE_CONFIG
-          fileName: s3_glue_config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-metadataSpecVersion: "1.0"
+  - suite: unitTests
+  - suite: integrationTests
+    testSecrets:
+    - name: SECRET_DESTINATION-ICEBERG_S3_GLUE_CONFIG
+      fileName: s3_glue_config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+  - title: Apache Iceberg documentation
+    url: https://iceberg.apache.org/docs/latest/
+    type: api_reference
+  - title: Iceberg specification
+    url: https://iceberg.apache.org/spec/
+    type: api_reference
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-iceberg/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-iceberg/metadata.yaml
@@ -16,7 +16,7 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/iceberg
   tags:
-  - language:java
+    - language:java
   ab_internal:
     sl: 100
     ql: 100
@@ -24,19 +24,19 @@ data:
   connectorBuildOptions:
     baseImage: docker.io/airbyte/java-connector-base:2.0.0@sha256:5a1a21c75c5e1282606de9fa539ba136520abe2fbd013058e988bb0297a9f454
   connectorTestSuitesOptions:
-  - suite: unitTests
-  - suite: integrationTests
-    testSecrets:
-    - name: SECRET_DESTINATION-ICEBERG_S3_GLUE_CONFIG
-      fileName: s3_glue_config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION-ICEBERG_S3_GLUE_CONFIG
+          fileName: s3_glue_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
   externalDocumentationUrls:
-  - title: Apache Iceberg documentation
-    url: https://iceberg.apache.org/docs/latest/
-    type: api_reference
-  - title: Iceberg specification
-    url: https://iceberg.apache.org/spec/
-    type: api_reference
-metadataSpecVersion: '1.0'
+    - title: Apache Iceberg documentation
+      url: https://iceberg.apache.org/docs/latest/
+      type: api_reference
+    - title: Iceberg specification
+      url: https://iceberg.apache.org/spec/
+      type: api_reference
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-kafka/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-kafka/metadata.yaml
@@ -12,19 +12,29 @@ data:
   name: Kafka
   registryOverrides:
     cloud:
-      enabled: false # hide Kafka Destination https://github.com/airbytehq/airbyte-cloud/issues/2610
+      enabled: false
     oss:
       enabled: true
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/kafka
   tags:
-    - language:java
+  - language:java
   ab_internal:
     sl: 100
     ql: 100
     requireVersionIncrementsInPullRequests: false
   supportLevel: community
   connectorTestSuitesOptions:
-    - suite: unitTests
-    - suite: integrationTests
-metadataSpecVersion: "1.0"
+  - suite: unitTests
+  - suite: integrationTests
+  externalDocumentationUrls:
+  - title: Apache Kafka documentation
+    url: https://kafka.apache.org/documentation/
+    type: api_reference
+  - title: Security
+    url: https://kafka.apache.org/documentation/#security
+    type: authentication_guide
+  - title: Quotas
+    url: https://kafka.apache.org/documentation/#design_quotas
+    type: rate_limits
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-kafka/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-kafka/metadata.yaml
@@ -18,23 +18,23 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/kafka
   tags:
-  - language:java
+    - language:java
   ab_internal:
     sl: 100
     ql: 100
     requireVersionIncrementsInPullRequests: false
   supportLevel: community
   connectorTestSuitesOptions:
-  - suite: unitTests
-  - suite: integrationTests
+    - suite: unitTests
+    - suite: integrationTests
   externalDocumentationUrls:
-  - title: Apache Kafka documentation
-    url: https://kafka.apache.org/documentation/
-    type: api_reference
-  - title: Security
-    url: https://kafka.apache.org/documentation/#security
-    type: authentication_guide
-  - title: Quotas
-    url: https://kafka.apache.org/documentation/#design_quotas
-    type: rate_limits
-metadataSpecVersion: '1.0'
+    - title: Apache Kafka documentation
+      url: https://kafka.apache.org/documentation/
+      type: api_reference
+    - title: Security
+      url: https://kafka.apache.org/documentation/#security
+      type: authentication_guide
+    - title: Quotas
+      url: https://kafka.apache.org/documentation/#design_quotas
+      type: rate_limits
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-kafka/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-kafka/metadata.yaml
@@ -12,7 +12,7 @@ data:
   name: Kafka
   registryOverrides:
     cloud:
-      enabled: false
+      enabled: false # hide Kafka Destination https://github.com/airbytehq/airbyte-cloud/issues/2610
     oss:
       enabled: true
   releaseStage: alpha

--- a/airbyte-integrations/connectors/destination-keen/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-keen/metadata.yaml
@@ -16,9 +16,16 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/keen
   tags:
-    - language:java
+  - language:java
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: archived
-metadataSpecVersion: "1.0"
+  externalDocumentationUrls:
+  - title: Keen documentation
+    url: https://keen.io/docs/
+    type: api_reference
+  - title: Authentication
+    url: https://keen.io/docs/api/#authentication
+    type: authentication_guide
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-keen/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-keen/metadata.yaml
@@ -16,16 +16,16 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/keen
   tags:
-  - language:java
+    - language:java
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: archived
   externalDocumentationUrls:
-  - title: Keen documentation
-    url: https://keen.io/docs/
-    type: api_reference
-  - title: Authentication
-    url: https://keen.io/docs/api/#authentication
-    type: authentication_guide
-metadataSpecVersion: '1.0'
+    - title: Keen documentation
+      url: https://keen.io/docs/
+      type: api_reference
+    - title: Authentication
+      url: https://keen.io/docs/api/#authentication
+      type: authentication_guide
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-kinesis/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-kinesis/metadata.yaml
@@ -16,9 +16,25 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/kinesis
   tags:
-    - language:java
+  - language:java
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: archived
-metadataSpecVersion: "1.0"
+  externalDocumentationUrls:
+  - title: Kinesis documentation
+    url: https://docs.aws.amazon.com/kinesis/
+    type: api_reference
+  - title: IAM authentication
+    url: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html
+    type: authentication_guide
+  - title: IAM policies
+    url: https://docs.aws.amazon.com/streams/latest/dev/controlling-access.html
+    type: permissions_scopes
+  - title: Quotas and limits
+    url: https://docs.aws.amazon.com/streams/latest/dev/service-sizes-and-limits.html
+    type: rate_limits
+  - title: AWS Service Health Dashboard
+    url: https://health.aws.amazon.com/health/status
+    type: status_page
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-kinesis/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-kinesis/metadata.yaml
@@ -16,25 +16,25 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/kinesis
   tags:
-  - language:java
+    - language:java
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: archived
   externalDocumentationUrls:
-  - title: Kinesis documentation
-    url: https://docs.aws.amazon.com/kinesis/
-    type: api_reference
-  - title: IAM authentication
-    url: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html
-    type: authentication_guide
-  - title: IAM policies
-    url: https://docs.aws.amazon.com/streams/latest/dev/controlling-access.html
-    type: permissions_scopes
-  - title: Quotas and limits
-    url: https://docs.aws.amazon.com/streams/latest/dev/service-sizes-and-limits.html
-    type: rate_limits
-  - title: AWS Service Health Dashboard
-    url: https://health.aws.amazon.com/health/status
-    type: status_page
-metadataSpecVersion: '1.0'
+    - title: Kinesis documentation
+      url: https://docs.aws.amazon.com/kinesis/
+      type: api_reference
+    - title: IAM authentication
+      url: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html
+      type: authentication_guide
+    - title: IAM policies
+      url: https://docs.aws.amazon.com/streams/latest/dev/controlling-access.html
+      type: permissions_scopes
+    - title: Quotas and limits
+      url: https://docs.aws.amazon.com/streams/latest/dev/service-sizes-and-limits.html
+      type: rate_limits
+    - title: AWS Service Health Dashboard
+      url: https://health.aws.amazon.com/health/status
+      type: status_page
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-kvdb/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-kvdb/metadata.yaml
@@ -19,12 +19,16 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/kvdb
   tags:
-    - language:python
-    - cdk:python
+  - language:python
+  - cdk:python
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
-    - suite: unitTests
-metadataSpecVersion: "1.0"
+  - suite: unitTests
+  externalDocumentationUrls:
+  - title: KVDB documentation
+    url: https://kvdb.io/
+    type: api_reference
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-kvdb/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-kvdb/metadata.yaml
@@ -19,16 +19,16 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/kvdb
   tags:
-  - language:python
-  - cdk:python
+    - language:python
+    - cdk:python
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
-  - suite: unitTests
+    - suite: unitTests
   externalDocumentationUrls:
-  - title: KVDB documentation
-    url: https://kvdb.io/
-    type: api_reference
-metadataSpecVersion: '1.0'
+    - title: KVDB documentation
+      url: https://kvdb.io/
+      type: api_reference
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-langchain/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-langchain/metadata.yaml
@@ -26,12 +26,8 @@ data:
   releases:
     breakingChanges:
       0.1.0:
-        message:
-          "This version changes the way record ids are tracked internally.
-          If you are using a stream in **append-dedup** mode, you need to reset the
-          connection after doing the upgrade to avoid duplicates.
-
-          "
+        message: >
+          This version changes the way record ids are tracked internally. If you are using a stream in **append-dedup** mode, you need to reset the connection after doing the upgrade to avoid duplicates.
         upgradeDeadline: "2023-09-18"
   connectorTestSuitesOptions:
     - suite: unitTests

--- a/airbyte-integrations/connectors/destination-langchain/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-langchain/metadata.yaml
@@ -17,8 +17,8 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/langchain
   tags:
-  - language:python
-  - cdk:python
+    - language:python
+    - cdk:python
   ab_internal:
     sl: 100
     ql: 100
@@ -26,23 +26,24 @@ data:
   releases:
     breakingChanges:
       0.1.0:
-        message: 'This version changes the way record ids are tracked internally.
+        message:
+          "This version changes the way record ids are tracked internally.
           If you are using a stream in **append-dedup** mode, you need to reset the
           connection after doing the upgrade to avoid duplicates.
 
-          '
-        upgradeDeadline: '2023-09-18'
+          "
+        upgradeDeadline: "2023-09-18"
   connectorTestSuitesOptions:
-  - suite: unitTests
-  - suite: integrationTests
-    testSecrets:
-    - name: SECRET_DESTINATION-LANGCHAIN_CREDS
-      fileName: config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION-LANGCHAIN_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
   externalDocumentationUrls:
-  - title: LangChain documentation
-    url: https://python.langchain.com/docs/get_started/introduction
-    type: api_reference
-metadataSpecVersion: '1.0'
+    - title: LangChain documentation
+      url: https://python.langchain.com/docs/get_started/introduction
+      type: api_reference
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-langchain/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-langchain/metadata.yaml
@@ -17,8 +17,8 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/langchain
   tags:
-    - language:python
-    - cdk:python
+  - language:python
+  - cdk:python
   ab_internal:
     sl: 100
     ql: 100
@@ -26,16 +26,23 @@ data:
   releases:
     breakingChanges:
       0.1.0:
-        message: >
-          This version changes the way record ids are tracked internally. If you are using a stream in **append-dedup** mode, you need to reset the connection after doing the upgrade to avoid duplicates.
-        upgradeDeadline: "2023-09-18"
+        message: 'This version changes the way record ids are tracked internally.
+          If you are using a stream in **append-dedup** mode, you need to reset the
+          connection after doing the upgrade to avoid duplicates.
+
+          '
+        upgradeDeadline: '2023-09-18'
   connectorTestSuitesOptions:
-    - suite: unitTests
-    - suite: integrationTests
-      testSecrets:
-        - name: SECRET_DESTINATION-LANGCHAIN_CREDS
-          fileName: config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-metadataSpecVersion: "1.0"
+  - suite: unitTests
+  - suite: integrationTests
+    testSecrets:
+    - name: SECRET_DESTINATION-LANGCHAIN_CREDS
+      fileName: config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+  - title: LangChain documentation
+    url: https://python.langchain.com/docs/get_started/introduction
+    type: api_reference
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-local-json/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-local-json/metadata.yaml
@@ -7,8 +7,8 @@ data:
     baseImage: docker.io/airbyte/java-connector-base:2.0.1@sha256:ec89bd1a89e825514dd2fc8730ba299a3ae1544580a078df0e35c5202c2085b3
   connectorSubtype: file
   connectorTestSuitesOptions:
-    - suite: unitTests
-    - suite: integrationTests
+  - suite: unitTests
+  - suite: integrationTests
   connectorType: destination
   definitionId: a625d593-bba5-4a1c-a53d-2d246268a816
   dockerImageTag: 0.2.13
@@ -26,5 +26,9 @@ data:
   releaseStage: alpha
   supportLevel: community
   tags:
-    - language:java
-metadataSpecVersion: "1.0"
+  - language:java
+  externalDocumentationUrls:
+  - title: JSON specification
+    url: https://www.json.org/
+    type: api_reference
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-local-json/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-local-json/metadata.yaml
@@ -7,8 +7,8 @@ data:
     baseImage: docker.io/airbyte/java-connector-base:2.0.1@sha256:ec89bd1a89e825514dd2fc8730ba299a3ae1544580a078df0e35c5202c2085b3
   connectorSubtype: file
   connectorTestSuitesOptions:
-  - suite: unitTests
-  - suite: integrationTests
+    - suite: unitTests
+    - suite: integrationTests
   connectorType: destination
   definitionId: a625d593-bba5-4a1c-a53d-2d246268a816
   dockerImageTag: 0.2.13
@@ -26,9 +26,9 @@ data:
   releaseStage: alpha
   supportLevel: community
   tags:
-  - language:java
+    - language:java
   externalDocumentationUrls:
-  - title: JSON specification
-    url: https://www.json.org/
-    type: api_reference
-metadataSpecVersion: '1.0'
+    - title: JSON specification
+      url: https://www.json.org/
+      type: api_reference
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-mariadb-columnstore/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mariadb-columnstore/metadata.yaml
@@ -16,16 +16,16 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/mariadb-columnstore
   tags:
-  - language:java
+    - language:java
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: archived
   externalDocumentationUrls:
-  - title: MariaDB ColumnStore documentation
-    url: https://mariadb.com/kb/en/mariadb-columnstore/
-    type: api_reference
-  - title: SQL reference
-    url: https://mariadb.com/kb/en/sql-statements/
-    type: sql_reference
-metadataSpecVersion: '1.0'
+    - title: MariaDB ColumnStore documentation
+      url: https://mariadb.com/kb/en/mariadb-columnstore/
+      type: api_reference
+    - title: SQL reference
+      url: https://mariadb.com/kb/en/sql-statements/
+      type: sql_reference
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-mariadb-columnstore/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mariadb-columnstore/metadata.yaml
@@ -16,9 +16,16 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/mariadb-columnstore
   tags:
-    - language:java
+  - language:java
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: archived
-metadataSpecVersion: "1.0"
+  externalDocumentationUrls:
+  - title: MariaDB ColumnStore documentation
+    url: https://mariadb.com/kb/en/mariadb-columnstore/
+    type: api_reference
+  - title: SQL reference
+    url: https://mariadb.com/kb/en/sql-statements/
+    type: sql_reference
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-meilisearch/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-meilisearch/metadata.yaml
@@ -16,8 +16,8 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/meilisearch
   tags:
-  - language:python
-  - cdk:python
+    - language:python
+    - cdk:python
   ab_internal:
     sl: 100
     ql: 100
@@ -25,19 +25,19 @@ data:
   connectorBuildOptions:
     baseImage: docker.io/airbyte/python-connector-base:4.0.0@sha256:d9894b6895923b379f3006fa251147806919c62b7d9021b5cd125bb67d7bbe22
   connectorTestSuitesOptions:
-  - suite: unitTests
-  - suite: integrationTests
-    testSecrets:
-    - name: SECRET_DESTINATION_MEILISEARCH_CREDS
-      fileName: config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION_MEILISEARCH_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
   externalDocumentationUrls:
-  - title: Meilisearch documentation
-    url: https://www.meilisearch.com/docs
-    type: api_reference
-  - title: Authentication
-    url: https://www.meilisearch.com/docs/learn/security/master_api_keys
-    type: authentication_guide
-metadataSpecVersion: '1.0'
+    - title: Meilisearch documentation
+      url: https://www.meilisearch.com/docs
+      type: api_reference
+    - title: Authentication
+      url: https://www.meilisearch.com/docs/learn/security/master_api_keys
+      type: authentication_guide
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-meilisearch/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-meilisearch/metadata.yaml
@@ -16,8 +16,8 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/meilisearch
   tags:
-    - language:python
-    - cdk:python
+  - language:python
+  - cdk:python
   ab_internal:
     sl: 100
     ql: 100
@@ -25,12 +25,19 @@ data:
   connectorBuildOptions:
     baseImage: docker.io/airbyte/python-connector-base:4.0.0@sha256:d9894b6895923b379f3006fa251147806919c62b7d9021b5cd125bb67d7bbe22
   connectorTestSuitesOptions:
-    - suite: unitTests
-    - suite: integrationTests
-      testSecrets:
-        - name: SECRET_DESTINATION_MEILISEARCH_CREDS
-          fileName: config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-metadataSpecVersion: "1.0"
+  - suite: unitTests
+  - suite: integrationTests
+    testSecrets:
+    - name: SECRET_DESTINATION_MEILISEARCH_CREDS
+      fileName: config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+  - title: Meilisearch documentation
+    url: https://www.meilisearch.com/docs
+    type: api_reference
+  - title: Authentication
+    url: https://www.meilisearch.com/docs/learn/security/master_api_keys
+    type: authentication_guide
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-milvus/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-milvus/metadata.yaml
@@ -1,10 +1,10 @@
 data:
   allowedHosts:
     hosts:
-      - "${indexing.host}"
-      - api.openai.com
-      - api.cohere.ai
-      - "${embedding.api_base}"
+    - ${indexing.host}
+    - api.openai.com
+    - api.cohere.ai
+    - ${embedding.api_base}
   registryOverrides:
     cloud:
       enabled: true
@@ -12,11 +12,10 @@ data:
       enabled: true
   resourceRequirements:
     jobSpecific:
-      - jobType: sync
-        # TODO: Remove once https://github.com/airbytehq/airbyte/issues/30611 is resolved
-        resourceRequirements:
-          memory_limit: 2Gi
-          memory_request: 2Gi
+    - jobType: sync
+      resourceRequirements:
+        memory_limit: 2Gi
+        memory_request: 2Gi
   connectorBuildOptions:
     baseImage: docker.io/airbyte/python-connector-base:4.0.2@sha256:9fdb1888c4264cf6fee473649ecb593f56f58e5d0096a87ee0b231777e2e3e73
   connectorSubtype: vectorstore
@@ -32,26 +31,36 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/milvus
   tags:
-    - language:python
-    - cdk:python
+  - language:python
+  - cdk:python
   ab_internal:
     sl: 300
     ql: 300
   supportLevel: certified
   connectorTestSuitesOptions:
-    - suite: unitTests
-    - suite: integrationTests
-      testSecrets:
-        - name: SECRET_DESTINATION-MILVUS_CREDS
-          fileName: config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-    - suite: acceptanceTests
-      testSecrets:
-        - name: SECRET_DESTINATION-MILVUS_CREDS
-          fileName: config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-metadataSpecVersion: "1.0"
+  - suite: unitTests
+  - suite: integrationTests
+    testSecrets:
+    - name: SECRET_DESTINATION-MILVUS_CREDS
+      fileName: config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+  - suite: acceptanceTests
+    testSecrets:
+    - name: SECRET_DESTINATION-MILVUS_CREDS
+      fileName: config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+  - title: Milvus documentation
+    url: https://milvus.io/docs
+    type: api_reference
+  - title: Authentication
+    url: https://milvus.io/docs/authenticate.md
+    type: authentication_guide
+  - title: Release notes
+    url: https://milvus.io/docs/release_notes.md
+    type: api_release_history
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-milvus/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-milvus/metadata.yaml
@@ -1,10 +1,10 @@
 data:
   allowedHosts:
     hosts:
-    - ${indexing.host}
-    - api.openai.com
-    - api.cohere.ai
-    - ${embedding.api_base}
+      - ${indexing.host}
+      - api.openai.com
+      - api.cohere.ai
+      - ${embedding.api_base}
   registryOverrides:
     cloud:
       enabled: true
@@ -12,10 +12,10 @@ data:
       enabled: true
   resourceRequirements:
     jobSpecific:
-    - jobType: sync
-      resourceRequirements:
-        memory_limit: 2Gi
-        memory_request: 2Gi
+      - jobType: sync
+        resourceRequirements:
+          memory_limit: 2Gi
+          memory_request: 2Gi
   connectorBuildOptions:
     baseImage: docker.io/airbyte/python-connector-base:4.0.2@sha256:9fdb1888c4264cf6fee473649ecb593f56f58e5d0096a87ee0b231777e2e3e73
   connectorSubtype: vectorstore
@@ -31,36 +31,36 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/milvus
   tags:
-  - language:python
-  - cdk:python
+    - language:python
+    - cdk:python
   ab_internal:
     sl: 300
     ql: 300
   supportLevel: certified
   connectorTestSuitesOptions:
-  - suite: unitTests
-  - suite: integrationTests
-    testSecrets:
-    - name: SECRET_DESTINATION-MILVUS_CREDS
-      fileName: config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
-  - suite: acceptanceTests
-    testSecrets:
-    - name: SECRET_DESTINATION-MILVUS_CREDS
-      fileName: config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION-MILVUS_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_DESTINATION-MILVUS_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
   externalDocumentationUrls:
-  - title: Milvus documentation
-    url: https://milvus.io/docs
-    type: api_reference
-  - title: Authentication
-    url: https://milvus.io/docs/authenticate.md
-    type: authentication_guide
-  - title: Release notes
-    url: https://milvus.io/docs/release_notes.md
-    type: api_release_history
-metadataSpecVersion: '1.0'
+    - title: Milvus documentation
+      url: https://milvus.io/docs
+      type: api_reference
+    - title: Authentication
+      url: https://milvus.io/docs/authenticate.md
+      type: authentication_guide
+    - title: Release notes
+      url: https://milvus.io/docs/release_notes.md
+      type: api_release_history
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-mongodb-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mongodb-strict-encrypt/metadata.yaml
@@ -5,9 +5,9 @@ data:
     baseImage: docker.io/airbyte/java-connector-base:2.0.2@sha256:f8e47304842a2c4d75ac223cf4b3c4117aa1c5c9207149369d296616815fe5b0
   registryOverrides:
     cloud:
-      enabled: false # strict encrypt connectors are deployed to Cloud by their non strict encrypt sibling.
+      enabled: false
     oss:
-      enabled: false # strict encrypt connectors are not used on OSS.
+      enabled: false
   connectorSubtype: database
   connectorType: destination
   definitionId: 8b746512-8c2e-6ac1-4adc-b59faafd473c
@@ -20,14 +20,27 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/mongodb
   tags:
-    - language:java
+  - language:java
   connectorTestSuitesOptions:
-    - suite: unitTests
-    - suite: integrationTests
-      testSecrets:
-        - name: SECRET_DESTINATION-MONGODB-STRICT-ENCRYPT_CREDENTIALS__CREDS
-          fileName: credentials.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-metadataSpecVersion: "1.0"
+  - suite: unitTests
+  - suite: integrationTests
+    testSecrets:
+    - name: SECRET_DESTINATION-MONGODB-STRICT-ENCRYPT_CREDENTIALS__CREDS
+      fileName: credentials.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+  - title: MongoDB documentation
+    url: https://www.mongodb.com/docs/
+    type: api_reference
+  - title: Authentication
+    url: https://www.mongodb.com/docs/manual/core/authentication/
+    type: authentication_guide
+  - title: Role-based access control
+    url: https://www.mongodb.com/docs/manual/core/authorization/
+    type: permissions_scopes
+  - title: MongoDB Status
+    url: https://status.mongodb.com/
+    type: status_page
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-mongodb-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mongodb-strict-encrypt/metadata.yaml
@@ -20,27 +20,27 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/mongodb
   tags:
-  - language:java
+    - language:java
   connectorTestSuitesOptions:
-  - suite: unitTests
-  - suite: integrationTests
-    testSecrets:
-    - name: SECRET_DESTINATION-MONGODB-STRICT-ENCRYPT_CREDENTIALS__CREDS
-      fileName: credentials.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION-MONGODB-STRICT-ENCRYPT_CREDENTIALS__CREDS
+          fileName: credentials.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
   externalDocumentationUrls:
-  - title: MongoDB documentation
-    url: https://www.mongodb.com/docs/
-    type: api_reference
-  - title: Authentication
-    url: https://www.mongodb.com/docs/manual/core/authentication/
-    type: authentication_guide
-  - title: Role-based access control
-    url: https://www.mongodb.com/docs/manual/core/authorization/
-    type: permissions_scopes
-  - title: MongoDB Status
-    url: https://status.mongodb.com/
-    type: status_page
-metadataSpecVersion: '1.0'
+    - title: MongoDB documentation
+      url: https://www.mongodb.com/docs/
+      type: api_reference
+    - title: Authentication
+      url: https://www.mongodb.com/docs/manual/core/authentication/
+      type: authentication_guide
+    - title: Role-based access control
+      url: https://www.mongodb.com/docs/manual/core/authorization/
+      type: permissions_scopes
+    - title: MongoDB Status
+      url: https://status.mongodb.com/
+      type: status_page
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-mongodb-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mongodb-strict-encrypt/metadata.yaml
@@ -5,9 +5,9 @@ data:
     baseImage: docker.io/airbyte/java-connector-base:2.0.2@sha256:f8e47304842a2c4d75ac223cf4b3c4117aa1c5c9207149369d296616815fe5b0
   registryOverrides:
     cloud:
-      enabled: false
+      enabled: false # strict encrypt connectors are deployed to Cloud by their non strict encrypt sibling.
     oss:
-      enabled: false
+      enabled: false # strict encrypt connectors are not used on OSS.
   connectorSubtype: database
   connectorType: destination
   definitionId: 8b746512-8c2e-6ac1-4adc-b59faafd473c

--- a/airbyte-integrations/connectors/destination-mongodb/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mongodb/metadata.yaml
@@ -19,13 +19,26 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/mongodb
   tags:
-    - language:java
+  - language:java
   ab_internal:
     sl: 100
     ql: 100
     requireVersionIncrementsInPullRequests: false
   supportLevel: community
   connectorTestSuitesOptions:
-    - suite: unitTests
-    - suite: integrationTests
-metadataSpecVersion: "1.0"
+  - suite: unitTests
+  - suite: integrationTests
+  externalDocumentationUrls:
+  - title: MongoDB documentation
+    url: https://www.mongodb.com/docs/
+    type: api_reference
+  - title: Authentication
+    url: https://www.mongodb.com/docs/manual/core/authentication/
+    type: authentication_guide
+  - title: Role-based access control
+    url: https://www.mongodb.com/docs/manual/core/authorization/
+    type: permissions_scopes
+  - title: MongoDB Status
+    url: https://status.mongodb.com/
+    type: status_page
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-mongodb/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mongodb/metadata.yaml
@@ -19,26 +19,26 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/mongodb
   tags:
-  - language:java
+    - language:java
   ab_internal:
     sl: 100
     ql: 100
     requireVersionIncrementsInPullRequests: false
   supportLevel: community
   connectorTestSuitesOptions:
-  - suite: unitTests
-  - suite: integrationTests
+    - suite: unitTests
+    - suite: integrationTests
   externalDocumentationUrls:
-  - title: MongoDB documentation
-    url: https://www.mongodb.com/docs/
-    type: api_reference
-  - title: Authentication
-    url: https://www.mongodb.com/docs/manual/core/authentication/
-    type: authentication_guide
-  - title: Role-based access control
-    url: https://www.mongodb.com/docs/manual/core/authorization/
-    type: permissions_scopes
-  - title: MongoDB Status
-    url: https://status.mongodb.com/
-    type: status_page
-metadataSpecVersion: '1.0'
+    - title: MongoDB documentation
+      url: https://www.mongodb.com/docs/
+      type: api_reference
+    - title: Authentication
+      url: https://www.mongodb.com/docs/manual/core/authentication/
+      type: authentication_guide
+    - title: Role-based access control
+      url: https://www.mongodb.com/docs/manual/core/authorization/
+      type: permissions_scopes
+    - title: MongoDB Status
+      url: https://status.mongodb.com/
+      type: status_page
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-motherduck/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-motherduck/metadata.yaml
@@ -24,46 +24,46 @@ data:
       packageName: airbyte-destination-motherduck
   resourceRequirements:
     jobSpecific:
-    - jobType: check_connection
-      resourceRequirements:
-        memory_limit: 800Mi
-        memory_request: 800Mi
-    - jobType: sync
-      resourceRequirements:
-        memory_limit: 2Gi
-        memory_request: 2Gi
+      - jobType: check_connection
+        resourceRequirements:
+          memory_limit: 800Mi
+          memory_request: 800Mi
+      - jobType: sync
+        resourceRequirements:
+          memory_limit: 2Gi
+          memory_request: 2Gi
   documentationUrl: https://docs.airbyte.com/integrations/destinations/motherduck
   tags:
-  - language:python
-  - cdk:python
+    - language:python
+    - cdk:python
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
-  - suite: unitTests
-  - suite: integrationTests
-    testSecrets:
-    - name: SECRET_DESTINATION_DUCKDB__MOTHERDUCK__CREDS
-      fileName: config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
-  - suite: acceptanceTests
-    testSecrets:
-    - name: SECRET_DESTINATION_DUCKDB__MOTHERDUCK__CREDS
-      fileName: config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION_DUCKDB__MOTHERDUCK__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_DESTINATION_DUCKDB__MOTHERDUCK__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
   externalDocumentationUrls:
-  - title: MotherDuck documentation
-    url: https://motherduck.com/docs
-    type: api_reference
-  - title: Authentication
-    url: https://motherduck.com/docs/key-tasks/authenticating-and-connecting-to-motherduck/
-    type: authentication_guide
-  - title: MotherDuck Status
-    url: https://status.motherduck.com/
-    type: status_page
-metadataSpecVersion: '1.0'
+    - title: MotherDuck documentation
+      url: https://motherduck.com/docs
+      type: api_reference
+    - title: Authentication
+      url: https://motherduck.com/docs/key-tasks/authenticating-and-connecting-to-motherduck/
+      type: authentication_guide
+    - title: MotherDuck Status
+      url: https://status.motherduck.com/
+      type: status_page
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-motherduck/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-motherduck/metadata.yaml
@@ -24,36 +24,46 @@ data:
       packageName: airbyte-destination-motherduck
   resourceRequirements:
     jobSpecific:
-      - jobType: check_connection
-        resourceRequirements:
-          memory_limit: 800Mi
-          memory_request: 800Mi
-      - jobType: sync
-        resourceRequirements:
-          memory_limit: 2Gi
-          memory_request: 2Gi
+    - jobType: check_connection
+      resourceRequirements:
+        memory_limit: 800Mi
+        memory_request: 800Mi
+    - jobType: sync
+      resourceRequirements:
+        memory_limit: 2Gi
+        memory_request: 2Gi
   documentationUrl: https://docs.airbyte.com/integrations/destinations/motherduck
   tags:
-    - language:python
-    - cdk:python
+  - language:python
+  - cdk:python
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
-    - suite: unitTests
-    - suite: integrationTests
-      testSecrets:
-        - name: SECRET_DESTINATION_DUCKDB__MOTHERDUCK__CREDS
-          fileName: config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-    - suite: acceptanceTests
-      testSecrets:
-        - name: SECRET_DESTINATION_DUCKDB__MOTHERDUCK__CREDS
-          fileName: config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-metadataSpecVersion: "1.0"
+  - suite: unitTests
+  - suite: integrationTests
+    testSecrets:
+    - name: SECRET_DESTINATION_DUCKDB__MOTHERDUCK__CREDS
+      fileName: config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+  - suite: acceptanceTests
+    testSecrets:
+    - name: SECRET_DESTINATION_DUCKDB__MOTHERDUCK__CREDS
+      fileName: config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+  - title: MotherDuck documentation
+    url: https://motherduck.com/docs
+    type: api_reference
+  - title: Authentication
+    url: https://motherduck.com/docs/key-tasks/authenticating-and-connecting-to-motherduck/
+    type: authentication_guide
+  - title: MotherDuck Status
+    url: https://status.motherduck.com/
+    type: status_page
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-mqtt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mqtt/metadata.yaml
@@ -16,13 +16,13 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/mqtt
   tags:
-  - language:java
+    - language:java
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: archived
   externalDocumentationUrls:
-  - title: MQTT specification
-    url: https://mqtt.org/mqtt-specification/
-    type: api_reference
-metadataSpecVersion: '1.0'
+    - title: MQTT specification
+      url: https://mqtt.org/mqtt-specification/
+      type: api_reference
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-mqtt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mqtt/metadata.yaml
@@ -16,9 +16,13 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/mqtt
   tags:
-    - language:java
+  - language:java
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: archived
-metadataSpecVersion: "1.0"
+  externalDocumentationUrls:
+  - title: MQTT specification
+    url: https://mqtt.org/mqtt-specification/
+    type: api_reference
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-mssql/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mssql/metadata.yaml
@@ -7,14 +7,14 @@ data:
     baseImage: docker.io/airbyte/java-connector-base:2.0.1@sha256:ec89bd1a89e825514dd2fc8730ba299a3ae1544580a078df0e35c5202c2085b3
   connectorSubtype: database
   connectorTestSuitesOptions:
-    - suite: unitTests
-    - suite: integrationTests
-      testSecrets:
-        - fileName: bulk_upload_config.json
-          name: SECRET_DESTINATION_MSSQL_V2_BULK_LOAD_CONFIG
-          secretStore:
-            alias: airbyte-connector-testing-secret-store
-            type: GSM
+  - suite: unitTests
+  - suite: integrationTests
+    testSecrets:
+    - fileName: bulk_upload_config.json
+      name: SECRET_DESTINATION_MSSQL_V2_BULK_LOAD_CONFIG
+      secretStore:
+        alias: airbyte-connector-testing-secret-store
+        type: GSM
   connectorType: destination
   definitionId: d4353156-9217-4cad-8dd7-c108fd4f74cf
   dockerImageTag: 2.2.14
@@ -32,18 +32,30 @@ data:
   releases:
     breakingChanges:
       2.0.0:
-        message: >
-          'This version introduces new configuration options (bulk insert via Azure Cloud Storage) and removes
-           the use of a raw table prior to final insertion in the destination table.  These changes will either
-           require the execution of a truncate refresh on an existing connection or the creation of a new connection.
-           If a new connection is set up, you may delete the old connection and the raw table in the destination after
-          a successful initial sync of the new connection.
-
-          '
-        upgradeDeadline: "2025-09-11"
+        message: "'This version introduces new configuration options (bulk insert\
+          \ via Azure Cloud Storage) and removes\n the use of a raw table prior to\
+          \ final insertion in the destination table.  These changes will either\n\
+          \ require the execution of a truncate refresh on an existing connection\
+          \ or the creation of a new connection.\n If a new connection is set up,\
+          \ you may delete the old connection and the raw table in the destination\
+          \ after\na successful initial sync of the new connection.\n'\n"
+        upgradeDeadline: '2025-09-11'
   releaseStage: generally_available
   supportLevel: certified
   supportsRefreshes: true
   tags:
-    - language:java
-metadataSpecVersion: "1.0"
+  - language:java
+  externalDocumentationUrls:
+  - title: SQL Server documentation
+    url: https://learn.microsoft.com/en-us/sql/sql-server/
+    type: api_reference
+  - title: Transact-SQL reference
+    url: https://learn.microsoft.com/en-us/sql/t-sql/language-reference
+    type: sql_reference
+  - title: Authentication and authorization
+    url: https://learn.microsoft.com/en-us/sql/relational-databases/security/authentication-access/getting-started-with-database-engine-permissions
+    type: authentication_guide
+  - title: Permissions
+    url: https://learn.microsoft.com/en-us/sql/relational-databases/security/permissions-database-engine
+    type: permissions_scopes
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-mssql/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mssql/metadata.yaml
@@ -32,14 +32,14 @@ data:
   releases:
     breakingChanges:
       2.0.0:
-        message:
-          "'This version introduces new configuration options (bulk insert\
-          \ via Azure Cloud Storage) and removes\n the use of a raw table prior to\
-          \ final insertion in the destination table.  These changes will either\n\
-          \ require the execution of a truncate refresh on an existing connection\
-          \ or the creation of a new connection.\n If a new connection is set up,\
-          \ you may delete the old connection and the raw table in the destination\
-          \ after\na successful initial sync of the new connection.\n'\n"
+        message: >
+          'This version introduces new configuration options (bulk insert via Azure Cloud Storage) and removes
+           the use of a raw table prior to final insertion in the destination table.  These changes will either
+           require the execution of a truncate refresh on an existing connection or the creation of a new connection.
+           If a new connection is set up, you may delete the old connection and the raw table in the destination after
+          a successful initial sync of the new connection.
+
+          '
         upgradeDeadline: "2025-09-11"
   releaseStage: generally_available
   supportLevel: certified

--- a/airbyte-integrations/connectors/destination-mssql/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mssql/metadata.yaml
@@ -7,14 +7,14 @@ data:
     baseImage: docker.io/airbyte/java-connector-base:2.0.1@sha256:ec89bd1a89e825514dd2fc8730ba299a3ae1544580a078df0e35c5202c2085b3
   connectorSubtype: database
   connectorTestSuitesOptions:
-  - suite: unitTests
-  - suite: integrationTests
-    testSecrets:
-    - fileName: bulk_upload_config.json
-      name: SECRET_DESTINATION_MSSQL_V2_BULK_LOAD_CONFIG
-      secretStore:
-        alias: airbyte-connector-testing-secret-store
-        type: GSM
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - fileName: bulk_upload_config.json
+          name: SECRET_DESTINATION_MSSQL_V2_BULK_LOAD_CONFIG
+          secretStore:
+            alias: airbyte-connector-testing-secret-store
+            type: GSM
   connectorType: destination
   definitionId: d4353156-9217-4cad-8dd7-c108fd4f74cf
   dockerImageTag: 2.2.14
@@ -32,30 +32,31 @@ data:
   releases:
     breakingChanges:
       2.0.0:
-        message: "'This version introduces new configuration options (bulk insert\
+        message:
+          "'This version introduces new configuration options (bulk insert\
           \ via Azure Cloud Storage) and removes\n the use of a raw table prior to\
           \ final insertion in the destination table.  These changes will either\n\
           \ require the execution of a truncate refresh on an existing connection\
           \ or the creation of a new connection.\n If a new connection is set up,\
           \ you may delete the old connection and the raw table in the destination\
           \ after\na successful initial sync of the new connection.\n'\n"
-        upgradeDeadline: '2025-09-11'
+        upgradeDeadline: "2025-09-11"
   releaseStage: generally_available
   supportLevel: certified
   supportsRefreshes: true
   tags:
-  - language:java
+    - language:java
   externalDocumentationUrls:
-  - title: SQL Server documentation
-    url: https://learn.microsoft.com/en-us/sql/sql-server/
-    type: api_reference
-  - title: Transact-SQL reference
-    url: https://learn.microsoft.com/en-us/sql/t-sql/language-reference
-    type: sql_reference
-  - title: Authentication and authorization
-    url: https://learn.microsoft.com/en-us/sql/relational-databases/security/authentication-access/getting-started-with-database-engine-permissions
-    type: authentication_guide
-  - title: Permissions
-    url: https://learn.microsoft.com/en-us/sql/relational-databases/security/permissions-database-engine
-    type: permissions_scopes
-metadataSpecVersion: '1.0'
+    - title: SQL Server documentation
+      url: https://learn.microsoft.com/en-us/sql/sql-server/
+      type: api_reference
+    - title: Transact-SQL reference
+      url: https://learn.microsoft.com/en-us/sql/t-sql/language-reference
+      type: sql_reference
+    - title: Authentication and authorization
+      url: https://learn.microsoft.com/en-us/sql/relational-databases/security/authentication-access/getting-started-with-database-engine-permissions
+      type: authentication_guide
+    - title: Permissions
+      url: https://learn.microsoft.com/en-us/sql/relational-databases/security/permissions-database-engine
+      type: permissions_scopes
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-mysql-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mysql-strict-encrypt/metadata.yaml
@@ -5,8 +5,8 @@ data:
     baseImage: docker.io/airbyte/java-connector-base:2.0.1@sha256:ec89bd1a89e825514dd2fc8730ba299a3ae1544580a078df0e35c5202c2085b3
   connectorSubtype: database
   connectorTestSuitesOptions:
-  - suite: unitTests
-  - suite: integrationTests
+    - suite: unitTests
+    - suite: integrationTests
   connectorType: destination
   definitionId: ca81ee7c-3163-4246-af40-094cc31e5e42
   dockerImageTag: 1.1.1
@@ -25,7 +25,8 @@ data:
   releases:
     breakingChanges:
       1.0.0:
-        message: '**Do not upgrade until you have run a test upgrade as outlined [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#testing-destinations-v2-for-a-single-connection)**.
+        message:
+          "**Do not upgrade until you have run a test upgrade as outlined [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#testing-destinations-v2-for-a-single-connection)**.
 
           This version introduces [Destinations V2](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#what-is-destinations-v2),
           which provides better error handling, incremental delivery of data for large
@@ -38,22 +39,22 @@ data:
           at their next sync. You can manually sync existing connections prior to
           the next scheduled sync to start the upgrade early.
 
-          '
-        upgradeDeadline: '2024-05-15'
+          "
+        upgradeDeadline: "2024-05-15"
   supportsDbt: true
   tags:
-  - language:java
+    - language:java
   externalDocumentationUrls:
-  - title: MySQL documentation
-    url: https://dev.mysql.com/doc/
-    type: api_reference
-  - title: SQL statement syntax
-    url: https://dev.mysql.com/doc/refman/8.0/en/sql-statements.html
-    type: sql_reference
-  - title: Access control and account management
-    url: https://dev.mysql.com/doc/refman/8.0/en/access-control.html
-    type: authentication_guide
-  - title: GRANT statement
-    url: https://dev.mysql.com/doc/refman/8.0/en/grant.html
-    type: permissions_scopes
-metadataSpecVersion: '1.0'
+    - title: MySQL documentation
+      url: https://dev.mysql.com/doc/
+      type: api_reference
+    - title: SQL statement syntax
+      url: https://dev.mysql.com/doc/refman/8.0/en/sql-statements.html
+      type: sql_reference
+    - title: Access control and account management
+      url: https://dev.mysql.com/doc/refman/8.0/en/access-control.html
+      type: authentication_guide
+    - title: GRANT statement
+      url: https://dev.mysql.com/doc/refman/8.0/en/grant.html
+      type: permissions_scopes
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-mysql-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mysql-strict-encrypt/metadata.yaml
@@ -5,8 +5,8 @@ data:
     baseImage: docker.io/airbyte/java-connector-base:2.0.1@sha256:ec89bd1a89e825514dd2fc8730ba299a3ae1544580a078df0e35c5202c2085b3
   connectorSubtype: database
   connectorTestSuitesOptions:
-    - suite: unitTests
-    - suite: integrationTests
+  - suite: unitTests
+  - suite: integrationTests
   connectorType: destination
   definitionId: ca81ee7c-3163-4246-af40-094cc31e5e42
   dockerImageTag: 1.1.1
@@ -25,8 +25,7 @@ data:
   releases:
     breakingChanges:
       1.0.0:
-        message:
-          "**Do not upgrade until you have run a test upgrade as outlined [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#testing-destinations-v2-for-a-single-connection)**.
+        message: '**Do not upgrade until you have run a test upgrade as outlined [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#testing-destinations-v2-for-a-single-connection)**.
 
           This version introduces [Destinations V2](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#what-is-destinations-v2),
           which provides better error handling, incremental delivery of data for large
@@ -39,9 +38,22 @@ data:
           at their next sync. You can manually sync existing connections prior to
           the next scheduled sync to start the upgrade early.
 
-          "
-        upgradeDeadline: "2024-05-15"
+          '
+        upgradeDeadline: '2024-05-15'
   supportsDbt: true
   tags:
-    - language:java
-metadataSpecVersion: "1.0"
+  - language:java
+  externalDocumentationUrls:
+  - title: MySQL documentation
+    url: https://dev.mysql.com/doc/
+    type: api_reference
+  - title: SQL statement syntax
+    url: https://dev.mysql.com/doc/refman/8.0/en/sql-statements.html
+    type: sql_reference
+  - title: Access control and account management
+    url: https://dev.mysql.com/doc/refman/8.0/en/access-control.html
+    type: authentication_guide
+  - title: GRANT statement
+    url: https://dev.mysql.com/doc/refman/8.0/en/grant.html
+    type: permissions_scopes
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-mysql/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mysql/metadata.yaml
@@ -7,19 +7,19 @@ data:
     baseImage: docker.io/airbyte/java-connector-base:2.0.1@sha256:ec89bd1a89e825514dd2fc8730ba299a3ae1544580a078df0e35c5202c2085b3
   connectorSubtype: database
   connectorTestSuitesOptions:
-    - suite: unitTests
-    - suite: integrationTests
-      testSecrets:
-        - fileName: ssh-key-config.json
-          name: SECRET_DESTINATION-MYSQL_SSH-KEY__CREDS
-          secretStore:
-            alias: airbyte-connector-testing-secret-store
-            type: GSM
-        - fileName: ssh-pwd-config.json
-          name: SECRET_DESTINATION-MYSQL_SSH-PWD__CREDS
-          secretStore:
-            alias: airbyte-connector-testing-secret-store
-            type: GSM
+  - suite: unitTests
+  - suite: integrationTests
+    testSecrets:
+    - fileName: ssh-key-config.json
+      name: SECRET_DESTINATION-MYSQL_SSH-KEY__CREDS
+      secretStore:
+        alias: airbyte-connector-testing-secret-store
+        type: GSM
+    - fileName: ssh-pwd-config.json
+      name: SECRET_DESTINATION-MYSQL_SSH-PWD__CREDS
+      secretStore:
+        alias: airbyte-connector-testing-secret-store
+        type: GSM
   connectorType: destination
   definitionId: ca81ee7c-3163-4246-af40-094cc31e5e42
   dockerImageTag: 1.1.1
@@ -39,8 +39,7 @@ data:
   releases:
     breakingChanges:
       1.0.0:
-        message:
-          "**Do not upgrade until you have run a test upgrade as outlined [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#testing-destinations-v2-for-a-single-connection)**.
+        message: '**Do not upgrade until you have run a test upgrade as outlined [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#testing-destinations-v2-for-a-single-connection)**.
 
           This version introduces [Destinations V2](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#what-is-destinations-v2),
           which provides better error handling and improved final table structures.
@@ -50,10 +49,23 @@ data:
 
           Selecting `Upgrade` will upgrade **all** connections using this destination
           at their next sync. You can manually sync existing connections prior to
-          the next scheduled sync to start the upgrade early."
-        upgradeDeadline: "2024-06-05"
+          the next scheduled sync to start the upgrade early.'
+        upgradeDeadline: '2024-06-05'
   supportLevel: community
   supportsDbt: true
   tags:
-    - language:java
-metadataSpecVersion: "1.0"
+  - language:java
+  externalDocumentationUrls:
+  - title: MySQL documentation
+    url: https://dev.mysql.com/doc/
+    type: api_reference
+  - title: SQL statement syntax
+    url: https://dev.mysql.com/doc/refman/8.0/en/sql-statements.html
+    type: sql_reference
+  - title: Access control and account management
+    url: https://dev.mysql.com/doc/refman/8.0/en/access-control.html
+    type: authentication_guide
+  - title: GRANT statement
+    url: https://dev.mysql.com/doc/refman/8.0/en/grant.html
+    type: permissions_scopes
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-mysql/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mysql/metadata.yaml
@@ -7,19 +7,19 @@ data:
     baseImage: docker.io/airbyte/java-connector-base:2.0.1@sha256:ec89bd1a89e825514dd2fc8730ba299a3ae1544580a078df0e35c5202c2085b3
   connectorSubtype: database
   connectorTestSuitesOptions:
-  - suite: unitTests
-  - suite: integrationTests
-    testSecrets:
-    - fileName: ssh-key-config.json
-      name: SECRET_DESTINATION-MYSQL_SSH-KEY__CREDS
-      secretStore:
-        alias: airbyte-connector-testing-secret-store
-        type: GSM
-    - fileName: ssh-pwd-config.json
-      name: SECRET_DESTINATION-MYSQL_SSH-PWD__CREDS
-      secretStore:
-        alias: airbyte-connector-testing-secret-store
-        type: GSM
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - fileName: ssh-key-config.json
+          name: SECRET_DESTINATION-MYSQL_SSH-KEY__CREDS
+          secretStore:
+            alias: airbyte-connector-testing-secret-store
+            type: GSM
+        - fileName: ssh-pwd-config.json
+          name: SECRET_DESTINATION-MYSQL_SSH-PWD__CREDS
+          secretStore:
+            alias: airbyte-connector-testing-secret-store
+            type: GSM
   connectorType: destination
   definitionId: ca81ee7c-3163-4246-af40-094cc31e5e42
   dockerImageTag: 1.1.1
@@ -39,7 +39,8 @@ data:
   releases:
     breakingChanges:
       1.0.0:
-        message: '**Do not upgrade until you have run a test upgrade as outlined [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#testing-destinations-v2-for-a-single-connection)**.
+        message:
+          "**Do not upgrade until you have run a test upgrade as outlined [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#testing-destinations-v2-for-a-single-connection)**.
 
           This version introduces [Destinations V2](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#what-is-destinations-v2),
           which provides better error handling and improved final table structures.
@@ -49,23 +50,23 @@ data:
 
           Selecting `Upgrade` will upgrade **all** connections using this destination
           at their next sync. You can manually sync existing connections prior to
-          the next scheduled sync to start the upgrade early.'
-        upgradeDeadline: '2024-06-05'
+          the next scheduled sync to start the upgrade early."
+        upgradeDeadline: "2024-06-05"
   supportLevel: community
   supportsDbt: true
   tags:
-  - language:java
+    - language:java
   externalDocumentationUrls:
-  - title: MySQL documentation
-    url: https://dev.mysql.com/doc/
-    type: api_reference
-  - title: SQL statement syntax
-    url: https://dev.mysql.com/doc/refman/8.0/en/sql-statements.html
-    type: sql_reference
-  - title: Access control and account management
-    url: https://dev.mysql.com/doc/refman/8.0/en/access-control.html
-    type: authentication_guide
-  - title: GRANT statement
-    url: https://dev.mysql.com/doc/refman/8.0/en/grant.html
-    type: permissions_scopes
-metadataSpecVersion: '1.0'
+    - title: MySQL documentation
+      url: https://dev.mysql.com/doc/
+      type: api_reference
+    - title: SQL statement syntax
+      url: https://dev.mysql.com/doc/refman/8.0/en/sql-statements.html
+      type: sql_reference
+    - title: Access control and account management
+      url: https://dev.mysql.com/doc/refman/8.0/en/access-control.html
+      type: authentication_guide
+    - title: GRANT statement
+      url: https://dev.mysql.com/doc/refman/8.0/en/grant.html
+      type: permissions_scopes
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-oracle-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-oracle-strict-encrypt/metadata.yaml
@@ -5,9 +5,9 @@ data:
     requireVersionIncrementsInPullRequests: false
   registryOverrides:
     cloud:
-      enabled: false # strict encrypt connectors are deployed to Cloud by their non strict encrypt sibling.
+      enabled: false
     oss:
-      enabled: false # strict encrypt connectors are not used on OSS.
+      enabled: false
   connectorSubtype: database
   connectorType: destination
   definitionId: 3986776d-2319-4de9-8af8-db14c0996e72
@@ -21,18 +21,33 @@ data:
   releases:
     breakingChanges:
       1.0.0:
-        upgradeDeadline: "2024-05-01"
-        message: >
-          This version removes the option to use "normalization" with Oracle. It also changes
-          the schema and database of Airbyte's "raw" tables to be compatible with the new
-          [Destinations V2](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#what-is-destinations-v2)
-          format. These changes will likely require updates to downstream dbt / SQL models.
-          Selecting `Upgrade` will upgrade **all** connections using this destination at their next sync.
+        upgradeDeadline: '2024-05-01'
+        message: 'This version removes the option to use "normalization" with Oracle.
+          It also changes the schema and database of Airbyte''s "raw" tables to be
+          compatible with the new [Destinations V2](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#what-is-destinations-v2)
+          format. These changes will likely require updates to downstream dbt / SQL
+          models. Selecting `Upgrade` will upgrade **all** connections using this
+          destination at their next sync.
+
+          '
   documentationUrl: https://docs.airbyte.com/integrations/destinations/oracle
   supportsDbt: true
   tags:
-    - language:java
+  - language:java
   connectorTestSuitesOptions:
-    - suite: unitTests
-    - suite: integrationTests
-metadataSpecVersion: "1.0"
+  - suite: unitTests
+  - suite: integrationTests
+  externalDocumentationUrls:
+  - title: Oracle Database documentation
+    url: https://docs.oracle.com/en/database/
+    type: api_reference
+  - title: SQL language reference
+    url: https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/
+    type: sql_reference
+  - title: Database authentication
+    url: https://docs.oracle.com/en/database/oracle/oracle-database/19/dbseg/configuring-authentication.html
+    type: authentication_guide
+  - title: Managing security
+    url: https://docs.oracle.com/en/database/oracle/oracle-database/19/dbseg/
+    type: permissions_scopes
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-oracle-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-oracle-strict-encrypt/metadata.yaml
@@ -5,9 +5,9 @@ data:
     requireVersionIncrementsInPullRequests: false
   registryOverrides:
     cloud:
-      enabled: false
+      enabled: false # strict encrypt connectors are deployed to Cloud by their non strict encrypt sibling.
     oss:
-      enabled: false
+      enabled: false # strict encrypt connectors are not used on OSS.
   connectorSubtype: database
   connectorType: destination
   definitionId: 3986776d-2319-4de9-8af8-db14c0996e72
@@ -22,15 +22,12 @@ data:
     breakingChanges:
       1.0.0:
         upgradeDeadline: "2024-05-01"
-        message:
-          'This version removes the option to use "normalization" with Oracle.
-          It also changes the schema and database of Airbyte''s "raw" tables to be
-          compatible with the new [Destinations V2](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#what-is-destinations-v2)
-          format. These changes will likely require updates to downstream dbt / SQL
-          models. Selecting `Upgrade` will upgrade **all** connections using this
-          destination at their next sync.
-
-          '
+        message: >
+          This version removes the option to use "normalization" with Oracle. It also changes
+          the schema and database of Airbyte's "raw" tables to be compatible with the new
+          [Destinations V2](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#what-is-destinations-v2)
+          format. These changes will likely require updates to downstream dbt / SQL models.
+          Selecting `Upgrade` will upgrade **all** connections using this destination at their next sync.
   documentationUrl: https://docs.airbyte.com/integrations/destinations/oracle
   supportsDbt: true
   tags:

--- a/airbyte-integrations/connectors/destination-oracle-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-oracle-strict-encrypt/metadata.yaml
@@ -21,8 +21,9 @@ data:
   releases:
     breakingChanges:
       1.0.0:
-        upgradeDeadline: '2024-05-01'
-        message: 'This version removes the option to use "normalization" with Oracle.
+        upgradeDeadline: "2024-05-01"
+        message:
+          'This version removes the option to use "normalization" with Oracle.
           It also changes the schema and database of Airbyte''s "raw" tables to be
           compatible with the new [Destinations V2](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#what-is-destinations-v2)
           format. These changes will likely require updates to downstream dbt / SQL
@@ -33,21 +34,21 @@ data:
   documentationUrl: https://docs.airbyte.com/integrations/destinations/oracle
   supportsDbt: true
   tags:
-  - language:java
+    - language:java
   connectorTestSuitesOptions:
-  - suite: unitTests
-  - suite: integrationTests
+    - suite: unitTests
+    - suite: integrationTests
   externalDocumentationUrls:
-  - title: Oracle Database documentation
-    url: https://docs.oracle.com/en/database/
-    type: api_reference
-  - title: SQL language reference
-    url: https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/
-    type: sql_reference
-  - title: Database authentication
-    url: https://docs.oracle.com/en/database/oracle/oracle-database/19/dbseg/configuring-authentication.html
-    type: authentication_guide
-  - title: Managing security
-    url: https://docs.oracle.com/en/database/oracle/oracle-database/19/dbseg/
-    type: permissions_scopes
-metadataSpecVersion: '1.0'
+    - title: Oracle Database documentation
+      url: https://docs.oracle.com/en/database/
+      type: api_reference
+    - title: SQL language reference
+      url: https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/
+      type: sql_reference
+    - title: Database authentication
+      url: https://docs.oracle.com/en/database/oracle/oracle-database/19/dbseg/configuring-authentication.html
+      type: authentication_guide
+    - title: Managing security
+      url: https://docs.oracle.com/en/database/oracle/oracle-database/19/dbseg/
+      type: permissions_scopes
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-oracle/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-oracle/metadata.yaml
@@ -22,27 +22,42 @@ data:
   releases:
     breakingChanges:
       1.0.0:
-        upgradeDeadline: "2024-05-01"
-        message: >
-          This version removes the option to use "normalization" with Oracle. It also changes
-          the schema and database of Airbyte's "raw" tables to be compatible with the new
-          [Destinations V2](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#what-is-destinations-v2)
-          format. These changes will likely require updates to downstream dbt / SQL models.
-          Selecting `Upgrade` will upgrade **all** connections using this destination at their next sync.
+        upgradeDeadline: '2024-05-01'
+        message: 'This version removes the option to use "normalization" with Oracle.
+          It also changes the schema and database of Airbyte''s "raw" tables to be
+          compatible with the new [Destinations V2](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#what-is-destinations-v2)
+          format. These changes will likely require updates to downstream dbt / SQL
+          models. Selecting `Upgrade` will upgrade **all** connections using this
+          destination at their next sync.
+
+          '
   tags:
-    - language:java
+  - language:java
   ab_internal:
     sl: 100
     ql: 200
     requireVersionIncrementsInPullRequests: false
   supportLevel: community
   connectorTestSuitesOptions:
-    - suite: unitTests
-    - suite: integrationTests
-      testSecrets:
-        - name: SECRET_DESTINATION-ORACLE__CREDS
-          fileName: config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-metadataSpecVersion: "1.0"
+  - suite: unitTests
+  - suite: integrationTests
+    testSecrets:
+    - name: SECRET_DESTINATION-ORACLE__CREDS
+      fileName: config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+  - title: Oracle Database documentation
+    url: https://docs.oracle.com/en/database/
+    type: api_reference
+  - title: SQL language reference
+    url: https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/
+    type: sql_reference
+  - title: Database authentication
+    url: https://docs.oracle.com/en/database/oracle/oracle-database/19/dbseg/configuring-authentication.html
+    type: authentication_guide
+  - title: Managing security
+    url: https://docs.oracle.com/en/database/oracle/oracle-database/19/dbseg/
+    type: permissions_scopes
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-oracle/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-oracle/metadata.yaml
@@ -22,8 +22,9 @@ data:
   releases:
     breakingChanges:
       1.0.0:
-        upgradeDeadline: '2024-05-01'
-        message: 'This version removes the option to use "normalization" with Oracle.
+        upgradeDeadline: "2024-05-01"
+        message:
+          'This version removes the option to use "normalization" with Oracle.
           It also changes the schema and database of Airbyte''s "raw" tables to be
           compatible with the new [Destinations V2](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#what-is-destinations-v2)
           format. These changes will likely require updates to downstream dbt / SQL
@@ -32,32 +33,32 @@ data:
 
           '
   tags:
-  - language:java
+    - language:java
   ab_internal:
     sl: 100
     ql: 200
     requireVersionIncrementsInPullRequests: false
   supportLevel: community
   connectorTestSuitesOptions:
-  - suite: unitTests
-  - suite: integrationTests
-    testSecrets:
-    - name: SECRET_DESTINATION-ORACLE__CREDS
-      fileName: config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION-ORACLE__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
   externalDocumentationUrls:
-  - title: Oracle Database documentation
-    url: https://docs.oracle.com/en/database/
-    type: api_reference
-  - title: SQL language reference
-    url: https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/
-    type: sql_reference
-  - title: Database authentication
-    url: https://docs.oracle.com/en/database/oracle/oracle-database/19/dbseg/configuring-authentication.html
-    type: authentication_guide
-  - title: Managing security
-    url: https://docs.oracle.com/en/database/oracle/oracle-database/19/dbseg/
-    type: permissions_scopes
-metadataSpecVersion: '1.0'
+    - title: Oracle Database documentation
+      url: https://docs.oracle.com/en/database/
+      type: api_reference
+    - title: SQL language reference
+      url: https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/
+      type: sql_reference
+    - title: Database authentication
+      url: https://docs.oracle.com/en/database/oracle/oracle-database/19/dbseg/configuring-authentication.html
+      type: authentication_guide
+    - title: Managing security
+      url: https://docs.oracle.com/en/database/oracle/oracle-database/19/dbseg/
+      type: permissions_scopes
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-oracle/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-oracle/metadata.yaml
@@ -23,15 +23,12 @@ data:
     breakingChanges:
       1.0.0:
         upgradeDeadline: "2024-05-01"
-        message:
-          'This version removes the option to use "normalization" with Oracle.
-          It also changes the schema and database of Airbyte''s "raw" tables to be
-          compatible with the new [Destinations V2](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#what-is-destinations-v2)
-          format. These changes will likely require updates to downstream dbt / SQL
-          models. Selecting `Upgrade` will upgrade **all** connections using this
-          destination at their next sync.
-
-          '
+        message: >
+          This version removes the option to use "normalization" with Oracle. It also changes
+          the schema and database of Airbyte's "raw" tables to be compatible with the new
+          [Destinations V2](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#what-is-destinations-v2)
+          format. These changes will likely require updates to downstream dbt / SQL models.
+          Selecting `Upgrade` will upgrade **all** connections using this destination at their next sync.
   tags:
     - language:java
   ab_internal:

--- a/airbyte-integrations/connectors/destination-pgvector/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-pgvector/metadata.yaml
@@ -41,6 +41,8 @@ data:
     - language:python
     - cdk:python
   connectorTestSuitesOptions:
+    # Temporarily disabled due to test coverage not passing
+    # - suite: unitTests
     - suite: integrationTests
       testSecrets:
         - name: SECRET_DESTINATION-PGVECTOR__CREDS

--- a/airbyte-integrations/connectors/destination-pgvector/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-pgvector/metadata.yaml
@@ -4,9 +4,9 @@ data:
     sl: 200
   allowedHosts:
     hosts:
-      - api.openai.com
-      - api.cohere.ai
-      - ${embedding.api_base}
+    - api.openai.com
+    - api.cohere.ai
+    - ${embedding.api_base}
   connectorBuildOptions:
     baseImage: docker.io/airbyte/python-connector-base:4.0.2@sha256:9fdb1888c4264cf6fee473649ecb593f56f58e5d0096a87ee0b231777e2e3e73
   connectorSubtype: vectorstore
@@ -32,22 +32,27 @@ data:
   releaseStage: beta
   resourceRequirements:
     jobSpecific:
-      - jobType: sync
-        resourceRequirements:
-          memory_limit: 2Gi
-          memory_request: 2Gi
+    - jobType: sync
+      resourceRequirements:
+        memory_limit: 2Gi
+        memory_request: 2Gi
   supportLevel: certified
   tags:
-    - language:python
-    - cdk:python
+  - language:python
+  - cdk:python
   connectorTestSuitesOptions:
-    # Temporarily disabled due to test coverage not passing
-    # - suite: unitTests
-    - suite: integrationTests
-      testSecrets:
-        - name: SECRET_DESTINATION-PGVECTOR__CREDS
-          fileName: config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-metadataSpecVersion: "1.0"
+  - suite: integrationTests
+    testSecrets:
+    - name: SECRET_DESTINATION-PGVECTOR__CREDS
+      fileName: config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+  - title: pgvector documentation
+    url: https://github.com/pgvector/pgvector
+    type: api_reference
+  - title: PostgreSQL documentation
+    url: https://www.postgresql.org/docs/current/
+    type: api_reference
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-pgvector/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-pgvector/metadata.yaml
@@ -4,9 +4,9 @@ data:
     sl: 200
   allowedHosts:
     hosts:
-    - api.openai.com
-    - api.cohere.ai
-    - ${embedding.api_base}
+      - api.openai.com
+      - api.cohere.ai
+      - ${embedding.api_base}
   connectorBuildOptions:
     baseImage: docker.io/airbyte/python-connector-base:4.0.2@sha256:9fdb1888c4264cf6fee473649ecb593f56f58e5d0096a87ee0b231777e2e3e73
   connectorSubtype: vectorstore
@@ -32,27 +32,27 @@ data:
   releaseStage: beta
   resourceRequirements:
     jobSpecific:
-    - jobType: sync
-      resourceRequirements:
-        memory_limit: 2Gi
-        memory_request: 2Gi
+      - jobType: sync
+        resourceRequirements:
+          memory_limit: 2Gi
+          memory_request: 2Gi
   supportLevel: certified
   tags:
-  - language:python
-  - cdk:python
+    - language:python
+    - cdk:python
   connectorTestSuitesOptions:
-  - suite: integrationTests
-    testSecrets:
-    - name: SECRET_DESTINATION-PGVECTOR__CREDS
-      fileName: config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION-PGVECTOR__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
   externalDocumentationUrls:
-  - title: pgvector documentation
-    url: https://github.com/pgvector/pgvector
-    type: api_reference
-  - title: PostgreSQL documentation
-    url: https://www.postgresql.org/docs/current/
-    type: api_reference
-metadataSpecVersion: '1.0'
+    - title: pgvector documentation
+      url: https://github.com/pgvector/pgvector
+      type: api_reference
+    - title: PostgreSQL documentation
+      url: https://www.postgresql.org/docs/current/
+      type: api_reference
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-pinecone/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-pinecone/metadata.yaml
@@ -22,7 +22,7 @@ data:
   name: Pinecone
   remoteRegistries:
     pypi:
-      enabled: false
+      enabled: false # TODO: enable once the CLI is working
       packageName: airbyte-destination-pinecone
   registryOverrides:
     cloud:

--- a/airbyte-integrations/connectors/destination-pinecone/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-pinecone/metadata.yaml
@@ -4,10 +4,10 @@ data:
     sl: 300
   allowedHosts:
     hosts:
-      - "*.${indexing.pinecone_environment}.pinecone.io"
-      - api.openai.com
-      - api.cohere.ai
-      - ${embedding.api_base}
+    - '*.${indexing.pinecone_environment}.pinecone.io'
+    - api.openai.com
+    - api.cohere.ai
+    - ${embedding.api_base}
   connectorBuildOptions:
     baseImage: docker.io/airbyte/python-connector-base:4.0.2@sha256:9fdb1888c4264cf6fee473649ecb593f56f58e5d0096a87ee0b231777e2e3e73
   connectorSubtype: vectorstore
@@ -22,7 +22,7 @@ data:
   name: Pinecone
   remoteRegistries:
     pypi:
-      enabled: false # TODO: enable once the CLI is working
+      enabled: false
       packageName: airbyte-destination-pinecone
   registryOverrides:
     cloud:
@@ -33,28 +33,44 @@ data:
   releaseStage: beta
   resourceRequirements:
     jobSpecific:
-      - jobType: sync
-        resourceRequirements:
-          memory_limit: 2Gi
-          memory_request: 2Gi
+    - jobType: sync
+      resourceRequirements:
+        memory_limit: 2Gi
+        memory_request: 2Gi
   supportLevel: certified
   tags:
-    - language:python
-    - cdk:python
+  - language:python
+  - cdk:python
   connectorTestSuitesOptions:
-    - suite: unitTests
-    - suite: integrationTests
-      testSecrets:
-        - name: SECRET_DESTINATION-PINECONE__CREDS
-          fileName: config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-    - suite: acceptanceTests
-      testSecrets:
-        - name: SECRET_DESTINATION-PINECONE__CREDS
-          fileName: config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-metadataSpecVersion: "1.0"
+  - suite: unitTests
+  - suite: integrationTests
+    testSecrets:
+    - name: SECRET_DESTINATION-PINECONE__CREDS
+      fileName: config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+  - suite: acceptanceTests
+    testSecrets:
+    - name: SECRET_DESTINATION-PINECONE__CREDS
+      fileName: config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+  - title: Pinecone documentation
+    url: https://docs.pinecone.io/
+    type: api_reference
+  - title: Authentication
+    url: https://docs.pinecone.io/guides/get-started/authentication
+    type: authentication_guide
+  - title: Rate limits
+    url: https://docs.pinecone.io/troubleshooting/rate-limits
+    type: rate_limits
+  - title: Release notes
+    url: https://docs.pinecone.io/release-notes
+    type: api_release_history
+  - title: Pinecone Status
+    url: https://status.pinecone.io/
+    type: status_page
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-pinecone/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-pinecone/metadata.yaml
@@ -4,10 +4,10 @@ data:
     sl: 300
   allowedHosts:
     hosts:
-    - '*.${indexing.pinecone_environment}.pinecone.io'
-    - api.openai.com
-    - api.cohere.ai
-    - ${embedding.api_base}
+      - "*.${indexing.pinecone_environment}.pinecone.io"
+      - api.openai.com
+      - api.cohere.ai
+      - ${embedding.api_base}
   connectorBuildOptions:
     baseImage: docker.io/airbyte/python-connector-base:4.0.2@sha256:9fdb1888c4264cf6fee473649ecb593f56f58e5d0096a87ee0b231777e2e3e73
   connectorSubtype: vectorstore
@@ -33,44 +33,44 @@ data:
   releaseStage: beta
   resourceRequirements:
     jobSpecific:
-    - jobType: sync
-      resourceRequirements:
-        memory_limit: 2Gi
-        memory_request: 2Gi
+      - jobType: sync
+        resourceRequirements:
+          memory_limit: 2Gi
+          memory_request: 2Gi
   supportLevel: certified
   tags:
-  - language:python
-  - cdk:python
+    - language:python
+    - cdk:python
   connectorTestSuitesOptions:
-  - suite: unitTests
-  - suite: integrationTests
-    testSecrets:
-    - name: SECRET_DESTINATION-PINECONE__CREDS
-      fileName: config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
-  - suite: acceptanceTests
-    testSecrets:
-    - name: SECRET_DESTINATION-PINECONE__CREDS
-      fileName: config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION-PINECONE__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_DESTINATION-PINECONE__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
   externalDocumentationUrls:
-  - title: Pinecone documentation
-    url: https://docs.pinecone.io/
-    type: api_reference
-  - title: Authentication
-    url: https://docs.pinecone.io/guides/get-started/authentication
-    type: authentication_guide
-  - title: Rate limits
-    url: https://docs.pinecone.io/troubleshooting/rate-limits
-    type: rate_limits
-  - title: Release notes
-    url: https://docs.pinecone.io/release-notes
-    type: api_release_history
-  - title: Pinecone Status
-    url: https://status.pinecone.io/
-    type: status_page
-metadataSpecVersion: '1.0'
+    - title: Pinecone documentation
+      url: https://docs.pinecone.io/
+      type: api_reference
+    - title: Authentication
+      url: https://docs.pinecone.io/guides/get-started/authentication
+      type: authentication_guide
+    - title: Rate limits
+      url: https://docs.pinecone.io/troubleshooting/rate-limits
+      type: rate_limits
+    - title: Release notes
+      url: https://docs.pinecone.io/release-notes
+      type: api_release_history
+    - title: Pinecone Status
+      url: https://status.pinecone.io/
+      type: status_page
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-postgres-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-postgres-strict-encrypt/metadata.yaml
@@ -23,7 +23,8 @@ data:
       enableProgressiveRollout: false
     breakingChanges:
       2.0.0:
-        message: 'This version introduces [Destinations V2](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#what-is-destinations-v2),
+        message:
+          "This version introduces [Destinations V2](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#what-is-destinations-v2),
           which provides better error handling, incremental delivery of data for large
           syncs, and improved final table structures. To review the breaking changes,
           and how to upgrade, see [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#quick-start-to-upgrading).
@@ -32,28 +33,28 @@ data:
           Selecting `Upgrade` will upgrade **all** connections using this destination
           at their next sync. For more controlled upgrade [see instructions](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#upgrading-connections-one-by-one-with-dual-writing).
 
-          '
-        upgradeDeadline: '2024-05-31'
+          "
+        upgradeDeadline: "2024-05-31"
   releaseStage: generally_available
   supportLevel: certified
   supportsRefreshes: true
   supportsDbt: true
   tags:
-  - language:java
+    - language:java
   connectorTestSuitesOptions:
-  - suite: unitTests
-  - suite: integrationTests
+    - suite: unitTests
+    - suite: integrationTests
   externalDocumentationUrls:
-  - title: PostgreSQL documentation
-    url: https://www.postgresql.org/docs/current/
-    type: api_reference
-  - title: SQL commands
-    url: https://www.postgresql.org/docs/current/sql-commands.html
-    type: sql_reference
-  - title: Client authentication
-    url: https://www.postgresql.org/docs/current/client-authentication.html
-    type: authentication_guide
-  - title: Database roles and privileges
-    url: https://www.postgresql.org/docs/current/user-manag.html
-    type: permissions_scopes
-metadataSpecVersion: '1.0'
+    - title: PostgreSQL documentation
+      url: https://www.postgresql.org/docs/current/
+      type: api_reference
+    - title: SQL commands
+      url: https://www.postgresql.org/docs/current/sql-commands.html
+      type: sql_reference
+    - title: Client authentication
+      url: https://www.postgresql.org/docs/current/client-authentication.html
+      type: authentication_guide
+    - title: Database roles and privileges
+      url: https://www.postgresql.org/docs/current/user-manag.html
+      type: permissions_scopes
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-postgres-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-postgres-strict-encrypt/metadata.yaml
@@ -23,19 +23,37 @@ data:
       enableProgressiveRollout: false
     breakingChanges:
       2.0.0:
-        message: >
-          This version introduces [Destinations V2](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#what-is-destinations-v2), which provides better error handling, incremental delivery of data for large syncs, and improved final table structures.
-          To review the breaking changes, and how to upgrade, see [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#quick-start-to-upgrading).
-          These changes will likely require updates to downstream dbt / SQL models, which we walk through [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#updating-downstream-transformations).
-          Selecting `Upgrade` will upgrade **all** connections using this destination at their next sync. For more controlled upgrade [see instructions](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#upgrading-connections-one-by-one-with-dual-writing).
-        upgradeDeadline: "2024-05-31"
+        message: 'This version introduces [Destinations V2](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#what-is-destinations-v2),
+          which provides better error handling, incremental delivery of data for large
+          syncs, and improved final table structures. To review the breaking changes,
+          and how to upgrade, see [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#quick-start-to-upgrading).
+          These changes will likely require updates to downstream dbt / SQL models,
+          which we walk through [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#updating-downstream-transformations).
+          Selecting `Upgrade` will upgrade **all** connections using this destination
+          at their next sync. For more controlled upgrade [see instructions](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#upgrading-connections-one-by-one-with-dual-writing).
+
+          '
+        upgradeDeadline: '2024-05-31'
   releaseStage: generally_available
   supportLevel: certified
   supportsRefreshes: true
   supportsDbt: true
   tags:
-    - language:java
+  - language:java
   connectorTestSuitesOptions:
-    - suite: unitTests
-    - suite: integrationTests
-metadataSpecVersion: "1.0"
+  - suite: unitTests
+  - suite: integrationTests
+  externalDocumentationUrls:
+  - title: PostgreSQL documentation
+    url: https://www.postgresql.org/docs/current/
+    type: api_reference
+  - title: SQL commands
+    url: https://www.postgresql.org/docs/current/sql-commands.html
+    type: sql_reference
+  - title: Client authentication
+    url: https://www.postgresql.org/docs/current/client-authentication.html
+    type: authentication_guide
+  - title: Database roles and privileges
+    url: https://www.postgresql.org/docs/current/user-manag.html
+    type: permissions_scopes
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-postgres-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-postgres-strict-encrypt/metadata.yaml
@@ -23,17 +23,11 @@ data:
       enableProgressiveRollout: false
     breakingChanges:
       2.0.0:
-        message:
-          "This version introduces [Destinations V2](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#what-is-destinations-v2),
-          which provides better error handling, incremental delivery of data for large
-          syncs, and improved final table structures. To review the breaking changes,
-          and how to upgrade, see [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#quick-start-to-upgrading).
-          These changes will likely require updates to downstream dbt / SQL models,
-          which we walk through [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#updating-downstream-transformations).
-          Selecting `Upgrade` will upgrade **all** connections using this destination
-          at their next sync. For more controlled upgrade [see instructions](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#upgrading-connections-one-by-one-with-dual-writing).
-
-          "
+        message: >
+          This version introduces [Destinations V2](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#what-is-destinations-v2), which provides better error handling, incremental delivery of data for large syncs, and improved final table structures.
+          To review the breaking changes, and how to upgrade, see [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#quick-start-to-upgrading).
+          These changes will likely require updates to downstream dbt / SQL models, which we walk through [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#updating-downstream-transformations).
+          Selecting `Upgrade` will upgrade **all** connections using this destination at their next sync. For more controlled upgrade [see instructions](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#upgrading-connections-one-by-one-with-dual-writing).
         upgradeDeadline: "2024-05-31"
   releaseStage: generally_available
   supportLevel: certified

--- a/airbyte-integrations/connectors/destination-postgres/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-postgres/metadata.yaml
@@ -26,7 +26,8 @@ data:
       enableProgressiveRollout: false
     breakingChanges:
       2.0.0:
-        message: 'This version introduces [Destinations V2](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#what-is-destinations-v2),
+        message:
+          "This version introduces [Destinations V2](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#what-is-destinations-v2),
           which provides better error handling, incremental delivery of data for large
           syncs, and improved final table structures. To review the breaking changes,
           and how to upgrade, see [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#quick-start-to-upgrading).
@@ -35,34 +36,34 @@ data:
           Selecting `Upgrade` will upgrade **all** connections using this destination
           at their next sync. For more controlled upgrade [see instructions](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#upgrading-connections-one-by-one-with-dual-writing).
 
-          '
-        upgradeDeadline: '2024-05-31'
+          "
+        upgradeDeadline: "2024-05-31"
   releaseStage: generally_available
   supportLevel: certified
   supportsDbt: true
   supportsRefreshes: true
   tags:
-  - language:java
+    - language:java
   connectorTestSuitesOptions:
-  - suite: unitTests
-  - suite: integrationTests
-    testSecrets:
-    - name: SECRET_DESTINATION-POSTGRES_CREDENTIALS__CREDS
-      fileName: credentials.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION-POSTGRES_CREDENTIALS__CREDS
+          fileName: credentials.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
   externalDocumentationUrls:
-  - title: PostgreSQL documentation
-    url: https://www.postgresql.org/docs/current/
-    type: api_reference
-  - title: SQL commands
-    url: https://www.postgresql.org/docs/current/sql-commands.html
-    type: sql_reference
-  - title: Client authentication
-    url: https://www.postgresql.org/docs/current/client-authentication.html
-    type: authentication_guide
-  - title: Database roles and privileges
-    url: https://www.postgresql.org/docs/current/user-manag.html
-    type: permissions_scopes
-metadataSpecVersion: '1.0'
+    - title: PostgreSQL documentation
+      url: https://www.postgresql.org/docs/current/
+      type: api_reference
+    - title: SQL commands
+      url: https://www.postgresql.org/docs/current/sql-commands.html
+      type: sql_reference
+    - title: Client authentication
+      url: https://www.postgresql.org/docs/current/client-authentication.html
+      type: authentication_guide
+    - title: Database roles and privileges
+      url: https://www.postgresql.org/docs/current/user-manag.html
+      type: permissions_scopes
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-postgres/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-postgres/metadata.yaml
@@ -26,25 +26,43 @@ data:
       enableProgressiveRollout: false
     breakingChanges:
       2.0.0:
-        message: >
-          This version introduces [Destinations V2](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#what-is-destinations-v2), which provides better error handling, incremental delivery of data for large syncs, and improved final table structures.
-          To review the breaking changes, and how to upgrade, see [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#quick-start-to-upgrading).
-          These changes will likely require updates to downstream dbt / SQL models, which we walk through [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#updating-downstream-transformations).
-          Selecting `Upgrade` will upgrade **all** connections using this destination at their next sync. For more controlled upgrade [see instructions](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#upgrading-connections-one-by-one-with-dual-writing).
-        upgradeDeadline: "2024-05-31"
+        message: 'This version introduces [Destinations V2](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#what-is-destinations-v2),
+          which provides better error handling, incremental delivery of data for large
+          syncs, and improved final table structures. To review the breaking changes,
+          and how to upgrade, see [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#quick-start-to-upgrading).
+          These changes will likely require updates to downstream dbt / SQL models,
+          which we walk through [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#updating-downstream-transformations).
+          Selecting `Upgrade` will upgrade **all** connections using this destination
+          at their next sync. For more controlled upgrade [see instructions](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#upgrading-connections-one-by-one-with-dual-writing).
+
+          '
+        upgradeDeadline: '2024-05-31'
   releaseStage: generally_available
   supportLevel: certified
   supportsDbt: true
   supportsRefreshes: true
   tags:
-    - language:java
+  - language:java
   connectorTestSuitesOptions:
-    - suite: unitTests
-    - suite: integrationTests
-      testSecrets:
-        - name: SECRET_DESTINATION-POSTGRES_CREDENTIALS__CREDS
-          fileName: credentials.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-metadataSpecVersion: "1.0"
+  - suite: unitTests
+  - suite: integrationTests
+    testSecrets:
+    - name: SECRET_DESTINATION-POSTGRES_CREDENTIALS__CREDS
+      fileName: credentials.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+  - title: PostgreSQL documentation
+    url: https://www.postgresql.org/docs/current/
+    type: api_reference
+  - title: SQL commands
+    url: https://www.postgresql.org/docs/current/sql-commands.html
+    type: sql_reference
+  - title: Client authentication
+    url: https://www.postgresql.org/docs/current/client-authentication.html
+    type: authentication_guide
+  - title: Database roles and privileges
+    url: https://www.postgresql.org/docs/current/user-manag.html
+    type: permissions_scopes
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-postgres/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-postgres/metadata.yaml
@@ -26,17 +26,11 @@ data:
       enableProgressiveRollout: false
     breakingChanges:
       2.0.0:
-        message:
-          "This version introduces [Destinations V2](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#what-is-destinations-v2),
-          which provides better error handling, incremental delivery of data for large
-          syncs, and improved final table structures. To review the breaking changes,
-          and how to upgrade, see [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#quick-start-to-upgrading).
-          These changes will likely require updates to downstream dbt / SQL models,
-          which we walk through [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#updating-downstream-transformations).
-          Selecting `Upgrade` will upgrade **all** connections using this destination
-          at their next sync. For more controlled upgrade [see instructions](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#upgrading-connections-one-by-one-with-dual-writing).
-
-          "
+        message: >
+          This version introduces [Destinations V2](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#what-is-destinations-v2), which provides better error handling, incremental delivery of data for large syncs, and improved final table structures.
+          To review the breaking changes, and how to upgrade, see [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#quick-start-to-upgrading).
+          These changes will likely require updates to downstream dbt / SQL models, which we walk through [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#updating-downstream-transformations).
+          Selecting `Upgrade` will upgrade **all** connections using this destination at their next sync. For more controlled upgrade [see instructions](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#upgrading-connections-one-by-one-with-dual-writing).
         upgradeDeadline: "2024-05-31"
   releaseStage: generally_available
   supportLevel: certified

--- a/airbyte-integrations/connectors/destination-pubsub/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-pubsub/metadata.yaml
@@ -7,14 +7,14 @@ data:
     baseImage: docker.io/airbyte/java-connector-base:2.0.1@sha256:ec89bd1a89e825514dd2fc8730ba299a3ae1544580a078df0e35c5202c2085b3
   connectorSubtype: api
   connectorTestSuitesOptions:
-  - suite: unitTests
-  - suite: integrationTests
-    testSecrets:
-    - fileName: credentials.json
-      name: SECRET_DESTINATION-PUBSUB_CREDENTIALS__CREDS
-      secretStore:
-        alias: airbyte-connector-testing-secret-store
-        type: GSM
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - fileName: credentials.json
+          name: SECRET_DESTINATION-PUBSUB_CREDENTIALS__CREDS
+          secretStore:
+            alias: airbyte-connector-testing-secret-store
+            type: GSM
   connectorType: destination
   definitionId: 356668e2-7e34-47f3-a3b0-67a8a481b692
   dockerImageTag: 0.2.3
@@ -32,21 +32,21 @@ data:
   releaseStage: alpha
   supportLevel: community
   tags:
-  - language:java
+    - language:java
   externalDocumentationUrls:
-  - title: Pub/Sub documentation
-    url: https://cloud.google.com/pubsub/docs
-    type: api_reference
-  - title: Service account authentication
-    url: https://cloud.google.com/iam/docs/service-accounts
-    type: authentication_guide
-  - title: Access control
-    url: https://cloud.google.com/pubsub/docs/access-control
-    type: permissions_scopes
-  - title: Quotas and limits
-    url: https://cloud.google.com/pubsub/quotas
-    type: rate_limits
-  - title: Google Cloud Status
-    url: https://status.cloud.google.com/
-    type: status_page
-metadataSpecVersion: '1.0'
+    - title: Pub/Sub documentation
+      url: https://cloud.google.com/pubsub/docs
+      type: api_reference
+    - title: Service account authentication
+      url: https://cloud.google.com/iam/docs/service-accounts
+      type: authentication_guide
+    - title: Access control
+      url: https://cloud.google.com/pubsub/docs/access-control
+      type: permissions_scopes
+    - title: Quotas and limits
+      url: https://cloud.google.com/pubsub/quotas
+      type: rate_limits
+    - title: Google Cloud Status
+      url: https://status.cloud.google.com/
+      type: status_page
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-pubsub/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-pubsub/metadata.yaml
@@ -7,14 +7,14 @@ data:
     baseImage: docker.io/airbyte/java-connector-base:2.0.1@sha256:ec89bd1a89e825514dd2fc8730ba299a3ae1544580a078df0e35c5202c2085b3
   connectorSubtype: api
   connectorTestSuitesOptions:
-    - suite: unitTests
-    - suite: integrationTests
-      testSecrets:
-        - fileName: credentials.json
-          name: SECRET_DESTINATION-PUBSUB_CREDENTIALS__CREDS
-          secretStore:
-            alias: airbyte-connector-testing-secret-store
-            type: GSM
+  - suite: unitTests
+  - suite: integrationTests
+    testSecrets:
+    - fileName: credentials.json
+      name: SECRET_DESTINATION-PUBSUB_CREDENTIALS__CREDS
+      secretStore:
+        alias: airbyte-connector-testing-secret-store
+        type: GSM
   connectorType: destination
   definitionId: 356668e2-7e34-47f3-a3b0-67a8a481b692
   dockerImageTag: 0.2.3
@@ -32,5 +32,21 @@ data:
   releaseStage: alpha
   supportLevel: community
   tags:
-    - language:java
-metadataSpecVersion: "1.0"
+  - language:java
+  externalDocumentationUrls:
+  - title: Pub/Sub documentation
+    url: https://cloud.google.com/pubsub/docs
+    type: api_reference
+  - title: Service account authentication
+    url: https://cloud.google.com/iam/docs/service-accounts
+    type: authentication_guide
+  - title: Access control
+    url: https://cloud.google.com/pubsub/docs/access-control
+    type: permissions_scopes
+  - title: Quotas and limits
+    url: https://cloud.google.com/pubsub/quotas
+    type: rate_limits
+  - title: Google Cloud Status
+    url: https://status.cloud.google.com/
+    type: status_page
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-pulsar/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-pulsar/metadata.yaml
@@ -16,9 +16,16 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/pulsar
   tags:
-    - language:java
+  - language:java
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: archived
-metadataSpecVersion: "1.0"
+  externalDocumentationUrls:
+  - title: Apache Pulsar documentation
+    url: https://pulsar.apache.org/docs/en/standalone/
+    type: api_reference
+  - title: Security
+    url: https://pulsar.apache.org/docs/en/security-overview/
+    type: authentication_guide
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-pulsar/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-pulsar/metadata.yaml
@@ -16,16 +16,16 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/pulsar
   tags:
-  - language:java
+    - language:java
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: archived
   externalDocumentationUrls:
-  - title: Apache Pulsar documentation
-    url: https://pulsar.apache.org/docs/en/standalone/
-    type: api_reference
-  - title: Security
-    url: https://pulsar.apache.org/docs/en/security-overview/
-    type: authentication_guide
-metadataSpecVersion: '1.0'
+    - title: Apache Pulsar documentation
+      url: https://pulsar.apache.org/docs/en/standalone/
+      type: api_reference
+    - title: Security
+      url: https://pulsar.apache.org/docs/en/security-overview/
+      type: authentication_guide
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-qdrant/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-qdrant/metadata.yaml
@@ -6,16 +6,16 @@ data:
       enabled: true
   allowedHosts:
     hosts:
-    - ${indexing.url}
-    - api.openai.com
-    - api.cohere.ai
-    - ${embedding.api_base}
+      - ${indexing.url}
+      - api.openai.com
+      - api.cohere.ai
+      - ${embedding.api_base}
   resourceRequirements:
     jobSpecific:
-    - jobType: sync
-      resourceRequirements:
-        memory_limit: 2Gi
-        memory_request: 2Gi
+      - jobType: sync
+        resourceRequirements:
+          memory_limit: 2Gi
+          memory_request: 2Gi
   connectorBuildOptions:
     baseImage: docker.io/airbyte/python-connector-base:4.0.0@sha256:d9894b6895923b379f3006fa251147806919c62b7d9021b5cd125bb67d7bbe22
   connectorSubtype: vectorstore
@@ -31,22 +31,22 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/qdrant
   tags:
-  - language:python
-  - cdk:python
+    - language:python
+    - cdk:python
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
-  - suite: unitTests
+    - suite: unitTests
   externalDocumentationUrls:
-  - title: Qdrant documentation
-    url: https://qdrant.tech/documentation/
-    type: api_reference
-  - title: Authentication
-    url: https://qdrant.tech/documentation/guides/security/
-    type: authentication_guide
-  - title: Release notes
-    url: https://github.com/qdrant/qdrant/releases
-    type: api_release_history
-metadataSpecVersion: '1.0'
+    - title: Qdrant documentation
+      url: https://qdrant.tech/documentation/
+      type: api_reference
+    - title: Authentication
+      url: https://qdrant.tech/documentation/guides/security/
+      type: authentication_guide
+    - title: Release notes
+      url: https://github.com/qdrant/qdrant/releases
+      type: api_release_history
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-qdrant/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-qdrant/metadata.yaml
@@ -6,17 +6,16 @@ data:
       enabled: true
   allowedHosts:
     hosts:
-      - "${indexing.url}"
-      - api.openai.com
-      - api.cohere.ai
-      - "${embedding.api_base}"
+    - ${indexing.url}
+    - api.openai.com
+    - api.cohere.ai
+    - ${embedding.api_base}
   resourceRequirements:
     jobSpecific:
-      - jobType: sync
-        # TODO: Remove once https://github.com/airbytehq/airbyte/issues/30611 is resolved
-        resourceRequirements:
-          memory_limit: 2Gi
-          memory_request: 2Gi
+    - jobType: sync
+      resourceRequirements:
+        memory_limit: 2Gi
+        memory_request: 2Gi
   connectorBuildOptions:
     baseImage: docker.io/airbyte/python-connector-base:4.0.0@sha256:d9894b6895923b379f3006fa251147806919c62b7d9021b5cd125bb67d7bbe22
   connectorSubtype: vectorstore
@@ -32,12 +31,22 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/qdrant
   tags:
-    - language:python
-    - cdk:python
+  - language:python
+  - cdk:python
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
-    - suite: unitTests
-metadataSpecVersion: "1.0"
+  - suite: unitTests
+  externalDocumentationUrls:
+  - title: Qdrant documentation
+    url: https://qdrant.tech/documentation/
+    type: api_reference
+  - title: Authentication
+    url: https://qdrant.tech/documentation/guides/security/
+    type: authentication_guide
+  - title: Release notes
+    url: https://github.com/qdrant/qdrant/releases
+    type: api_release_history
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-qdrant/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-qdrant/metadata.yaml
@@ -13,6 +13,7 @@ data:
   resourceRequirements:
     jobSpecific:
       - jobType: sync
+        # TODO: Remove once https://github.com/airbytehq/airbyte/issues/30611 is resolved
         resourceRequirements:
           memory_limit: 2Gi
           memory_request: 2Gi

--- a/airbyte-integrations/connectors/destination-r2/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-r2/metadata.yaml
@@ -16,9 +16,22 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/r2
   tags:
-    - language:java
+  - language:java
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: archived
-metadataSpecVersion: "1.0"
+  externalDocumentationUrls:
+  - title: Cloudflare R2 documentation
+    url: https://developers.cloudflare.com/r2/
+    type: api_reference
+  - title: Authentication
+    url: https://developers.cloudflare.com/r2/api/s3/tokens/
+    type: authentication_guide
+  - title: Limits
+    url: https://developers.cloudflare.com/r2/platform/limits/
+    type: rate_limits
+  - title: Cloudflare Status
+    url: https://www.cloudflarestatus.com/
+    type: status_page
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-r2/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-r2/metadata.yaml
@@ -16,22 +16,22 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/r2
   tags:
-  - language:java
+    - language:java
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: archived
   externalDocumentationUrls:
-  - title: Cloudflare R2 documentation
-    url: https://developers.cloudflare.com/r2/
-    type: api_reference
-  - title: Authentication
-    url: https://developers.cloudflare.com/r2/api/s3/tokens/
-    type: authentication_guide
-  - title: Limits
-    url: https://developers.cloudflare.com/r2/platform/limits/
-    type: rate_limits
-  - title: Cloudflare Status
-    url: https://www.cloudflarestatus.com/
-    type: status_page
-metadataSpecVersion: '1.0'
+    - title: Cloudflare R2 documentation
+      url: https://developers.cloudflare.com/r2/
+      type: api_reference
+    - title: Authentication
+      url: https://developers.cloudflare.com/r2/api/s3/tokens/
+      type: authentication_guide
+    - title: Limits
+      url: https://developers.cloudflare.com/r2/platform/limits/
+      type: rate_limits
+    - title: Cloudflare Status
+      url: https://www.cloudflarestatus.com/
+      type: status_page
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-rabbitmq/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-rabbitmq/metadata.yaml
@@ -10,7 +10,7 @@ data:
   name: RabbitMQ
   registryOverrides:
     cloud:
-      enabled: false
+      enabled: false # hide RabbitMQ Destination https://github.com/airbytehq/airbyte/issues/16315
     oss:
       enabled: true
   releaseStage: alpha
@@ -24,6 +24,16 @@ data:
   supportLevel: community
   connectorTestSuitesOptions:
     - suite: unitTests
+    # Disable integration tests
+    # They are not passing
+    # No Airbyte Cloud Usage
+    # - suite: integrationTests
+    #   testSecrets:
+    #     - name: SECRET_DESTINATION-RABBITMQ__CREDS
+    #       fileName: config.json
+    #       secretStore:
+    #         type: GSM
+    #         alias: airbyte-connector-testing-secret-store
   connectorBuildOptions:
     baseImage: docker.io/airbyte/python-connector-base:4.0.0@sha256:d9894b6895923b379f3006fa251147806919c62b7d9021b5cd125bb67d7bbe22
   externalDocumentationUrls:

--- a/airbyte-integrations/connectors/destination-rabbitmq/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-rabbitmq/metadata.yaml
@@ -10,30 +10,27 @@ data:
   name: RabbitMQ
   registryOverrides:
     cloud:
-      enabled: false # hide RabbitMQ Destination https://github.com/airbytehq/airbyte/issues/16315
+      enabled: false
     oss:
       enabled: true
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/rabbitmq
   tags:
-    - language:python
-    - cdk:python
+  - language:python
+  - cdk:python
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
-    - suite: unitTests
-    # Disable integration tests
-    # They are not passing
-    # No Airbyte Cloud Usage
-    # - suite: integrationTests
-    #   testSecrets:
-    #     - name: SECRET_DESTINATION-RABBITMQ__CREDS
-    #       fileName: config.json
-    #       secretStore:
-    #         type: GSM
-    #         alias: airbyte-connector-testing-secret-store
+  - suite: unitTests
   connectorBuildOptions:
     baseImage: docker.io/airbyte/python-connector-base:4.0.0@sha256:d9894b6895923b379f3006fa251147806919c62b7d9021b5cd125bb67d7bbe22
-metadataSpecVersion: "1.0"
+  externalDocumentationUrls:
+  - title: RabbitMQ documentation
+    url: https://www.rabbitmq.com/documentation.html
+    type: api_reference
+  - title: Access control
+    url: https://www.rabbitmq.com/access-control.html
+    type: permissions_scopes
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-rabbitmq/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-rabbitmq/metadata.yaml
@@ -16,21 +16,21 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/rabbitmq
   tags:
-  - language:python
-  - cdk:python
+    - language:python
+    - cdk:python
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
-  - suite: unitTests
+    - suite: unitTests
   connectorBuildOptions:
     baseImage: docker.io/airbyte/python-connector-base:4.0.0@sha256:d9894b6895923b379f3006fa251147806919c62b7d9021b5cd125bb67d7bbe22
   externalDocumentationUrls:
-  - title: RabbitMQ documentation
-    url: https://www.rabbitmq.com/documentation.html
-    type: api_reference
-  - title: Access control
-    url: https://www.rabbitmq.com/access-control.html
-    type: permissions_scopes
-metadataSpecVersion: '1.0'
+    - title: RabbitMQ documentation
+      url: https://www.rabbitmq.com/documentation.html
+      type: api_reference
+    - title: Access control
+      url: https://www.rabbitmq.com/access-control.html
+      type: permissions_scopes
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-ragie/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-ragie/metadata.yaml
@@ -1,7 +1,7 @@
 data:
   allowedHosts:
     hosts:
-      - "api.ragie.ai"
+    - api.ragie.ai
   registryOverrides:
     oss:
       enabled: true
@@ -23,6 +23,10 @@ data:
   supportLevel: community
   documentationUrl: https://docs.airbyte.com/integrations/destinations/ragie
   tags:
-    - language:python
-    - cdk:python
-metadataSpecVersion: "1.0"
+  - language:python
+  - cdk:python
+  externalDocumentationUrls:
+  - title: Ragie documentation
+    url: https://docs.ragie.ai/
+    type: api_reference
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-ragie/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-ragie/metadata.yaml
@@ -1,7 +1,7 @@
 data:
   allowedHosts:
     hosts:
-    - api.ragie.ai
+      - api.ragie.ai
   registryOverrides:
     oss:
       enabled: true
@@ -23,10 +23,10 @@ data:
   supportLevel: community
   documentationUrl: https://docs.airbyte.com/integrations/destinations/ragie
   tags:
-  - language:python
-  - cdk:python
+    - language:python
+    - cdk:python
   externalDocumentationUrls:
-  - title: Ragie documentation
-    url: https://docs.ragie.ai/
-    type: api_reference
-metadataSpecVersion: '1.0'
+    - title: Ragie documentation
+      url: https://docs.ragie.ai/
+      type: api_reference
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-redis/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-redis/metadata.yaml
@@ -18,13 +18,23 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/redis
   tags:
-    - language:java
+  - language:java
   ab_internal:
     sl: 100
     ql: 100
     requireVersionIncrementsInPullRequests: false
   supportLevel: community
   connectorTestSuitesOptions:
-    - suite: unitTests
-    - suite: integrationTests
-metadataSpecVersion: "1.0"
+  - suite: unitTests
+  - suite: integrationTests
+  externalDocumentationUrls:
+  - title: Redis documentation
+    url: https://redis.io/docs/
+    type: api_reference
+  - title: Redis ACL
+    url: https://redis.io/docs/management/security/acl/
+    type: permissions_scopes
+  - title: Release notes
+    url: https://redis.io/docs/about/releases/
+    type: api_release_history
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-redis/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-redis/metadata.yaml
@@ -18,23 +18,23 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/redis
   tags:
-  - language:java
+    - language:java
   ab_internal:
     sl: 100
     ql: 100
     requireVersionIncrementsInPullRequests: false
   supportLevel: community
   connectorTestSuitesOptions:
-  - suite: unitTests
-  - suite: integrationTests
+    - suite: unitTests
+    - suite: integrationTests
   externalDocumentationUrls:
-  - title: Redis documentation
-    url: https://redis.io/docs/
-    type: api_reference
-  - title: Redis ACL
-    url: https://redis.io/docs/management/security/acl/
-    type: permissions_scopes
-  - title: Release notes
-    url: https://redis.io/docs/about/releases/
-    type: api_release_history
-metadataSpecVersion: '1.0'
+    - title: Redis documentation
+      url: https://redis.io/docs/
+      type: api_reference
+    - title: Redis ACL
+      url: https://redis.io/docs/management/security/acl/
+      type: permissions_scopes
+    - title: Release notes
+      url: https://redis.io/docs/about/releases/
+      type: api_release_history
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-redpanda/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-redpanda/metadata.yaml
@@ -16,19 +16,19 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/redpanda
   tags:
-  - language:java
+    - language:java
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: archived
   externalDocumentationUrls:
-  - title: Redpanda documentation
-    url: https://docs.redpanda.com/
-    type: api_reference
-  - title: Authentication
-    url: https://docs.redpanda.com/docs/manage/security/authentication/
-    type: authentication_guide
-  - title: Redpanda Cloud Status
-    url: https://status.redpanda.com/
-    type: status_page
-metadataSpecVersion: '1.0'
+    - title: Redpanda documentation
+      url: https://docs.redpanda.com/
+      type: api_reference
+    - title: Authentication
+      url: https://docs.redpanda.com/docs/manage/security/authentication/
+      type: authentication_guide
+    - title: Redpanda Cloud Status
+      url: https://status.redpanda.com/
+      type: status_page
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-redpanda/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-redpanda/metadata.yaml
@@ -16,9 +16,19 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/redpanda
   tags:
-    - language:java
+  - language:java
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: archived
-metadataSpecVersion: "1.0"
+  externalDocumentationUrls:
+  - title: Redpanda documentation
+    url: https://docs.redpanda.com/
+    type: api_reference
+  - title: Authentication
+    url: https://docs.redpanda.com/docs/manage/security/authentication/
+    type: authentication_guide
+  - title: Redpanda Cloud Status
+    url: https://status.redpanda.com/
+    type: status_page
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-redshift/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-redshift/metadata.yaml
@@ -6,39 +6,39 @@ data:
     baseImage: docker.io/airbyte/java-connector-base:2.0.1@sha256:ec89bd1a89e825514dd2fc8730ba299a3ae1544580a078df0e35c5202c2085b3
   connectorSubtype: database
   connectorTestSuitesOptions:
-  - suite: unitTests
-  - suite: integrationTests
-    testSecrets:
-    - fileName: 1s1t_config.json
-      name: SECRET_DESTINATION-REDSHIFT_1S1T_CONFIG
-      secretStore:
-        alias: airbyte-connector-testing-secret-store
-        type: GSM
-    - fileName: 1s1t_config_raw_schema_override.json
-      name: SECRET_DESTINATION-REDSHIFT_1S1T_CONFIG_RAW_SCHEMA_OVERRIDE_DISABLE_TYPING_DEDUPING
-      secretStore:
-        alias: airbyte-connector-testing-secret-store
-        type: GSM
-    - fileName: 1s1t_config_staging.json
-      name: SECRET_DESTINATION-REDSHIFT_1S1T_CONFIG_STAGING
-      secretStore:
-        alias: airbyte-connector-testing-secret-store
-        type: GSM
-    - fileName: 1s1t_config_staging_raw_schema_override.json
-      name: SECRET_DESTINATION-REDSHIFT_1S1T_CONFIG_STAGING_RAW_SCHEMA_OVERRIDE_DISABLE_TYPING_DEDUPING
-      secretStore:
-        alias: airbyte-connector-testing-secret-store
-        type: GSM
-    - fileName: config_staging.json
-      name: SECRET_DESTINATION-REDSHIFT_STAGING__CREDS
-      secretStore:
-        alias: airbyte-connector-testing-secret-store
-        type: GSM
-    - fileName: config.json
-      name: SECRET_DESTINATION-REDSHIFT__CREDS
-      secretStore:
-        alias: airbyte-connector-testing-secret-store
-        type: GSM
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - fileName: 1s1t_config.json
+          name: SECRET_DESTINATION-REDSHIFT_1S1T_CONFIG
+          secretStore:
+            alias: airbyte-connector-testing-secret-store
+            type: GSM
+        - fileName: 1s1t_config_raw_schema_override.json
+          name: SECRET_DESTINATION-REDSHIFT_1S1T_CONFIG_RAW_SCHEMA_OVERRIDE_DISABLE_TYPING_DEDUPING
+          secretStore:
+            alias: airbyte-connector-testing-secret-store
+            type: GSM
+        - fileName: 1s1t_config_staging.json
+          name: SECRET_DESTINATION-REDSHIFT_1S1T_CONFIG_STAGING
+          secretStore:
+            alias: airbyte-connector-testing-secret-store
+            type: GSM
+        - fileName: 1s1t_config_staging_raw_schema_override.json
+          name: SECRET_DESTINATION-REDSHIFT_1S1T_CONFIG_STAGING_RAW_SCHEMA_OVERRIDE_DISABLE_TYPING_DEDUPING
+          secretStore:
+            alias: airbyte-connector-testing-secret-store
+            type: GSM
+        - fileName: config_staging.json
+          name: SECRET_DESTINATION-REDSHIFT_STAGING__CREDS
+          secretStore:
+            alias: airbyte-connector-testing-secret-store
+            type: GSM
+        - fileName: config.json
+          name: SECRET_DESTINATION-REDSHIFT__CREDS
+          secretStore:
+            alias: airbyte-connector-testing-secret-store
+            type: GSM
   connectorType: destination
   definitionId: f7a7d195-377f-cf5b-70a5-be6b819019dc
   dockerImageTag: 3.5.3
@@ -57,7 +57,8 @@ data:
   releases:
     breakingChanges:
       2.0.0:
-        message: 'This version introduces [Destinations V2](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#what-is-destinations-v2),
+        message:
+          "This version introduces [Destinations V2](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#what-is-destinations-v2),
           which provides better error handling, incremental delivery of data for large
           syncs, and improved final table structures. To review the breaking changes,
           and how to upgrade, see [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#quick-start-to-upgrading).
@@ -67,45 +68,46 @@ data:
           at their next sync. You can manually sync existing connections prior to
           the next scheduled sync to start the upgrade early.
 
-          '
-        upgradeDeadline: '2024-03-15'
+          "
+        upgradeDeadline: "2024-03-15"
       3.0.0:
-        message: 'Version 3.0.0 of destination-redshift removes support for the "standard
+        message:
+          'Version 3.0.0 of destination-redshift removes support for the "standard
           inserts" mode. S3 staging was always preferred for being faster and less
           expensive, and as part of Airbyte 1.0, we are officially removing the inferior
           "standard inserts" mode. Upgrading to this version of the destination will
           require a configuration with an S3 staging area.
 
           '
-        upgradeDeadline: '2024-07-31'
+        upgradeDeadline: "2024-07-31"
   resourceRequirements:
     jobSpecific:
-    - jobType: sync
-      resourceRequirements:
-        memory_limit: 1Gi
-        memory_request: 1Gi
+      - jobType: sync
+        resourceRequirements:
+          memory_limit: 1Gi
+          memory_request: 1Gi
   supportLevel: certified
   supportsDbt: true
   supportsRefreshes: true
   tags:
-  - language:java
+    - language:java
   externalDocumentationUrls:
-  - title: Release notes
-    url: https://docs.aws.amazon.com/redshift/latest/mgmt/release-notes.html
-    type: api_release_history
-  - title: SQL reference
-    url: https://docs.aws.amazon.com/redshift/latest/dg/c_SQL_reference.html
-    type: sql_reference
-  - title: Database authentication
-    url: https://docs.aws.amazon.com/redshift/latest/mgmt/generating-user-credentials.html
-    type: authentication_guide
-  - title: Access control
-    url: https://docs.aws.amazon.com/redshift/latest/dg/r_GRANT.html
-    type: permissions_scopes
-  - title: Quotas and limits
-    url: https://docs.aws.amazon.com/redshift/latest/mgmt/amazon-redshift-limits.html
-    type: rate_limits
-  - title: AWS Service Health Dashboard
-    url: https://health.aws.amazon.com/health/status
-    type: status_page
-metadataSpecVersion: '1.0'
+    - title: Release notes
+      url: https://docs.aws.amazon.com/redshift/latest/mgmt/release-notes.html
+      type: api_release_history
+    - title: SQL reference
+      url: https://docs.aws.amazon.com/redshift/latest/dg/c_SQL_reference.html
+      type: sql_reference
+    - title: Database authentication
+      url: https://docs.aws.amazon.com/redshift/latest/mgmt/generating-user-credentials.html
+      type: authentication_guide
+    - title: Access control
+      url: https://docs.aws.amazon.com/redshift/latest/dg/r_GRANT.html
+      type: permissions_scopes
+    - title: Quotas and limits
+      url: https://docs.aws.amazon.com/redshift/latest/mgmt/amazon-redshift-limits.html
+      type: rate_limits
+    - title: AWS Service Health Dashboard
+      url: https://health.aws.amazon.com/health/status
+      type: status_page
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-redshift/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-redshift/metadata.yaml
@@ -6,39 +6,39 @@ data:
     baseImage: docker.io/airbyte/java-connector-base:2.0.1@sha256:ec89bd1a89e825514dd2fc8730ba299a3ae1544580a078df0e35c5202c2085b3
   connectorSubtype: database
   connectorTestSuitesOptions:
-    - suite: unitTests
-    - suite: integrationTests
-      testSecrets:
-        - fileName: 1s1t_config.json
-          name: SECRET_DESTINATION-REDSHIFT_1S1T_CONFIG
-          secretStore:
-            alias: airbyte-connector-testing-secret-store
-            type: GSM
-        - fileName: 1s1t_config_raw_schema_override.json
-          name: SECRET_DESTINATION-REDSHIFT_1S1T_CONFIG_RAW_SCHEMA_OVERRIDE_DISABLE_TYPING_DEDUPING
-          secretStore:
-            alias: airbyte-connector-testing-secret-store
-            type: GSM
-        - fileName: 1s1t_config_staging.json
-          name: SECRET_DESTINATION-REDSHIFT_1S1T_CONFIG_STAGING
-          secretStore:
-            alias: airbyte-connector-testing-secret-store
-            type: GSM
-        - fileName: 1s1t_config_staging_raw_schema_override.json
-          name: SECRET_DESTINATION-REDSHIFT_1S1T_CONFIG_STAGING_RAW_SCHEMA_OVERRIDE_DISABLE_TYPING_DEDUPING
-          secretStore:
-            alias: airbyte-connector-testing-secret-store
-            type: GSM
-        - fileName: config_staging.json
-          name: SECRET_DESTINATION-REDSHIFT_STAGING__CREDS
-          secretStore:
-            alias: airbyte-connector-testing-secret-store
-            type: GSM
-        - fileName: config.json
-          name: SECRET_DESTINATION-REDSHIFT__CREDS
-          secretStore:
-            alias: airbyte-connector-testing-secret-store
-            type: GSM
+  - suite: unitTests
+  - suite: integrationTests
+    testSecrets:
+    - fileName: 1s1t_config.json
+      name: SECRET_DESTINATION-REDSHIFT_1S1T_CONFIG
+      secretStore:
+        alias: airbyte-connector-testing-secret-store
+        type: GSM
+    - fileName: 1s1t_config_raw_schema_override.json
+      name: SECRET_DESTINATION-REDSHIFT_1S1T_CONFIG_RAW_SCHEMA_OVERRIDE_DISABLE_TYPING_DEDUPING
+      secretStore:
+        alias: airbyte-connector-testing-secret-store
+        type: GSM
+    - fileName: 1s1t_config_staging.json
+      name: SECRET_DESTINATION-REDSHIFT_1S1T_CONFIG_STAGING
+      secretStore:
+        alias: airbyte-connector-testing-secret-store
+        type: GSM
+    - fileName: 1s1t_config_staging_raw_schema_override.json
+      name: SECRET_DESTINATION-REDSHIFT_1S1T_CONFIG_STAGING_RAW_SCHEMA_OVERRIDE_DISABLE_TYPING_DEDUPING
+      secretStore:
+        alias: airbyte-connector-testing-secret-store
+        type: GSM
+    - fileName: config_staging.json
+      name: SECRET_DESTINATION-REDSHIFT_STAGING__CREDS
+      secretStore:
+        alias: airbyte-connector-testing-secret-store
+        type: GSM
+    - fileName: config.json
+      name: SECRET_DESTINATION-REDSHIFT__CREDS
+      secretStore:
+        alias: airbyte-connector-testing-secret-store
+        type: GSM
   connectorType: destination
   definitionId: f7a7d195-377f-cf5b-70a5-be6b819019dc
   dockerImageTag: 3.5.3
@@ -57,8 +57,7 @@ data:
   releases:
     breakingChanges:
       2.0.0:
-        message:
-          "This version introduces [Destinations V2](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#what-is-destinations-v2),
+        message: 'This version introduces [Destinations V2](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#what-is-destinations-v2),
           which provides better error handling, incremental delivery of data for large
           syncs, and improved final table structures. To review the breaking changes,
           and how to upgrade, see [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#quick-start-to-upgrading).
@@ -68,27 +67,45 @@ data:
           at their next sync. You can manually sync existing connections prior to
           the next scheduled sync to start the upgrade early.
 
-          "
-        upgradeDeadline: "2024-03-15"
+          '
+        upgradeDeadline: '2024-03-15'
       3.0.0:
-        message:
-          'Version 3.0.0 of destination-redshift removes support for the "standard
+        message: 'Version 3.0.0 of destination-redshift removes support for the "standard
           inserts" mode. S3 staging was always preferred for being faster and less
           expensive, and as part of Airbyte 1.0, we are officially removing the inferior
           "standard inserts" mode. Upgrading to this version of the destination will
           require a configuration with an S3 staging area.
 
           '
-        upgradeDeadline: "2024-07-31"
+        upgradeDeadline: '2024-07-31'
   resourceRequirements:
     jobSpecific:
-      - jobType: sync
-        resourceRequirements:
-          memory_limit: 1Gi
-          memory_request: 1Gi
+    - jobType: sync
+      resourceRequirements:
+        memory_limit: 1Gi
+        memory_request: 1Gi
   supportLevel: certified
   supportsDbt: true
   supportsRefreshes: true
   tags:
-    - language:java
-metadataSpecVersion: "1.0"
+  - language:java
+  externalDocumentationUrls:
+  - title: Release notes
+    url: https://docs.aws.amazon.com/redshift/latest/mgmt/release-notes.html
+    type: api_release_history
+  - title: SQL reference
+    url: https://docs.aws.amazon.com/redshift/latest/dg/c_SQL_reference.html
+    type: sql_reference
+  - title: Database authentication
+    url: https://docs.aws.amazon.com/redshift/latest/mgmt/generating-user-credentials.html
+    type: authentication_guide
+  - title: Access control
+    url: https://docs.aws.amazon.com/redshift/latest/dg/r_GRANT.html
+    type: permissions_scopes
+  - title: Quotas and limits
+    url: https://docs.aws.amazon.com/redshift/latest/mgmt/amazon-redshift-limits.html
+    type: rate_limits
+  - title: AWS Service Health Dashboard
+    url: https://health.aws.amazon.com/health/status
+    type: status_page
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-rockset/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-rockset/metadata.yaml
@@ -15,9 +15,19 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/rockset
   tags:
-    - language:java
+  - language:java
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: archived
-metadataSpecVersion: "1.0"
+  externalDocumentationUrls:
+  - title: Rockset documentation
+    url: https://rockset.com/docs/
+    type: api_reference
+  - title: API reference
+    url: https://rockset.com/docs/rest-api/
+    type: api_reference
+  - title: Authentication
+    url: https://rockset.com/docs/rest-api/#authentication
+    type: authentication_guide
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-rockset/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-rockset/metadata.yaml
@@ -15,19 +15,19 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/rockset
   tags:
-  - language:java
+    - language:java
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: archived
   externalDocumentationUrls:
-  - title: Rockset documentation
-    url: https://rockset.com/docs/
-    type: api_reference
-  - title: API reference
-    url: https://rockset.com/docs/rest-api/
-    type: api_reference
-  - title: Authentication
-    url: https://rockset.com/docs/rest-api/#authentication
-    type: authentication_guide
-metadataSpecVersion: '1.0'
+    - title: Rockset documentation
+      url: https://rockset.com/docs/
+      type: api_reference
+    - title: API reference
+      url: https://rockset.com/docs/rest-api/
+      type: api_reference
+    - title: Authentication
+      url: https://rockset.com/docs/rest-api/#authentication
+      type: authentication_guide
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-s3-data-lake/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/metadata.yaml
@@ -12,24 +12,24 @@ data:
       enabled: true
   connectorSubtype: file
   connectorTestSuitesOptions:
-    - suite: unitTests
-    - suite: integrationTests
-      testSecrets:
-        - name: SECRET_DESTINATION-ICEBERG_V2_S3_GLUE_CONFIG
-          fileName: glue.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-        - name: SECRET_DESTINATION-ICEBERG_V2_S3_GLUE_ASSUME_ROLE_CONFIG
-          fileName: glue_assume_role.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-        - name: SECRET_DESTINATION-ICEBERG_V2_S3_GLUE_ASSUME_ROLE_SYSTEM_AWS_CONFIG
-          fileName: glue_aws_assume_role.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
+  - suite: unitTests
+  - suite: integrationTests
+    testSecrets:
+    - name: SECRET_DESTINATION-ICEBERG_V2_S3_GLUE_CONFIG
+      fileName: glue.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+    - name: SECRET_DESTINATION-ICEBERG_V2_S3_GLUE_ASSUME_ROLE_CONFIG
+      fileName: glue_assume_role.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+    - name: SECRET_DESTINATION-ICEBERG_V2_S3_GLUE_ASSUME_ROLE_SYSTEM_AWS_CONFIG
+      fileName: glue_aws_assume_role.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
   connectorType: destination
   definitionId: 716ca874-520b-4902-9f80-9fad66754b89
   dockerImageTag: 0.3.41
@@ -43,5 +43,15 @@ data:
   supportLevel: certified
   supportsRefreshes: true
   tags:
-    - language:java
-metadataSpecVersion: "1.0"
+  - language:java
+  externalDocumentationUrls:
+  - title: AWS S3 documentation
+    url: https://docs.aws.amazon.com/s3/
+    type: api_reference
+  - title: IAM authentication
+    url: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html
+    type: authentication_guide
+  - title: Bucket policies and permissions
+    url: https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-policy-language-overview.html
+    type: permissions_scopes
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-s3-data-lake/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/metadata.yaml
@@ -12,24 +12,24 @@ data:
       enabled: true
   connectorSubtype: file
   connectorTestSuitesOptions:
-  - suite: unitTests
-  - suite: integrationTests
-    testSecrets:
-    - name: SECRET_DESTINATION-ICEBERG_V2_S3_GLUE_CONFIG
-      fileName: glue.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
-    - name: SECRET_DESTINATION-ICEBERG_V2_S3_GLUE_ASSUME_ROLE_CONFIG
-      fileName: glue_assume_role.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
-    - name: SECRET_DESTINATION-ICEBERG_V2_S3_GLUE_ASSUME_ROLE_SYSTEM_AWS_CONFIG
-      fileName: glue_aws_assume_role.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION-ICEBERG_V2_S3_GLUE_CONFIG
+          fileName: glue.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-ICEBERG_V2_S3_GLUE_ASSUME_ROLE_CONFIG
+          fileName: glue_assume_role.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-ICEBERG_V2_S3_GLUE_ASSUME_ROLE_SYSTEM_AWS_CONFIG
+          fileName: glue_aws_assume_role.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
   connectorType: destination
   definitionId: 716ca874-520b-4902-9f80-9fad66754b89
   dockerImageTag: 0.3.41
@@ -43,15 +43,15 @@ data:
   supportLevel: certified
   supportsRefreshes: true
   tags:
-  - language:java
+    - language:java
   externalDocumentationUrls:
-  - title: AWS S3 documentation
-    url: https://docs.aws.amazon.com/s3/
-    type: api_reference
-  - title: IAM authentication
-    url: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html
-    type: authentication_guide
-  - title: Bucket policies and permissions
-    url: https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-policy-language-overview.html
-    type: permissions_scopes
-metadataSpecVersion: '1.0'
+    - title: AWS S3 documentation
+      url: https://docs.aws.amazon.com/s3/
+      type: api_reference
+    - title: IAM authentication
+      url: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html
+      type: authentication_guide
+    - title: Bucket policies and permissions
+      url: https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-policy-language-overview.html
+      type: permissions_scopes
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-s3-glue/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3-glue/metadata.yaml
@@ -16,17 +16,27 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/s3-glue
   tags:
-    - language:java
+  - language:java
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: archived
   connectorTestSuitesOptions:
-    - suite: integrationTests
-      testSecrets:
-        - name: SECRET_DESTINATION-S3-GLUE__CREDS
-          fileName: config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-metadataSpecVersion: "1.0"
+  - suite: integrationTests
+    testSecrets:
+    - name: SECRET_DESTINATION-S3-GLUE__CREDS
+      fileName: config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+  - title: AWS Glue documentation
+    url: https://docs.aws.amazon.com/glue/
+    type: api_reference
+  - title: IAM authentication
+    url: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html
+    type: authentication_guide
+  - title: IAM policies
+    url: https://docs.aws.amazon.com/glue/latest/dg/security-iam.html
+    type: permissions_scopes
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-s3-glue/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3-glue/metadata.yaml
@@ -16,27 +16,27 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/s3-glue
   tags:
-  - language:java
+    - language:java
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: archived
   connectorTestSuitesOptions:
-  - suite: integrationTests
-    testSecrets:
-    - name: SECRET_DESTINATION-S3-GLUE__CREDS
-      fileName: config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION-S3-GLUE__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
   externalDocumentationUrls:
-  - title: AWS Glue documentation
-    url: https://docs.aws.amazon.com/glue/
-    type: api_reference
-  - title: IAM authentication
-    url: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html
-    type: authentication_guide
-  - title: IAM policies
-    url: https://docs.aws.amazon.com/glue/latest/dg/security-iam.html
-    type: permissions_scopes
-metadataSpecVersion: '1.0'
+    - title: AWS Glue documentation
+      url: https://docs.aws.amazon.com/glue/
+      type: api_reference
+    - title: IAM authentication
+      url: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html
+      type: authentication_guide
+    - title: IAM policies
+      url: https://docs.aws.amazon.com/glue/latest/dg/security-iam.html
+      type: permissions_scopes
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-s3/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3/metadata.yaml
@@ -12,11 +12,11 @@ data:
     dataChannel:
       version: 0.0.2
       supportedSerialization:
-      - JSONL
-      - PROTOBUF
+        - JSONL
+        - PROTOBUF
       supportedTransport:
-      - SOCKET
-      - STDIO
+        - SOCKET
+        - STDIO
   connectorBuildOptions:
     baseImage: docker.io/airbyte/java-connector-base:2.0.1@sha256:ec89bd1a89e825514dd2fc8730ba299a3ae1544580a078df0e35c5202c2085b3
   registryOverrides:
@@ -28,22 +28,23 @@ data:
   releases:
     breakingChanges:
       1.0.0:
-        message: '**This release includes breaking changes, including major revisions
+        message:
+          "**This release includes breaking changes, including major revisions
           to the schema of stored data. Do not upgrade without reviewing the migration
           guide.**
 
-          '
-        upgradeDeadline: '2024-10-08'
+          "
+        upgradeDeadline: "2024-10-08"
     rolloutConfiguration:
       enableProgressiveRollout: false
   resourceRequirements:
     jobSpecific:
-    - jobType: sync
-      resourceRequirements:
-        memory_request: 2Gi
+      - jobType: sync
+        resourceRequirements:
+          memory_request: 2Gi
   documentationUrl: https://docs.airbyte.com/integrations/destinations/s3
   tags:
-  - language:java
+    - language:java
   ab_internal:
     sl: 300
     ql: 300
@@ -52,118 +53,118 @@ data:
   supportsRefreshes: true
   supportsFileTransfer: true
   connectorTestSuitesOptions:
-  - suite: unitTests
-  - suite: integrationTests
-    testSecrets:
-    - name: SECRET_DESTINATION-S3-V2-MINIMAL-REQUIRED-CONFIG
-      fileName: s3_dest_v2_minimal_required_config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
-    - name: SECRET_DESTINATION-S3-V2-JSONL-ROOT-LEVEL-FLATTENING
-      fileName: s3_dest_v2_jsonl_root_level_flattening_config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
-    - name: SECRET_DESTINATION-S3-V2-JSONL-GZIP
-      fileName: s3_dest_v2_jsonl_gzip_config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
-    - name: SECRET_DESTINATION-S3-V2-CSV
-      fileName: s3_dest_v2_csv_config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
-    - name: SECRET_DESTINATION-S3-V2-CSV-ROOT-LEVEL-FLATTENING
-      fileName: s3_dest_v2_csv_root_level_flattening_config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
-    - name: SECRET_DESTINATION-S3-V2-CSV-GZIP
-      fileName: s3_dest_v2_csv_gzip_config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
-    - name: SECRET_DESTINATION-S3-V2-AVRO
-      fileName: s3_dest_v2_avro_config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
-    - name: SECRET_DESTINATION-S3-V2-AVRO-BZIP2
-      fileName: s3_dest_v2_avro_bzip2_config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
-    - name: SECRET_DESTINATION-S3-V2-PARQUET
-      fileName: s3_dest_v2_parquet_config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
-    - name: SECRET_DESTINATION-S3-V2-PARQUET-SNAPPY
-      fileName: s3_dest_v2_parquet_snappy_config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
-    - name: SECRET_DESTINATION-S3-ASSUME-ROLE-CONFIG
-      fileName: s3_dest_assume_role_config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
-    - name: SECRET_DESTINATION-S3_CREDS
-      fileName: config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
-    - name: SECRET_DESTINATION-S3_MIN_REQUIRED_PERMISSIONS_CREDS
-      fileName: s3_dest_min_required_permissions_creds.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
-    - name: SECRET_DESTINATION-S3_POLICY_MANAGER_CREDENTIALS
-      fileName: s3_dest_policy_manager_credentials.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
-    - name: SECRET_DESTINATION-S3_DEST_IAM_ROLE_CREDENTIALS_FOR_ASSUME_ROLE_AUTH
-      fileName: s3_dest_iam_role_credentials_for_assume_role_auth.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
-    - name: SECRET_DESTINATION-S3-V2-ENDPOINT_URL
-      fileName: s3_dest_v2_endpoint_url_config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
-    - name: SECRET_DESTINATION-S3-V2-ENDPOINT_EMPTY_URL
-      fileName: s3_dest_v2_endpoint_empty_url_config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
-    - name: SECRET_DESTINATION-S3-V2_AMBIGUOUS_FILEPATH
-      fileName: s3_dest_v2_ambiguous_filepath_config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
-    - name: SECRET_DESTINATION-S3-V2_CSV_ASSUME_ROLE
-      fileName: s3_dest_v2_csv_assume_role_config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION-S3-V2-MINIMAL-REQUIRED-CONFIG
+          fileName: s3_dest_v2_minimal_required_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-S3-V2-JSONL-ROOT-LEVEL-FLATTENING
+          fileName: s3_dest_v2_jsonl_root_level_flattening_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-S3-V2-JSONL-GZIP
+          fileName: s3_dest_v2_jsonl_gzip_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-S3-V2-CSV
+          fileName: s3_dest_v2_csv_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-S3-V2-CSV-ROOT-LEVEL-FLATTENING
+          fileName: s3_dest_v2_csv_root_level_flattening_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-S3-V2-CSV-GZIP
+          fileName: s3_dest_v2_csv_gzip_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-S3-V2-AVRO
+          fileName: s3_dest_v2_avro_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-S3-V2-AVRO-BZIP2
+          fileName: s3_dest_v2_avro_bzip2_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-S3-V2-PARQUET
+          fileName: s3_dest_v2_parquet_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-S3-V2-PARQUET-SNAPPY
+          fileName: s3_dest_v2_parquet_snappy_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-S3-ASSUME-ROLE-CONFIG
+          fileName: s3_dest_assume_role_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-S3_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-S3_MIN_REQUIRED_PERMISSIONS_CREDS
+          fileName: s3_dest_min_required_permissions_creds.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-S3_POLICY_MANAGER_CREDENTIALS
+          fileName: s3_dest_policy_manager_credentials.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-S3_DEST_IAM_ROLE_CREDENTIALS_FOR_ASSUME_ROLE_AUTH
+          fileName: s3_dest_iam_role_credentials_for_assume_role_auth.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-S3-V2-ENDPOINT_URL
+          fileName: s3_dest_v2_endpoint_url_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-S3-V2-ENDPOINT_EMPTY_URL
+          fileName: s3_dest_v2_endpoint_empty_url_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-S3-V2_AMBIGUOUS_FILEPATH
+          fileName: s3_dest_v2_ambiguous_filepath_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-S3-V2_CSV_ASSUME_ROLE
+          fileName: s3_dest_v2_csv_assume_role_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
   externalDocumentationUrls:
-  - title: AWS S3 documentation
-    url: https://docs.aws.amazon.com/s3/
-    type: api_reference
-  - title: IAM authentication
-    url: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html
-    type: authentication_guide
-  - title: Bucket policies and permissions
-    url: https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-policy-language-overview.html
-    type: permissions_scopes
-  - title: Request rate and performance
-    url: https://docs.aws.amazon.com/AmazonS3/latest/userguide/optimizing-performance.html
-    type: rate_limits
-  - title: AWS Service Health Dashboard
-    url: https://health.aws.amazon.com/health/status
-    type: status_page
-metadataSpecVersion: '1.0'
+    - title: AWS S3 documentation
+      url: https://docs.aws.amazon.com/s3/
+      type: api_reference
+    - title: IAM authentication
+      url: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html
+      type: authentication_guide
+    - title: Bucket policies and permissions
+      url: https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-policy-language-overview.html
+      type: permissions_scopes
+    - title: Request rate and performance
+      url: https://docs.aws.amazon.com/AmazonS3/latest/userguide/optimizing-performance.html
+      type: rate_limits
+    - title: AWS Service Health Dashboard
+      url: https://health.aws.amazon.com/health/status
+      type: status_page
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-s3/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3/metadata.yaml
@@ -28,12 +28,8 @@ data:
   releases:
     breakingChanges:
       1.0.0:
-        message:
-          "**This release includes breaking changes, including major revisions
-          to the schema of stored data. Do not upgrade without reviewing the migration
-          guide.**
-
-          "
+        message: >
+          **This release includes breaking changes, including major revisions to the schema of stored data. Do not upgrade without reviewing the migration guide.**
         upgradeDeadline: "2024-10-08"
     rolloutConfiguration:
       enableProgressiveRollout: false

--- a/airbyte-integrations/connectors/destination-s3/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3/metadata.yaml
@@ -10,9 +10,13 @@ data:
   name: S3
   connectorIPCOptions:
     dataChannel:
-      version: "0.0.2"
-      supportedSerialization: ["JSONL", "PROTOBUF"]
-      supportedTransport: ["SOCKET", "STDIO"]
+      version: 0.0.2
+      supportedSerialization:
+      - JSONL
+      - PROTOBUF
+      supportedTransport:
+      - SOCKET
+      - STDIO
   connectorBuildOptions:
     baseImage: docker.io/airbyte/java-connector-base:2.0.1@sha256:ec89bd1a89e825514dd2fc8730ba299a3ae1544580a078df0e35c5202c2085b3
   registryOverrides:
@@ -24,19 +28,22 @@ data:
   releases:
     breakingChanges:
       1.0.0:
-        message: >
-          **This release includes breaking changes, including major revisions to the schema of stored data. Do not upgrade without reviewing the migration guide.**
-        upgradeDeadline: "2024-10-08"
+        message: '**This release includes breaking changes, including major revisions
+          to the schema of stored data. Do not upgrade without reviewing the migration
+          guide.**
+
+          '
+        upgradeDeadline: '2024-10-08'
     rolloutConfiguration:
       enableProgressiveRollout: false
   resourceRequirements:
     jobSpecific:
-      - jobType: sync
-        resourceRequirements:
-          memory_request: 2Gi
+    - jobType: sync
+      resourceRequirements:
+        memory_request: 2Gi
   documentationUrl: https://docs.airbyte.com/integrations/destinations/s3
   tags:
-    - language:java
+  - language:java
   ab_internal:
     sl: 300
     ql: 300
@@ -45,102 +52,118 @@ data:
   supportsRefreshes: true
   supportsFileTransfer: true
   connectorTestSuitesOptions:
-    - suite: unitTests
-    - suite: integrationTests
-      testSecrets:
-        - name: SECRET_DESTINATION-S3-V2-MINIMAL-REQUIRED-CONFIG
-          fileName: s3_dest_v2_minimal_required_config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-        - name: SECRET_DESTINATION-S3-V2-JSONL-ROOT-LEVEL-FLATTENING
-          fileName: s3_dest_v2_jsonl_root_level_flattening_config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-        - name: SECRET_DESTINATION-S3-V2-JSONL-GZIP
-          fileName: s3_dest_v2_jsonl_gzip_config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-        - name: SECRET_DESTINATION-S3-V2-CSV
-          fileName: s3_dest_v2_csv_config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-        - name: SECRET_DESTINATION-S3-V2-CSV-ROOT-LEVEL-FLATTENING
-          fileName: s3_dest_v2_csv_root_level_flattening_config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-        - name: SECRET_DESTINATION-S3-V2-CSV-GZIP
-          fileName: s3_dest_v2_csv_gzip_config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-        - name: SECRET_DESTINATION-S3-V2-AVRO
-          fileName: s3_dest_v2_avro_config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-        - name: SECRET_DESTINATION-S3-V2-AVRO-BZIP2
-          fileName: s3_dest_v2_avro_bzip2_config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-        - name: SECRET_DESTINATION-S3-V2-PARQUET
-          fileName: s3_dest_v2_parquet_config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-        - name: SECRET_DESTINATION-S3-V2-PARQUET-SNAPPY
-          fileName: s3_dest_v2_parquet_snappy_config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-        - name: SECRET_DESTINATION-S3-ASSUME-ROLE-CONFIG
-          fileName: s3_dest_assume_role_config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-        - name: SECRET_DESTINATION-S3_CREDS
-          fileName: config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-        - name: SECRET_DESTINATION-S3_MIN_REQUIRED_PERMISSIONS_CREDS
-          fileName: s3_dest_min_required_permissions_creds.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-        - name: SECRET_DESTINATION-S3_POLICY_MANAGER_CREDENTIALS
-          fileName: s3_dest_policy_manager_credentials.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-        - name: SECRET_DESTINATION-S3_DEST_IAM_ROLE_CREDENTIALS_FOR_ASSUME_ROLE_AUTH
-          fileName: s3_dest_iam_role_credentials_for_assume_role_auth.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-        - name: SECRET_DESTINATION-S3-V2-ENDPOINT_URL
-          fileName: s3_dest_v2_endpoint_url_config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-        - name: SECRET_DESTINATION-S3-V2-ENDPOINT_EMPTY_URL
-          fileName: s3_dest_v2_endpoint_empty_url_config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-        - name: SECRET_DESTINATION-S3-V2_AMBIGUOUS_FILEPATH
-          fileName: s3_dest_v2_ambiguous_filepath_config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-        - name: SECRET_DESTINATION-S3-V2_CSV_ASSUME_ROLE
-          fileName: s3_dest_v2_csv_assume_role_config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-metadataSpecVersion: "1.0"
+  - suite: unitTests
+  - suite: integrationTests
+    testSecrets:
+    - name: SECRET_DESTINATION-S3-V2-MINIMAL-REQUIRED-CONFIG
+      fileName: s3_dest_v2_minimal_required_config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+    - name: SECRET_DESTINATION-S3-V2-JSONL-ROOT-LEVEL-FLATTENING
+      fileName: s3_dest_v2_jsonl_root_level_flattening_config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+    - name: SECRET_DESTINATION-S3-V2-JSONL-GZIP
+      fileName: s3_dest_v2_jsonl_gzip_config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+    - name: SECRET_DESTINATION-S3-V2-CSV
+      fileName: s3_dest_v2_csv_config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+    - name: SECRET_DESTINATION-S3-V2-CSV-ROOT-LEVEL-FLATTENING
+      fileName: s3_dest_v2_csv_root_level_flattening_config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+    - name: SECRET_DESTINATION-S3-V2-CSV-GZIP
+      fileName: s3_dest_v2_csv_gzip_config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+    - name: SECRET_DESTINATION-S3-V2-AVRO
+      fileName: s3_dest_v2_avro_config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+    - name: SECRET_DESTINATION-S3-V2-AVRO-BZIP2
+      fileName: s3_dest_v2_avro_bzip2_config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+    - name: SECRET_DESTINATION-S3-V2-PARQUET
+      fileName: s3_dest_v2_parquet_config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+    - name: SECRET_DESTINATION-S3-V2-PARQUET-SNAPPY
+      fileName: s3_dest_v2_parquet_snappy_config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+    - name: SECRET_DESTINATION-S3-ASSUME-ROLE-CONFIG
+      fileName: s3_dest_assume_role_config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+    - name: SECRET_DESTINATION-S3_CREDS
+      fileName: config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+    - name: SECRET_DESTINATION-S3_MIN_REQUIRED_PERMISSIONS_CREDS
+      fileName: s3_dest_min_required_permissions_creds.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+    - name: SECRET_DESTINATION-S3_POLICY_MANAGER_CREDENTIALS
+      fileName: s3_dest_policy_manager_credentials.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+    - name: SECRET_DESTINATION-S3_DEST_IAM_ROLE_CREDENTIALS_FOR_ASSUME_ROLE_AUTH
+      fileName: s3_dest_iam_role_credentials_for_assume_role_auth.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+    - name: SECRET_DESTINATION-S3-V2-ENDPOINT_URL
+      fileName: s3_dest_v2_endpoint_url_config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+    - name: SECRET_DESTINATION-S3-V2-ENDPOINT_EMPTY_URL
+      fileName: s3_dest_v2_endpoint_empty_url_config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+    - name: SECRET_DESTINATION-S3-V2_AMBIGUOUS_FILEPATH
+      fileName: s3_dest_v2_ambiguous_filepath_config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+    - name: SECRET_DESTINATION-S3-V2_CSV_ASSUME_ROLE
+      fileName: s3_dest_v2_csv_assume_role_config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+  - title: AWS S3 documentation
+    url: https://docs.aws.amazon.com/s3/
+    type: api_reference
+  - title: IAM authentication
+    url: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html
+    type: authentication_guide
+  - title: Bucket policies and permissions
+    url: https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-policy-language-overview.html
+    type: permissions_scopes
+  - title: Request rate and performance
+    url: https://docs.aws.amazon.com/AmazonS3/latest/userguide/optimizing-performance.html
+    type: rate_limits
+  - title: AWS Service Health Dashboard
+    url: https://health.aws.amazon.com/health/status
+    type: status_page
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-scylla/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-scylla/metadata.yaml
@@ -16,9 +16,19 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/scylla
   tags:
-    - language:java
+  - language:java
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: archived
-metadataSpecVersion: "1.0"
+  externalDocumentationUrls:
+  - title: ScyllaDB documentation
+    url: https://docs.scylladb.com/
+    type: api_reference
+  - title: CQL reference
+    url: https://docs.scylladb.com/stable/cql/
+    type: sql_reference
+  - title: Authentication
+    url: https://docs.scylladb.com/stable/operating-scylla/security/authentication.html
+    type: authentication_guide
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-scylla/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-scylla/metadata.yaml
@@ -16,19 +16,19 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/scylla
   tags:
-  - language:java
+    - language:java
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: archived
   externalDocumentationUrls:
-  - title: ScyllaDB documentation
-    url: https://docs.scylladb.com/
-    type: api_reference
-  - title: CQL reference
-    url: https://docs.scylladb.com/stable/cql/
-    type: sql_reference
-  - title: Authentication
-    url: https://docs.scylladb.com/stable/operating-scylla/security/authentication.html
-    type: authentication_guide
-metadataSpecVersion: '1.0'
+    - title: ScyllaDB documentation
+      url: https://docs.scylladb.com/
+      type: api_reference
+    - title: CQL reference
+      url: https://docs.scylladb.com/stable/cql/
+      type: sql_reference
+    - title: Authentication
+      url: https://docs.scylladb.com/stable/operating-scylla/security/authentication.html
+      type: authentication_guide
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-selectdb/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-selectdb/metadata.yaml
@@ -16,13 +16,13 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/selectdb
   tags:
-  - language:java
+    - language:java
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: archived
   externalDocumentationUrls:
-  - title: SelectDB documentation
-    url: https://en.selectdb.com/docs
-    type: api_reference
-metadataSpecVersion: '1.0'
+    - title: SelectDB documentation
+      url: https://en.selectdb.com/docs
+      type: api_reference
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-selectdb/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-selectdb/metadata.yaml
@@ -16,9 +16,13 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/selectdb
   tags:
-    - language:java
+  - language:java
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: archived
-metadataSpecVersion: "1.0"
+  externalDocumentationUrls:
+  - title: SelectDB documentation
+    url: https://en.selectdb.com/docs
+    type: api_reference
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-sftp-json/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-sftp-json/metadata.yaml
@@ -6,8 +6,8 @@ data:
     baseImage: docker.io/airbyte/python-connector-base:4.0.0@sha256:d9894b6895923b379f3006fa251147806919c62b7d9021b5cd125bb67d7bbe22
   connectorSubtype: file
   connectorTestSuitesOptions:
-  - suite: unitTests
-  - suite: integrationTests
+    - suite: unitTests
+    - suite: integrationTests
   connectorType: destination
   definitionId: e9810f61-4bab-46d2-bb22-edfc902e0644
   dockerImageTag: 0.2.15
@@ -25,10 +25,10 @@ data:
   releaseStage: alpha
   supportLevel: community
   tags:
-  - language:python
-  - cdk:python
+    - language:python
+    - cdk:python
   externalDocumentationUrls:
-  - title: SFTP protocol documentation
-    url: https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer
-    type: api_reference
-metadataSpecVersion: '1.0'
+    - title: SFTP protocol documentation
+      url: https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer
+      type: api_reference
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-sftp-json/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-sftp-json/metadata.yaml
@@ -6,8 +6,8 @@ data:
     baseImage: docker.io/airbyte/python-connector-base:4.0.0@sha256:d9894b6895923b379f3006fa251147806919c62b7d9021b5cd125bb67d7bbe22
   connectorSubtype: file
   connectorTestSuitesOptions:
-    - suite: unitTests
-    - suite: integrationTests
+  - suite: unitTests
+  - suite: integrationTests
   connectorType: destination
   definitionId: e9810f61-4bab-46d2-bb22-edfc902e0644
   dockerImageTag: 0.2.15
@@ -25,6 +25,10 @@ data:
   releaseStage: alpha
   supportLevel: community
   tags:
-    - language:python
-    - cdk:python
-metadataSpecVersion: "1.0"
+  - language:python
+  - cdk:python
+  externalDocumentationUrls:
+  - title: SFTP protocol documentation
+    url: https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer
+    type: api_reference
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-singlestore/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-singlestore/metadata.yaml
@@ -17,15 +17,15 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/singlestore
   tags:
-  - language:java
+    - language:java
   externalDocumentationUrls:
-  - title: SingleStore documentation
-    url: https://docs.singlestore.com/
-    type: api_reference
-  - title: SQL reference
-    url: https://docs.singlestore.com/db/latest/reference/sql-reference/
-    type: sql_reference
-  - title: Authentication
-    url: https://docs.singlestore.com/db/latest/security/authentication/
-    type: authentication_guide
-metadataSpecVersion: '1.0'
+    - title: SingleStore documentation
+      url: https://docs.singlestore.com/
+      type: api_reference
+    - title: SQL reference
+      url: https://docs.singlestore.com/db/latest/reference/sql-reference/
+      type: sql_reference
+    - title: Authentication
+      url: https://docs.singlestore.com/db/latest/security/authentication/
+      type: authentication_guide
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-singlestore/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-singlestore/metadata.yaml
@@ -12,10 +12,20 @@ data:
   icon: icon.svg
   license: ELv2
   name: SingleStore
-  releaseDate:
+  releaseDate: null
   supportLevel: community
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/singlestore
   tags:
-    - language:java
-metadataSpecVersion: "1.0"
+  - language:java
+  externalDocumentationUrls:
+  - title: SingleStore documentation
+    url: https://docs.singlestore.com/
+    type: api_reference
+  - title: SQL reference
+    url: https://docs.singlestore.com/db/latest/reference/sql-reference/
+    type: sql_reference
+  - title: Authentication
+    url: https://docs.singlestore.com/db/latest/security/authentication/
+    type: authentication_guide
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-snowflake-cortex/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-snowflake-cortex/metadata.yaml
@@ -4,10 +4,10 @@ data:
     sl: 300
   allowedHosts:
     hosts:
-    - '*.snowflakecomputing.com'
-    - api.openai.com
-    - api.cohere.ai
-    - ${embedding.api_base}
+      - "*.snowflakecomputing.com"
+      - api.openai.com
+      - api.cohere.ai
+      - ${embedding.api_base}
   connectorBuildOptions:
     baseImage: docker.io/airbyte/python-connector-base:4.0.2@sha256:9fdb1888c4264cf6fee473649ecb593f56f58e5d0096a87ee0b231777e2e3e73
   connectorSubtype: vectorstore
@@ -33,30 +33,30 @@ data:
   releaseStage: beta
   resourceRequirements:
     jobSpecific:
-    - jobType: sync
-      resourceRequirements:
-        memory_limit: 2Gi
-        memory_request: 2Gi
+      - jobType: sync
+        resourceRequirements:
+          memory_limit: 2Gi
+          memory_request: 2Gi
   supportLevel: certified
   tags:
-  - language:python
-  - cdk:python
+    - language:python
+    - cdk:python
   connectorTestSuitesOptions:
-  - suite: integrationTests
-    testSecrets:
-    - name: SECRET_DESTINATION-SNOWFLAKE-CORTEX__CREDS
-      fileName: config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION-SNOWFLAKE-CORTEX__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
   externalDocumentationUrls:
-  - title: Snowflake Cortex documentation
-    url: https://docs.snowflake.com/en/user-guide/snowflake-cortex
-    type: api_reference
-  - title: Snowflake SQL reference
-    url: https://docs.snowflake.com/en/sql-reference
-    type: sql_reference
-  - title: Key pair authentication
-    url: https://docs.snowflake.com/en/user-guide/key-pair-auth
-    type: authentication_guide
-metadataSpecVersion: '1.0'
+    - title: Snowflake Cortex documentation
+      url: https://docs.snowflake.com/en/user-guide/snowflake-cortex
+      type: api_reference
+    - title: Snowflake SQL reference
+      url: https://docs.snowflake.com/en/sql-reference
+      type: sql_reference
+    - title: Key pair authentication
+      url: https://docs.snowflake.com/en/user-guide/key-pair-auth
+      type: authentication_guide
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-snowflake-cortex/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-snowflake-cortex/metadata.yaml
@@ -42,6 +42,8 @@ data:
     - language:python
     - cdk:python
   connectorTestSuitesOptions:
+    # Temporarily disabled due to test coverage not passing
+    # - suite: unitTests
     - suite: integrationTests
       testSecrets:
         - name: SECRET_DESTINATION-SNOWFLAKE-CORTEX__CREDS

--- a/airbyte-integrations/connectors/destination-snowflake-cortex/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-snowflake-cortex/metadata.yaml
@@ -4,10 +4,10 @@ data:
     sl: 300
   allowedHosts:
     hosts:
-      - "*.snowflakecomputing.com"
-      - api.openai.com
-      - api.cohere.ai
-      - ${embedding.api_base}
+    - '*.snowflakecomputing.com'
+    - api.openai.com
+    - api.cohere.ai
+    - ${embedding.api_base}
   connectorBuildOptions:
     baseImage: docker.io/airbyte/python-connector-base:4.0.2@sha256:9fdb1888c4264cf6fee473649ecb593f56f58e5d0096a87ee0b231777e2e3e73
   connectorSubtype: vectorstore
@@ -33,22 +33,30 @@ data:
   releaseStage: beta
   resourceRequirements:
     jobSpecific:
-      - jobType: sync
-        resourceRequirements:
-          memory_limit: 2Gi
-          memory_request: 2Gi
+    - jobType: sync
+      resourceRequirements:
+        memory_limit: 2Gi
+        memory_request: 2Gi
   supportLevel: certified
   tags:
-    - language:python
-    - cdk:python
+  - language:python
+  - cdk:python
   connectorTestSuitesOptions:
-    # Temporarily disabled due to test coverage not passing
-    # - suite: unitTests
-    - suite: integrationTests
-      testSecrets:
-        - name: SECRET_DESTINATION-SNOWFLAKE-CORTEX__CREDS
-          fileName: config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-metadataSpecVersion: "1.0"
+  - suite: integrationTests
+    testSecrets:
+    - name: SECRET_DESTINATION-SNOWFLAKE-CORTEX__CREDS
+      fileName: config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+  - title: Snowflake Cortex documentation
+    url: https://docs.snowflake.com/en/user-guide/snowflake-cortex
+    type: api_reference
+  - title: Snowflake SQL reference
+    url: https://docs.snowflake.com/en/sql-reference
+    type: sql_reference
+  - title: Key pair authentication
+    url: https://docs.snowflake.com/en/user-guide/key-pair-auth
+    type: authentication_guide
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-snowflake/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-snowflake/metadata.yaml
@@ -17,11 +17,11 @@ data:
     dataChannel:
       version: 0.0.2
       supportedSerialization:
-      - JSONL
-      - PROTOBUF
+        - JSONL
+        - PROTOBUF
       supportedTransport:
-      - SOCKET
-      - STDIO
+        - SOCKET
+        - STDIO
   connectorBuildOptions:
     baseImage: docker.io/airbyte/java-connector-base:2.0.3@sha256:119b8506bca069bbc8357a275936c7e2b0994e6947b81f1bf8d6ce9e16db7d47
   registryOverrides:
@@ -34,9 +34,10 @@ data:
     breakingChanges:
       2.0.0:
         message: Remove GCS/S3 loading method support.
-        upgradeDeadline: '2023-08-31'
+        upgradeDeadline: "2023-08-31"
       3.0.0:
-        message: '**Do not upgrade until you have run a test upgrade as outlined [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#testing-destinations-v2-for-a-single-connection)**.
+        message:
+          "**Do not upgrade until you have run a test upgrade as outlined [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#testing-destinations-v2-for-a-single-connection)**.
 
           This version introduces [Destinations V2](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#what-is-destinations-v2),
           which provides better error handling, incremental delivery of data for large
@@ -49,72 +50,73 @@ data:
           at their next sync. You can manually sync existing connections prior to
           the next scheduled sync to start the upgrade early.
 
-          '
-        upgradeDeadline: '2023-11-07'
+          "
+        upgradeDeadline: "2023-11-07"
       4.0.0:
-        message: If you never interact with the raw tables, you can upgrade without
+        message:
+          If you never interact with the raw tables, you can upgrade without
           taking any action. Otherwise, make sure to read the migration guide for
           more details.
-        upgradeDeadline: '2026-01-06'
+        upgradeDeadline: "2026-01-06"
   resourceRequirements:
     jobSpecific:
-    - jobType: sync
-      resourceRequirements:
-        memory_limit: 2Gi
-        memory_request: 2Gi
+      - jobType: sync
+        resourceRequirements:
+          memory_limit: 2Gi
+          memory_request: 2Gi
   supportLevel: certified
   supportsDbt: true
   supportsRefreshes: true
   tags:
-  - language:java
+    - language:java
   connectorTestSuitesOptions:
-  - suite: unitTests
-  - suite: integrationTests
-    testSecrets:
-    - name: SECRET_DESTINATION-SNOWFLAKE_INTERNAL_STAGING_CONFIG_DISABLETD
-      fileName: 1s1t_disabletd_internal_staging_config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
-    - name: SECRET_DESTINATION-SNOWFLAKE_INTERNAL_STAGING_CONFIG_RAW_SCHEMA_OVERRIDE_DISABLETD
-      fileName: 1s1t_disabletd_internal_staging_config_raw_schema_override.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
-    - name: SECRET_DESTINATION_SNOWFLAKE_1S1T_INTERNAL_STAGING_CREDS
-      fileName: 1s1t_internal_staging_config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
-    - name: SECRET_DESTINATION_SNOWFLAKE_1S1T_INTERNAL_STAGING_CREDS_RAW_SCHEMA_OVERRIDE
-      fileName: 1s1t_internal_staging_config_raw_schema_override.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
-    - name: SECRET_DESTINATION_SNOWFLAKE_INSUFFICIENT_PERMISSIONS_CREDS
-      fileName: config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
-    - name: SECRET_DESTINATION_SNOWFLAKE_QUOTED_IDENTIFIERS_IGNORE_CASE_CREDS
-      fileName: 1s1t_case_insensitive.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION-SNOWFLAKE_INTERNAL_STAGING_CONFIG_DISABLETD
+          fileName: 1s1t_disabletd_internal_staging_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-SNOWFLAKE_INTERNAL_STAGING_CONFIG_RAW_SCHEMA_OVERRIDE_DISABLETD
+          fileName: 1s1t_disabletd_internal_staging_config_raw_schema_override.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION_SNOWFLAKE_1S1T_INTERNAL_STAGING_CREDS
+          fileName: 1s1t_internal_staging_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION_SNOWFLAKE_1S1T_INTERNAL_STAGING_CREDS_RAW_SCHEMA_OVERRIDE
+          fileName: 1s1t_internal_staging_config_raw_schema_override.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION_SNOWFLAKE_INSUFFICIENT_PERMISSIONS_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION_SNOWFLAKE_QUOTED_IDENTIFIERS_IGNORE_CASE_CREDS
+          fileName: 1s1t_case_insensitive.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
   externalDocumentationUrls:
-  - title: Release notes
-    url: https://docs.snowflake.com/en/release-notes
-    type: api_release_history
-  - title: SQL reference
-    url: https://docs.snowflake.com/en/sql-reference
-    type: sql_reference
-  - title: Key pair authentication
-    url: https://docs.snowflake.com/en/user-guide/key-pair-auth
-    type: authentication_guide
-  - title: Access control
-    url: https://docs.snowflake.com/en/user-guide/security-access-control
-    type: permissions_scopes
-  - title: Snowflake Status
-    url: https://status.snowflake.com/
-    type: status_page
-metadataSpecVersion: '1.0'
+    - title: Release notes
+      url: https://docs.snowflake.com/en/release-notes
+      type: api_release_history
+    - title: SQL reference
+      url: https://docs.snowflake.com/en/sql-reference
+      type: sql_reference
+    - title: Key pair authentication
+      url: https://docs.snowflake.com/en/user-guide/key-pair-auth
+      type: authentication_guide
+    - title: Access control
+      url: https://docs.snowflake.com/en/user-guide/security-access-control
+      type: permissions_scopes
+    - title: Snowflake Status
+      url: https://status.snowflake.com/
+      type: status_page
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-snowflake/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-snowflake/metadata.yaml
@@ -15,9 +15,13 @@ data:
   name: Snowflake
   connectorIPCOptions:
     dataChannel:
-      version: "0.0.2"
-      supportedSerialization: ["JSONL", "PROTOBUF"]
-      supportedTransport: ["SOCKET", "STDIO"]
+      version: 0.0.2
+      supportedSerialization:
+      - JSONL
+      - PROTOBUF
+      supportedTransport:
+      - SOCKET
+      - STDIO
   connectorBuildOptions:
     baseImage: docker.io/airbyte/java-connector-base:2.0.3@sha256:119b8506bca069bbc8357a275936c7e2b0994e6947b81f1bf8d6ce9e16db7d47
   registryOverrides:
@@ -30,56 +34,87 @@ data:
     breakingChanges:
       2.0.0:
         message: Remove GCS/S3 loading method support.
-        upgradeDeadline: "2023-08-31"
+        upgradeDeadline: '2023-08-31'
       3.0.0:
-        message: "**Do not upgrade until you have run a test upgrade as outlined [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#testing-destinations-v2-for-a-single-connection)**.\nThis version introduces [Destinations V2](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#what-is-destinations-v2), which provides better error handling, incremental delivery of data for large syncs, and improved final table structures. To review the breaking changes, and how to upgrade, see [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#quick-start-to-upgrading). These changes will likely require updates to downstream dbt / SQL models, which we walk through [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#updating-downstream-transformations).\nSelecting `Upgrade` will upgrade **all** connections using this destination at their next sync. You can manually sync existing connections prior to the next scheduled sync to start the upgrade early.\n"
-        upgradeDeadline: "2023-11-07"
+        message: '**Do not upgrade until you have run a test upgrade as outlined [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#testing-destinations-v2-for-a-single-connection)**.
+
+          This version introduces [Destinations V2](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#what-is-destinations-v2),
+          which provides better error handling, incremental delivery of data for large
+          syncs, and improved final table structures. To review the breaking changes,
+          and how to upgrade, see [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#quick-start-to-upgrading).
+          These changes will likely require updates to downstream dbt / SQL models,
+          which we walk through [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#updating-downstream-transformations).
+
+          Selecting `Upgrade` will upgrade **all** connections using this destination
+          at their next sync. You can manually sync existing connections prior to
+          the next scheduled sync to start the upgrade early.
+
+          '
+        upgradeDeadline: '2023-11-07'
       4.0.0:
-        message: "If you never interact with the raw tables, you can upgrade without taking any action. Otherwise, make sure to read the migration guide for more details."
-        upgradeDeadline: "2026-01-06"
+        message: If you never interact with the raw tables, you can upgrade without
+          taking any action. Otherwise, make sure to read the migration guide for
+          more details.
+        upgradeDeadline: '2026-01-06'
   resourceRequirements:
     jobSpecific:
-      - jobType: sync
-        resourceRequirements:
-          memory_limit: 2Gi
-          memory_request: 2Gi
+    - jobType: sync
+      resourceRequirements:
+        memory_limit: 2Gi
+        memory_request: 2Gi
   supportLevel: certified
   supportsDbt: true
   supportsRefreshes: true
   tags:
-    - language:java
+  - language:java
   connectorTestSuitesOptions:
-    - suite: unitTests
-    - suite: integrationTests
-      testSecrets:
-        - name: SECRET_DESTINATION-SNOWFLAKE_INTERNAL_STAGING_CONFIG_DISABLETD
-          fileName: 1s1t_disabletd_internal_staging_config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-        - name: SECRET_DESTINATION-SNOWFLAKE_INTERNAL_STAGING_CONFIG_RAW_SCHEMA_OVERRIDE_DISABLETD
-          fileName: 1s1t_disabletd_internal_staging_config_raw_schema_override.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-        - name: SECRET_DESTINATION_SNOWFLAKE_1S1T_INTERNAL_STAGING_CREDS
-          fileName: 1s1t_internal_staging_config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-        - name: SECRET_DESTINATION_SNOWFLAKE_1S1T_INTERNAL_STAGING_CREDS_RAW_SCHEMA_OVERRIDE
-          fileName: 1s1t_internal_staging_config_raw_schema_override.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-        - name: SECRET_DESTINATION_SNOWFLAKE_INSUFFICIENT_PERMISSIONS_CREDS
-          fileName: config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-        - name: SECRET_DESTINATION_SNOWFLAKE_QUOTED_IDENTIFIERS_IGNORE_CASE_CREDS
-          fileName: 1s1t_case_insensitive.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-metadataSpecVersion: "1.0"
+  - suite: unitTests
+  - suite: integrationTests
+    testSecrets:
+    - name: SECRET_DESTINATION-SNOWFLAKE_INTERNAL_STAGING_CONFIG_DISABLETD
+      fileName: 1s1t_disabletd_internal_staging_config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+    - name: SECRET_DESTINATION-SNOWFLAKE_INTERNAL_STAGING_CONFIG_RAW_SCHEMA_OVERRIDE_DISABLETD
+      fileName: 1s1t_disabletd_internal_staging_config_raw_schema_override.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+    - name: SECRET_DESTINATION_SNOWFLAKE_1S1T_INTERNAL_STAGING_CREDS
+      fileName: 1s1t_internal_staging_config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+    - name: SECRET_DESTINATION_SNOWFLAKE_1S1T_INTERNAL_STAGING_CREDS_RAW_SCHEMA_OVERRIDE
+      fileName: 1s1t_internal_staging_config_raw_schema_override.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+    - name: SECRET_DESTINATION_SNOWFLAKE_INSUFFICIENT_PERMISSIONS_CREDS
+      fileName: config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+    - name: SECRET_DESTINATION_SNOWFLAKE_QUOTED_IDENTIFIERS_IGNORE_CASE_CREDS
+      fileName: 1s1t_case_insensitive.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+  - title: Release notes
+    url: https://docs.snowflake.com/en/release-notes
+    type: api_release_history
+  - title: SQL reference
+    url: https://docs.snowflake.com/en/sql-reference
+    type: sql_reference
+  - title: Key pair authentication
+    url: https://docs.snowflake.com/en/user-guide/key-pair-auth
+    type: authentication_guide
+  - title: Access control
+    url: https://docs.snowflake.com/en/user-guide/security-access-control
+    type: permissions_scopes
+  - title: Snowflake Status
+    url: https://status.snowflake.com/
+    type: status_page
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-snowflake/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-snowflake/metadata.yaml
@@ -36,27 +36,10 @@ data:
         message: Remove GCS/S3 loading method support.
         upgradeDeadline: "2023-08-31"
       3.0.0:
-        message:
-          "**Do not upgrade until you have run a test upgrade as outlined [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#testing-destinations-v2-for-a-single-connection)**.
-
-          This version introduces [Destinations V2](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#what-is-destinations-v2),
-          which provides better error handling, incremental delivery of data for large
-          syncs, and improved final table structures. To review the breaking changes,
-          and how to upgrade, see [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#quick-start-to-upgrading).
-          These changes will likely require updates to downstream dbt / SQL models,
-          which we walk through [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#updating-downstream-transformations).
-
-          Selecting `Upgrade` will upgrade **all** connections using this destination
-          at their next sync. You can manually sync existing connections prior to
-          the next scheduled sync to start the upgrade early.
-
-          "
+        message: "**Do not upgrade until you have run a test upgrade as outlined [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#testing-destinations-v2-for-a-single-connection)**.\nThis version introduces [Destinations V2](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#what-is-destinations-v2), which provides better error handling, incremental delivery of data for large syncs, and improved final table structures. To review the breaking changes, and how to upgrade, see [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#quick-start-to-upgrading). These changes will likely require updates to downstream dbt / SQL models, which we walk through [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#updating-downstream-transformations).\nSelecting `Upgrade` will upgrade **all** connections using this destination at their next sync. You can manually sync existing connections prior to the next scheduled sync to start the upgrade early.\n"
         upgradeDeadline: "2023-11-07"
       4.0.0:
-        message:
-          If you never interact with the raw tables, you can upgrade without
-          taking any action. Otherwise, make sure to read the migration guide for
-          more details.
+        message: "If you never interact with the raw tables, you can upgrade without taking any action. Otherwise, make sure to read the migration guide for more details."
         upgradeDeadline: "2026-01-06"
   resourceRequirements:
     jobSpecific:

--- a/airbyte-integrations/connectors/destination-sqlite/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-sqlite/metadata.yaml
@@ -16,22 +16,22 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/sqlite
   tags:
-  - language:python
-  - cdk:python
+    - language:python
+    - cdk:python
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
-  - suite: unitTests
-  - suite: integrationTests
+    - suite: unitTests
+    - suite: integrationTests
   connectorBuildOptions:
     baseImage: docker.io/airbyte/python-connector-base:4.0.0@sha256:d9894b6895923b379f3006fa251147806919c62b7d9021b5cd125bb67d7bbe22
   externalDocumentationUrls:
-  - title: SQLite documentation
-    url: https://www.sqlite.org/docs.html
-    type: api_reference
-  - title: SQL reference
-    url: https://www.sqlite.org/lang.html
-    type: sql_reference
-metadataSpecVersion: '1.0'
+    - title: SQLite documentation
+      url: https://www.sqlite.org/docs.html
+      type: api_reference
+    - title: SQL reference
+      url: https://www.sqlite.org/lang.html
+      type: sql_reference
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-sqlite/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-sqlite/metadata.yaml
@@ -16,15 +16,22 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/sqlite
   tags:
-    - language:python
-    - cdk:python
+  - language:python
+  - cdk:python
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
-    - suite: unitTests
-    - suite: integrationTests
+  - suite: unitTests
+  - suite: integrationTests
   connectorBuildOptions:
     baseImage: docker.io/airbyte/python-connector-base:4.0.0@sha256:d9894b6895923b379f3006fa251147806919c62b7d9021b5cd125bb67d7bbe22
-metadataSpecVersion: "1.0"
+  externalDocumentationUrls:
+  - title: SQLite documentation
+    url: https://www.sqlite.org/docs.html
+    type: api_reference
+  - title: SQL reference
+    url: https://www.sqlite.org/lang.html
+    type: sql_reference
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-starburst-galaxy/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-starburst-galaxy/metadata.yaml
@@ -18,19 +18,26 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/starburst-galaxy
   tags:
-    - language:java
+  - language:java
   ab_internal:
     sl: 100
     ql: 100
     requireVersionIncrementsInPullRequests: false
   supportLevel: community
   connectorTestSuitesOptions:
-    - suite: unitTests
-    - suite: integrationTests
-      testSecrets:
-        - name: SECRET_DESTINATION-STARBURST-GALAXY_CREDENTIALS__CREDS
-          fileName: config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-metadataSpecVersion: "1.0"
+  - suite: unitTests
+  - suite: integrationTests
+    testSecrets:
+    - name: SECRET_DESTINATION-STARBURST-GALAXY_CREDENTIALS__CREDS
+      fileName: config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+  - title: Starburst Galaxy documentation
+    url: https://docs.starburst.io/starburst-galaxy/
+    type: api_reference
+  - title: SQL reference
+    url: https://docs.starburst.io/latest/sql.html
+    type: sql_reference
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-starburst-galaxy/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-starburst-galaxy/metadata.yaml
@@ -18,26 +18,26 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/starburst-galaxy
   tags:
-  - language:java
+    - language:java
   ab_internal:
     sl: 100
     ql: 100
     requireVersionIncrementsInPullRequests: false
   supportLevel: community
   connectorTestSuitesOptions:
-  - suite: unitTests
-  - suite: integrationTests
-    testSecrets:
-    - name: SECRET_DESTINATION-STARBURST-GALAXY_CREDENTIALS__CREDS
-      fileName: config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION-STARBURST-GALAXY_CREDENTIALS__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
   externalDocumentationUrls:
-  - title: Starburst Galaxy documentation
-    url: https://docs.starburst.io/starburst-galaxy/
-    type: api_reference
-  - title: SQL reference
-    url: https://docs.starburst.io/latest/sql.html
-    type: sql_reference
-metadataSpecVersion: '1.0'
+    - title: Starburst Galaxy documentation
+      url: https://docs.starburst.io/starburst-galaxy/
+      type: api_reference
+    - title: SQL reference
+      url: https://docs.starburst.io/latest/sql.html
+      type: sql_reference
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-surrealdb/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-surrealdb/metadata.yaml
@@ -1,7 +1,7 @@
 data:
   allowedHosts:
     hosts:
-    - '*'
+      - "*"
   connectorBuildOptions:
     baseImage: docker.io/airbyte/python-connector-base:4.0.0@sha256:d9894b6895923b379f3006fa251147806919c62b7d9021b5cd125bb67d7bbe22
   connectorSubtype: database
@@ -27,29 +27,29 @@ data:
       packageName: airbyte-destination-surrealdb
   resourceRequirements:
     jobSpecific:
-    - jobType: check_connection
-      resourceRequirements:
-        memory_limit: 800Mi
-        memory_request: 800Mi
-    - jobType: sync
-      resourceRequirements:
-        memory_limit: 2Gi
-        memory_request: 2Gi
+      - jobType: check_connection
+        resourceRequirements:
+          memory_limit: 800Mi
+          memory_request: 800Mi
+      - jobType: sync
+        resourceRequirements:
+          memory_limit: 2Gi
+          memory_request: 2Gi
   documentationUrl: https://docs.airbyte.com/integrations/destinations/surrealdb
   tags:
-  - language:python
-  - cdk:python
+    - language:python
+    - cdk:python
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
-  - suite: unitTests
+    - suite: unitTests
   externalDocumentationUrls:
-  - title: SurrealDB documentation
-    url: https://surrealdb.com/docs
-    type: api_reference
-  - title: Authentication
-    url: https://surrealdb.com/docs/surrealdb/security/authentication
-    type: authentication_guide
-metadataSpecVersion: '1.0'
+    - title: SurrealDB documentation
+      url: https://surrealdb.com/docs
+      type: api_reference
+    - title: Authentication
+      url: https://surrealdb.com/docs/surrealdb/security/authentication
+      type: authentication_guide
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-surrealdb/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-surrealdb/metadata.yaml
@@ -1,7 +1,7 @@
 data:
   allowedHosts:
     hosts:
-      - "*"
+    - '*'
   connectorBuildOptions:
     baseImage: docker.io/airbyte/python-connector-base:4.0.0@sha256:d9894b6895923b379f3006fa251147806919c62b7d9021b5cd125bb67d7bbe22
   connectorSubtype: database
@@ -27,24 +27,29 @@ data:
       packageName: airbyte-destination-surrealdb
   resourceRequirements:
     jobSpecific:
-      - jobType: check_connection
-        resourceRequirements:
-          memory_limit: 800Mi
-          memory_request: 800Mi
-      - jobType: sync
-        resourceRequirements:
-          memory_limit: 2Gi
-          memory_request: 2Gi
+    - jobType: check_connection
+      resourceRequirements:
+        memory_limit: 800Mi
+        memory_request: 800Mi
+    - jobType: sync
+      resourceRequirements:
+        memory_limit: 2Gi
+        memory_request: 2Gi
   documentationUrl: https://docs.airbyte.com/integrations/destinations/surrealdb
   tags:
-    - language:python
-    - cdk:python
+  - language:python
+  - cdk:python
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
-    - suite: unitTests
-    # - suite: integrationTests
-    # - suite: acceptanceTests
-metadataSpecVersion: "1.0"
+  - suite: unitTests
+  externalDocumentationUrls:
+  - title: SurrealDB documentation
+    url: https://surrealdb.com/docs
+    type: api_reference
+  - title: Authentication
+    url: https://surrealdb.com/docs/surrealdb/security/authentication
+    type: authentication_guide
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-teradata/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-teradata/metadata.yaml
@@ -22,40 +22,41 @@ data:
   releases:
     breakingChanges:
       1.0.0:
-        message: Teradata support now Destination v2 format. Requires you to resync
+        message:
+          Teradata support now Destination v2 format. Requires you to resync
           your data to Teradata destination in the new format.
-        upgradeDeadline: '2025-08-01'
+        upgradeDeadline: "2025-08-01"
   tags:
-  - language:java
+    - language:java
   ab_internal:
     sl: 100
     ql: 100
     requireVersionIncrementsInPullRequests: false
   supportLevel: community
   connectorTestSuitesOptions:
-  - suite: unitTests
-  - suite: integrationTests
-    testSecrets:
-    - name: SECRET_DESTINATION-TERADATA_SSL__CREDS
-      fileName: sslconfig.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
-    - name: SECRET_DESTINATION-TERADATA__CREDS
-      fileName: config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
-    - name: SECRET_DESTINATION-TERADATA__FAILURE_CREDS
-      fileName: failureconfig.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION-TERADATA_SSL__CREDS
+          fileName: sslconfig.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-TERADATA__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-TERADATA__FAILURE_CREDS
+          fileName: failureconfig.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
   externalDocumentationUrls:
-  - title: Teradata documentation
-    url: https://docs.teradata.com/
-    type: api_reference
-  - title: SQL reference
-    url: https://docs.teradata.com/r/Teradata-VantageTM-SQL-Data-Definition-Language-Syntax-and-Examples/July-2021
-    type: sql_reference
-metadataSpecVersion: '1.0'
+    - title: Teradata documentation
+      url: https://docs.teradata.com/
+      type: api_reference
+    - title: SQL reference
+      url: https://docs.teradata.com/r/Teradata-VantageTM-SQL-Data-Definition-Language-Syntax-and-Examples/July-2021
+      type: sql_reference
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-teradata/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-teradata/metadata.yaml
@@ -22,32 +22,40 @@ data:
   releases:
     breakingChanges:
       1.0.0:
-        message: "Teradata support now Destination v2 format. Requires you to resync your data to Teradata destination in the new format."
-        upgradeDeadline: "2025-08-01"
+        message: Teradata support now Destination v2 format. Requires you to resync
+          your data to Teradata destination in the new format.
+        upgradeDeadline: '2025-08-01'
   tags:
-    - language:java
+  - language:java
   ab_internal:
     sl: 100
     ql: 100
     requireVersionIncrementsInPullRequests: false
   supportLevel: community
   connectorTestSuitesOptions:
-    - suite: unitTests
-    - suite: integrationTests
-      testSecrets:
-        - name: SECRET_DESTINATION-TERADATA_SSL__CREDS
-          fileName: sslconfig.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-        - name: SECRET_DESTINATION-TERADATA__CREDS
-          fileName: config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-        - name: SECRET_DESTINATION-TERADATA__FAILURE_CREDS
-          fileName: failureconfig.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-metadataSpecVersion: "1.0"
+  - suite: unitTests
+  - suite: integrationTests
+    testSecrets:
+    - name: SECRET_DESTINATION-TERADATA_SSL__CREDS
+      fileName: sslconfig.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+    - name: SECRET_DESTINATION-TERADATA__CREDS
+      fileName: config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+    - name: SECRET_DESTINATION-TERADATA__FAILURE_CREDS
+      fileName: failureconfig.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+  - title: Teradata documentation
+    url: https://docs.teradata.com/
+    type: api_reference
+  - title: SQL reference
+    url: https://docs.teradata.com/r/Teradata-VantageTM-SQL-Data-Definition-Language-Syntax-and-Examples/July-2021
+    type: sql_reference
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-teradata/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-teradata/metadata.yaml
@@ -22,9 +22,7 @@ data:
   releases:
     breakingChanges:
       1.0.0:
-        message:
-          Teradata support now Destination v2 format. Requires you to resync
-          your data to Teradata destination in the new format.
+        message: "Teradata support now Destination v2 format. Requires you to resync your data to Teradata destination in the new format."
         upgradeDeadline: "2025-08-01"
   tags:
     - language:java

--- a/airbyte-integrations/connectors/destination-tidb/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-tidb/metadata.yaml
@@ -21,19 +21,19 @@ data:
   documentationUrl: https://docs.airbyte.com/integrations/destinations/tidb
   supportsDbt: true
   tags:
-  - language:java
+    - language:java
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: archived
   externalDocumentationUrls:
-  - title: TiDB documentation
-    url: https://docs.pingcap.com/tidb/stable
-    type: api_reference
-  - title: SQL reference
-    url: https://docs.pingcap.com/tidb/stable/sql-statement-overview
-    type: sql_reference
-  - title: TiDB Cloud Status
-    url: https://status.tidbcloud.com/
-    type: status_page
-metadataSpecVersion: '1.0'
+    - title: TiDB documentation
+      url: https://docs.pingcap.com/tidb/stable
+      type: api_reference
+    - title: SQL reference
+      url: https://docs.pingcap.com/tidb/stable/sql-statement-overview
+      type: sql_reference
+    - title: TiDB Cloud Status
+      url: https://status.tidbcloud.com/
+      type: status_page
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-tidb/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-tidb/metadata.yaml
@@ -21,9 +21,19 @@ data:
   documentationUrl: https://docs.airbyte.com/integrations/destinations/tidb
   supportsDbt: true
   tags:
-    - language:java
+  - language:java
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: archived
-metadataSpecVersion: "1.0"
+  externalDocumentationUrls:
+  - title: TiDB documentation
+    url: https://docs.pingcap.com/tidb/stable
+    type: api_reference
+  - title: SQL reference
+    url: https://docs.pingcap.com/tidb/stable/sql-statement-overview
+    type: sql_reference
+  - title: TiDB Cloud Status
+    url: https://status.tidbcloud.com/
+    type: status_page
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-timeplus/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-timeplus/metadata.yaml
@@ -16,24 +16,21 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/timeplus
   tags:
-    - language:python
-    - cdk:python
+  - language:python
+  - cdk:python
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
-    - suite: unitTests
-    # Disabling integration tests
-    # They are not passing
-    # No Airbyte Cloud Usage
-    # - suite: integrationTests
-    #   testSecrets:
-    #     - name: SECRET_DESTINATION-TIMEPLUS__CREDS
-    #       fileName: config.json
-    #       secretStore:
-    #         type: GSM
-    #         alias: airbyte-connector-testing-secret-store
+  - suite: unitTests
   connectorBuildOptions:
     baseImage: docker.io/airbyte/python-connector-base:4.0.0@sha256:d9894b6895923b379f3006fa251147806919c62b7d9021b5cd125bb67d7bbe22
-metadataSpecVersion: "1.0"
+  externalDocumentationUrls:
+  - title: Timeplus documentation
+    url: https://docs.timeplus.com/
+    type: api_reference
+  - title: SQL reference
+    url: https://docs.timeplus.com/sql-reference
+    type: sql_reference
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-timeplus/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-timeplus/metadata.yaml
@@ -16,21 +16,21 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/timeplus
   tags:
-  - language:python
-  - cdk:python
+    - language:python
+    - cdk:python
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
-  - suite: unitTests
+    - suite: unitTests
   connectorBuildOptions:
     baseImage: docker.io/airbyte/python-connector-base:4.0.0@sha256:d9894b6895923b379f3006fa251147806919c62b7d9021b5cd125bb67d7bbe22
   externalDocumentationUrls:
-  - title: Timeplus documentation
-    url: https://docs.timeplus.com/
-    type: api_reference
-  - title: SQL reference
-    url: https://docs.timeplus.com/sql-reference
-    type: sql_reference
-metadataSpecVersion: '1.0'
+    - title: Timeplus documentation
+      url: https://docs.timeplus.com/
+      type: api_reference
+    - title: SQL reference
+      url: https://docs.timeplus.com/sql-reference
+      type: sql_reference
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-timeplus/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-timeplus/metadata.yaml
@@ -24,6 +24,16 @@ data:
   supportLevel: community
   connectorTestSuitesOptions:
     - suite: unitTests
+    # Disabling integration tests
+    # They are not passing
+    # No Airbyte Cloud Usage
+    # - suite: integrationTests
+    #   testSecrets:
+    #     - name: SECRET_DESTINATION-TIMEPLUS__CREDS
+    #       fileName: config.json
+    #       secretStore:
+    #         type: GSM
+    #         alias: airbyte-connector-testing-secret-store
   connectorBuildOptions:
     baseImage: docker.io/airbyte/python-connector-base:4.0.0@sha256:d9894b6895923b379f3006fa251147806919c62b7d9021b5cd125bb67d7bbe22
   externalDocumentationUrls:

--- a/airbyte-integrations/connectors/destination-typesense/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-typesense/metadata.yaml
@@ -18,26 +18,26 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/typesense
   tags:
-  - language:python
-  - cdk:python
+    - language:python
+    - cdk:python
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
-  - suite: unitTests
-  - suite: integrationTests
-    testSecrets:
-    - name: SECRET_DESTINATION-TYPESENSE_CREDS
-      fileName: config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION-TYPESENSE_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
   externalDocumentationUrls:
-  - title: Typesense documentation
-    url: https://typesense.org/docs/
-    type: api_reference
-  - title: Authentication
-    url: https://typesense.org/docs/latest/api/authentication.html
-    type: authentication_guide
-metadataSpecVersion: '1.0'
+    - title: Typesense documentation
+      url: https://typesense.org/docs/
+      type: api_reference
+    - title: Authentication
+      url: https://typesense.org/docs/latest/api/authentication.html
+      type: authentication_guide
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-typesense/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-typesense/metadata.yaml
@@ -18,19 +18,26 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/typesense
   tags:
-    - language:python
-    - cdk:python
+  - language:python
+  - cdk:python
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
-    - suite: unitTests
-    - suite: integrationTests
-      testSecrets:
-        - name: SECRET_DESTINATION-TYPESENSE_CREDS
-          fileName: config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-metadataSpecVersion: "1.0"
+  - suite: unitTests
+  - suite: integrationTests
+    testSecrets:
+    - name: SECRET_DESTINATION-TYPESENSE_CREDS
+      fileName: config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+  - title: Typesense documentation
+    url: https://typesense.org/docs/
+    type: api_reference
+  - title: Authentication
+    url: https://typesense.org/docs/latest/api/authentication.html
+    type: authentication_guide
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-vectara/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-vectara/metadata.yaml
@@ -1,8 +1,8 @@
 data:
   allowedHosts:
     hosts:
-      - api.vectara.io
-      - "vectara-prod-${self.customer_id}.auth.us-west-2.amazoncognito.com"
+    - api.vectara.io
+    - vectara-prod-${self.customer_id}.auth.us-west-2.amazoncognito.com
   registryOverrides:
     oss:
       enabled: true
@@ -21,21 +21,28 @@ data:
   name: Vectara
   remoteRegistries:
     pypi:
-      enabled: false # TODO: enable once the CLI is working
+      enabled: false
       packageName: airbyte-destination-vectara
   releaseDate: 2023-12-16
   releaseStage: alpha
   supportLevel: community
   documentationUrl: https://docs.airbyte.com/integrations/destinations/vectara
   tags:
-    - language:python
-    - cdk:python
+  - language:python
+  - cdk:python
   connectorTestSuitesOptions:
-    - suite: integrationTests
-      testSecrets:
-        - name: SECRET_DESTINATION_VECTARA_CREDS
-          fileName: config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-metadataSpecVersion: "1.0"
+  - suite: integrationTests
+    testSecrets:
+    - name: SECRET_DESTINATION_VECTARA_CREDS
+      fileName: config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+  - title: Vectara documentation
+    url: https://docs.vectara.com/
+    type: api_reference
+  - title: Authentication
+    url: https://docs.vectara.com/docs/learn/authentication/auth-overview
+    type: authentication_guide
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-vectara/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-vectara/metadata.yaml
@@ -1,8 +1,8 @@
 data:
   allowedHosts:
     hosts:
-    - api.vectara.io
-    - vectara-prod-${self.customer_id}.auth.us-west-2.amazoncognito.com
+      - api.vectara.io
+      - vectara-prod-${self.customer_id}.auth.us-west-2.amazoncognito.com
   registryOverrides:
     oss:
       enabled: true
@@ -28,21 +28,21 @@ data:
   supportLevel: community
   documentationUrl: https://docs.airbyte.com/integrations/destinations/vectara
   tags:
-  - language:python
-  - cdk:python
+    - language:python
+    - cdk:python
   connectorTestSuitesOptions:
-  - suite: integrationTests
-    testSecrets:
-    - name: SECRET_DESTINATION_VECTARA_CREDS
-      fileName: config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION_VECTARA_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
   externalDocumentationUrls:
-  - title: Vectara documentation
-    url: https://docs.vectara.com/
-    type: api_reference
-  - title: Authentication
-    url: https://docs.vectara.com/docs/learn/authentication/auth-overview
-    type: authentication_guide
-metadataSpecVersion: '1.0'
+    - title: Vectara documentation
+      url: https://docs.vectara.com/
+      type: api_reference
+    - title: Authentication
+      url: https://docs.vectara.com/docs/learn/authentication/auth-overview
+      type: authentication_guide
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-vectara/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-vectara/metadata.yaml
@@ -21,7 +21,7 @@ data:
   name: Vectara
   remoteRegistries:
     pypi:
-      enabled: false
+      enabled: false # TODO: enable once the CLI is working
       packageName: airbyte-destination-vectara
   releaseDate: 2023-12-16
   releaseStage: alpha

--- a/airbyte-integrations/connectors/destination-vertica/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-vertica/metadata.yaml
@@ -16,9 +16,16 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/vertica
   tags:
-    - language:java
+  - language:java
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: archived
-metadataSpecVersion: "1.0"
+  externalDocumentationUrls:
+  - title: Vertica documentation
+    url: https://www.vertica.com/docs/latest/HTML/Content/Home.htm
+    type: api_reference
+  - title: SQL reference
+    url: https://www.vertica.com/docs/latest/HTML/Content/Authoring/SQLReferenceManual/SQLReferenceManual.htm
+    type: sql_reference
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-vertica/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-vertica/metadata.yaml
@@ -16,16 +16,16 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/vertica
   tags:
-  - language:java
+    - language:java
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: archived
   externalDocumentationUrls:
-  - title: Vertica documentation
-    url: https://www.vertica.com/docs/latest/HTML/Content/Home.htm
-    type: api_reference
-  - title: SQL reference
-    url: https://www.vertica.com/docs/latest/HTML/Content/Authoring/SQLReferenceManual/SQLReferenceManual.htm
-    type: sql_reference
-metadataSpecVersion: '1.0'
+    - title: Vertica documentation
+      url: https://www.vertica.com/docs/latest/HTML/Content/Home.htm
+      type: api_reference
+    - title: SQL reference
+      url: https://www.vertica.com/docs/latest/HTML/Content/Authoring/SQLReferenceManual/SQLReferenceManual.htm
+      type: sql_reference
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-weaviate/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-weaviate/metadata.yaml
@@ -4,10 +4,10 @@ data:
     sl: 300
   allowedHosts:
     hosts:
-    - ${indexing.host}
-    - api.openai.com
-    - api.cohere.ai
-    - ${embedding.api_base}
+      - ${indexing.host}
+      - api.openai.com
+      - api.cohere.ai
+      - ${embedding.api_base}
   connectorBuildOptions:
     baseImage: docker.io/airbyte/python-connector-base:4.0.2@sha256:9fdb1888c4264cf6fee473649ecb593f56f58e5d0096a87ee0b231777e2e3e73
   connectorSubtype: vectorstore
@@ -29,45 +29,46 @@ data:
   releases:
     breakingChanges:
       0.2.0:
-        message: 'After upgrading, you need to reconfigure the source. For more details
+        message:
+          "After upgrading, you need to reconfigure the source. For more details
           check out the migration guide.
 
-          '
-        upgradeDeadline: '2023-10-01'
+          "
+        upgradeDeadline: "2023-10-01"
   resourceRequirements:
     jobSpecific:
-    - jobType: sync
-      resourceRequirements:
-        memory_limit: 2Gi
-        memory_request: 2Gi
+      - jobType: sync
+        resourceRequirements:
+          memory_limit: 2Gi
+          memory_request: 2Gi
   supportLevel: certified
   tags:
-  - language:python
-  - cdk:python
+    - language:python
+    - cdk:python
   connectorTestSuitesOptions:
-  - suite: unitTests
-  - suite: integrationTests
-    testSecrets:
-    - name: SECRET_DESTINATION-WEAVIATE_CREDS
-      fileName: config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
-  - suite: acceptanceTests
-    testSecrets:
-    - name: SECRET_DESTINATION-WEAVIATE_CREDS
-      fileName: config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION-WEAVIATE_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_DESTINATION-WEAVIATE_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
   externalDocumentationUrls:
-  - title: Weaviate documentation
-    url: https://weaviate.io/developers/weaviate
-    type: api_reference
-  - title: Authentication
-    url: https://weaviate.io/developers/weaviate/configuration/authentication
-    type: authentication_guide
-  - title: Release notes
-    url: https://weaviate.io/developers/weaviate/release-notes
-    type: api_release_history
-metadataSpecVersion: '1.0'
+    - title: Weaviate documentation
+      url: https://weaviate.io/developers/weaviate
+      type: api_reference
+    - title: Authentication
+      url: https://weaviate.io/developers/weaviate/configuration/authentication
+      type: authentication_guide
+    - title: Release notes
+      url: https://weaviate.io/developers/weaviate/release-notes
+      type: api_release_history
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-weaviate/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-weaviate/metadata.yaml
@@ -29,11 +29,7 @@ data:
   releases:
     breakingChanges:
       0.2.0:
-        message:
-          "After upgrading, you need to reconfigure the source. For more details
-          check out the migration guide.
-
-          "
+        message: "After upgrading, you need to reconfigure the source. For more details check out the migration guide.\n"
         upgradeDeadline: "2023-10-01"
   resourceRequirements:
     jobSpecific:

--- a/airbyte-integrations/connectors/destination-weaviate/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-weaviate/metadata.yaml
@@ -4,10 +4,10 @@ data:
     sl: 300
   allowedHosts:
     hosts:
-      - ${indexing.host}
-      - api.openai.com
-      - api.cohere.ai
-      - ${embedding.api_base}
+    - ${indexing.host}
+    - api.openai.com
+    - api.cohere.ai
+    - ${embedding.api_base}
   connectorBuildOptions:
     baseImage: docker.io/airbyte/python-connector-base:4.0.2@sha256:9fdb1888c4264cf6fee473649ecb593f56f58e5d0096a87ee0b231777e2e3e73
   connectorSubtype: vectorstore
@@ -29,32 +29,45 @@ data:
   releases:
     breakingChanges:
       0.2.0:
-        message: "After upgrading, you need to reconfigure the source. For more details check out the migration guide.\n"
-        upgradeDeadline: "2023-10-01"
+        message: 'After upgrading, you need to reconfigure the source. For more details
+          check out the migration guide.
+
+          '
+        upgradeDeadline: '2023-10-01'
   resourceRequirements:
     jobSpecific:
-      - jobType: sync
-        resourceRequirements:
-          memory_limit: 2Gi
-          memory_request: 2Gi
+    - jobType: sync
+      resourceRequirements:
+        memory_limit: 2Gi
+        memory_request: 2Gi
   supportLevel: certified
   tags:
-    - language:python
-    - cdk:python
+  - language:python
+  - cdk:python
   connectorTestSuitesOptions:
-    - suite: unitTests
-    - suite: integrationTests
-      testSecrets:
-        - name: SECRET_DESTINATION-WEAVIATE_CREDS
-          fileName: config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-    - suite: acceptanceTests
-      testSecrets:
-        - name: SECRET_DESTINATION-WEAVIATE_CREDS
-          fileName: config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-metadataSpecVersion: "1.0"
+  - suite: unitTests
+  - suite: integrationTests
+    testSecrets:
+    - name: SECRET_DESTINATION-WEAVIATE_CREDS
+      fileName: config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+  - suite: acceptanceTests
+    testSecrets:
+    - name: SECRET_DESTINATION-WEAVIATE_CREDS
+      fileName: config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+  - title: Weaviate documentation
+    url: https://weaviate.io/developers/weaviate
+    type: api_reference
+  - title: Authentication
+    url: https://weaviate.io/developers/weaviate/configuration/authentication
+    type: authentication_guide
+  - title: Release notes
+    url: https://weaviate.io/developers/weaviate/release-notes
+    type: api_release_history
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-xata/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-xata/metadata.yaml
@@ -16,21 +16,31 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/xata
   tags:
-    - language:python
-    - cdk:python
+  - language:python
+  - cdk:python
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
-    - suite: unitTests
-    - suite: integrationTests
-      testSecrets:
-        - name: SECRET_DESTINATION-XATA__CREDS
-          fileName: config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
+  - suite: unitTests
+  - suite: integrationTests
+    testSecrets:
+    - name: SECRET_DESTINATION-XATA__CREDS
+      fileName: config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
   connectorBuildOptions:
     baseImage: docker.io/airbyte/python-connector-base:4.0.0@sha256:d9894b6895923b379f3006fa251147806919c62b7d9021b5cd125bb67d7bbe22
-metadataSpecVersion: "1.0"
+  externalDocumentationUrls:
+  - title: Xata documentation
+    url: https://xata.io/docs
+    type: api_reference
+  - title: Authentication
+    url: https://xata.io/docs/concepts/api-keys
+    type: authentication_guide
+  - title: Xata Status
+    url: https://status.xata.io/
+    type: status_page
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-xata/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-xata/metadata.yaml
@@ -16,31 +16,31 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/xata
   tags:
-  - language:python
-  - cdk:python
+    - language:python
+    - cdk:python
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
-  - suite: unitTests
-  - suite: integrationTests
-    testSecrets:
-    - name: SECRET_DESTINATION-XATA__CREDS
-      fileName: config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION-XATA__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
   connectorBuildOptions:
     baseImage: docker.io/airbyte/python-connector-base:4.0.0@sha256:d9894b6895923b379f3006fa251147806919c62b7d9021b5cd125bb67d7bbe22
   externalDocumentationUrls:
-  - title: Xata documentation
-    url: https://xata.io/docs
-    type: api_reference
-  - title: Authentication
-    url: https://xata.io/docs/concepts/api-keys
-    type: authentication_guide
-  - title: Xata Status
-    url: https://status.xata.io/
-    type: status_page
-metadataSpecVersion: '1.0'
+    - title: Xata documentation
+      url: https://xata.io/docs
+      type: api_reference
+    - title: Authentication
+      url: https://xata.io/docs/concepts/api-keys
+      type: authentication_guide
+    - title: Xata Status
+      url: https://status.xata.io/
+      type: status_page
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-yellowbrick/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-yellowbrick/metadata.yaml
@@ -25,13 +25,20 @@ data:
   supportLevel: community
   supportsDbt: false
   tags:
-    - language:java
+  - language:java
   connectorTestSuitesOptions:
-    - suite: integrationTests
-      testSecrets:
-        - name: SECRET_DESTINATION-YELLOWBRICK_CREDENTIALS__CREDS
-          fileName: config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-metadataSpecVersion: "1.0"
+  - suite: integrationTests
+    testSecrets:
+    - name: SECRET_DESTINATION-YELLOWBRICK_CREDENTIALS__CREDS
+      fileName: config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+  - title: Yellowbrick documentation
+    url: https://docs.yellowbrick.com/
+    type: api_reference
+  - title: SQL reference
+    url: https://docs.yellowbrick.com/6.7.1/sql_reference/sql_reference.html
+    type: sql_reference
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-yellowbrick/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-yellowbrick/metadata.yaml
@@ -25,20 +25,20 @@ data:
   supportLevel: community
   supportsDbt: false
   tags:
-  - language:java
+    - language:java
   connectorTestSuitesOptions:
-  - suite: integrationTests
-    testSecrets:
-    - name: SECRET_DESTINATION-YELLOWBRICK_CREDENTIALS__CREDS
-      fileName: config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION-YELLOWBRICK_CREDENTIALS__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
   externalDocumentationUrls:
-  - title: Yellowbrick documentation
-    url: https://docs.yellowbrick.com/
-    type: api_reference
-  - title: SQL reference
-    url: https://docs.yellowbrick.com/6.7.1/sql_reference/sql_reference.html
-    type: sql_reference
-metadataSpecVersion: '1.0'
+    - title: Yellowbrick documentation
+      url: https://docs.yellowbrick.com/
+      type: api_reference
+    - title: SQL reference
+      url: https://docs.yellowbrick.com/6.7.1/sql_reference/sql_reference.html
+      type: sql_reference
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-yugabytedb/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-yugabytedb/metadata.yaml
@@ -16,9 +16,19 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/yugabytedb
   tags:
-    - language:java
+  - language:java
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: archived
-metadataSpecVersion: "1.0"
+  externalDocumentationUrls:
+  - title: YugabyteDB documentation
+    url: https://docs.yugabyte.com/
+    type: api_reference
+  - title: YSQL reference
+    url: https://docs.yugabyte.com/preview/api/ysql/
+    type: sql_reference
+  - title: Authentication
+    url: https://docs.yugabyte.com/preview/secure/authentication/
+    type: authentication_guide
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-yugabytedb/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-yugabytedb/metadata.yaml
@@ -16,19 +16,19 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/yugabytedb
   tags:
-  - language:java
+    - language:java
   ab_internal:
     sl: 100
     ql: 100
   supportLevel: archived
   externalDocumentationUrls:
-  - title: YugabyteDB documentation
-    url: https://docs.yugabyte.com/
-    type: api_reference
-  - title: YSQL reference
-    url: https://docs.yugabyte.com/preview/api/ysql/
-    type: sql_reference
-  - title: Authentication
-    url: https://docs.yugabyte.com/preview/secure/authentication/
-    type: authentication_guide
-metadataSpecVersion: '1.0'
+    - title: YugabyteDB documentation
+      url: https://docs.yugabyte.com/
+      type: api_reference
+    - title: YSQL reference
+      url: https://docs.yugabyte.com/preview/api/ysql/
+      type: sql_reference
+    - title: Authentication
+      url: https://docs.yugabyte.com/preview/secure/authentication/
+      type: authentication_guide
+metadataSpecVersion: "1.0"


### PR DESCRIPTION
## What

Adds `externalDocumentationUrls` to all destination connectors (Group A) following the pattern established in PR #69290. This provides users with quick access to vendor documentation for API changes, authentication, rate limits, and other critical information.

Related to the user request from AJ Steers (@aaronsteers) in Slack to replicate PR #69290 across all connectors in groups of ~50.

**Link to Devin run**: https://app.devin.ai/sessions/278efaf8c49f4261b899f1c1f465c91a

## How

1. **Schema Enhancement**: Added 8 new documentation type options to the `externalDocumentationUrls` enum:
   - `authentication_guide` - OAuth/API key setup documentation
   - `permissions_scopes` - Required roles, permissions, OAuth scopes
   - `rate_limits` - Rate limits, quotas, throttling behavior
   - `status_page` - Vendor status/uptime pages
   - `data_model_reference` - Object/field/endpoint reference for SaaS APIs
   - `sql_reference` - SQL dialect/reference docs for databases
   - `migration_guide` - Vendor migration/breaking-change guides
   - `developer_community` - Official forums/communities

2. **Documentation Guide**: Created comprehensive guide at `airbyte-ci/connectors/metadata_service/docs/external_documentation_urls.md` explaining:
   - Documentation type taxonomy with examples
   - How to find and select appropriate URLs
   - Connector family-specific guidance (data warehouses, databases, SaaS APIs, vector stores)
   - URL selection heuristics and maintenance guidelines

3. **Connector Updates**: Added `externalDocumentationUrls` to 85 destination connectors with appropriate vendor documentation links:
   - Data warehouses (BigQuery, Snowflake, Redshift, Databricks): SQL references, authentication, permissions, rate limits, status pages
   - Databases (Postgres, MySQL, MongoDB, etc.): SQL references, authentication, permissions
   - Cloud storage (S3, GCS, Azure Blob): Authentication, permissions, rate limits, status pages
   - Vector stores (Pinecone, Weaviate, Qdrant, etc.): API references, authentication, release notes
   - SaaS APIs (HubSpot, Customer.io, Google Sheets): API references, OAuth, rate limits, status pages
   - Message queues (Kafka, Kinesis, Pub/Sub, etc.): API references, authentication, quotas

4. **Skipped**: `destination-dev-null` (test destination with no external documentation)

## Review guide

### Critical items to review:

1. **Schema changes** (`airbyte-ci/connectors/metadata_service/lib/metadata_service/models/src/ConnectorMetadataDefinitionV0.yaml`):
   - Verify the 8 new enum values are appropriate and well-defined
   - Check that the schema change is backward compatible

2. **Generated models** (`.json` and `.py` files):
   - Confirm the regenerated models correctly reflect the schema changes

3. **Documentation guide** (`airbyte-ci/connectors/metadata_service/docs/external_documentation_urls.md`):
   - Review the documentation type taxonomy for completeness and accuracy
   - Verify the guidance aligns with Airbyte's documentation standards

4. **Sample connector metadata** - Spot-check a few connectors from different categories:
   - **Data warehouse**: `destination-snowflake/metadata.yaml` (lines 104-119)
   - **Database**: `destination-postgres/metadata.yaml`
   - **Cloud storage**: `destination-s3/metadata.yaml`
   - **Vector store**: `destination-pinecone/metadata.yaml`
   - **SaaS API**: `destination-hubspot/metadata.yaml`

5. **URL validity**: Spot-check that URLs are:
   - Accessible (not 404s)
   - Official vendor documentation (not third-party)
   - Canonical/version-agnostic where possible
   - Correctly categorized by type

6. **YAML formatting**: Note that PyYAML reformatted some files (quote style changes from `"1.0"` to `'1.0'` for `metadataSpecVersion`). Verify this is acceptable.

## User Impact

**Positive:**
- Users can quickly access vendor documentation for authentication, rate limits, API changes, and other critical information directly from connector metadata
- Improved discoverability of vendor resources for troubleshooting and configuration
- Consistent documentation structure across all destination connectors

**Potential concerns:**
- URLs may become stale over time if vendors restructure their documentation
- Some URLs might require authentication to access (though `requiresLogin` flag can be added if needed)
- YAML formatting changes (quote styles) in metadata files

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

This is purely additive metadata - reverting would simply remove the `externalDocumentationUrls` fields from connector metadata. No breaking changes to connector functionality.

---

**Requested by**: AJ Steers (aj@airbyte.io, @aaronsteers)