### PR TITLE
feat: Add external documentation URLs to Group E source connectors (source-facebook-pages through source-gong)

### DIFF
--- a/airbyte-integrations/connectors/source-facebook-pages/metadata.yaml
+++ b/airbyte-integrations/connectors/source-facebook-pages/metadata.yaml
@@ -47,4 +47,17 @@ data:
         - name: facebook-pages_config_dev_null
           id: 4446147a-669a-472b-bda8-6ee069eb3099
     - suite: unitTests
+  externalDocumentationUrls:
+    - title: Facebook Pages API reference
+      url: https://developers.facebook.com/docs/pages/
+      type: api_reference
+    - title: Facebook Graph API changelog
+      url: https://developers.facebook.com/docs/graph-api/changelog/
+      type: api_release_history
+    - title: Facebook authentication guide
+      url: https://developers.facebook.com/docs/facebook-login/guides/access-tokens/
+      type: authentication_guide
+    - title: Facebook Platform Status
+      url: https://developers.facebook.com/status/
+      type: status_page
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-factorial/metadata.yaml
+++ b/airbyte-integrations/connectors/source-factorial/metadata.yaml
@@ -33,3 +33,10 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Factorial API documentation
+      url: https://apidoc.factorialhr.com/
+      type: api_reference
+    - title: Factorial authentication
+      url: https://apidoc.factorialhr.com/#authentication
+      type: authentication_guide

--- a/airbyte-integrations/connectors/source-fastbill/metadata.yaml
+++ b/airbyte-integrations/connectors/source-fastbill/metadata.yaml
@@ -41,4 +41,11 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+    - title: FastBill API documentation
+      url: https://apidocs.fastbill.com/
+      type: api_reference
+    - title: FastBill authentication
+      url: https://apidocs.fastbill.com/fastbill/en/fundamentals.html#authentication
+      type: authentication_guide
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-fastly/metadata.yaml
+++ b/airbyte-integrations/connectors/source-fastly/metadata.yaml
@@ -33,3 +33,16 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Fastly API reference
+      url: https://developer.fastly.com/reference/api/
+      type: api_reference
+    - title: Fastly API authentication
+      url: https://developer.fastly.com/reference/api/#authentication
+      type: authentication_guide
+    - title: Fastly API rate limits
+      url: https://developer.fastly.com/reference/api/#rate-limiting
+      type: rate_limits
+    - title: Fastly Status
+      url: https://status.fastly.com/
+      type: status_page

--- a/airbyte-integrations/connectors/source-fauna/metadata.yaml
+++ b/airbyte-integrations/connectors/source-fauna/metadata.yaml
@@ -42,4 +42,14 @@ data:
   tags:
     - language:python
     - cdk:python
+  externalDocumentationUrls:
+    - title: Fauna API reference
+      url: https://docs.fauna.com/fauna/current/api/
+      type: api_reference
+    - title: Fauna authentication
+      url: https://docs.fauna.com/fauna/current/security/
+      type: authentication_guide
+    - title: Fauna Status
+      url: https://status.fauna.com/
+      type: status_page
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-file/metadata.yaml
+++ b/airbyte-integrations/connectors/source-file/metadata.yaml
@@ -95,4 +95,8 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+    - title: File source documentation
+      url: https://docs.airbyte.com/integrations/sources/file
+      type: other
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-fillout/metadata.yaml
+++ b/airbyte-integrations/connectors/source-fillout/metadata.yaml
@@ -33,3 +33,7 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Fillout API documentation
+      url: https://www.fillout.com/help/fillout-rest-api
+      type: api_reference

--- a/airbyte-integrations/connectors/source-finage/metadata.yaml
+++ b/airbyte-integrations/connectors/source-finage/metadata.yaml
@@ -33,3 +33,10 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Finage API documentation
+      url: https://finage.co.uk/docs/api
+      type: api_reference
+    - title: Finage authentication
+      url: https://finage.co.uk/docs/api/getting-started
+      type: authentication_guide

--- a/airbyte-integrations/connectors/source-financial-modelling/metadata.yaml
+++ b/airbyte-integrations/connectors/source-financial-modelling/metadata.yaml
@@ -33,3 +33,7 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Financial Modeling Prep API
+      url: https://site.financialmodelingprep.com/developer/docs
+      type: api_reference

--- a/airbyte-integrations/connectors/source-finnhub/metadata.yaml
+++ b/airbyte-integrations/connectors/source-finnhub/metadata.yaml
@@ -33,3 +33,13 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Finnhub API documentation
+      url: https://finnhub.io/docs/api
+      type: api_reference
+    - title: Finnhub authentication
+      url: https://finnhub.io/docs/api/authentication
+      type: authentication_guide
+    - title: Finnhub rate limits
+      url: https://finnhub.io/pricing
+      type: rate_limits

--- a/airbyte-integrations/connectors/source-finnworlds/metadata.yaml
+++ b/airbyte-integrations/connectors/source-finnworlds/metadata.yaml
@@ -33,3 +33,7 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Finnworlds API documentation
+      url: https://api.finnworlds.com/docs
+      type: api_reference

--- a/airbyte-integrations/connectors/source-firebase-realtime-database/metadata.yaml
+++ b/airbyte-integrations/connectors/source-firebase-realtime-database/metadata.yaml
@@ -32,4 +32,14 @@ data:
     - suite: unitTests
   connectorBuildOptions:
     baseImage: docker.io/airbyte/python-connector-base:4.0.0@sha256:d9894b6895923b379f3006fa251147806919c62b7d9021b5cd125bb67d7bbe22
+  externalDocumentationUrls:
+    - title: Firebase Realtime Database REST API
+      url: https://firebase.google.com/docs/reference/rest/database
+      type: api_reference
+    - title: Firebase authentication
+      url: https://firebase.google.com/docs/database/rest/auth
+      type: authentication_guide
+    - title: Firebase Status Dashboard
+      url: https://status.firebase.google.com/
+      type: status_page
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-firebolt/metadata.yaml
+++ b/airbyte-integrations/connectors/source-firebolt/metadata.yaml
@@ -56,4 +56,14 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+    - title: Firebolt API reference
+      url: https://docs.firebolt.io/godocs/Overview/api-reference.html
+      type: api_reference
+    - title: Firebolt authentication
+      url: https://docs.firebolt.io/godocs/Guides/managing-your-organization/service-accounts.html
+      type: authentication_guide
+    - title: Firebolt Status
+      url: https://status.firebolt.io/
+      type: status_page
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-firehydrant/metadata.yaml
+++ b/airbyte-integrations/connectors/source-firehydrant/metadata.yaml
@@ -33,3 +33,13 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: FireHydrant API documentation
+      url: https://firehydrant.com/docs/api/
+      type: api_reference
+    - title: FireHydrant authentication
+      url: https://firehydrant.com/docs/api/#authentication
+      type: authentication_guide
+    - title: FireHydrant Status
+      url: https://status.firehydrant.io/
+      type: status_page

--- a/airbyte-integrations/connectors/source-fleetio/metadata.yaml
+++ b/airbyte-integrations/connectors/source-fleetio/metadata.yaml
@@ -26,4 +26,11 @@ data:
   tags:
     - cdk:low-code
     - language:manifest-only
+  externalDocumentationUrls:
+    - title: Fleetio API documentation
+      url: https://developer.fleetio.com/
+      type: api_reference
+    - title: Fleetio authentication
+      url: https://developer.fleetio.com/#authentication
+      type: authentication_guide
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-flexmail/metadata.yaml
+++ b/airbyte-integrations/connectors/source-flexmail/metadata.yaml
@@ -33,3 +33,7 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Flexmail API documentation
+      url: https://api.flexmail.eu/documentation/
+      type: api_reference

--- a/airbyte-integrations/connectors/source-flexport/metadata.yaml
+++ b/airbyte-integrations/connectors/source-flexport/metadata.yaml
@@ -33,4 +33,11 @@ data:
   supportLevel: community
   connectorBuildOptions:
     baseImage: docker.io/airbyte/source-declarative-manifest:7.5.0@sha256:92e539d5003b33c3624eae7715aee6e39b7b2f1f0eeb6003d37e649a06847ae8
+  externalDocumentationUrls:
+    - title: Flexport API documentation
+      url: https://developers.flexport.com/
+      type: api_reference
+    - title: Flexport authentication
+      url: https://developers.flexport.com/s/authentication
+      type: authentication_guide
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-float/metadata.yaml
+++ b/airbyte-integrations/connectors/source-float/metadata.yaml
@@ -33,3 +33,13 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Float API documentation
+      url: https://dev.float.com/
+      type: api_reference
+    - title: Float authentication
+      url: https://dev.float.com/#authentication
+      type: authentication_guide
+    - title: Float rate limits
+      url: https://dev.float.com/#rate-limiting
+      type: rate_limits

--- a/airbyte-integrations/connectors/source-flowlu/metadata.yaml
+++ b/airbyte-integrations/connectors/source-flowlu/metadata.yaml
@@ -33,3 +33,7 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Flowlu API documentation
+      url: https://www.flowlu.com/api/
+      type: api_reference

--- a/airbyte-integrations/connectors/source-formbricks/metadata.yaml
+++ b/airbyte-integrations/connectors/source-formbricks/metadata.yaml
@@ -33,3 +33,7 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Formbricks API documentation
+      url: https://formbricks.com/docs/api/overview
+      type: api_reference

--- a/airbyte-integrations/connectors/source-free-agent-connector/metadata.yaml
+++ b/airbyte-integrations/connectors/source-free-agent-connector/metadata.yaml
@@ -33,3 +33,10 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: FreeAgent API documentation
+      url: https://dev.freeagent.com/
+      type: api_reference
+    - title: FreeAgent OAuth guide
+      url: https://dev.freeagent.com/docs/quick_start
+      type: authentication_guide

--- a/airbyte-integrations/connectors/source-freightview/metadata.yaml
+++ b/airbyte-integrations/connectors/source-freightview/metadata.yaml
@@ -33,3 +33,7 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Freightview API documentation
+      url: https://docs.freightview.com/
+      type: api_reference

--- a/airbyte-integrations/connectors/source-freshbooks/metadata.yaml
+++ b/airbyte-integrations/connectors/source-freshbooks/metadata.yaml
@@ -33,3 +33,13 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: FreshBooks API reference
+      url: https://www.freshbooks.com/api/start
+      type: api_reference
+    - title: FreshBooks authentication
+      url: https://www.freshbooks.com/api/authentication
+      type: authentication_guide
+    - title: FreshBooks rate limits
+      url: https://www.freshbooks.com/api/rate_limiting
+      type: rate_limits

--- a/airbyte-integrations/connectors/source-freshcaller/metadata.yaml
+++ b/airbyte-integrations/connectors/source-freshcaller/metadata.yaml
@@ -40,4 +40,14 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  externalDocumentationUrls:
+    - title: Freshcaller API reference
+      url: https://developers.freshcaller.com/api/
+      type: api_reference
+    - title: Freshcaller authentication
+      url: https://developers.freshcaller.com/api/#authentication
+      type: authentication_guide
+    - title: Freshworks Status
+      url: https://status.freshworks.com/
+      type: status_page
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-freshchat/metadata.yaml
+++ b/airbyte-integrations/connectors/source-freshchat/metadata.yaml
@@ -33,3 +33,13 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Freshchat API reference
+      url: https://developers.freshchat.com/api/
+      type: api_reference
+    - title: Freshchat authentication
+      url: https://developers.freshchat.com/api/#authentication
+      type: authentication_guide
+    - title: Freshworks Status
+      url: https://status.freshworks.com/
+      type: status_page

--- a/airbyte-integrations/connectors/source-freshsales/metadata.yaml
+++ b/airbyte-integrations/connectors/source-freshsales/metadata.yaml
@@ -63,4 +63,14 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+    - title: Freshsales API reference
+      url: https://developers.freshworks.com/crm/api/
+      type: api_reference
+    - title: Freshsales authentication
+      url: https://developers.freshworks.com/crm/api/#authentication
+      type: authentication_guide
+    - title: Freshworks Status
+      url: https://status.freshworks.com/
+      type: status_page
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-freshservice/metadata.yaml
+++ b/airbyte-integrations/connectors/source-freshservice/metadata.yaml
@@ -41,4 +41,14 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+    - title: Freshservice API reference
+      url: https://api.freshservice.com/
+      type: api_reference
+    - title: Freshservice authentication
+      url: https://api.freshservice.com/#authentication
+      type: authentication_guide
+    - title: Freshworks Status
+      url: https://status.freshworks.com/
+      type: status_page
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-front/metadata.yaml
+++ b/airbyte-integrations/connectors/source-front/metadata.yaml
@@ -33,3 +33,16 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Front API reference
+      url: https://dev.frontapp.com/reference/introduction
+      type: api_reference
+    - title: Front authentication
+      url: https://dev.frontapp.com/docs/authentication
+      type: authentication_guide
+    - title: Front rate limits
+      url: https://dev.frontapp.com/docs/rate-limiting
+      type: rate_limits
+    - title: Front Status
+      url: https://status.front.com/
+      type: status_page

--- a/airbyte-integrations/connectors/source-fulcrum/metadata.yaml
+++ b/airbyte-integrations/connectors/source-fulcrum/metadata.yaml
@@ -33,3 +33,10 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Fulcrum API documentation
+      url: https://developer.fulcrumapp.com/
+      type: api_reference
+    - title: Fulcrum authentication
+      url: https://developer.fulcrumapp.com/general/authentication/
+      type: authentication_guide

--- a/airbyte-integrations/connectors/source-fullstory/metadata.yaml
+++ b/airbyte-integrations/connectors/source-fullstory/metadata.yaml
@@ -38,4 +38,14 @@ data:
   #           alias: airbyte-connector-testing-secret-store
   connectorBuildOptions:
     baseImage: docker.io/airbyte/source-declarative-manifest:6.51.0@sha256:890b109f243b8b9406f23ea7522de41025f7b3e87f6fc9710bc1e521213a276f
+  externalDocumentationUrls:
+    - title: FullStory API reference
+      url: https://developer.fullstory.com/reference
+      type: api_reference
+    - title: FullStory authentication
+      url: https://developer.fullstory.com/introduction
+      type: authentication_guide
+    - title: FullStory Status
+      url: https://status.fullstory.com/
+      type: status_page
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-gainsight-px/metadata.yaml
+++ b/airbyte-integrations/connectors/source-gainsight-px/metadata.yaml
@@ -43,4 +43,8 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+    - title: Gainsight PX API documentation
+      url: https://support.gainsight.com/PX/API_for_Developers/02Usage_of_Different_APIs
+      type: api_reference
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-gcs/metadata.yaml
+++ b/airbyte-integrations/connectors/source-gcs/metadata.yaml
@@ -72,4 +72,14 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+    - title: Google Cloud Storage documentation
+      url: https://cloud.google.com/storage/docs
+      type: api_reference
+    - title: GCS authentication
+      url: https://cloud.google.com/storage/docs/authentication
+      type: authentication_guide
+    - title: Google Cloud Status
+      url: https://status.cloud.google.com/
+      type: status_page
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-genesys/metadata.yaml
+++ b/airbyte-integrations/connectors/source-genesys/metadata.yaml
@@ -30,4 +30,17 @@ data:
     - suite: unitTests
   connectorBuildOptions:
     baseImage: docker.io/airbyte/python-connector-base:4.0.0@sha256:d9894b6895923b379f3006fa251147806919c62b7d9021b5cd125bb67d7bbe22
+  externalDocumentationUrls:
+    - title: Genesys Cloud API reference
+      url: https://developer.genesys.cloud/api/
+      type: api_reference
+    - title: Genesys authentication
+      url: https://developer.genesys.cloud/authorization/
+      type: authentication_guide
+    - title: Genesys rate limits
+      url: https://developer.genesys.cloud/api/rest/rate_limits
+      type: rate_limits
+    - title: Genesys Cloud Status
+      url: https://status.mypurecloud.com/
+      type: status_page
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-getgist/metadata.yaml
+++ b/airbyte-integrations/connectors/source-getgist/metadata.yaml
@@ -33,3 +33,7 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Gist API documentation
+      url: https://developers.getgist.com/
+      type: api_reference

--- a/airbyte-integrations/connectors/source-getlago/metadata.yaml
+++ b/airbyte-integrations/connectors/source-getlago/metadata.yaml
@@ -40,4 +40,11 @@ data:
             alias: airbyte-connector-testing-secret-store
   connectorBuildOptions:
     baseImage: docker.io/airbyte/source-declarative-manifest:7.5.0@sha256:92e539d5003b33c3624eae7715aee6e39b7b2f1f0eeb6003d37e649a06847ae8
+  externalDocumentationUrls:
+    - title: Lago API documentation
+      url: https://doc.getlago.com/api-reference/intro
+      type: api_reference
+    - title: Lago authentication
+      url: https://doc.getlago.com/api-reference/intro#authentication
+      type: authentication_guide
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-giphy/metadata.yaml
+++ b/airbyte-integrations/connectors/source-giphy/metadata.yaml
@@ -33,3 +33,10 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: GIPHY API documentation
+      url: https://developers.giphy.com/docs/api/
+      type: api_reference
+    - title: GIPHY rate limits
+      url: https://developers.giphy.com/docs/api/#rate-limiting
+      type: rate_limits

--- a/airbyte-integrations/connectors/source-gitbook/metadata.yaml
+++ b/airbyte-integrations/connectors/source-gitbook/metadata.yaml
@@ -33,3 +33,10 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: GitBook API documentation
+      url: https://developer.gitbook.com/
+      type: api_reference
+    - title: GitBook authentication
+      url: https://developer.gitbook.com/gitbook-api/authentication
+      type: authentication_guide

--- a/airbyte-integrations/connectors/source-github/metadata.yaml
+++ b/airbyte-integrations/connectors/source-github/metadata.yaml
@@ -81,4 +81,20 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+    - title: GitHub REST API reference
+      url: https://docs.github.com/en/rest
+      type: api_reference
+    - title: GitHub API changelog
+      url: https://github.blog/changelog/label/api/
+      type: api_release_history
+    - title: GitHub authentication
+      url: https://docs.github.com/en/rest/overview/authenticating-to-the-rest-api
+      type: authentication_guide
+    - title: GitHub rate limits
+      url: https://docs.github.com/en/rest/overview/rate-limits-for-the-rest-api
+      type: rate_limits
+    - title: GitHub Status
+      url: https://www.githubstatus.com/
+      type: status_page
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-glassfrog/metadata.yaml
+++ b/airbyte-integrations/connectors/source-glassfrog/metadata.yaml
@@ -44,4 +44,8 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+    - title: GlassFrog API documentation
+      url: https://documenter.getpostman.com/view/1014385/glassfrog-api-v3/2SJViY
+      type: api_reference
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-gmail/metadata.yaml
+++ b/airbyte-integrations/connectors/source-gmail/metadata.yaml
@@ -33,3 +33,16 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Gmail API reference
+      url: https://developers.google.com/gmail/api/reference/rest
+      type: api_reference
+    - title: Gmail authentication
+      url: https://developers.google.com/gmail/api/auth/about-auth
+      type: authentication_guide
+    - title: Gmail API quotas
+      url: https://developers.google.com/gmail/api/reference/quota
+      type: rate_limits
+    - title: Google Workspace Status
+      url: https://www.google.com/appsstatus/
+      type: status_page

--- a/airbyte-integrations/connectors/source-gnews/metadata.yaml
+++ b/airbyte-integrations/connectors/source-gnews/metadata.yaml
@@ -41,4 +41,8 @@ data:
             alias: airbyte-connector-testing-secret-store
   connectorBuildOptions:
     baseImage: docker.io/airbyte/source-declarative-manifest:6.51.0@sha256:890b109f243b8b9406f23ea7522de41025f7b3e87f6fc9710bc1e521213a276f
+  externalDocumentationUrls:
+    - title: GNews API documentation
+      url: https://gnews.io/docs/
+      type: api_reference
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-gocardless/metadata.yaml
+++ b/airbyte-integrations/connectors/source-gocardless/metadata.yaml
@@ -28,4 +28,17 @@ data:
   supportLevel: community
   connectorBuildOptions:
     baseImage: docker.io/airbyte/source-declarative-manifest:6.51.0@sha256:890b109f243b8b9406f23ea7522de41025f7b3e87f6fc9710bc1e521213a276f
+  externalDocumentationUrls:
+    - title: GoCardless API reference
+      url: https://developer.gocardless.com/api-reference/
+      type: api_reference
+    - title: GoCardless authentication
+      url: https://developer.gocardless.com/getting-started/api/making-your-first-api-request/
+      type: authentication_guide
+    - title: GoCardless rate limits
+      url: https://developer.gocardless.com/api-reference/#making-requests-rate-limiting
+      type: rate_limits
+    - title: GoCardless Status
+      url: https://status.gocardless.com/
+      type: status_page
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-goldcast/metadata.yaml
+++ b/airbyte-integrations/connectors/source-goldcast/metadata.yaml
@@ -32,4 +32,8 @@ data:
   tags:
     - cdk:low-code
     - language:manifest-only
+  externalDocumentationUrls:
+    - title: Goldcast API documentation
+      url: https://www.goldcast.io/api-docs
+      type: api_reference
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-gologin/metadata.yaml
+++ b/airbyte-integrations/connectors/source-gologin/metadata.yaml
@@ -33,3 +33,7 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: GoLogin API documentation
+      url: https://api.gologin.com/docs
+      type: api_reference

--- a/airbyte-integrations/connectors/source-gong/metadata.yaml
+++ b/airbyte-integrations/connectors/source-gong/metadata.yaml
@@ -36,4 +36,14 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+    - title: Gong API reference
+      url: https://us-66463.app.gong.io/settings/api/documentation
+      type: api_reference
+    - title: Gong authentication
+      url: https://us-66463.app.gong.io/settings/api/documentation#overview
+      type: authentication_guide
+    - title: Gong rate limits
+      url: https://us-66463.app.gong.io/settings/api/documentation#rate-limits
+      type: rate_limits
 metadataSpecVersion: "1.0"


### PR DESCRIPTION
## What

This PR adds `externalDocumentationUrls` metadata to 45 source connectors in Group E (source-facebook-pages through source-gong). This is part of an ongoing effort to add external documentation links to all Airbyte connectors, improving discoverability of vendor documentation for users and developers.

**Context:**
- Group A (86 destinations): Merged in #69353
- Group B (47 sources): Merged in #69724
- Group C (49 sources): Merged in #69730
- Group D (50 sources): Merged in #69731
- **Group E (45 sources): This PR**
- Groups F-M (387 sources): Remaining

**Note:** 5 connectors in this range (source-facebook-marketing, source-faker, source-freshdesk, source-gitlab, source-google-ads) already had externalDocumentationUrls and were skipped.

## How

Used surgical text insertion to add only the `externalDocumentationUrls` sections to metadata.yaml files without reformatting the entire files. This approach ensures minimal diffs (only insertions, no deletions) and preserves existing file formatting.

Each connector received curated documentation URLs categorized by type:
- `api_reference`: API documentation and reference guides
- `api_release_history`: Changelogs and release notes
- `authentication_guide`: Authentication and authorization docs
- `rate_limits`: Rate limiting documentation
- `status_page`: Service status pages
- `other`: Miscellaneous documentation

## Review guide

**Key areas to review:**
1. **URL validity**: Spot-check a few connectors to verify URLs are correct and accessible (e.g., source-github, source-gmail, source-front)
2. **Type categorization**: Verify that URL types make sense (e.g., status pages should be status_page, not api_reference)
3. **Diff cleanliness**: Confirm only externalDocumentationUrls sections were added, no other formatting changes
4. **Consistency**: Compare with previous groups (A-D) to ensure similar quality and structure

**Files to spot-check:**
- `airbyte-integrations/connectors/source-github/metadata.yaml` - Should have comprehensive docs (5 URLs)
- `airbyte-integrations/connectors/source-gmail/metadata.yaml` - Google Workspace connector
- `airbyte-integrations/connectors/source-front/metadata.yaml` - Should have status page
- `airbyte-integrations/connectors/source-fastly/metadata.yaml` - Should have rate limits

## User Impact

**Positive:**
- Users can now discover vendor documentation directly from connector metadata
- Improves self-service troubleshooting and configuration
- Better visibility into API changes, deprecations, and rate limits

**Negative:**
- None expected - this is additive metadata only

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

This PR only adds metadata fields and doesn't change any connector functionality. Reverting would simply remove the documentation URLs.

---

**Requested by:** AJ Steers (@aaronsteers)  
**Session:** https://app.devin.ai/sessions/278efaf8c49f4261b899f1c1f465c91a  
**Commit message note:** Added `[skip ci]` flag to test CI bypass behavior per user request