### PR TITLE
feat: Add external documentation URLs to Group B source connectors (source-100ms through source-box)

### DIFF
--- a/airbyte-integrations/connectors/source-100ms/metadata.yaml
+++ b/airbyte-integrations/connectors/source-100ms/metadata.yaml
@@ -33,3 +33,13 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: API reference
+      url: https://www.100ms.live/docs/api-reference/javascript/v2/home/content
+      type: api_reference
+    - title: Authentication and tokens
+      url: https://www.100ms.live/docs/get-started/v2/get-started/security-and-tokens
+      type: authentication_guide
+    - title: 100ms Status
+      url: https://status.100ms.live
+      type: status_page

--- a/airbyte-integrations/connectors/source-7shifts/metadata.yaml
+++ b/airbyte-integrations/connectors/source-7shifts/metadata.yaml
@@ -33,3 +33,13 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: API documentation
+      url: https://developers.7shifts.com/reference/introduction
+      type: api_reference
+    - title: Authentication
+      url: https://developers.7shifts.com/docs/authentication
+      type: authentication_guide
+    - title: Rate limits
+      url: https://developers.7shifts.com/docs/rate-limiting
+      type: rate_limits

--- a/airbyte-integrations/connectors/source-activecampaign/metadata.yaml
+++ b/airbyte-integrations/connectors/source-activecampaign/metadata.yaml
@@ -44,4 +44,14 @@ data:
   #           alias: airbyte-connector-testing-secret-store
   connectorBuildOptions:
     baseImage: docker.io/airbyte/source-declarative-manifest:6.48.16@sha256:651a0bbdc634378737fb833fdf43666f9d9b5b633c68a35cc03ab6e56cb4d6e7
+  externalDocumentationUrls:
+    - title: API documentation
+      url: https://developers.activecampaign.com/reference/overview
+      type: api_reference
+    - title: Authentication
+      url: https://developers.activecampaign.com/reference/authentication
+      type: authentication_guide
+    - title: Rate limits
+      url: https://developers.activecampaign.com/reference/rate-limits
+      type: rate_limits
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-acuity-scheduling/metadata.yaml
+++ b/airbyte-integrations/connectors/source-acuity-scheduling/metadata.yaml
@@ -33,3 +33,10 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: API documentation
+      url: https://developers.acuityscheduling.com/
+      type: api_reference
+    - title: Authentication
+      url: https://developers.acuityscheduling.com/docs/getting-started
+      type: authentication_guide

--- a/airbyte-integrations/connectors/source-adjust/metadata.yaml
+++ b/airbyte-integrations/connectors/source-adjust/metadata.yaml
@@ -30,4 +30,11 @@ data:
     - suite: unitTests
   connectorBuildOptions:
     baseImage: docker.io/airbyte/python-connector-base:3.0.2@sha256:73697fbe1c0e2ebb8ed58e2268484bb4bfb2cb56b653808e1680cbc50bafef75
+  externalDocumentationUrls:
+    - title: API documentation
+      url: https://help.adjust.com/en/article/reports-endpoint
+      type: api_reference
+    - title: Authentication
+      url: https://help.adjust.com/en/article/authentication
+      type: authentication_guide
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-adobe-commerce-magento/metadata.yaml
+++ b/airbyte-integrations/connectors/source-adobe-commerce-magento/metadata.yaml
@@ -33,3 +33,13 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: REST API reference
+      url: https://developer.adobe.com/commerce/webapi/rest/
+      type: api_reference
+    - title: Authentication
+      url: https://developer.adobe.com/commerce/webapi/get-started/authentication/
+      type: authentication_guide
+    - title: Release notes
+      url: https://experienceleague.adobe.com/docs/commerce-operations/release/notes/overview.html
+      type: api_release_history

--- a/airbyte-integrations/connectors/source-agilecrm/metadata.yaml
+++ b/airbyte-integrations/connectors/source-agilecrm/metadata.yaml
@@ -33,3 +33,7 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: API documentation
+      url: https://github.com/agilecrm/rest-api
+      type: api_reference

--- a/airbyte-integrations/connectors/source-aha/metadata.yaml
+++ b/airbyte-integrations/connectors/source-aha/metadata.yaml
@@ -43,4 +43,14 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+    - title: API reference
+      url: https://www.aha.io/api
+      type: api_reference
+    - title: Authentication
+      url: https://www.aha.io/api/authentication
+      type: authentication_guide
+    - title: Rate limits
+      url: https://www.aha.io/api/rate_limiting
+      type: rate_limits
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-airbyte/metadata.yaml
+++ b/airbyte-integrations/connectors/source-airbyte/metadata.yaml
@@ -33,3 +33,10 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: API reference
+      url: https://reference.airbyte.com/reference/getting-started
+      type: api_reference
+    - title: Authentication
+      url: https://docs.airbyte.com/using-airbyte/getting-started/api
+      type: authentication_guide

--- a/airbyte-integrations/connectors/source-aircall/metadata.yaml
+++ b/airbyte-integrations/connectors/source-aircall/metadata.yaml
@@ -40,4 +40,14 @@ data:
             alias: airbyte-connector-testing-secret-store
   connectorBuildOptions:
     baseImage: docker.io/airbyte/source-declarative-manifest:7.4.1@sha256:71df19e2ee555ca5b14abbec01d50104c79c9b84cb9cc323284d24333361900a
+  externalDocumentationUrls:
+    - title: API documentation
+      url: https://developer.aircall.io/api-references/
+      type: api_reference
+    - title: Authentication
+      url: https://developer.aircall.io/api-references/#authentication
+      type: authentication_guide
+    - title: Rate limits
+      url: https://developer.aircall.io/api-references/#rate-limit
+      type: rate_limits
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-akeneo/metadata.yaml
+++ b/airbyte-integrations/connectors/source-akeneo/metadata.yaml
@@ -32,3 +32,10 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: API reference
+      url: https://api.akeneo.com/
+      type: api_reference
+    - title: Authentication
+      url: https://api.akeneo.com/documentation/authentication.html
+      type: authentication_guide

--- a/airbyte-integrations/connectors/source-algolia/metadata.yaml
+++ b/airbyte-integrations/connectors/source-algolia/metadata.yaml
@@ -33,3 +33,13 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: API reference
+      url: https://www.algolia.com/doc/rest-api/search/
+      type: api_reference
+    - title: Authentication
+      url: https://www.algolia.com/doc/guides/security/api-keys/
+      type: authentication_guide
+    - title: Rate limits
+      url: https://www.algolia.com/doc/guides/scaling/servers-clusters/#rate-limits
+      type: rate_limits

--- a/airbyte-integrations/connectors/source-alpaca-broker-api/metadata.yaml
+++ b/airbyte-integrations/connectors/source-alpaca-broker-api/metadata.yaml
@@ -33,3 +33,13 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Broker API documentation
+      url: https://docs.alpaca.markets/docs/broker-api
+      type: api_reference
+    - title: Authentication
+      url: https://docs.alpaca.markets/docs/broker-api-keys
+      type: authentication_guide
+    - title: Rate limits
+      url: https://docs.alpaca.markets/docs/rate-limits
+      type: rate_limits

--- a/airbyte-integrations/connectors/source-alpha-vantage/metadata.yaml
+++ b/airbyte-integrations/connectors/source-alpha-vantage/metadata.yaml
@@ -40,4 +40,11 @@ data:
       #         alias: airbyte-connector-testing-secret-store
   connectorBuildOptions:
     baseImage: docker.io/airbyte/source-declarative-manifest:6.51.0@sha256:890b109f243b8b9406f23ea7522de41025f7b3e87f6fc9710bc1e521213a276f
+  externalDocumentationUrls:
+    - title: API documentation
+      url: https://www.alphavantage.co/documentation/
+      type: api_reference
+    - title: API support
+      url: https://www.alphavantage.co/support/
+      type: other
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-amazon-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-amazon-ads/metadata.yaml
@@ -114,4 +114,14 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+    - title: Advertising API
+      url: https://advertising.amazon.com/API/docs/en-us
+      type: api_reference
+    - title: Authorization
+      url: https://advertising.amazon.com/API/docs/en-us/get-started/authorization
+      type: authentication_guide
+    - title: Rate limits
+      url: https://advertising.amazon.com/API/docs/en-us/get-started/developer-notes#rate-limiting
+      type: rate_limits
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/metadata.yaml
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/metadata.yaml
@@ -75,4 +75,14 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+    - title: SP-API documentation
+      url: https://developer-docs.amazon.com/sp-api/
+      type: api_reference
+    - title: Authorization
+      url: https://developer-docs.amazon.com/sp-api/docs/authorizing-selling-partner-api-applications
+      type: authentication_guide
+    - title: Usage plans and rate limits
+      url: https://developer-docs.amazon.com/sp-api/docs/usage-plans-and-rate-limits-in-the-sp-api
+      type: rate_limits
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-amazon-sqs/metadata.yaml
+++ b/airbyte-integrations/connectors/source-amazon-sqs/metadata.yaml
@@ -57,4 +57,14 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+    - title: Amazon SQS API reference
+      url: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/
+      type: api_reference
+    - title: Authentication and access control
+      url: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-authentication-and-access-control.html
+      type: authentication_guide
+    - title: Quotas
+      url: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-quotas.html
+      type: rate_limits
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-amplitude/metadata.yaml
+++ b/airbyte-integrations/connectors/source-amplitude/metadata.yaml
@@ -63,4 +63,14 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+    - title: Analytics API
+      url: https://www.docs.developers.amplitude.com/analytics/apis/http-v2-api/
+      type: api_reference
+    - title: Authentication
+      url: https://www.docs.developers.amplitude.com/analytics/apis/authentication/
+      type: authentication_guide
+    - title: Rate limits
+      url: https://www.docs.developers.amplitude.com/analytics/apis/http-v2-api/#rate-limits
+      type: rate_limits
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-apify-dataset/metadata.yaml
+++ b/airbyte-integrations/connectors/source-apify-dataset/metadata.yaml
@@ -52,4 +52,14 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+    - title: API reference
+      url: https://docs.apify.com/api/v2
+      type: api_reference
+    - title: Authentication
+      url: https://docs.apify.com/api/v2#/introduction/authentication
+      type: authentication_guide
+    - title: Rate limiting
+      url: https://docs.apify.com/api/v2#/introduction/rate-limiting
+      type: rate_limits
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-appcues/metadata.yaml
+++ b/airbyte-integrations/connectors/source-appcues/metadata.yaml
@@ -33,3 +33,7 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: API documentation
+      url: https://docs.appcues.com/en_US/api
+      type: api_reference

--- a/airbyte-integrations/connectors/source-appfigures/metadata.yaml
+++ b/airbyte-integrations/connectors/source-appfigures/metadata.yaml
@@ -33,3 +33,10 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: API documentation
+      url: https://docs.appfigures.com/
+      type: api_reference
+    - title: Authentication
+      url: https://docs.appfigures.com/authentication
+      type: authentication_guide

--- a/airbyte-integrations/connectors/source-appfollow/metadata.yaml
+++ b/airbyte-integrations/connectors/source-appfollow/metadata.yaml
@@ -49,4 +49,8 @@ data:
             alias: airbyte-connector-testing-secret-store
   connectorBuildOptions:
     baseImage: docker.io/airbyte/source-declarative-manifest:7.5.0@sha256:92e539d5003b33c3624eae7715aee6e39b7b2f1f0eeb6003d37e649a06847ae8
+  externalDocumentationUrls:
+    - title: API documentation
+      url: https://appfollow.docs.apiary.io/
+      type: api_reference
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-apple-search-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-apple-search-ads/metadata.yaml
@@ -48,4 +48,11 @@ data:
   supportLevel: community
   connectorBuildOptions:
     baseImage: docker.io/airbyte/source-declarative-manifest:7.5.0@sha256:92e539d5003b33c3624eae7715aee6e39b7b2f1f0eeb6003d37e649a06847ae8
+  externalDocumentationUrls:
+    - title: API reference
+      url: https://developer.apple.com/documentation/apple_search_ads
+      type: api_reference
+    - title: Authentication
+      url: https://developer.apple.com/documentation/apple_search_ads/implementing_oauth_for_the_apple_search_ads_api
+      type: authentication_guide
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-appsflyer/metadata.yaml
+++ b/airbyte-integrations/connectors/source-appsflyer/metadata.yaml
@@ -44,4 +44,11 @@ data:
     #         alias: airbyte-connector-testing-secret-store
   connectorBuildOptions:
     baseImage: docker.io/airbyte/python-connector-base:4.0.0@sha256:d9894b6895923b379f3006fa251147806919c62b7d9021b5cd125bb67d7bbe22
+  externalDocumentationUrls:
+    - title: API documentation
+      url: https://dev.appsflyer.com/hc/reference
+      type: api_reference
+    - title: Authentication
+      url: https://dev.appsflyer.com/hc/docs/authentication
+      type: authentication_guide
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-appstore-singer/metadata.yaml
+++ b/airbyte-integrations/connectors/source-appstore-singer/metadata.yaml
@@ -27,4 +27,11 @@ data:
     sl: 100
     ql: 100
   supportLevel: archived
+  externalDocumentationUrls:
+    - title: App Store Connect API
+      url: https://developer.apple.com/documentation/appstoreconnectapi
+      type: api_reference
+    - title: Authentication
+      url: https://developer.apple.com/documentation/appstoreconnectapi/generating_tokens_for_api_requests
+      type: authentication_guide
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-apptivo/metadata.yaml
+++ b/airbyte-integrations/connectors/source-apptivo/metadata.yaml
@@ -33,3 +33,7 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: API documentation
+      url: https://www.apptivo.com/api/
+      type: api_reference

--- a/airbyte-integrations/connectors/source-asana/metadata.yaml
+++ b/airbyte-integrations/connectors/source-asana/metadata.yaml
@@ -57,4 +57,17 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+    - title: API reference
+      url: https://developers.asana.com/reference/rest-api-reference
+      type: api_reference
+    - title: Authentication
+      url: https://developers.asana.com/docs/authentication
+      type: authentication_guide
+    - title: Rate limits
+      url: https://developers.asana.com/docs/rate-limits
+      type: rate_limits
+    - title: Asana Status
+      url: https://status.asana.com/
+      type: status_page
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-ashby/metadata.yaml
+++ b/airbyte-integrations/connectors/source-ashby/metadata.yaml
@@ -30,4 +30,11 @@ data:
     - suite: unitTests
   connectorBuildOptions:
     baseImage: docker.io/airbyte/source-declarative-manifest:6.48.10@sha256:09947fb38d07e515f9901a12f22cc44f1512f6148703341de80403c0e0c1b8c3
+  externalDocumentationUrls:
+    - title: API documentation
+      url: https://developers.ashbyhq.com/
+      type: api_reference
+    - title: Authentication
+      url: https://developers.ashbyhq.com/#authentication
+      type: authentication_guide
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-assemblyai/metadata.yaml
+++ b/airbyte-integrations/connectors/source-assemblyai/metadata.yaml
@@ -33,3 +33,10 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: API reference
+      url: https://www.assemblyai.com/docs
+      type: api_reference
+    - title: Authentication
+      url: https://www.assemblyai.com/docs/getting-started/authentication
+      type: authentication_guide

--- a/airbyte-integrations/connectors/source-auth0/metadata.yaml
+++ b/airbyte-integrations/connectors/source-auth0/metadata.yaml
@@ -44,4 +44,17 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+    - title: Management API
+      url: https://auth0.com/docs/api/management/v2
+      type: api_reference
+    - title: Authentication
+      url: https://auth0.com/docs/secure/tokens/access-tokens/management-api-access-tokens
+      type: authentication_guide
+    - title: Rate limits
+      url: https://auth0.com/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy
+      type: rate_limits
+    - title: Auth0 Status
+      url: https://status.auth0.com/
+      type: status_page
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-aviationstack/metadata.yaml
+++ b/airbyte-integrations/connectors/source-aviationstack/metadata.yaml
@@ -33,3 +33,7 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: API documentation
+      url: https://aviationstack.com/documentation
+      type: api_reference

--- a/airbyte-integrations/connectors/source-avni/metadata.yaml
+++ b/airbyte-integrations/connectors/source-avni/metadata.yaml
@@ -38,4 +38,8 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+    - title: API documentation
+      url: https://avni.readme.io/reference/api-overview
+      type: api_reference
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-awin-advertiser/metadata.yaml
+++ b/airbyte-integrations/connectors/source-awin-advertiser/metadata.yaml
@@ -33,3 +33,7 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: API documentation
+      url: https://wiki.awin.com/index.php/Advertiser_API
+      type: api_reference

--- a/airbyte-integrations/connectors/source-aws-cloudtrail/metadata.yaml
+++ b/airbyte-integrations/connectors/source-aws-cloudtrail/metadata.yaml
@@ -52,4 +52,14 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+    - title: CloudTrail API reference
+      url: https://docs.aws.amazon.com/awscloudtrail/latest/APIReference/
+      type: api_reference
+    - title: Authentication
+      url: https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-authentication.html
+      type: authentication_guide
+    - title: Service quotas
+      url: https://docs.aws.amazon.com/awscloudtrail/latest/userguide/WhatIsCloudTrail-Limits.html
+      type: rate_limits
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-azure-table/metadata.yaml
+++ b/airbyte-integrations/connectors/source-azure-table/metadata.yaml
@@ -41,4 +41,11 @@ data:
             alias: airbyte-connector-testing-secret-store
   connectorBuildOptions:
     baseImage: docker.io/airbyte/python-connector-base:4.0.2@sha256:9fdb1888c4264cf6fee473649ecb593f56f58e5d0096a87ee0b231777e2e3e73
+  externalDocumentationUrls:
+    - title: Table Storage REST API
+      url: https://learn.microsoft.com/en-us/rest/api/storageservices/table-service-rest-api
+      type: api_reference
+    - title: Authentication
+      url: https://learn.microsoft.com/en-us/rest/api/storageservices/authorize-requests-to-azure-storage
+      type: authentication_guide
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-babelforce/metadata.yaml
+++ b/airbyte-integrations/connectors/source-babelforce/metadata.yaml
@@ -32,4 +32,8 @@ data:
   supportLevel: community
   connectorBuildOptions:
     baseImage: docker.io/airbyte/source-declarative-manifest:7.0.0@sha256:af8807056f8218ecf0d4ec6b6ee717cdf20251fee5d2c1c77b5723771363b9b0
+  externalDocumentationUrls:
+    - title: API documentation
+      url: https://api.babelforce.com/
+      type: api_reference
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-bamboo-hr/metadata.yaml
+++ b/airbyte-integrations/connectors/source-bamboo-hr/metadata.yaml
@@ -45,4 +45,11 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+    - title: API documentation
+      url: https://documentation.bamboohr.com/docs
+      type: api_reference
+    - title: Authentication
+      url: https://documentation.bamboohr.com/docs/getting-started
+      type: authentication_guide
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-basecamp/metadata.yaml
+++ b/airbyte-integrations/connectors/source-basecamp/metadata.yaml
@@ -34,3 +34,13 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Basecamp 3 API
+      url: https://github.com/basecamp/bc3-api
+      type: api_reference
+    - title: Authentication
+      url: https://github.com/basecamp/api/blob/master/sections/authentication.md
+      type: authentication_guide
+    - title: Rate limiting
+      url: https://github.com/basecamp/bc3-api#rate-limiting
+      type: rate_limits

--- a/airbyte-integrations/connectors/source-beamer/metadata.yaml
+++ b/airbyte-integrations/connectors/source-beamer/metadata.yaml
@@ -33,3 +33,7 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: API documentation
+      url: https://www.getbeamer.com/api
+      type: api_reference

--- a/airbyte-integrations/connectors/source-bigcommerce/metadata.yaml
+++ b/airbyte-integrations/connectors/source-bigcommerce/metadata.yaml
@@ -48,4 +48,14 @@ data:
   #           alias: airbyte-connector-testing-secret-store
   connectorBuildOptions:
     baseImage: docker.io/airbyte/source-declarative-manifest:6.51.0@sha256:890b109f243b8b9406f23ea7522de41025f7b3e87f6fc9710bc1e521213a276f
+  externalDocumentationUrls:
+    - title: API documentation
+      url: https://developer.bigcommerce.com/docs/rest
+      type: api_reference
+    - title: Authentication
+      url: https://developer.bigcommerce.com/docs/start/authentication
+      type: authentication_guide
+    - title: Rate limits
+      url: https://developer.bigcommerce.com/docs/start/best-practices#api-rate-limits
+      type: rate_limits
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-bigmailer/metadata.yaml
+++ b/airbyte-integrations/connectors/source-bigmailer/metadata.yaml
@@ -33,3 +33,7 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: API documentation
+      url: https://www.bigmailer.io/api
+      type: api_reference

--- a/airbyte-integrations/connectors/source-bigquery/metadata.yaml
+++ b/airbyte-integrations/connectors/source-bigquery/metadata.yaml
@@ -37,4 +37,17 @@ data:
   supportLevel: community
   tags:
     - language:java
+  externalDocumentationUrls:
+    - title: BigQuery REST API
+      url: https://cloud.google.com/bigquery/docs/reference/rest
+      type: api_reference
+    - title: Authentication
+      url: https://cloud.google.com/bigquery/docs/authentication
+      type: authentication_guide
+    - title: Quotas and limits
+      url: https://cloud.google.com/bigquery/quotas
+      type: rate_limits
+    - title: Release notes
+      url: https://cloud.google.com/bigquery/docs/release-notes
+      type: api_release_history
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-bitly/metadata.yaml
+++ b/airbyte-integrations/connectors/source-bitly/metadata.yaml
@@ -33,3 +33,13 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: API reference
+      url: https://dev.bitly.com/api-reference/
+      type: api_reference
+    - title: Authentication
+      url: https://dev.bitly.com/docs/getting-started/authentication/
+      type: authentication_guide
+    - title: Rate limits
+      url: https://dev.bitly.com/docs/getting-started/rate-limits/
+      type: rate_limits

--- a/airbyte-integrations/connectors/source-blogger/metadata.yaml
+++ b/airbyte-integrations/connectors/source-blogger/metadata.yaml
@@ -33,3 +33,10 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Blogger API
+      url: https://developers.google.com/blogger/docs/3.0/reference
+      type: api_reference
+    - title: Authentication
+      url: https://developers.google.com/blogger/docs/3.0/using#authentication
+      type: authentication_guide

--- a/airbyte-integrations/connectors/source-bluetally/metadata.yaml
+++ b/airbyte-integrations/connectors/source-bluetally/metadata.yaml
@@ -33,3 +33,7 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: API documentation
+      url: https://bluetally.readme.io/
+      type: api_reference

--- a/airbyte-integrations/connectors/source-boldsign/metadata.yaml
+++ b/airbyte-integrations/connectors/source-boldsign/metadata.yaml
@@ -33,3 +33,10 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: API reference
+      url: https://developers.boldsign.com/api-reference
+      type: api_reference
+    - title: Authentication
+      url: https://developers.boldsign.com/authentication
+      type: authentication_guide

--- a/airbyte-integrations/connectors/source-box/metadata.yaml
+++ b/airbyte-integrations/connectors/source-box/metadata.yaml
@@ -33,3 +33,16 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Box API reference
+      url: https://developer.box.com/reference/
+      type: api_reference
+    - title: Authentication
+      url: https://developer.box.com/guides/authentication/
+      type: authentication_guide
+    - title: Rate limits
+      url: https://developer.box.com/guides/api-calls/permissions-and-errors/rate-limits/
+      type: rate_limits
+    - title: Box Status
+      url: https://status.box.com/
+      type: status_page


### PR DESCRIPTION
## What

Add `externalDocumentationUrls` sections to 47 source connectors in Group B (source-100ms through source-box), providing links to official vendor documentation such as API references, authentication guides, rate limits, and status pages.

This continues the effort started in PR airbytehq/airbyte#69290 and Group A (destinations) in PR airbytehq/airbyte#69353.

**Connectors updated:** source-100ms, source-7shifts, source-activecampaign, source-acuity-scheduling, source-adjust, source-adobe-commerce-magento, source-agilecrm, source-aha, source-airbyte, source-aircall, source-akeneo, source-algolia, source-alpaca-broker-api, source-alpha-vantage, source-amazon-ads, source-amazon-seller-partner, source-amazon-sqs, source-amplitude, source-apify-dataset, source-appcues, source-appfigures, source-appfollow, source-apple-search-ads, source-appsflyer, source-appstore-singer, source-apptivo, source-asana, source-ashby, source-assemblyai, source-auth0, source-aviationstack, source-avni, source-awin-advertiser, source-aws-cloudtrail, source-azure-table, source-babelforce, source-bamboo-hr, source-basecamp, source-beamer, source-bigcommerce, source-bigmailer, source-bigquery, source-bitly, source-blogger, source-bluetally, source-boldsign, source-box

**Skipped:** source-airtable (already has docs from PR airbytehq/airbyte#69290), source-azure-blob-storage, source-bing-ads (already have docs)

## How

Used surgical text insertion to add the `externalDocumentationUrls` sections to each connector's metadata.yaml file. This approach:
- Preserves original file formatting to minimize diff noise (lesson learned from Group A)
- Only adds the new section without modifying any existing fields
- Handles both file structures (metadataSpecVersion at top or bottom)
- Researched official vendor documentation for each connector to populate accurate URLs

## Review guide

**Critical items to review:**
1. **URL accuracy**: Spot-check a sample of URLs across different connectors to verify they're correct and accessible (e.g., source-100ms, source-asana, source-bigquery, source-box)
2. **URL type appropriateness**: Verify the `type` field values (api_reference, authentication_guide, rate_limits, status_page, etc.) match the actual content
3. **YAML formatting**: Confirm the surgical insertion preserved formatting and didn't introduce any structural issues
4. **Consistency**: Compare with Group A (PR airbytehq/airbyte#69353) to ensure consistent approach

**Files to review:**
- Sample connectors with different URL counts: source-100ms (3 URLs), source-asana (4 URLs), source-bigquery (4 URLs)
- Sample connectors with different file structures: source-100ms (metadataSpecVersion at top), source-asana (metadataSpecVersion at bottom)

## User Impact

Users will now have quick access to official vendor documentation directly from the Airbyte UI when configuring these 47 source connectors. This improves the user experience by providing easy access to:
- API reference documentation
- Authentication setup guides
- Rate limit information
- Service status pages
- Other relevant vendor resources

**No negative side effects expected** - this is purely additive metadata that enhances the UI without changing any connector functionality.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

This PR only adds metadata fields and doesn't modify any connector logic or existing configuration. It can be safely reverted without impacting connector functionality.

---

**Link to Devin run:** https://app.devin.ai/sessions/278efaf8c49f4261b899f1c1f465c91a

**Requested by:** AJ Steers (@aaronsteers)