### PR TITLE
feat(metadata-service): Add connector version yank functionality

### DIFF
--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/commands.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/commands.py
@@ -2,14 +2,16 @@
 # Copyright (c) 2025 Airbyte, Inc., all rights reserved.
 #
 
+import json
 import logging
 import pathlib
+from datetime import datetime
 
 import click
 import sentry_sdk
 from pydantic import ValidationError
 
-from metadata_service.constants import METADATA_FILE_NAME, VALID_REGISTRIES
+from metadata_service.constants import METADATA_FILE_NAME, METADATA_FOLDER, VALID_REGISTRIES
 from metadata_service.gcs_upload import (
     MetadataDeleteInfo,
     MetadataUploadInfo,
@@ -260,10 +262,6 @@ def generate_registry_report(bucket_name: str):
 @click.option("--operator", type=click.STRING, required=False, default="", help="Name of the operator performing the yank.")
 @sentry_sdk.trace
 def yank_version(connector_docker_repository: str, connector_version: str, bucket_name: str, reason: str, operator: str):
-    import json
-    from datetime import datetime
-
-    from metadata_service.constants import METADATA_FOLDER
     from metadata_service.helpers.gcs import get_gcs_storage_client
 
     sentry_sdk.set_tag("command", "yank_version")
@@ -310,7 +308,6 @@ def yank_version(connector_docker_repository: str, connector_version: str, bucke
 @click.argument("bucket-name", type=click.STRING, required=True)
 @sentry_sdk.trace
 def unyank_version(connector_docker_repository: str, connector_version: str, bucket_name: str):
-    from metadata_service.constants import METADATA_FOLDER
     from metadata_service.helpers.gcs import get_gcs_storage_client
 
     sentry_sdk.set_tag("command", "unyank_version")

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/helpers/gcs.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/helpers/gcs.py
@@ -34,3 +34,23 @@ def safe_read_gcs_file(gcs_blob: storage.Blob) -> Optional[str]:
         return None
 
     return gcs_blob.download_as_string().decode("utf-8")
+
+
+def is_version_yanked(bucket: storage.Bucket, docker_repository: str, version: str) -> bool:
+    """Check if a specific connector version has been yanked.
+
+    A version is considered yanked if a .yanked marker file exists in its GCS directory.
+
+    Args:
+        bucket (storage.Bucket): The GCS bucket.
+        docker_repository (str): The docker repository (e.g., 'airbyte/source-postgres').
+        version (str): The version to check (e.g., '3.7.0').
+
+    Returns:
+        bool: True if the version is yanked, False otherwise.
+    """
+    from metadata_service.constants import METADATA_FOLDER
+
+    yank_marker_path = f"{METADATA_FOLDER}/{docker_repository}/{version}/.yanked"
+    yank_marker_blob = bucket.blob(yank_marker_path)
+    return yank_marker_blob.exists()

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/registry.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/registry.py
@@ -113,9 +113,7 @@ def _apply_release_candidates(
 
     # If the relase candidate is older than the latest registry entry, don't apply the release candidate and return the latest registry entry
     try:
-        if parse_version(release_candidate_registry_entry.dockerImageTag) < parse_version(
-            latest_registry_entry["dockerImageTag"]
-        ):
+        if parse_version(release_candidate_registry_entry.dockerImageTag) < parse_version(latest_registry_entry["dockerImageTag"]):
             return latest_registry_entry
     except Exception as e:
         logger.error(f"Error parsing version for release candidate comparison: {e}")

--- a/airbyte-ci/connectors/metadata_service/lib/tests/test_yank.py
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/test_yank.py
@@ -1,0 +1,58 @@
+#
+# Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+#
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from metadata_service.helpers.gcs import is_version_yanked
+
+
+class TestIsVersionYanked:
+    """Tests for is_version_yanked function."""
+
+    def test_is_version_yanked_returns_true_when_marker_exists(self):
+        """Test that is_version_yanked returns True when .yanked marker exists."""
+        mock_bucket = Mock()
+        mock_blob = Mock()
+        mock_blob.exists.return_value = True
+        mock_bucket.blob.return_value = mock_blob
+
+        result = is_version_yanked(mock_bucket, "airbyte/source-postgres", "3.7.0")
+
+        assert result is True
+        mock_bucket.blob.assert_called_once_with("metadata/airbyte/source-postgres/3.7.0/.yanked")
+        mock_blob.exists.assert_called_once()
+
+    def test_is_version_yanked_returns_false_when_marker_does_not_exist(self):
+        """Test that is_version_yanked returns False when .yanked marker does not exist."""
+        mock_bucket = Mock()
+        mock_blob = Mock()
+        mock_blob.exists.return_value = False
+        mock_bucket.blob.return_value = mock_blob
+
+        result = is_version_yanked(mock_bucket, "airbyte/source-postgres", "3.7.0")
+
+        assert result is False
+        mock_bucket.blob.assert_called_once_with("metadata/airbyte/source-postgres/3.7.0/.yanked")
+        mock_blob.exists.assert_called_once()
+
+    @pytest.mark.parametrize(
+        "docker_repository,version,expected_path",
+        [
+            ("airbyte/source-postgres", "3.7.0", "metadata/airbyte/source-postgres/3.7.0/.yanked"),
+            ("airbyte/destination-bigquery", "1.2.3", "metadata/airbyte/destination-bigquery/1.2.3/.yanked"),
+            ("airbyte/source-hubspot", "5.0.0-rc.1", "metadata/airbyte/source-hubspot/5.0.0-rc.1/.yanked"),
+        ],
+    )
+    def test_is_version_yanked_constructs_correct_path(self, docker_repository, version, expected_path):
+        """Test that is_version_yanked constructs the correct GCS path for different connectors."""
+        mock_bucket = Mock()
+        mock_blob = Mock()
+        mock_blob.exists.return_value = False
+        mock_bucket.blob.return_value = mock_blob
+
+        is_version_yanked(mock_bucket, docker_repository, version)
+
+        mock_bucket.blob.assert_called_once_with(expected_path)


### PR DESCRIPTION
## What

Implements a "yank" mechanism for connector releases that allows emergency rollback of bad connector versions without requiring GitHub PRs. When a connector version is yanked, the registry generation process automatically falls back to the latest non-yanked version.

**Requested by:** AJ Steers (@aaronsteers) in https://airbytehq-team.slack.com/archives/C08BHPUMEPJ/p1763443955487739

**Link to Devin run:** https://app.devin.ai/sessions/2b5c532b5ad5457aa3f076dd2da637f0

## How

1. **Yank Marker System**: Introduces a `.yanked` marker file stored in GCS at `metadata/{docker_repository}/{version}/.yanked` containing metadata (timestamp, reason, operator)

2. **Registry Generation Changes**: Modified `_get_latest_registry_entries()` to check if the current 'latest' version is yanked. If so, it calls `_get_latest_non_yanked_version()` which:
   - Lists all versions for the connector
   - Sorts them by semver (highest first)
   - Returns the first non-yanked version

3. **CLI Commands**: Added two new commands to the metadata-service CLI:
   - `yank_version`: Creates a yank marker in GCS
   - `unyank_version`: Removes a yank marker from GCS

## Review guide

**Critical paths to review:**

1. **`registry.py`** - Registry generation logic changes
   - `_get_latest_non_yanked_version()`: New function that finds the latest non-yanked version by listing all versions. **Performance concern**: This lists all blobs with a prefix - could be slow for connectors with many versions.
   - `_get_latest_registry_entries()`: Modified to check for yanked versions and fall back to alternatives. **Edge case**: What happens if all versions are yanked?

2. **`helpers/gcs.py`** - Yank checking logic
   - `is_version_yanked()`: Simple existence check for `.yanked` marker file. **Note**: This is called during registry generation for every connector.

3. **`commands.py`** - CLI commands
   - `yank_version()` and `unyank_version()`: Direct GCS operations. **Security**: These bypass all GitHub workflows and directly modify GCS.

4. **`test_yank.py`** - Unit tests
   - Basic tests for `is_version_yanked()` only. **Gap**: No integration tests with real GCS data or tests for the registry generation logic.

## User Impact

**Positive:**
- Operators can quickly yank bad connector releases without waiting for PR review/merge
- Registry automatically serves the next-best version when a version is yanked
- Audit trail via yank marker metadata (timestamp, reason, operator)

**Negative/Risks:**
- **Untested in production**: This modifies critical registry generation logic and has not been tested against real GCS data
- **Performance**: Listing all versions for a connector could be slow during registry generation
- **No gradual rollout**: Yanking a version immediately affects all users on the next registry refresh
- **Edge cases**: Behavior when all versions are yanked is to skip the connector entirely (may not be desired)
- **No documentation**: Users don't have guidance on when/how to use this feature

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

The changes are additive and don't modify existing behavior unless a yank marker exists. Reverting would simply disable the yank checking logic, and any existing yank markers would be ignored.

---

## Human Review Checklist

- [ ] Verify the performance implications of `_get_latest_non_yanked_version()` listing all blobs
- [ ] Confirm the behavior when all versions of a connector are yanked is acceptable
- [ ] Review error handling for GCS connectivity issues during yank checks
- [ ] Consider whether integration tests with real GCS data are needed before merge
- [ ] Evaluate whether documentation should be added before merge
- [ ] Assess whether this should be tested in a staging environment first