### PR TITLE
feat: Add external documentation URLs to Group D source connectors (source-commercetools through source-ezofficeinventory)

### DIFF
--- a/airbyte-integrations/connectors/source-commercetools/metadata.yaml
+++ b/airbyte-integrations/connectors/source-commercetools/metadata.yaml
@@ -43,4 +43,17 @@ data:
   #           alias: airbyte-connector-testing-secret-store
   connectorBuildOptions:
     baseImage: docker.io/airbyte/python-connector-base:4.0.0@sha256:d9894b6895923b379f3006fa251147806919c62b7d9021b5cd125bb67d7bbe22
+  externalDocumentationUrls:
+    - title: commercetools API reference
+      url: https://docs.commercetools.com/api/
+      type: api_reference
+    - title: commercetools authentication
+      url: https://docs.commercetools.com/api/authorization
+      type: authentication_guide
+    - title: commercetools rate limits
+      url: https://docs.commercetools.com/api/general-concepts#rate-limits
+      type: rate_limits
+    - title: commercetools Status
+      url: https://status.commercetools.com/
+      type: status_page
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-concord/metadata.yaml
+++ b/airbyte-integrations/connectors/source-concord/metadata.yaml
@@ -33,3 +33,10 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Concord API documentation
+      url: https://concord.walmartlabs.com/docs/api/
+      type: api_reference
+    - title: Concord authentication
+      url: https://concord.walmartlabs.com/docs/getting-started/authentication.html
+      type: authentication_guide

--- a/airbyte-integrations/connectors/source-configcat/metadata.yaml
+++ b/airbyte-integrations/connectors/source-configcat/metadata.yaml
@@ -40,4 +40,14 @@ data:
             alias: airbyte-connector-testing-secret-store
   connectorBuildOptions:
     baseImage: docker.io/airbyte/source-declarative-manifest:6.51.0@sha256:890b109f243b8b9406f23ea7522de41025f7b3e87f6fc9710bc1e521213a276f
+  externalDocumentationUrls:
+    - title: ConfigCat Public Management API
+      url: https://api.configcat.com/docs/
+      type: api_reference
+    - title: ConfigCat authentication
+      url: https://configcat.com/docs/advanced/public-api/
+      type: authentication_guide
+    - title: ConfigCat Status
+      url: https://status.configcat.com/
+      type: status_page
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-confluence/metadata.yaml
+++ b/airbyte-integrations/connectors/source-confluence/metadata.yaml
@@ -49,4 +49,17 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+    - title: Confluence Cloud REST API
+      url: https://developer.atlassian.com/cloud/confluence/rest/v2/intro/
+      type: api_reference
+    - title: Confluence authentication
+      url: https://developer.atlassian.com/cloud/confluence/rest/v2/intro/#authentication
+      type: authentication_guide
+    - title: Confluence rate limits
+      url: https://developer.atlassian.com/cloud/confluence/rate-limiting/
+      type: rate_limits
+    - title: Atlassian Status
+      url: https://status.atlassian.com/
+      type: status_page
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-convertkit/metadata.yaml
+++ b/airbyte-integrations/connectors/source-convertkit/metadata.yaml
@@ -40,4 +40,11 @@ data:
   #           alias: airbyte-connector-testing-secret-store
   connectorBuildOptions:
     baseImage: docker.io/airbyte/source-declarative-manifest:6.51.0@sha256:890b109f243b8b9406f23ea7522de41025f7b3e87f6fc9710bc1e521213a276f
+  externalDocumentationUrls:
+    - title: ConvertKit API reference
+      url: https://developers.convertkit.com/
+      type: api_reference
+    - title: ConvertKit authentication
+      url: https://developers.convertkit.com/#authentication
+      type: authentication_guide
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-convex/metadata.yaml
+++ b/airbyte-integrations/connectors/source-convex/metadata.yaml
@@ -41,4 +41,14 @@ data:
             alias: airbyte-connector-testing-secret-store
   connectorBuildOptions:
     baseImage: docker.io/airbyte/python-connector-base:4.0.2@sha256:9fdb1888c4264cf6fee473649ecb593f56f58e5d0096a87ee0b231777e2e3e73
+  externalDocumentationUrls:
+    - title: Convex HTTP API
+      url: https://docs.convex.dev/http-api/
+      type: api_reference
+    - title: Convex authentication
+      url: https://docs.convex.dev/auth
+      type: authentication_guide
+    - title: Convex Status
+      url: https://status.convex.dev/
+      type: status_page
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-copper/metadata.yaml
+++ b/airbyte-integrations/connectors/source-copper/metadata.yaml
@@ -38,4 +38,14 @@ data:
       #           type: GSM
       #           alias: airbyte-connector-testing-secret-store
     - language:manifest-only
+  externalDocumentationUrls:
+    - title: Copper API reference
+      url: https://developer.copper.com/
+      type: api_reference
+    - title: Copper authentication
+      url: https://developer.copper.com/#authentication
+      type: authentication_guide
+    - title: Copper rate limits
+      url: https://developer.copper.com/#rate-limiting
+      type: rate_limits
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-couchbase/metadata.yaml
+++ b/airbyte-integrations/connectors/source-couchbase/metadata.yaml
@@ -44,4 +44,11 @@ data:
     #         alias: airbyte-connector-testing-secret-store
   connectorBuildOptions:
     baseImage: docker.io/airbyte/python-connector-base:4.0.0@sha256:d9894b6895923b379f3006fa251147806919c62b7d9021b5cd125bb67d7bbe22
+  externalDocumentationUrls:
+    - title: Couchbase SQL++ reference
+      url: https://docs.couchbase.com/server/current/n1ql/n1ql-language-reference/index.html
+      type: sql_reference
+    - title: Couchbase authentication
+      url: https://docs.couchbase.com/server/current/learn/security/authentication.html
+      type: authentication_guide
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-countercyclical/metadata.yaml
+++ b/airbyte-integrations/connectors/source-countercyclical/metadata.yaml
@@ -33,3 +33,7 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Countercyclical API documentation
+      url: https://countercyclical.io/docs/api
+      type: api_reference

--- a/airbyte-integrations/connectors/source-courier/metadata.yaml
+++ b/airbyte-integrations/connectors/source-courier/metadata.yaml
@@ -26,4 +26,17 @@ data:
     sl: 100
     ql: 100
   supportLevel: archived
+  externalDocumentationUrls:
+    - title: Courier API reference
+      url: https://www.courier.com/docs/reference/
+      type: api_reference
+    - title: Courier authentication
+      url: https://www.courier.com/docs/reference/auth/
+      type: authentication_guide
+    - title: Courier rate limits
+      url: https://www.courier.com/docs/reference/rate-limits/
+      type: rate_limits
+    - title: Courier Status
+      url: https://status.courier.com/
+      type: status_page
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-customer-io/metadata.yaml
+++ b/airbyte-integrations/connectors/source-customer-io/metadata.yaml
@@ -32,4 +32,17 @@ data:
   tags:
     - cdk:low-code
     - language:manifest-only
+  externalDocumentationUrls:
+    - title: Customer.io API reference
+      url: https://customer.io/docs/api/
+      type: api_reference
+    - title: Customer.io authentication
+      url: https://customer.io/docs/api/#section/Authentication
+      type: authentication_guide
+    - title: Customer.io rate limits
+      url: https://customer.io/docs/api/#section/Rate-Limiting
+      type: rate_limits
+    - title: Customer.io Status
+      url: https://status.customer.io/
+      type: status_page
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-customerly/metadata.yaml
+++ b/airbyte-integrations/connectors/source-customerly/metadata.yaml
@@ -33,3 +33,10 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Customerly API documentation
+      url: https://docs.customerly.io/api/
+      type: api_reference
+    - title: Customerly authentication
+      url: https://docs.customerly.io/api/#authentication
+      type: authentication_guide

--- a/airbyte-integrations/connectors/source-datadog/metadata.yaml
+++ b/airbyte-integrations/connectors/source-datadog/metadata.yaml
@@ -56,4 +56,17 @@ data:
             alias: airbyte-connector-testing-secret-store
   connectorBuildOptions:
     baseImage: docker.io/airbyte/source-declarative-manifest:6.51.0@sha256:890b109f243b8b9406f23ea7522de41025f7b3e87f6fc9710bc1e521213a276f
+  externalDocumentationUrls:
+    - title: Datadog API reference
+      url: https://docs.datadoghq.com/api/latest/
+      type: api_reference
+    - title: Datadog authentication
+      url: https://docs.datadoghq.com/account_management/api-app-keys/
+      type: authentication_guide
+    - title: Datadog rate limits
+      url: https://docs.datadoghq.com/api/latest/rate-limits/
+      type: rate_limits
+    - title: Datadog Status
+      url: https://status.datadoghq.com/
+      type: status_page
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-datagen/metadata.yaml
+++ b/airbyte-integrations/connectors/source-datagen/metadata.yaml
@@ -28,4 +28,8 @@ data:
   supportLevel: community
   tags:
     - language:java
+  externalDocumentationUrls:
+    - title: Airbyte data generator documentation
+      url: https://docs.airbyte.com/integrations/sources/datagen
+      type: other
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-datascope/metadata.yaml
+++ b/airbyte-integrations/connectors/source-datascope/metadata.yaml
@@ -43,4 +43,11 @@ data:
   #           alias: airbyte-connector-testing-secret-store
   connectorBuildOptions:
     baseImage: docker.io/airbyte/source-declarative-manifest:6.48.10@sha256:09947fb38d07e515f9901a12f22cc44f1512f6148703341de80403c0e0c1b8c3
+  externalDocumentationUrls:
+    - title: DataScope API documentation
+      url: https://app.mydatascope.com/api/external/docs/
+      type: api_reference
+    - title: DataScope authentication
+      url: https://app.mydatascope.com/api/external/docs/#section/Authentication
+      type: authentication_guide
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-db2/metadata.yaml
+++ b/airbyte-integrations/connectors/source-db2/metadata.yaml
@@ -29,4 +29,11 @@ data:
   supportLevel: community
   tags:
     - language:java
+  externalDocumentationUrls:
+    - title: IBM Db2 SQL reference
+      url: https://www.ibm.com/docs/en/db2/11.5?topic=reference-sql
+      type: sql_reference
+    - title: IBM Db2 authentication
+      url: https://www.ibm.com/docs/en/db2/11.5?topic=security-authentication
+      type: authentication_guide
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-dbt/metadata.yaml
+++ b/airbyte-integrations/connectors/source-dbt/metadata.yaml
@@ -33,3 +33,13 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: dbt Cloud API reference
+      url: https://docs.getdbt.com/dbt-cloud/api-v2
+      type: api_reference
+    - title: dbt Cloud authentication
+      url: https://docs.getdbt.com/dbt-cloud/api-v2#section/Authentication
+      type: authentication_guide
+    - title: dbt Cloud Status
+      url: https://status.getdbt.com/
+      type: status_page

--- a/airbyte-integrations/connectors/source-defillama/metadata.yaml
+++ b/airbyte-integrations/connectors/source-defillama/metadata.yaml
@@ -32,3 +32,7 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: DefiLlama API documentation
+      url: https://defillama.com/docs/api
+      type: api_reference

--- a/airbyte-integrations/connectors/source-delighted/metadata.yaml
+++ b/airbyte-integrations/connectors/source-delighted/metadata.yaml
@@ -39,4 +39,14 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+    - title: Delighted API reference
+      url: https://delighted.com/docs/api
+      type: api_reference
+    - title: Delighted authentication
+      url: https://delighted.com/docs/api#authentication
+      type: authentication_guide
+    - title: Delighted rate limits
+      url: https://delighted.com/docs/api#rate-limiting
+      type: rate_limits
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-deputy/metadata.yaml
+++ b/airbyte-integrations/connectors/source-deputy/metadata.yaml
@@ -32,3 +32,13 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Deputy API reference
+      url: https://www.deputy.com/api-doc/API/Getting_Started
+      type: api_reference
+    - title: Deputy authentication
+      url: https://www.deputy.com/api-doc/API/Authentication
+      type: authentication_guide
+    - title: Deputy rate limits
+      url: https://www.deputy.com/api-doc/API/Rate_Limiting
+      type: rate_limits

--- a/airbyte-integrations/connectors/source-ding-connect/metadata.yaml
+++ b/airbyte-integrations/connectors/source-ding-connect/metadata.yaml
@@ -33,3 +33,10 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Ding Connect API documentation
+      url: https://docs.ding.com/
+      type: api_reference
+    - title: Ding authentication
+      url: https://docs.ding.com/#authentication
+      type: authentication_guide

--- a/airbyte-integrations/connectors/source-dixa/metadata.yaml
+++ b/airbyte-integrations/connectors/source-dixa/metadata.yaml
@@ -40,4 +40,14 @@ data:
             alias: airbyte-connector-testing-secret-store
   connectorBuildOptions:
     baseImage: docker.io/airbyte/source-declarative-manifest:6.51.0@sha256:890b109f243b8b9406f23ea7522de41025f7b3e87f6fc9710bc1e521213a276f
+  externalDocumentationUrls:
+    - title: Dixa API reference
+      url: https://docs.dixa.io/openapi/
+      type: api_reference
+    - title: Dixa authentication
+      url: https://docs.dixa.io/openapi/dixa-api/#section/Authentication
+      type: authentication_guide
+    - title: Dixa rate limits
+      url: https://docs.dixa.io/openapi/dixa-api/#section/Rate-limiting
+      type: rate_limits
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-dockerhub/metadata.yaml
+++ b/airbyte-integrations/connectors/source-dockerhub/metadata.yaml
@@ -45,4 +45,17 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+    - title: Docker Hub API reference
+      url: https://docs.docker.com/docker-hub/api/latest/
+      type: api_reference
+    - title: Docker Hub authentication
+      url: https://docs.docker.com/docker-hub/api/latest/#section/Authentication
+      type: authentication_guide
+    - title: Docker Hub rate limits
+      url: https://docs.docker.com/docker-hub/download-rate-limit/
+      type: rate_limits
+    - title: Docker Status
+      url: https://www.dockerstatus.com/
+      type: status_page
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-docuseal/metadata.yaml
+++ b/airbyte-integrations/connectors/source-docuseal/metadata.yaml
@@ -33,3 +33,10 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: DocuSeal API documentation
+      url: https://www.docuseal.co/docs/api
+      type: api_reference
+    - title: DocuSeal authentication
+      url: https://www.docuseal.co/docs/api#authentication
+      type: authentication_guide

--- a/airbyte-integrations/connectors/source-dolibarr/metadata.yaml
+++ b/airbyte-integrations/connectors/source-dolibarr/metadata.yaml
@@ -38,3 +38,10 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Dolibarr REST API
+      url: https://wiki.dolibarr.org/index.php/REST_API
+      type: api_reference
+    - title: Dolibarr authentication
+      url: https://wiki.dolibarr.org/index.php/REST_API#Authentication
+      type: authentication_guide

--- a/airbyte-integrations/connectors/source-dremio/metadata.yaml
+++ b/airbyte-integrations/connectors/source-dremio/metadata.yaml
@@ -40,4 +40,14 @@ data:
             alias: airbyte-connector-testing-secret-store
   connectorBuildOptions:
     baseImage: docker.io/airbyte/source-declarative-manifest:6.51.0@sha256:890b109f243b8b9406f23ea7522de41025f7b3e87f6fc9710bc1e521213a276f
+  externalDocumentationUrls:
+    - title: Dremio REST API
+      url: https://docs.dremio.com/software/rest-api/
+      type: api_reference
+    - title: Dremio SQL reference
+      url: https://docs.dremio.com/software/sql-reference/
+      type: sql_reference
+    - title: Dremio authentication
+      url: https://docs.dremio.com/software/rest-api/authentication/
+      type: authentication_guide
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-drift/metadata.yaml
+++ b/airbyte-integrations/connectors/source-drift/metadata.yaml
@@ -45,4 +45,14 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+    - title: Drift API reference
+      url: https://devdocs.drift.com/
+      type: api_reference
+    - title: Drift authentication
+      url: https://devdocs.drift.com/#authentication
+      type: authentication_guide
+    - title: Drift rate limits
+      url: https://devdocs.drift.com/#rate-limiting
+      type: rate_limits
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-drip/metadata.yaml
+++ b/airbyte-integrations/connectors/source-drip/metadata.yaml
@@ -33,3 +33,13 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Drip REST API
+      url: https://developer.drip.com/
+      type: api_reference
+    - title: Drip authentication
+      url: https://developer.drip.com/#authentication
+      type: authentication_guide
+    - title: Drip rate limits
+      url: https://developer.drip.com/#rate-limiting
+      type: rate_limits

--- a/airbyte-integrations/connectors/source-dropbox-sign/metadata.yaml
+++ b/airbyte-integrations/connectors/source-dropbox-sign/metadata.yaml
@@ -33,3 +33,13 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Dropbox Sign API reference
+      url: https://developers.hellosign.com/api/reference/
+      type: api_reference
+    - title: Dropbox Sign authentication
+      url: https://developers.hellosign.com/api/reference/authentication/
+      type: authentication_guide
+    - title: Dropbox Sign rate limits
+      url: https://developers.hellosign.com/api/reference/rate-limiting/
+      type: rate_limits

--- a/airbyte-integrations/connectors/source-dv-360/metadata.yaml
+++ b/airbyte-integrations/connectors/source-dv-360/metadata.yaml
@@ -26,4 +26,14 @@ data:
     sl: 100
     ql: 100
   supportLevel: archived
+  externalDocumentationUrls:
+    - title: Display & Video 360 API
+      url: https://developers.google.com/display-video/api/reference/rest
+      type: api_reference
+    - title: DV360 authentication
+      url: https://developers.google.com/display-video/api/guides/authentication
+      type: authentication_guide
+    - title: DV360 rate limits
+      url: https://developers.google.com/display-video/api/guides/how-tos/quota
+      type: rate_limits
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-dwolla/metadata.yaml
+++ b/airbyte-integrations/connectors/source-dwolla/metadata.yaml
@@ -33,3 +33,16 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Dwolla API reference
+      url: https://developers.dwolla.com/api-reference
+      type: api_reference
+    - title: Dwolla authentication
+      url: https://developers.dwolla.com/guides/auth
+      type: authentication_guide
+    - title: Dwolla rate limits
+      url: https://developers.dwolla.com/api-reference#rate-limits
+      type: rate_limits
+    - title: Dwolla Status
+      url: https://status.dwolla.com/
+      type: status_page

--- a/airbyte-integrations/connectors/source-dynamodb/metadata.yaml
+++ b/airbyte-integrations/connectors/source-dynamodb/metadata.yaml
@@ -33,4 +33,17 @@ data:
   supportLevel: community
   tags:
     - language:java
+  externalDocumentationUrls:
+    - title: Amazon DynamoDB API reference
+      url: https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/
+      type: api_reference
+    - title: DynamoDB authentication
+      url: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/authentication-and-access-control.html
+      type: authentication_guide
+    - title: DynamoDB rate limits
+      url: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Limits.html
+      type: rate_limits
+    - title: AWS Service Health Dashboard
+      url: https://health.aws.amazon.com/health/status
+      type: status_page
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-e-conomic/metadata.yaml
+++ b/airbyte-integrations/connectors/source-e-conomic/metadata.yaml
@@ -33,3 +33,13 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: e-conomic REST API
+      url: https://restdocs.e-conomic.com/
+      type: api_reference
+    - title: e-conomic authentication
+      url: https://www.e-conomic.com/developer/connect
+      type: authentication_guide
+    - title: e-conomic rate limits
+      url: https://restdocs.e-conomic.com/#rate-limiting
+      type: rate_limits

--- a/airbyte-integrations/connectors/source-e2e-test-cloud/metadata.yaml
+++ b/airbyte-integrations/connectors/source-e2e-test-cloud/metadata.yaml
@@ -26,4 +26,8 @@ data:
   connectorTestSuitesOptions:
     - suite: unitTests
     - suite: integrationTests
+  externalDocumentationUrls:
+    - title: Airbyte E2E test cloud source documentation
+      url: https://docs.airbyte.com/integrations/sources/e2e-test
+      type: other
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-e2e-test/metadata.yaml
+++ b/airbyte-integrations/connectors/source-e2e-test/metadata.yaml
@@ -26,4 +26,8 @@ data:
   connectorTestSuitesOptions:
     - suite: unitTests
     - suite: integrationTests
+  externalDocumentationUrls:
+    - title: Airbyte E2E test source documentation
+      url: https://docs.airbyte.com/integrations/sources/e2e-test
+      type: other
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-easypost/metadata.yaml
+++ b/airbyte-integrations/connectors/source-easypost/metadata.yaml
@@ -33,3 +33,16 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: EasyPost API reference
+      url: https://www.easypost.com/docs/api
+      type: api_reference
+    - title: EasyPost authentication
+      url: https://www.easypost.com/docs/api#authentication
+      type: authentication_guide
+    - title: EasyPost rate limits
+      url: https://www.easypost.com/docs/api#rate-limiting
+      type: rate_limits
+    - title: EasyPost Status
+      url: https://status.easypost.com/
+      type: status_page

--- a/airbyte-integrations/connectors/source-easypromos/metadata.yaml
+++ b/airbyte-integrations/connectors/source-easypromos/metadata.yaml
@@ -33,3 +33,10 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Easypromos API documentation
+      url: https://developers.easypromos.com/
+      type: api_reference
+    - title: Easypromos authentication
+      url: https://developers.easypromos.com/#authentication
+      type: authentication_guide

--- a/airbyte-integrations/connectors/source-ebay-finance/metadata.yaml
+++ b/airbyte-integrations/connectors/source-ebay-finance/metadata.yaml
@@ -34,3 +34,16 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: eBay Finances API
+      url: https://developer.ebay.com/api-docs/sell/finances/overview.html
+      type: api_reference
+    - title: eBay authentication
+      url: https://developer.ebay.com/api-docs/static/oauth-tokens.html
+      type: authentication_guide
+    - title: eBay rate limits
+      url: https://developer.ebay.com/support/app-check
+      type: rate_limits
+    - title: eBay Developer Status
+      url: https://developer.ebay.com/support/api-status
+      type: status_page

--- a/airbyte-integrations/connectors/source-ebay-fulfillment/metadata.yaml
+++ b/airbyte-integrations/connectors/source-ebay-fulfillment/metadata.yaml
@@ -33,3 +33,16 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: eBay Fulfillment API
+      url: https://developer.ebay.com/api-docs/sell/fulfillment/overview.html
+      type: api_reference
+    - title: eBay authentication
+      url: https://developer.ebay.com/api-docs/static/oauth-tokens.html
+      type: authentication_guide
+    - title: eBay rate limits
+      url: https://developer.ebay.com/support/app-check
+      type: rate_limits
+    - title: eBay Developer Status
+      url: https://developer.ebay.com/support/api-status
+      type: status_page

--- a/airbyte-integrations/connectors/source-elasticemail/metadata.yaml
+++ b/airbyte-integrations/connectors/source-elasticemail/metadata.yaml
@@ -33,3 +33,13 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Elastic Email API reference
+      url: https://elasticemail.com/developers/api-documentation/
+      type: api_reference
+    - title: Elastic Email authentication
+      url: https://elasticemail.com/developers/api-documentation/authentication
+      type: authentication_guide
+    - title: Elastic Email rate limits
+      url: https://elasticemail.com/developers/api-documentation/rate-limiting
+      type: rate_limits

--- a/airbyte-integrations/connectors/source-elasticsearch/metadata.yaml
+++ b/airbyte-integrations/connectors/source-elasticsearch/metadata.yaml
@@ -26,4 +26,14 @@ data:
   supportLevel: community
   tags:
     - language:java
+  externalDocumentationUrls:
+    - title: Elasticsearch REST APIs
+      url: https://www.elastic.co/guide/en/elasticsearch/reference/current/rest-apis.html
+      type: api_reference
+    - title: Elasticsearch authentication
+      url: https://www.elastic.co/guide/en/elasticsearch/reference/current/setting-up-authentication.html
+      type: authentication_guide
+    - title: Elastic Cloud Status
+      url: https://status.elastic.co/
+      type: status_page
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-emailoctopus/metadata.yaml
+++ b/airbyte-integrations/connectors/source-emailoctopus/metadata.yaml
@@ -40,4 +40,14 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+    - title: EmailOctopus API documentation
+      url: https://emailoctopus.com/api-documentation
+      type: api_reference
+    - title: EmailOctopus authentication
+      url: https://emailoctopus.com/api-documentation#authentication
+      type: authentication_guide
+    - title: EmailOctopus rate limits
+      url: https://emailoctopus.com/api-documentation#rate-limiting
+      type: rate_limits
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-employment-hero/metadata.yaml
+++ b/airbyte-integrations/connectors/source-employment-hero/metadata.yaml
@@ -33,3 +33,10 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Employment Hero API reference
+      url: https://developer.employmenthero.com/
+      type: api_reference
+    - title: Employment Hero authentication
+      url: https://developer.employmenthero.com/api-references/authentication/
+      type: authentication_guide

--- a/airbyte-integrations/connectors/source-encharge/metadata.yaml
+++ b/airbyte-integrations/connectors/source-encharge/metadata.yaml
@@ -33,3 +33,10 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Encharge API reference
+      url: https://developers.encharge.io/
+      type: api_reference
+    - title: Encharge authentication
+      url: https://developers.encharge.io/#authentication
+      type: authentication_guide

--- a/airbyte-integrations/connectors/source-eventbrite/metadata.yaml
+++ b/airbyte-integrations/connectors/source-eventbrite/metadata.yaml
@@ -33,3 +33,16 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Eventbrite API reference
+      url: https://www.eventbrite.com/platform/api
+      type: api_reference
+    - title: Eventbrite authentication
+      url: https://www.eventbrite.com/platform/api#/introduction/authentication
+      type: authentication_guide
+    - title: Eventbrite rate limits
+      url: https://www.eventbrite.com/platform/api#/introduction/rate-limits
+      type: rate_limits
+    - title: Eventbrite Status
+      url: https://status.eventbrite.com/
+      type: status_page

--- a/airbyte-integrations/connectors/source-eventee/metadata.yaml
+++ b/airbyte-integrations/connectors/source-eventee/metadata.yaml
@@ -33,3 +33,10 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Eventee API documentation
+      url: https://eventee.co/api-documentation
+      type: api_reference
+    - title: Eventee authentication
+      url: https://eventee.co/api-documentation#authentication
+      type: authentication_guide

--- a/airbyte-integrations/connectors/source-eventzilla/metadata.yaml
+++ b/airbyte-integrations/connectors/source-eventzilla/metadata.yaml
@@ -33,3 +33,10 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Eventzilla API documentation
+      url: https://www.eventzilla.net/api/
+      type: api_reference
+    - title: Eventzilla authentication
+      url: https://www.eventzilla.net/api/#authentication
+      type: authentication_guide

--- a/airbyte-integrations/connectors/source-everhour/metadata.yaml
+++ b/airbyte-integrations/connectors/source-everhour/metadata.yaml
@@ -42,4 +42,14 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+    - title: Everhour API reference
+      url: https://everhour.docs.apiary.io/
+      type: api_reference
+    - title: Everhour authentication
+      url: https://everhour.docs.apiary.io/#introduction/authentication
+      type: authentication_guide
+    - title: Everhour rate limits
+      url: https://everhour.docs.apiary.io/#introduction/rate-limiting
+      type: rate_limits
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-exchange-rates/metadata.yaml
+++ b/airbyte-integrations/connectors/source-exchange-rates/metadata.yaml
@@ -45,4 +45,11 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+    - title: Exchange Rates API documentation
+      url: https://exchangeratesapi.io/documentation/
+      type: api_reference
+    - title: Exchange Rates authentication
+      url: https://exchangeratesapi.io/documentation/#authentication
+      type: authentication_guide
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-ezofficeinventory/metadata.yaml
+++ b/airbyte-integrations/connectors/source-ezofficeinventory/metadata.yaml
@@ -33,3 +33,13 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: EZOfficeInventory API reference
+      url: https://ezofficeinventory.com/developers
+      type: api_reference
+    - title: EZOfficeInventory authentication
+      url: https://ezofficeinventory.com/developers/docs/authentication
+      type: authentication_guide
+    - title: EZOfficeInventory rate limits
+      url: https://ezofficeinventory.com/developers/docs/rate-limiting
+      type: rate_limits


### PR DESCRIPTION
## What

This PR adds `externalDocumentationUrls` metadata to 50 source connectors (Group D: source-commercetools through source-ezofficeinventory). This is part of an ongoing effort to add external documentation links to all Airbyte connectors, improving discoverability of vendor documentation for users and developers.

**Context:**
- Group A (86 destinations): Merged in #69353
- Group B (47 sources): Merged in #69724  
- Group C (49 sources): Merged in #69730
- **Group D (50 sources): This PR**
- Groups E-M (437 sources): Remaining work

**Related Documentation:**
- Schema definition: `airbyte-ci/connectors/metadata_service/lib/metadata_service/models/src/ConnectorMetadataDefinitionV0.yaml`
- Best practices guide: `airbyte-ci/connectors/metadata_service/docs/external_documentation_urls.md`

## How

Used surgical text insertion to add `externalDocumentationUrls` sections to each connector's metadata.yaml file. This approach preserves existing file formatting and only adds the new documentation section.

Each connector receives curated external documentation URLs categorized by type:
- `api_reference`: API documentation and reference guides
- `authentication_guide`: Authentication and authorization documentation
- `rate_limits`: Rate limiting and quota documentation
- `status_page`: Service status and uptime monitoring pages
- `sql_reference`: SQL syntax and query documentation (for database connectors)

**Technical approach:**
- No connector version bumps (documentation-only changes)
- Format-preserving edits (no YAML reformatting)
- Clean diffs: 461 insertions, 0 deletions

## Review guide

**Key areas to review:**
1. **URL accuracy**: Spot-check 5-10 URLs to verify they point to valid, relevant documentation
2. **Type categorization**: Verify documentation types are correctly assigned (e.g., status pages marked as `status_page`, not `api_reference`)
3. **Diff cleanliness**: Confirm changes are purely additive with no formatting modifications
4. **Consistency**: Check that the format matches Groups A-C (already merged)

**Sample connectors to review:**
- `source-commercetools/metadata.yaml` - Full example with all URL types
- `source-datadog/metadata.yaml` - Popular connector with comprehensive docs
- `source-dynamodb/metadata.yaml` - AWS service example
- `source-elasticsearch/metadata.yaml` - Database connector example

## User Impact

**Positive:**
- Users can discover vendor documentation more easily when configuring connectors
- Developers have quick access to API references, authentication guides, and rate limit documentation
- Improved connector metadata quality and discoverability

**Negative:**
- None expected (purely additive metadata)

**CI Note:**
Expected CI failures on "Connector Version Increment Check" - this is intentional for metadata-only changes to avoid triggering 50 unnecessary connector releases. This follows the same pattern as Groups A-C which were successfully merged.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

This PR only adds optional metadata fields with no code changes. Reverting would simply remove the documentation URLs without affecting connector functionality.

---

**Requested by:** AJ Steers (@aaronsteers, aj@airbyte.io)  
**Session:** https://app.devin.ai/sessions/278efaf8c49f4261b899f1c1f465c91a