### PR TITLE
Destination Clickhouse: increase test timeout

### DIFF
--- a/airbyte-integrations/connectors/destination-bigquery/gradle.properties
+++ b/airbyte-integrations/connectors/destination-bigquery/gradle.properties
@@ -1,3 +1,3 @@
 testExecutionConcurrency=-1
-JunitMethodExecutionTimeout=10 m
+JunitMethodExecutionTimeout=10m
 cdkVersion=0.1.74

--- a/airbyte-integrations/connectors/destination-clickhouse/gradle.properties
+++ b/airbyte-integrations/connectors/destination-clickhouse/gradle.properties
@@ -1,1 +1,2 @@
 cdkVersion=0.1.78
+JunitMethodExecutionTimeout=10 m

--- a/airbyte-integrations/connectors/destination-clickhouse/gradle.properties
+++ b/airbyte-integrations/connectors/destination-clickhouse/gradle.properties
@@ -1,2 +1,2 @@
 cdkVersion=0.1.78
-JunitMethodExecutionTimeout=10 m
+JunitMethodExecutionTimeout=10m

--- a/airbyte-integrations/connectors/destination-databricks/gradle.properties
+++ b/airbyte-integrations/connectors/destination-databricks/gradle.properties
@@ -1,3 +1,3 @@
 testExecutionConcurrency=-1
 # increased timeout required during parallel workload on our small warehouse
-JunitMethodExecutionTimeout=10 m
+JunitMethodExecutionTimeout=10m

--- a/airbyte-integrations/connectors/destination-mysql/gradle.properties
+++ b/airbyte-integrations/connectors/destination-mysql/gradle.properties
@@ -1,4 +1,4 @@
 # our testcontainer has issues with too much concurrency.
 # 4 threads seems to be the sweet spot.
 testExecutionConcurrency=4
-JunitMethodExecutionTimeout=15 m
+JunitMethodExecutionTimeout=15m

--- a/airbyte-integrations/connectors/destination-postgres/gradle.properties
+++ b/airbyte-integrations/connectors/destination-postgres/gradle.properties
@@ -2,4 +2,4 @@
 # 4 threads seems to be the sweet spot.
 testExecutionConcurrency=4
 # large sync test takes a while, add 15m timeout.
-JunitMethodExecutionTimeout=15 m
+JunitMethodExecutionTimeout=15m

--- a/airbyte-integrations/connectors/destination-redshift/gradle.properties
+++ b/airbyte-integrations/connectors/destination-redshift/gradle.properties
@@ -1,1 +1,1 @@
-JunitMethodExecutionTimeout=15 m
+JunitMethodExecutionTimeout=15m

--- a/airbyte-integrations/connectors/destination-s3/gradle.properties
+++ b/airbyte-integrations/connectors/destination-s3/gradle.properties
@@ -1,3 +1,3 @@
 testExecutionConcurrency=-1
-JunitMethodExecutionTimeout=60 m
+JunitMethodExecutionTimeout=60m
 cdkVersion=0.1.61

--- a/airbyte-integrations/connectors/destination-singlestore/gradle.properties
+++ b/airbyte-integrations/connectors/destination-singlestore/gradle.properties
@@ -1,3 +1,3 @@
 testExecutionConcurrency=4
 # large sync test takes a while, add 15m timeout.
-JunitMethodExecutionTimeout=15 m
+JunitMethodExecutionTimeout=15m

--- a/airbyte-integrations/connectors/destination-snowflake/gradle.properties
+++ b/airbyte-integrations/connectors/destination-snowflake/gradle.properties
@@ -1,3 +1,3 @@
 testExecutionConcurrency=-1
 cdkVersion=0.1.78
-JunitMethodExecutionTimeout=10 m
+JunitMethodExecutionTimeout=10m

--- a/airbyte-integrations/connectors/destination-teradata/gradle.properties
+++ b/airbyte-integrations/connectors/destination-teradata/gradle.properties
@@ -1,3 +1,3 @@
 # Running syncs in sequence to avoid collisions with same database, so it is taking longer time to run all integration tests.
-JunitMethodExecutionTimeout=3 h
+JunitMethodExecutionTimeout=3h
 testExecutionConcurrency=4

--- a/airbyte-integrations/connectors/source-mongodb-v2/gradle.properties
+++ b/airbyte-integrations/connectors/source-mongodb-v2/gradle.properties
@@ -1,1 +1,1 @@
-JunitMethodExecutionTimeout=2 m
+JunitMethodExecutionTimeout=2m

--- a/airbyte-integrations/connectors/source-postgres/gradle.properties
+++ b/airbyte-integrations/connectors/source-postgres/gradle.properties
@@ -1,3 +1,3 @@
 testExecutionConcurrency=-1
 
-JunitMethodExecutionTimeout=5 m
+JunitMethodExecutionTimeout=5m

--- a/airbyte-integrations/connectors/source-singlestore/gradle.properties
+++ b/airbyte-integrations/connectors/source-singlestore/gradle.properties
@@ -1,3 +1,3 @@
 testExecutionConcurrency=1
 
-JunitMethodExecutionTimeout=5 m
+JunitMethodExecutionTimeout=5m

--- a/build.gradle
+++ b/build.gradle
@@ -196,6 +196,7 @@ allprojects {
         }
 
         systemProperty 'junit.jupiter.execution.timeout.default', junitMethodExecutionTimeout
+        systemProperty 'kotlinx.coroutines.test.default_timeout', junitMethodExecutionTimeout
         // This is used by the "old" cdk (i.e. airbyte-cdk/java)
         systemProperty 'JunitMethodExecutionTimeout', junitMethodExecutionTimeout
     }


### PR DESCRIPTION
we keep seeing transient errors - https://github.com/airbytehq/airbyte/actions/runs/19465685524/job/55700172253#step:11:2758

pretty sure this is b/c clickhouse just takes a few minutes to wake up.

`java.util.concurrent.TimeoutException: connect to database() timed out after 1 minute`