### PR TITLE
docs: Add external documentation URLs to Group C source connectors (source-box-data-extract through source-commcare)

### DIFF
--- a/airbyte-integrations/connectors/source-box-data-extract/metadata.yaml
+++ b/airbyte-integrations/connectors/source-box-data-extract/metadata.yaml
@@ -39,4 +39,17 @@ data:
   tags:
     - language:python
     - cdk:python
+  externalDocumentationUrls:
+    - title: Box Platform API reference
+      url: https://developer.box.com/reference/
+      type: api_reference
+    - title: Box authentication guide
+      url: https://developer.box.com/guides/authentication/
+      type: authentication_guide
+    - title: Box API rate limits
+      url: https://developer.box.com/guides/api-calls/permissions-and-errors/rate-limits/
+      type: rate_limits
+    - title: Box Platform Status
+      url: https://status.box.com/
+      type: status_page
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-braintree/metadata.yaml
+++ b/airbyte-integrations/connectors/source-braintree/metadata.yaml
@@ -43,4 +43,17 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+    - title: Braintree API reference
+      url: https://developer.paypal.com/braintree/docs/reference/overview
+      type: api_reference
+    - title: Braintree authentication
+      url: https://developer.paypal.com/braintree/docs/start/authentication
+      type: authentication_guide
+    - title: Braintree API rate limits
+      url: https://developer.paypal.com/braintree/docs/reference/general/rate-limiting
+      type: rate_limits
+    - title: Braintree Status
+      url: https://status.braintreepayments.com/
+      type: status_page
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-braze/metadata.yaml
+++ b/airbyte-integrations/connectors/source-braze/metadata.yaml
@@ -41,4 +41,17 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+    - title: Braze REST API reference
+      url: https://www.braze.com/docs/api/home
+      type: api_reference
+    - title: Braze API authentication
+      url: https://www.braze.com/docs/api/basics/
+      type: authentication_guide
+    - title: Braze API rate limits
+      url: https://www.braze.com/docs/api/api_limits/
+      type: rate_limits
+    - title: Braze Status
+      url: https://status.braze.com/
+      type: status_page
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-breezometer/metadata.yaml
+++ b/airbyte-integrations/connectors/source-breezometer/metadata.yaml
@@ -39,4 +39,11 @@ data:
   #           alias: airbyte-connector-testing-secret-store
   connectorBuildOptions:
     baseImage: docker.io/airbyte/source-declarative-manifest:6.48.10@sha256:09947fb38d07e515f9901a12f22cc44f1512f6148703341de80403c0e0c1b8c3
+  externalDocumentationUrls:
+    - title: BreezoMeter API documentation
+      url: https://docs.breezometer.com/api-documentation/
+      type: api_reference
+    - title: BreezoMeter authentication
+      url: https://docs.breezometer.com/api-documentation/introduction/#authentication
+      type: authentication_guide
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-breezy-hr/metadata.yaml
+++ b/airbyte-integrations/connectors/source-breezy-hr/metadata.yaml
@@ -34,3 +34,10 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Breezy HR API documentation
+      url: https://developer.breezy.hr/
+      type: api_reference
+    - title: Breezy HR authentication
+      url: https://developer.breezy.hr/#authentication
+      type: authentication_guide

--- a/airbyte-integrations/connectors/source-brevo/metadata.yaml
+++ b/airbyte-integrations/connectors/source-brevo/metadata.yaml
@@ -35,3 +35,16 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Brevo API reference
+      url: https://developers.brevo.com/reference
+      type: api_reference
+    - title: Brevo authentication guide
+      url: https://developers.brevo.com/docs/getting-started
+      type: authentication_guide
+    - title: Brevo API rate limits
+      url: https://developers.brevo.com/docs/api-limits
+      type: rate_limits
+    - title: Brevo Status
+      url: https://status.brevo.com/
+      type: status_page

--- a/airbyte-integrations/connectors/source-brex/metadata.yaml
+++ b/airbyte-integrations/connectors/source-brex/metadata.yaml
@@ -33,3 +33,13 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Brex API reference
+      url: https://developer.brex.com/openapi/
+      type: api_reference
+    - title: Brex authentication guide
+      url: https://developer.brex.com/docs/authentication/
+      type: authentication_guide
+    - title: Brex API rate limits
+      url: https://developer.brex.com/docs/rate_limits/
+      type: rate_limits

--- a/airbyte-integrations/connectors/source-bugsnag/metadata.yaml
+++ b/airbyte-integrations/connectors/source-bugsnag/metadata.yaml
@@ -33,3 +33,13 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Bugsnag Data Access API
+      url: https://bugsnagapiv2.docs.apiary.io/
+      type: api_reference
+    - title: Bugsnag authentication
+      url: https://docs.bugsnag.com/api/data-access/#authentication
+      type: authentication_guide
+    - title: Bugsnag Status
+      url: https://status.bugsnag.com/
+      type: status_page

--- a/airbyte-integrations/connectors/source-buildkite/metadata.yaml
+++ b/airbyte-integrations/connectors/source-buildkite/metadata.yaml
@@ -33,3 +33,16 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Buildkite REST API
+      url: https://buildkite.com/docs/apis/rest-api
+      type: api_reference
+    - title: Buildkite authentication
+      url: https://buildkite.com/docs/apis/rest-api#authentication
+      type: authentication_guide
+    - title: Buildkite API rate limits
+      url: https://buildkite.com/docs/apis/rest-api#rate-limiting
+      type: rate_limits
+    - title: Buildkite Status
+      url: https://www.buildkitestatus.com/
+      type: status_page

--- a/airbyte-integrations/connectors/source-bunny-inc/metadata.yaml
+++ b/airbyte-integrations/connectors/source-bunny-inc/metadata.yaml
@@ -33,3 +33,10 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Bunny.net API documentation
+      url: https://docs.bunny.net/reference/bunnynet-api-overview
+      type: api_reference
+    - title: Bunny.net authentication
+      url: https://docs.bunny.net/reference/authentication
+      type: authentication_guide

--- a/airbyte-integrations/connectors/source-buzzsprout/metadata.yaml
+++ b/airbyte-integrations/connectors/source-buzzsprout/metadata.yaml
@@ -33,3 +33,10 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Buzzsprout API documentation
+      url: https://github.com/Buzzsprout/buzzsprout-api
+      type: api_reference
+    - title: Buzzsprout authentication
+      url: https://github.com/Buzzsprout/buzzsprout-api#authentication
+      type: authentication_guide

--- a/airbyte-integrations/connectors/source-cal-com/metadata.yaml
+++ b/airbyte-integrations/connectors/source-cal-com/metadata.yaml
@@ -33,3 +33,10 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Cal.com API reference
+      url: https://cal.com/docs/api-reference/introduction
+      type: api_reference
+    - title: Cal.com authentication
+      url: https://cal.com/docs/api-reference/authentication
+      type: authentication_guide

--- a/airbyte-integrations/connectors/source-calendly/metadata.yaml
+++ b/airbyte-integrations/connectors/source-calendly/metadata.yaml
@@ -35,3 +35,16 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Calendly API reference
+      url: https://developer.calendly.com/api-docs
+      type: api_reference
+    - title: Calendly authentication
+      url: https://developer.calendly.com/getting-started
+      type: authentication_guide
+    - title: Calendly API rate limits
+      url: https://developer.calendly.com/api-docs/ZG9jOjM2MzE2MDM4-api-conventions#rate-limiting
+      type: rate_limits
+    - title: Calendly Status
+      url: https://status.calendly.com/
+      type: status_page

--- a/airbyte-integrations/connectors/source-callrail/metadata.yaml
+++ b/airbyte-integrations/connectors/source-callrail/metadata.yaml
@@ -39,4 +39,14 @@ data:
   #           alias: airbyte-connector-testing-secret-store
   connectorBuildOptions:
     baseImage: docker.io/airbyte/source-declarative-manifest:6.48.16@sha256:651a0bbdc634378737fb833fdf43666f9d9b5b633c68a35cc03ab6e56cb4d6e7
+  externalDocumentationUrls:
+    - title: CallRail API reference
+      url: https://apidocs.callrail.com/
+      type: api_reference
+    - title: CallRail authentication
+      url: https://apidocs.callrail.com/#authentication
+      type: authentication_guide
+    - title: CallRail API rate limits
+      url: https://apidocs.callrail.com/#rate-limiting
+      type: rate_limits
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-campaign-monitor/metadata.yaml
+++ b/airbyte-integrations/connectors/source-campaign-monitor/metadata.yaml
@@ -33,3 +33,13 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Campaign Monitor API reference
+      url: https://www.campaignmonitor.com/api/
+      type: api_reference
+    - title: Campaign Monitor authentication
+      url: https://www.campaignmonitor.com/api/getting-started/#authenticating
+      type: authentication_guide
+    - title: Campaign Monitor rate limits
+      url: https://www.campaignmonitor.com/api/getting-started/#rate-limiting
+      type: rate_limits

--- a/airbyte-integrations/connectors/source-campayn/metadata.yaml
+++ b/airbyte-integrations/connectors/source-campayn/metadata.yaml
@@ -33,3 +33,7 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Campayn API documentation
+      url: https://github.com/nebojsac/Campayn-API
+      type: api_reference

--- a/airbyte-integrations/connectors/source-canny/metadata.yaml
+++ b/airbyte-integrations/connectors/source-canny/metadata.yaml
@@ -33,3 +33,13 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Canny API reference
+      url: https://developers.canny.io/api-reference
+      type: api_reference
+    - title: Canny authentication
+      url: https://developers.canny.io/api-reference#authentication
+      type: authentication_guide
+    - title: Canny API rate limits
+      url: https://developers.canny.io/api-reference#rate-limits
+      type: rate_limits

--- a/airbyte-integrations/connectors/source-capsule-crm/metadata.yaml
+++ b/airbyte-integrations/connectors/source-capsule-crm/metadata.yaml
@@ -33,3 +33,13 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Capsule CRM API reference
+      url: https://developer.capsulecrm.com/
+      type: api_reference
+    - title: Capsule CRM authentication
+      url: https://developer.capsulecrm.com/v2/overview/authentication
+      type: authentication_guide
+    - title: Capsule CRM rate limits
+      url: https://developer.capsulecrm.com/v2/overview/rate-limiting
+      type: rate_limits

--- a/airbyte-integrations/connectors/source-captain-data/metadata.yaml
+++ b/airbyte-integrations/connectors/source-captain-data/metadata.yaml
@@ -28,4 +28,11 @@ data:
   supportLevel: community
   connectorBuildOptions:
     baseImage: docker.io/airbyte/source-declarative-manifest:6.48.10@sha256:09947fb38d07e515f9901a12f22cc44f1512f6148703341de80403c0e0c1b8c3
+  externalDocumentationUrls:
+    - title: Captain Data API documentation
+      url: https://docs.captaindata.co/api-documentation
+      type: api_reference
+    - title: Captain Data authentication
+      url: https://docs.captaindata.co/api-documentation/authentication
+      type: authentication_guide
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-care-quality-commission/metadata.yaml
+++ b/airbyte-integrations/connectors/source-care-quality-commission/metadata.yaml
@@ -33,3 +33,7 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: CQC Syndication API
+      url: https://www.cqc.org.uk/about-us/transparency/using-cqc-data
+      type: api_reference

--- a/airbyte-integrations/connectors/source-cart/metadata.yaml
+++ b/airbyte-integrations/connectors/source-cart/metadata.yaml
@@ -60,4 +60,11 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+    - title: Cart.com API documentation
+      url: https://developers.cart.com/
+      type: api_reference
+    - title: Cart.com authentication
+      url: https://developers.cart.com/docs/rest-api/authentication
+      type: authentication_guide
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-castor-edc/metadata.yaml
+++ b/airbyte-integrations/connectors/source-castor-edc/metadata.yaml
@@ -33,3 +33,10 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Castor EDC API reference
+      url: https://data.castoredc.com/api
+      type: api_reference
+    - title: Castor EDC authentication
+      url: https://helpdesk.castoredc.com/article/124-application-programming-interface-api
+      type: authentication_guide

--- a/airbyte-integrations/connectors/source-chameleon/metadata.yaml
+++ b/airbyte-integrations/connectors/source-chameleon/metadata.yaml
@@ -33,3 +33,13 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Chameleon API reference
+      url: https://developers.chameleon.io/reference/introduction
+      type: api_reference
+    - title: Chameleon authentication
+      url: https://developers.chameleon.io/reference/authentication
+      type: authentication_guide
+    - title: Chameleon rate limits
+      url: https://developers.chameleon.io/reference/rate-limiting
+      type: rate_limits

--- a/airbyte-integrations/connectors/source-chargedesk/metadata.yaml
+++ b/airbyte-integrations/connectors/source-chargedesk/metadata.yaml
@@ -33,3 +33,10 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Chargedesk API documentation
+      url: https://chargedesk.com/api-docs
+      type: api_reference
+    - title: Chargedesk authentication
+      url: https://chargedesk.com/api-docs/authentication
+      type: authentication_guide

--- a/airbyte-integrations/connectors/source-chargify/metadata.yaml
+++ b/airbyte-integrations/connectors/source-chargify/metadata.yaml
@@ -43,4 +43,14 @@ data:
   #           alias: airbyte-connector-testing-secret-store
   connectorBuildOptions:
     baseImage: docker.io/airbyte/source-declarative-manifest:6.48.10@sha256:09947fb38d07e515f9901a12f22cc44f1512f6148703341de80403c0e0c1b8c3
+  externalDocumentationUrls:
+    - title: Chargify API reference
+      url: https://developers.chargify.com/docs/api-docs/YXBpOjE0MTA4MjYx-chargify-api
+      type: api_reference
+    - title: Chargify authentication
+      url: https://developers.chargify.com/docs/api-docs/YXBpOjE0MTA4MjYx-authentication
+      type: authentication_guide
+    - title: Chargify rate limits
+      url: https://developers.chargify.com/docs/api-docs/YXBpOjE0MTA4MjYx-rate-limiting
+      type: rate_limits
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-chartmogul/metadata.yaml
+++ b/airbyte-integrations/connectors/source-chartmogul/metadata.yaml
@@ -56,4 +56,17 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+    - title: ChartMogul API reference
+      url: https://dev.chartmogul.com/reference
+      type: api_reference
+    - title: ChartMogul authentication
+      url: https://dev.chartmogul.com/docs/authentication
+      type: authentication_guide
+    - title: ChartMogul rate limits
+      url: https://dev.chartmogul.com/docs/rate-limits
+      type: rate_limits
+    - title: ChartMogul Status
+      url: https://status.chartmogul.com/
+      type: status_page
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-churnkey/metadata.yaml
+++ b/airbyte-integrations/connectors/source-churnkey/metadata.yaml
@@ -33,3 +33,10 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Churnkey API documentation
+      url: https://docs.churnkey.co/api
+      type: api_reference
+    - title: Churnkey authentication
+      url: https://docs.churnkey.co/api/authentication
+      type: authentication_guide

--- a/airbyte-integrations/connectors/source-cimis/metadata.yaml
+++ b/airbyte-integrations/connectors/source-cimis/metadata.yaml
@@ -33,3 +33,7 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: CIMIS Web API
+      url: https://cimis.water.ca.gov/WSNReportCriteria.aspx
+      type: api_reference

--- a/airbyte-integrations/connectors/source-cin7/metadata.yaml
+++ b/airbyte-integrations/connectors/source-cin7/metadata.yaml
@@ -41,3 +41,10 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Cin7 Core API reference
+      url: https://api.cin7.com/api/v1
+      type: api_reference
+    - title: Cin7 authentication
+      url: https://support.cin7.com/hc/en-us/articles/360002477115-API-Overview
+      type: authentication_guide

--- a/airbyte-integrations/connectors/source-circa/metadata.yaml
+++ b/airbyte-integrations/connectors/source-circa/metadata.yaml
@@ -33,3 +33,7 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Circa API documentation
+      url: https://docs.circa.co/api
+      type: api_reference

--- a/airbyte-integrations/connectors/source-circleci/metadata.yaml
+++ b/airbyte-integrations/connectors/source-circleci/metadata.yaml
@@ -33,3 +33,16 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: CircleCI API v2 reference
+      url: https://circleci.com/docs/api/v2/
+      type: api_reference
+    - title: CircleCI authentication
+      url: https://circleci.com/docs/api-developers-guide/#authentication
+      type: authentication_guide
+    - title: CircleCI API rate limits
+      url: https://circleci.com/docs/api-developers-guide/#rate-limits
+      type: rate_limits
+    - title: CircleCI Status
+      url: https://status.circleci.com/
+      type: status_page

--- a/airbyte-integrations/connectors/source-cisco-meraki/metadata.yaml
+++ b/airbyte-integrations/connectors/source-cisco-meraki/metadata.yaml
@@ -33,3 +33,16 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Cisco Meraki Dashboard API
+      url: https://developer.cisco.com/meraki/api-v1/
+      type: api_reference
+    - title: Meraki authentication
+      url: https://developer.cisco.com/meraki/api-v1/#!authorization
+      type: authentication_guide
+    - title: Meraki rate limits
+      url: https://developer.cisco.com/meraki/api-v1/#!rate-limit
+      type: rate_limits
+    - title: Meraki Status
+      url: https://status.meraki.com/
+      type: status_page

--- a/airbyte-integrations/connectors/source-clarif-ai/metadata.yaml
+++ b/airbyte-integrations/connectors/source-clarif-ai/metadata.yaml
@@ -33,3 +33,13 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Clarifai API reference
+      url: https://docs.clarifai.com/api-guide/api-overview
+      type: api_reference
+    - title: Clarifai authentication
+      url: https://docs.clarifai.com/api-guide/api-overview/api-clients
+      type: authentication_guide
+    - title: Clarifai Status
+      url: https://status.clarifai.com/
+      type: status_page

--- a/airbyte-integrations/connectors/source-clazar/metadata.yaml
+++ b/airbyte-integrations/connectors/source-clazar/metadata.yaml
@@ -29,4 +29,8 @@ data:
   tags:
     - cdk:low-code
     - language:manifest-only
+  externalDocumentationUrls:
+    - title: Clazar API documentation
+      url: https://clazar.io/api-docs
+      type: api_reference
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-clickhouse-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/source-clickhouse-strict-encrypt/metadata.yaml
@@ -26,4 +26,14 @@ data:
   releaseStage: alpha
   tags:
     - language:java
+  externalDocumentationUrls:
+    - title: ClickHouse HTTP interface
+      url: https://clickhouse.com/docs/en/interfaces/http
+      type: api_reference
+    - title: ClickHouse authentication
+      url: https://clickhouse.com/docs/en/operations/access-rights
+      type: authentication_guide
+    - title: ClickHouse SQL reference
+      url: https://clickhouse.com/docs/en/sql-reference
+      type: sql_reference
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-clickhouse/metadata.yaml
+++ b/airbyte-integrations/connectors/source-clickhouse/metadata.yaml
@@ -32,4 +32,14 @@ data:
   supportLevel: community
   tags:
     - language:java
+  externalDocumentationUrls:
+    - title: ClickHouse HTTP interface
+      url: https://clickhouse.com/docs/en/interfaces/http
+      type: api_reference
+    - title: ClickHouse authentication
+      url: https://clickhouse.com/docs/en/operations/access-rights
+      type: authentication_guide
+    - title: ClickHouse SQL reference
+      url: https://clickhouse.com/docs/en/sql-reference
+      type: sql_reference
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-clickup-api/metadata.yaml
+++ b/airbyte-integrations/connectors/source-clickup-api/metadata.yaml
@@ -44,4 +44,17 @@ data:
             alias: airbyte-connector-testing-secret-store
   connectorBuildOptions:
     baseImage: docker.io/airbyte/source-declarative-manifest:7.5.0@sha256:92e539d5003b33c3624eae7715aee6e39b7b2f1f0eeb6003d37e649a06847ae8
+  externalDocumentationUrls:
+    - title: ClickUp API reference
+      url: https://clickup.com/api/
+      type: api_reference
+    - title: ClickUp authentication
+      url: https://clickup.com/api/developer-portal/authentication/
+      type: authentication_guide
+    - title: ClickUp rate limits
+      url: https://clickup.com/api/developer-portal/rate-limits/
+      type: rate_limits
+    - title: ClickUp Status
+      url: https://status.clickup.com/
+      type: status_page
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-clockify/metadata.yaml
+++ b/airbyte-integrations/connectors/source-clockify/metadata.yaml
@@ -44,4 +44,14 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+    - title: Clockify API reference
+      url: https://docs.clockify.me/
+      type: api_reference
+    - title: Clockify authentication
+      url: https://docs.clockify.me/#section/Introduction/Authentication
+      type: authentication_guide
+    - title: Clockify rate limits
+      url: https://docs.clockify.me/#section/Introduction/Rate-limiting
+      type: rate_limits
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-clockodo/metadata.yaml
+++ b/airbyte-integrations/connectors/source-clockodo/metadata.yaml
@@ -33,3 +33,10 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Clockodo API documentation
+      url: https://www.clockodo.com/en/api/
+      type: api_reference
+    - title: Clockodo authentication
+      url: https://www.clockodo.com/en/api/#authentication
+      type: authentication_guide

--- a/airbyte-integrations/connectors/source-close-com/metadata.yaml
+++ b/airbyte-integrations/connectors/source-close-com/metadata.yaml
@@ -40,4 +40,17 @@ data:
             alias: airbyte-connector-testing-secret-store
   connectorBuildOptions:
     baseImage: docker.io/airbyte/source-declarative-manifest:6.48.10@sha256:09947fb38d07e515f9901a12f22cc44f1512f6148703341de80403c0e0c1b8c3
+  externalDocumentationUrls:
+    - title: Close API reference
+      url: https://developer.close.com/
+      type: api_reference
+    - title: Close authentication
+      url: https://developer.close.com/#authentication
+      type: authentication_guide
+    - title: Close API rate limits
+      url: https://developer.close.com/#rate-limiting
+      type: rate_limits
+    - title: Close Status
+      url: https://status.close.com/
+      type: status_page
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-cloudbeds/metadata.yaml
+++ b/airbyte-integrations/connectors/source-cloudbeds/metadata.yaml
@@ -33,3 +33,13 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Cloudbeds API reference
+      url: https://hotels.cloudbeds.com/api/docs/
+      type: api_reference
+    - title: Cloudbeds OAuth guide
+      url: https://hotels.cloudbeds.com/api/docs/#section/Authentication
+      type: authentication_guide
+    - title: Cloudbeds rate limits
+      url: https://hotels.cloudbeds.com/api/docs/#section/Rate-Limiting
+      type: rate_limits

--- a/airbyte-integrations/connectors/source-coassemble/metadata.yaml
+++ b/airbyte-integrations/connectors/source-coassemble/metadata.yaml
@@ -33,3 +33,10 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Coassemble API documentation
+      url: https://developers.coassemble.com/
+      type: api_reference
+    - title: Coassemble authentication
+      url: https://developers.coassemble.com/#authentication
+      type: authentication_guide

--- a/airbyte-integrations/connectors/source-cockroachdb/metadata.yaml
+++ b/airbyte-integrations/connectors/source-cockroachdb/metadata.yaml
@@ -29,4 +29,14 @@ data:
   supportLevel: community
   tags:
     - language:java
+  externalDocumentationUrls:
+    - title: CockroachDB SQL reference
+      url: https://www.cockroachlabs.com/docs/stable/sql-statements
+      type: sql_reference
+    - title: CockroachDB authentication
+      url: https://www.cockroachlabs.com/docs/stable/authentication
+      type: authentication_guide
+    - title: CockroachDB Status
+      url: https://status.cockroachlabs.com/
+      type: status_page
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-coda/metadata.yaml
+++ b/airbyte-integrations/connectors/source-coda/metadata.yaml
@@ -44,4 +44,14 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+    - title: Coda API reference
+      url: https://coda.io/developers/apis/v1
+      type: api_reference
+    - title: Coda authentication
+      url: https://coda.io/developers/apis/v1#section/Authentication
+      type: authentication_guide
+    - title: Coda rate limits
+      url: https://coda.io/developers/apis/v1#section/Rate-Limiting
+      type: rate_limits
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-codefresh/metadata.yaml
+++ b/airbyte-integrations/connectors/source-codefresh/metadata.yaml
@@ -33,3 +33,13 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Codefresh API reference
+      url: https://g.codefresh.io/api/
+      type: api_reference
+    - title: Codefresh authentication
+      url: https://codefresh.io/docs/docs/integrations/codefresh-api/#authentication
+      type: authentication_guide
+    - title: Codefresh Status
+      url: https://status.codefresh.io/
+      type: status_page

--- a/airbyte-integrations/connectors/source-coin-api/metadata.yaml
+++ b/airbyte-integrations/connectors/source-coin-api/metadata.yaml
@@ -40,4 +40,17 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+    - title: CoinAPI documentation
+      url: https://docs.coinapi.io/
+      type: api_reference
+    - title: CoinAPI authentication
+      url: https://docs.coinapi.io/#authentication
+      type: authentication_guide
+    - title: CoinAPI rate limits
+      url: https://docs.coinapi.io/#rate-limits
+      type: rate_limits
+    - title: CoinAPI Status
+      url: https://status.coinapi.io/
+      type: status_page
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-coingecko-coins/metadata.yaml
+++ b/airbyte-integrations/connectors/source-coingecko-coins/metadata.yaml
@@ -39,4 +39,17 @@ data:
   #         secretStore:
   #           type: GSM
   #           alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+    - title: CoinGecko API documentation
+      url: https://www.coingecko.com/en/api/documentation
+      type: api_reference
+    - title: CoinGecko authentication
+      url: https://www.coingecko.com/en/api/documentation
+      type: authentication_guide
+    - title: CoinGecko rate limits
+      url: https://www.coingecko.com/en/api/pricing
+      type: rate_limits
+    - title: CoinGecko Status
+      url: https://status.coingecko.com/
+      type: status_page
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-coinmarketcap/metadata.yaml
+++ b/airbyte-integrations/connectors/source-coinmarketcap/metadata.yaml
@@ -47,4 +47,17 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+    - title: CoinMarketCap API reference
+      url: https://coinmarketcap.com/api/documentation/v1/
+      type: api_reference
+    - title: CoinMarketCap authentication
+      url: https://coinmarketcap.com/api/documentation/v1/#section/Authentication
+      type: authentication_guide
+    - title: CoinMarketCap rate limits
+      url: https://coinmarketcap.com/api/documentation/v1/#section/Standards-and-Conventions
+      type: rate_limits
+    - title: CoinMarketCap Status
+      url: https://status.coinmarketcap.com/
+      type: status_page
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-commcare/metadata.yaml
+++ b/airbyte-integrations/connectors/source-commcare/metadata.yaml
@@ -30,4 +30,11 @@ data:
     - suite: unitTests
   connectorBuildOptions:
     baseImage: docker.io/airbyte/python-connector-base:4.0.0@sha256:d9894b6895923b379f3006fa251147806919c62b7d9021b5cd125bb67d7bbe22
+  externalDocumentationUrls:
+    - title: CommCare API reference
+      url: https://confluence.dimagi.com/display/commcarepublic/CommCare+HQ+APIs
+      type: api_reference
+    - title: CommCare authentication
+      url: https://confluence.dimagi.com/display/commcarepublic/Authentication
+      type: authentication_guide
 metadataSpecVersion: "1.0"


### PR DESCRIPTION
## What

This PR adds `externalDocumentationUrls` metadata to 49 source connectors (Group C: source-box-data-extract through source-commcare). This is part of an ongoing effort to add external documentation links to all Airbyte connectors, improving discoverability of vendor documentation for users and developers.

**Context:**
- Group A (86 destinations): Merged in #69353
- Group B (47 sources): Merged in #69724
- **Group C (49 sources): This PR**
- Groups D-M (487 sources): Remaining work

**Related Documentation:**
- Schema definition: `airbyte-ci/connectors/metadata_service/lib/metadata_service/models/src/ConnectorMetadataDefinitionV0.yaml`
- Best practices guide: `airbyte-ci/connectors/metadata_service/docs/external_documentation_urls.md`

## How

Used surgical text insertion to add `externalDocumentationUrls` sections to connector metadata.yaml files. This approach:
- Preserves exact file formatting (no unrelated changes)
- Only adds the new externalDocumentationUrls field
- Results in minimal, clean diffs (460 insertions, 0 deletions)

Each connector received curated documentation URLs for:
- API references
- Authentication guides
- Rate limit documentation
- Status pages
- SQL references (for database connectors)

**Note:** source-chargebee was skipped as it already had externalDocumentationUrls.

## Review guide

**High-priority items to review:**
1. Spot-check 5-10 random connectors to verify URLs are correct and accessible
2. Verify type classifications are appropriate (api_reference, authentication_guide, rate_limits, status_page, sql_reference)
3. Check YAML formatting consistency in sample files

**Sample connectors to review:**
- `source-braze/metadata.yaml` - Full set of doc types
- `source-clickhouse/metadata.yaml` - Database connector with sql_reference
- `source-calendly/metadata.yaml` - SaaS connector with status page
- `source-breezometer/metadata.yaml` - Minimal documentation (only 2 URLs)

**Expected CI behavior:**
- "Connector Version Increment Check" will fail for all 49 connectors (expected - no version bumps for metadata-only changes)
- This follows the same pattern as Groups A and B

## User Impact

**Positive:**
- Users can now discover vendor documentation directly from connector metadata
- Improved developer experience when working with these connectors
- Better visibility into API limitations, authentication methods, and service status

**Negative:**
- None - purely additive metadata changes with no runtime impact

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

This PR only adds optional metadata fields and doesn't modify any connector code or behavior. Reverting would simply remove the documentation URLs from metadata.

---

**Requested by:** AJ Steers (@aaronsteers)  
**Session:** https://app.devin.ai/sessions/278efaf8c49f4261b899f1c1f465c91a