### PR TITLE
docs(connector-development): Add best practices guide for editing metadata.yaml files

### DIFF
--- a/docs/platform/connector-development/connector-metadata-file.md
+++ b/docs/platform/connector-development/connector-metadata-file.md
@@ -241,3 +241,43 @@ They are language agnostic and are configured via the `acceptance-test-config.ym
 **Default secret paths**
 The listed secrets in `testSecrets` with a file name will be mounted to the connector's `secrets` directory. The `fileName` should be relative to this directory.
 E.G.: `fileName: config.json` will be mounted to `<connector-directory>/secrets/config.json`
+
+## The `externalDocumentationUrls` Section
+
+The `externalDocumentationUrls` field is an optional array that provides links to official vendor documentation for the connector. These URLs help users quickly access important external resources like API changelogs, authentication guides, rate limits, and status pages.
+
+### Structure
+
+Each entry in the `externalDocumentationUrls` array contains:
+- `title` (required): Display title for the documentation link
+- `url` (required): URL to the external documentation
+- `type` (optional): Category of documentation (e.g., `api_release_history`, `api_reference`, `authentication_guide`, `permissions_scopes`, `rate_limits`, `status_page`, etc.)
+- `requiresLogin` (optional, default: false): Whether the URL requires authentication to access
+
+### Example
+
+```yaml
+externalDocumentationUrls:
+  - title: Release notes
+    url: https://cloud.google.com/bigquery/docs/release-notes
+    type: api_release_history
+  - title: Standard SQL reference
+    url: https://cloud.google.com/bigquery/docs/reference/standard-sql
+    type: sql_reference
+  - title: Service account authentication
+    url: https://cloud.google.com/iam/docs/service-accounts
+    type: authentication_guide
+  - title: Access control and permissions
+    url: https://cloud.google.com/bigquery/docs/access-control
+    type: permissions_scopes
+  - title: Quotas and limits
+    url: https://cloud.google.com/bigquery/quotas
+    type: rate_limits
+  - title: Google Cloud Status
+    url: https://status.cloud.google.com/
+    type: status_page
+```
+
+### Comprehensive Guide
+
+For detailed guidance on identifying, scraping, and maintaining external documentation URLs, including best practices for avoiding unnecessary YAML formatting changes, see the [External Documentation URLs Guide](https://github.com/airbytehq/airbyte/blob/master/airbyte-ci/connectors/metadata_service/docs/external_documentation_urls.md).


### PR DESCRIPTION
## What

This PR enhances the connector development documentation by adding best practices for editing `metadata.yaml` files and documenting the `externalDocumentationUrls` field. This addresses lessons learned from [PR #69353](https://github.com/airbytehq/airbyte/pull/69353) where a format-fix bot created significant diff noise due to YAML re-dumping.

Related to the external documentation URLs feature added in PR #69353.

## How

**1. Added "Best Practices for Editing metadata.yaml Files" section to external_documentation_urls.md:**
- Documents the issue of YAML re-dumping causing unnecessary diffs
- Provides guidance on using `ruamel.yaml` with round-trip mode for format-preserving edits
- Explains Airbyte repository's YAML formatting conventions (2-space indentation, quote styles, flow vs block style)
- Includes practical code examples showing correct vs incorrect approaches
- Lists common pitfalls and how to avoid them

**2. Added `externalDocumentationUrls` section to connector-metadata-file.md:**
- Documents the structure and purpose of the `externalDocumentationUrls` field
- Provides a complete example showing all field types
- Cross-links to the comprehensive External Documentation URLs Guide for detailed guidance

## Review guide

1. **airbyte-ci/connectors/metadata_service/docs/external_documentation_urls.md** (lines 536-674)
   - Review the "Best Practices" section for technical accuracy
   - Verify the ruamel.yaml code examples are syntactically correct
   - Check if the guidance is comprehensive enough for future AI agents and maintainers

2. **docs/platform/connector-development/connector-metadata-file.md** (lines 245-284)
   - Verify the new section fits well with existing content
   - Check if the cross-link URL format is appropriate (currently uses GitHub URL to master branch)
   - Confirm the example YAML is consistent with the guide

## User Impact

**Positive:**
- Future contributors and AI agents will have clear guidance on how to edit metadata.yaml files without creating unnecessary diff noise
- Connector developers will understand the `externalDocumentationUrls` field structure and purpose
- Reduces the likelihood of format-fix bot creating large, noisy diffs in future PRs

**Potential concerns:**
- The cross-link uses a GitHub URL pointing to master branch, which may not be ideal for versioned documentation

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

This is purely documentation changes with no code or configuration modifications.

---

**Link to Devin run:** https://app.devin.ai/sessions/278efaf8c49f4261b899f1c1f465c91a

**Requested by:** AJ Steers (@aaronsteers)