### PR TITLE
feat: Add external documentation URLs to Group H source connectors (source-microsoft-entra-id through source-oura)

### DIFF
--- a/airbyte-integrations/connectors/source-microsoft-entra-id/metadata.yaml
+++ b/airbyte-integrations/connectors/source-microsoft-entra-id/metadata.yaml
@@ -33,3 +33,16 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Microsoft Entra ID API
+      url: https://learn.microsoft.com/en-us/graph/api/resources/azure-ad-overview
+      type: api_reference
+    - title: Microsoft Graph authentication
+      url: https://learn.microsoft.com/en-us/graph/auth/
+      type: authentication_guide
+    - title: Microsoft Graph throttling
+      url: https://learn.microsoft.com/en-us/graph/throttling
+      type: rate_limits
+    - title: Microsoft 365 Status
+      url: https://status.office365.com/
+      type: status_page

--- a/airbyte-integrations/connectors/source-microsoft-lists/metadata.yaml
+++ b/airbyte-integrations/connectors/source-microsoft-lists/metadata.yaml
@@ -42,3 +42,13 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Microsoft Lists API
+      url: https://learn.microsoft.com/en-us/graph/api/resources/list
+      type: api_reference
+    - title: Microsoft Graph authentication
+      url: https://learn.microsoft.com/en-us/graph/auth/
+      type: authentication_guide
+    - title: Microsoft 365 Status
+      url: https://status.office365.com/
+      type: status_page

--- a/airbyte-integrations/connectors/source-microsoft-onedrive/metadata.yaml
+++ b/airbyte-integrations/connectors/source-microsoft-onedrive/metadata.yaml
@@ -41,4 +41,17 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+    - title: OneDrive API reference
+      url: https://learn.microsoft.com/en-us/onedrive/developer/
+      type: api_reference
+    - title: OneDrive authentication
+      url: https://learn.microsoft.com/en-us/onedrive/developer/rest-api/getting-started/authentication
+      type: authentication_guide
+    - title: Microsoft Graph throttling
+      url: https://learn.microsoft.com/en-us/graph/throttling
+      type: rate_limits
+    - title: Microsoft 365 Status
+      url: https://status.office365.com/
+      type: status_page
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-microsoft-sharepoint/metadata.yaml
+++ b/airbyte-integrations/connectors/source-microsoft-sharepoint/metadata.yaml
@@ -47,4 +47,14 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+    - title: SharePoint REST API
+      url: https://learn.microsoft.com/en-us/sharepoint/dev/sp-add-ins/get-to-know-the-sharepoint-rest-service
+      type: api_reference
+    - title: SharePoint authentication
+      url: https://learn.microsoft.com/en-us/sharepoint/dev/sp-add-ins/authorization-and-authentication-of-sharepoint-add-ins
+      type: authentication_guide
+    - title: Microsoft 365 Status
+      url: https://status.office365.com/
+      type: status_page
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-microsoft-teams/metadata.yaml
+++ b/airbyte-integrations/connectors/source-microsoft-teams/metadata.yaml
@@ -68,4 +68,17 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+    - title: Microsoft Teams API
+      url: https://learn.microsoft.com/en-us/graph/api/resources/teams-api-overview
+      type: api_reference
+    - title: Microsoft Graph authentication
+      url: https://learn.microsoft.com/en-us/graph/auth/
+      type: authentication_guide
+    - title: Microsoft Graph throttling
+      url: https://learn.microsoft.com/en-us/graph/throttling
+      type: rate_limits
+    - title: Microsoft 365 Status
+      url: https://status.office365.com/
+      type: status_page
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-miro/metadata.yaml
+++ b/airbyte-integrations/connectors/source-miro/metadata.yaml
@@ -33,3 +33,13 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Miro REST API
+      url: https://developers.miro.com/reference/api-reference
+      type: api_reference
+    - title: Miro authentication
+      url: https://developers.miro.com/docs/getting-started-with-oauth
+      type: authentication_guide
+    - title: Miro rate limits
+      url: https://developers.miro.com/docs/rate-limits
+      type: rate_limits

--- a/airbyte-integrations/connectors/source-missive/metadata.yaml
+++ b/airbyte-integrations/connectors/source-missive/metadata.yaml
@@ -33,3 +33,7 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Missive API documentation
+      url: https://missiveapp.com/help/api-documentation
+      type: api_reference

--- a/airbyte-integrations/connectors/source-mixmax/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mixmax/metadata.yaml
@@ -33,3 +33,7 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Mixmax API documentation
+      url: https://developer.mixmax.com/
+      type: api_reference

--- a/airbyte-integrations/connectors/source-mixpanel/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mixpanel/metadata.yaml
@@ -100,4 +100,17 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+    - title: Mixpanel API reference
+      url: https://developer.mixpanel.com/reference/overview
+      type: api_reference
+    - title: Mixpanel authentication
+      url: https://developer.mixpanel.com/reference/authentication
+      type: authentication_guide
+    - title: Mixpanel rate limits
+      url: https://developer.mixpanel.com/reference/rate-limits
+      type: rate_limits
+    - title: Mixpanel Status
+      url: https://status.mixpanel.com/
+      type: status_page
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-mode/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mode/metadata.yaml
@@ -33,3 +33,10 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Mode API documentation
+      url: https://mode.com/developer/api-reference/
+      type: api_reference
+    - title: Mode authentication
+      url: https://mode.com/developer/api-reference/authentication/
+      type: authentication_guide

--- a/airbyte-integrations/connectors/source-monday/metadata.yaml
+++ b/airbyte-integrations/connectors/source-monday/metadata.yaml
@@ -82,4 +82,17 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+    - title: monday.com API reference
+      url: https://developer.monday.com/api-reference/docs
+      type: api_reference
+    - title: monday.com authentication
+      url: https://developer.monday.com/api-reference/docs/authentication
+      type: authentication_guide
+    - title: monday.com rate limits
+      url: https://developer.monday.com/api-reference/docs/rate-limits
+      type: rate_limits
+    - title: monday.com Status
+      url: https://status.monday.com/
+      type: status_page
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-mongodb-v2/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mongodb-v2/metadata.yaml
@@ -91,4 +91,11 @@ data:
   supportLevel: certified
   tags:
     - language:java
+  externalDocumentationUrls:
+    - title: MongoDB documentation
+      url: https://www.mongodb.com/docs/
+      type: api_reference
+    - title: MongoDB authentication
+      url: https://www.mongodb.com/docs/manual/core/authentication/
+      type: authentication_guide
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-mssql/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mssql/metadata.yaml
@@ -50,4 +50,11 @@ data:
     - suite: unitTests
     - suite: integrationTests
     - suite: acceptanceTests
+  externalDocumentationUrls:
+    - title: SQL Server documentation
+      url: https://learn.microsoft.com/en-us/sql/sql-server/
+      type: api_reference
+    - title: SQL Server authentication
+      url: https://learn.microsoft.com/en-us/sql/relational-databases/security/choose-an-authentication-mode
+      type: authentication_guide
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-mux/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mux/metadata.yaml
@@ -33,3 +33,13 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Mux API reference
+      url: https://docs.mux.com/api-reference
+      type: api_reference
+    - title: Mux authentication
+      url: https://docs.mux.com/guides/system/make-api-requests
+      type: authentication_guide
+    - title: Mux Status
+      url: https://status.mux.com/
+      type: status_page

--- a/airbyte-integrations/connectors/source-my-hours/metadata.yaml
+++ b/airbyte-integrations/connectors/source-my-hours/metadata.yaml
@@ -47,4 +47,8 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+    - title: My Hours API documentation
+      url: https://myhours.com/api
+      type: api_reference
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-mysql/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mysql/metadata.yaml
@@ -78,4 +78,11 @@ data:
         upgradeDeadline: "2023-08-17"
     rolloutConfiguration:
       enableProgressiveRollout: false
+  externalDocumentationUrls:
+    - title: MySQL documentation
+      url: https://dev.mysql.com/doc/
+      type: api_reference
+    - title: MySQL authentication
+      url: https://dev.mysql.com/doc/refman/8.0/en/access-control.html
+      type: authentication_guide
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-n8n/metadata.yaml
+++ b/airbyte-integrations/connectors/source-n8n/metadata.yaml
@@ -38,4 +38,8 @@ data:
   #           alias: airbyte-connector-testing-secret-store
   connectorBuildOptions:
     baseImage: docker.io/airbyte/source-declarative-manifest:6.48.6@sha256:18b5219ed52d5dd26e9a513f5d9c590ddd78da1779e72795f2669bc4420bc576
+  externalDocumentationUrls:
+    - title: n8n API documentation
+      url: https://docs.n8n.io/api/
+      type: api_reference
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-nasa/metadata.yaml
+++ b/airbyte-integrations/connectors/source-nasa/metadata.yaml
@@ -39,4 +39,8 @@ data:
     - language:manifest-only
   connectorBuildOptions:
     baseImage: docker.io/airbyte/source-declarative-manifest:6.60.0@sha256:8a01d4fabdc7cbee92a583cc30fe08bb8ebba0e8d54569920d29378772b31699
+  externalDocumentationUrls:
+    - title: NASA APIs
+      url: https://api.nasa.gov/
+      type: api_reference
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-navan/metadata.yaml
+++ b/airbyte-integrations/connectors/source-navan/metadata.yaml
@@ -33,3 +33,7 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Navan API documentation
+      url: https://developer.navan.com/
+      type: api_reference

--- a/airbyte-integrations/connectors/source-nebius-ai/metadata.yaml
+++ b/airbyte-integrations/connectors/source-nebius-ai/metadata.yaml
@@ -33,3 +33,7 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Nebius AI documentation
+      url: https://nebius.ai/docs/
+      type: api_reference

--- a/airbyte-integrations/connectors/source-netsuite/metadata.yaml
+++ b/airbyte-integrations/connectors/source-netsuite/metadata.yaml
@@ -37,4 +37,11 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+    - title: NetSuite REST API
+      url: https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/chapter_1540391670.html
+      type: api_reference
+    - title: NetSuite authentication
+      url: https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/section_4389727047.html
+      type: authentication_guide
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-news-api/metadata.yaml
+++ b/airbyte-integrations/connectors/source-news-api/metadata.yaml
@@ -44,4 +44,8 @@ data:
   #         secretStore:
   #           type: GSM
   #           alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+    - title: News API documentation
+      url: https://newsapi.org/docs
+      type: api_reference
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-newsdata-io/metadata.yaml
+++ b/airbyte-integrations/connectors/source-newsdata-io/metadata.yaml
@@ -33,3 +33,7 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: NewsData.io API documentation
+      url: https://newsdata.io/documentation
+      type: api_reference

--- a/airbyte-integrations/connectors/source-newsdata/metadata.yaml
+++ b/airbyte-integrations/connectors/source-newsdata/metadata.yaml
@@ -35,4 +35,8 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+    - title: NewsData.io API documentation
+      url: https://newsdata.io/documentation
+      type: api_reference
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-nexiopay/metadata.yaml
+++ b/airbyte-integrations/connectors/source-nexiopay/metadata.yaml
@@ -33,3 +33,7 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Nexio API documentation
+      url: https://docs.nexiopay.com/
+      type: api_reference

--- a/airbyte-integrations/connectors/source-ninjaone-rmm/metadata.yaml
+++ b/airbyte-integrations/connectors/source-ninjaone-rmm/metadata.yaml
@@ -33,3 +33,7 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: NinjaOne API documentation
+      url: https://developer.ninjarmm.com/
+      type: api_reference

--- a/airbyte-integrations/connectors/source-nocrm/metadata.yaml
+++ b/airbyte-integrations/connectors/source-nocrm/metadata.yaml
@@ -33,3 +33,7 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: noCRM API documentation
+      url: https://www.nocrm.io/api
+      type: api_reference

--- a/airbyte-integrations/connectors/source-northpass-lms/metadata.yaml
+++ b/airbyte-integrations/connectors/source-northpass-lms/metadata.yaml
@@ -32,4 +32,8 @@ data:
   tags:
     - cdk:low-code
     - language:manifest-only
+  externalDocumentationUrls:
+    - title: Northpass API documentation
+      url: https://developers.northpass.com/
+      type: api_reference
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-nutshell/metadata.yaml
+++ b/airbyte-integrations/connectors/source-nutshell/metadata.yaml
@@ -33,3 +33,10 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Nutshell API documentation
+      url: https://developers.nutshell.com/
+      type: api_reference
+    - title: Nutshell authentication
+      url: https://developers.nutshell.com/#authentication
+      type: authentication_guide

--- a/airbyte-integrations/connectors/source-nylas/metadata.yaml
+++ b/airbyte-integrations/connectors/source-nylas/metadata.yaml
@@ -33,3 +33,16 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Nylas API reference
+      url: https://developer.nylas.com/docs/api/
+      type: api_reference
+    - title: Nylas authentication
+      url: https://developer.nylas.com/docs/the-basics/authentication/
+      type: authentication_guide
+    - title: Nylas rate limits
+      url: https://developer.nylas.com/docs/dev-guide/platform/rate-limits/
+      type: rate_limits
+    - title: Nylas Status
+      url: https://status.nylas.com/
+      type: status_page

--- a/airbyte-integrations/connectors/source-nytimes/metadata.yaml
+++ b/airbyte-integrations/connectors/source-nytimes/metadata.yaml
@@ -40,4 +40,11 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+    - title: New York Times APIs
+      url: https://developer.nytimes.com/apis
+      type: api_reference
+    - title: NYT API authentication
+      url: https://developer.nytimes.com/get-started
+      type: authentication_guide
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-okta/metadata.yaml
+++ b/airbyte-integrations/connectors/source-okta/metadata.yaml
@@ -44,4 +44,17 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+    - title: Okta API reference
+      url: https://developer.okta.com/docs/reference/
+      type: api_reference
+    - title: Okta authentication
+      url: https://developer.okta.com/docs/guides/implement-oauth-for-okta/main/
+      type: authentication_guide
+    - title: Okta rate limits
+      url: https://developer.okta.com/docs/reference/rate-limits/
+      type: rate_limits
+    - title: Okta Status
+      url: https://status.okta.com/
+      type: status_page
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-omnisend/metadata.yaml
+++ b/airbyte-integrations/connectors/source-omnisend/metadata.yaml
@@ -33,3 +33,10 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Omnisend API documentation
+      url: https://api-docs.omnisend.com/
+      type: api_reference
+    - title: Omnisend authentication
+      url: https://api-docs.omnisend.com/reference/authentication
+      type: authentication_guide

--- a/airbyte-integrations/connectors/source-oncehub/metadata.yaml
+++ b/airbyte-integrations/connectors/source-oncehub/metadata.yaml
@@ -33,3 +33,7 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: OnceHub API documentation
+      url: https://developers.oncehub.com/
+      type: api_reference

--- a/airbyte-integrations/connectors/source-onepagecrm/metadata.yaml
+++ b/airbyte-integrations/connectors/source-onepagecrm/metadata.yaml
@@ -33,3 +33,7 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: OnePageCRM API documentation
+      url: https://developer.onepagecrm.com/
+      type: api_reference

--- a/airbyte-integrations/connectors/source-onesignal/metadata.yaml
+++ b/airbyte-integrations/connectors/source-onesignal/metadata.yaml
@@ -41,4 +41,17 @@ data:
   tags:
     - cdk:low-code
     - language:manifest-only
+  externalDocumentationUrls:
+    - title: OneSignal API reference
+      url: https://documentation.onesignal.com/reference
+      type: api_reference
+    - title: OneSignal authentication
+      url: https://documentation.onesignal.com/docs/accounts-and-keys
+      type: authentication_guide
+    - title: OneSignal rate limits
+      url: https://documentation.onesignal.com/docs/rate-limits
+      type: rate_limits
+    - title: OneSignal Status
+      url: https://status.onesignal.com/
+      type: status_page
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-onfleet/metadata.yaml
+++ b/airbyte-integrations/connectors/source-onfleet/metadata.yaml
@@ -33,3 +33,13 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Onfleet API reference
+      url: https://docs.onfleet.com/reference
+      type: api_reference
+    - title: Onfleet authentication
+      url: https://docs.onfleet.com/reference/authentication
+      type: authentication_guide
+    - title: Onfleet rate limits
+      url: https://docs.onfleet.com/reference/throttling
+      type: rate_limits

--- a/airbyte-integrations/connectors/source-open-data-dc/metadata.yaml
+++ b/airbyte-integrations/connectors/source-open-data-dc/metadata.yaml
@@ -33,3 +33,7 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Open Data DC
+      url: https://opendata.dc.gov/
+      type: api_reference

--- a/airbyte-integrations/connectors/source-open-exchange-rates/metadata.yaml
+++ b/airbyte-integrations/connectors/source-open-exchange-rates/metadata.yaml
@@ -40,4 +40,8 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+    - title: Open Exchange Rates API
+      url: https://docs.openexchangerates.org/
+      type: api_reference
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-openaq/metadata.yaml
+++ b/airbyte-integrations/connectors/source-openaq/metadata.yaml
@@ -33,3 +33,7 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: OpenAQ API documentation
+      url: https://docs.openaq.org/
+      type: api_reference

--- a/airbyte-integrations/connectors/source-openfda/metadata.yaml
+++ b/airbyte-integrations/connectors/source-openfda/metadata.yaml
@@ -33,3 +33,7 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: openFDA API documentation
+      url: https://open.fda.gov/apis/
+      type: api_reference

--- a/airbyte-integrations/connectors/source-openweather/metadata.yaml
+++ b/airbyte-integrations/connectors/source-openweather/metadata.yaml
@@ -40,4 +40,8 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+    - title: OpenWeather API documentation
+      url: https://openweathermap.org/api
+      type: api_reference
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-opinion-stage/metadata.yaml
+++ b/airbyte-integrations/connectors/source-opinion-stage/metadata.yaml
@@ -33,3 +33,7 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Opinion Stage API
+      url: https://www.opinionstage.com/api
+      type: api_reference

--- a/airbyte-integrations/connectors/source-opsgenie/metadata.yaml
+++ b/airbyte-integrations/connectors/source-opsgenie/metadata.yaml
@@ -35,4 +35,17 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+    - title: Opsgenie API reference
+      url: https://docs.opsgenie.com/docs/api-overview
+      type: api_reference
+    - title: Opsgenie authentication
+      url: https://docs.opsgenie.com/docs/api-authentication
+      type: authentication_guide
+    - title: Opsgenie rate limits
+      url: https://docs.opsgenie.com/docs/api-rate-limiting
+      type: rate_limits
+    - title: Opsgenie Status
+      url: https://status.opsgenie.com/
+      type: status_page
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-opuswatch/metadata.yaml
+++ b/airbyte-integrations/connectors/source-opuswatch/metadata.yaml
@@ -33,3 +33,7 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: OpusWatch API documentation
+      url: https://opuswatch.com/api
+      type: api_reference

--- a/airbyte-integrations/connectors/source-oracle-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/source-oracle-strict-encrypt/metadata.yaml
@@ -26,4 +26,11 @@ data:
   releaseStage: alpha
   tags:
     - language:java
+  externalDocumentationUrls:
+    - title: Oracle Database documentation
+      url: https://docs.oracle.com/en/database/
+      type: api_reference
+    - title: Oracle authentication
+      url: https://docs.oracle.com/en/database/oracle/oracle-database/19/dbseg/introduction-to-oracle-database-security.html
+      type: authentication_guide
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-oracle/metadata.yaml
+++ b/airbyte-integrations/connectors/source-oracle/metadata.yaml
@@ -38,4 +38,11 @@ data:
   supportLevel: community
   tags:
     - language:java
+  externalDocumentationUrls:
+    - title: Oracle Database documentation
+      url: https://docs.oracle.com/en/database/
+      type: api_reference
+    - title: Oracle authentication
+      url: https://docs.oracle.com/en/database/oracle/oracle-database/19/dbseg/introduction-to-oracle-database-security.html
+      type: authentication_guide
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-orb/metadata.yaml
+++ b/airbyte-integrations/connectors/source-orb/metadata.yaml
@@ -55,4 +55,14 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+    - title: Orb API reference
+      url: https://docs.withorb.com/reference/api-reference
+      type: api_reference
+    - title: Orb authentication
+      url: https://docs.withorb.com/reference/authentication
+      type: authentication_guide
+    - title: Orb Status
+      url: https://status.withorb.com/
+      type: status_page
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-oura/metadata.yaml
+++ b/airbyte-integrations/connectors/source-oura/metadata.yaml
@@ -32,4 +32,11 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  externalDocumentationUrls:
+    - title: Oura API documentation
+      url: https://cloud.ouraring.com/docs/
+      type: api_reference
+    - title: Oura authentication
+      url: https://cloud.ouraring.com/docs/authentication
+      type: authentication_guide
 metadataSpecVersion: "1.0"


### PR DESCRIPTION
## What

This PR adds `externalDocumentationUrls` metadata to 49 source connectors in Group H (source-microsoft-entra-id through source-oura). This is part of an ongoing effort to add external documentation links to all Airbyte connectors, improving discoverability of vendor documentation for users and developers.

**Context:**
- Group A (86 destinations): Merged in #69353
- Group B (47 sources): Merged in #69724
- Group C (49 sources): Merged in #69730
- Group D (50 sources): Merged in #69731
- Group E (45 sources): Merged in #69732
- Group F (44 sources): Merged in #69733
- Group G (46 sources): Merged in #69734
- **Group H (49 sources): This PR**
- Groups I-M (187 sources): Remaining

**Link to Devin run:** https://app.devin.ai/sessions/278efaf8c49f4261b899f1c1f465c91a  
**Requested by:** AJ Steers (@aaronsteers)

## How

Used surgical text insertion to add only the `externalDocumentationUrls` sections to connector metadata.yaml files, preserving existing formatting. Each connector receives curated documentation links categorized by type:
- `api_reference`: Main API documentation
- `authentication_guide`: Authentication/authorization docs
- `rate_limits`: Rate limiting information
- `status_page`: Service status pages

The changes are minimal and focused - only insertions, no deletions or reformatting of existing content.

## Review guide

**Key areas to review:**
1. **URL accuracy**: Spot-check a few URLs (especially for major connectors like Microsoft services, MongoDB, MySQL, Notion, Okta) to ensure they point to correct, relevant documentation
2. **Type categorization**: Verify that URL types make sense (e.g., authentication guides are actually about auth, not general API docs)
3. **YAML formatting**: Confirm the diff shows only insertions with proper indentation, no unintended formatting changes
4. **Skipped connector**: One connector (source-notion) was skipped because it already had externalDocumentationUrls - verify this is correct

**Connectors with most comprehensive docs (good spot-check candidates):**
- source-microsoft-entra-id (4 URLs)
- source-microsoft-teams (4 URLs)
- source-mixpanel (4 URLs)
- source-monday (4 URLs)
- source-notion (5 URLs - already existed)
- source-okta (4 URLs)

## User Impact

**Positive:**
- Users can now discover vendor documentation directly from connector metadata
- Improves self-service troubleshooting and configuration
- Better visibility into API capabilities, rate limits, and service status

**Negative:**
- None expected - this is purely additive metadata

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

This PR only adds metadata fields and doesn't change any functional code. Reverting would simply remove the documentation URLs from metadata, with no impact on connector functionality.