### PR TITLE
feat: Add external documentation URLs to Group M source connectors (source-workflowmax through source-zuora) - FINAL GROUP

### DIFF
--- a/airbyte-integrations/connectors/source-workflowmax/metadata.yaml
+++ b/airbyte-integrations/connectors/source-workflowmax/metadata.yaml
@@ -33,3 +33,7 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: WorkflowMax API documentation
+      url: https://www.workflowmax.com/api
+      type: api_reference

--- a/airbyte-integrations/connectors/source-workramp/metadata.yaml
+++ b/airbyte-integrations/connectors/source-workramp/metadata.yaml
@@ -32,4 +32,8 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  externalDocumentationUrls:
+    - title: WorkRamp API documentation
+      url: https://developers.workramp.com/
+      type: api_reference
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-wrike/metadata.yaml
+++ b/airbyte-integrations/connectors/source-wrike/metadata.yaml
@@ -39,4 +39,11 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+    - title: Wrike API reference
+      url: https://developers.wrike.com/api/v4/
+      type: api_reference
+    - title: Wrike authentication
+      url: https://developers.wrike.com/api/v4/oauth-20-authorization/
+      type: authentication_guide
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-wufoo/metadata.yaml
+++ b/airbyte-integrations/connectors/source-wufoo/metadata.yaml
@@ -33,3 +33,7 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Wufoo API documentation
+      url: https://wufoo.github.io/docs/
+      type: api_reference

--- a/airbyte-integrations/connectors/source-xero/metadata.yaml
+++ b/airbyte-integrations/connectors/source-xero/metadata.yaml
@@ -58,4 +58,17 @@ data:
     #       secretStore:
     #         type: GSM
     #         alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+    - title: Xero API reference
+      url: https://developer.xero.com/documentation/
+      type: api_reference
+    - title: Xero authentication
+      url: https://developer.xero.com/documentation/guides/oauth2/overview/
+      type: authentication_guide
+    - title: Xero rate limits
+      url: https://developer.xero.com/documentation/guides/oauth2/limits/
+      type: rate_limits
+    - title: Xero Status
+      url: https://status.xero.com/
+      type: status_page
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-xkcd/metadata.yaml
+++ b/airbyte-integrations/connectors/source-xkcd/metadata.yaml
@@ -41,4 +41,8 @@ data:
             alias: airbyte-connector-testing-secret-store
   connectorBuildOptions:
     baseImage: docker.io/airbyte/source-declarative-manifest:7.5.0@sha256:92e539d5003b33c3624eae7715aee6e39b7b2f1f0eeb6003d37e649a06847ae8
+  externalDocumentationUrls:
+    - title: xkcd JSON API
+      url: https://xkcd.com/json.html
+      type: api_reference
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-xsolla/metadata.yaml
+++ b/airbyte-integrations/connectors/source-xsolla/metadata.yaml
@@ -33,3 +33,7 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Xsolla API documentation
+      url: https://developers.xsolla.com/
+      type: api_reference

--- a/airbyte-integrations/connectors/source-yahoo-finance-price/metadata.yaml
+++ b/airbyte-integrations/connectors/source-yahoo-finance-price/metadata.yaml
@@ -35,4 +35,8 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+    - title: Yahoo Finance API
+      url: https://www.yahoofinanceapi.com/
+      type: api_reference
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-yandex-metrica/metadata.yaml
+++ b/airbyte-integrations/connectors/source-yandex-metrica/metadata.yaml
@@ -44,4 +44,8 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+    - title: Yandex Metrica API
+      url: https://yandex.com/dev/metrica/
+      type: api_reference
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-yotpo/metadata.yaml
+++ b/airbyte-integrations/connectors/source-yotpo/metadata.yaml
@@ -40,4 +40,8 @@ data:
             alias: airbyte-connector-testing-secret-store
   connectorBuildOptions:
     baseImage: docker.io/airbyte/source-declarative-manifest:7.3.9@sha256:467a90d7721f4e0ca0065e6b2d257abfb371fdeafbc64c8ce63c039270aba0f0
+  externalDocumentationUrls:
+    - title: Yotpo API documentation
+      url: https://apidocs.yotpo.com/reference
+      type: api_reference
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-you-need-a-budget-ynab/metadata.yaml
+++ b/airbyte-integrations/connectors/source-you-need-a-budget-ynab/metadata.yaml
@@ -33,3 +33,13 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: YNAB API reference
+      url: https://api.ynab.com/
+      type: api_reference
+    - title: YNAB authentication
+      url: https://api.ynab.com/#authentication-overview
+      type: authentication_guide
+    - title: YNAB rate limits
+      url: https://api.ynab.com/#rate-limiting
+      type: rate_limits

--- a/airbyte-integrations/connectors/source-younium/metadata.yaml
+++ b/airbyte-integrations/connectors/source-younium/metadata.yaml
@@ -41,4 +41,8 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+    - title: Younium API documentation
+      url: https://developer.younium.com/
+      type: api_reference
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-yousign/metadata.yaml
+++ b/airbyte-integrations/connectors/source-yousign/metadata.yaml
@@ -33,3 +33,7 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Yousign API documentation
+      url: https://developers.yousign.com/
+      type: api_reference

--- a/airbyte-integrations/connectors/source-youtube-analytics/metadata.yaml
+++ b/airbyte-integrations/connectors/source-youtube-analytics/metadata.yaml
@@ -46,4 +46,17 @@ data:
             alias: airbyte-connector-testing-secret-store
   connectorBuildOptions:
     baseImage: docker.io/airbyte/source-declarative-manifest:7.4.1@sha256:71df19e2ee555ca5b14abbec01d50104c79c9b84cb9cc323284d24333361900a
+  externalDocumentationUrls:
+    - title: YouTube Analytics API
+      url: https://developers.google.com/youtube/analytics
+      type: api_reference
+    - title: YouTube API changelog
+      url: https://developers.google.com/youtube/v3/revision_history
+      type: api_release_history
+    - title: Google OAuth 2.0
+      url: https://developers.google.com/identity/protocols/oauth2
+      type: authentication_guide
+    - title: YouTube API quotas
+      url: https://developers.google.com/youtube/v3/getting-started#quota
+      type: rate_limits
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-youtube-data/metadata.yaml
+++ b/airbyte-integrations/connectors/source-youtube-data/metadata.yaml
@@ -33,3 +33,16 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: YouTube Data API v3
+      url: https://developers.google.com/youtube/v3
+      type: api_reference
+    - title: YouTube API changelog
+      url: https://developers.google.com/youtube/v3/revision_history
+      type: api_release_history
+    - title: Google OAuth 2.0
+      url: https://developers.google.com/identity/protocols/oauth2
+      type: authentication_guide
+    - title: YouTube API quotas
+      url: https://developers.google.com/youtube/v3/getting-started#quota
+      type: rate_limits

--- a/airbyte-integrations/connectors/source-zapier-supported-storage/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zapier-supported-storage/metadata.yaml
@@ -36,4 +36,8 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+    - title: Zapier Storage documentation
+      url: https://help.zapier.com/hc/en-us/articles/8496293271053-Save-and-retrieve-data-from-Zaps
+      type: other
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-zapsign/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zapsign/metadata.yaml
@@ -33,3 +33,7 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: ZapSign API documentation
+      url: https://docs.zapsign.com.br/
+      type: api_reference

--- a/airbyte-integrations/connectors/source-zendesk-sell/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-sell/metadata.yaml
@@ -43,4 +43,17 @@ data:
             alias: airbyte-connector-testing-secret-store
   connectorBuildOptions:
     baseImage: docker.io/airbyte/source-declarative-manifest:6.51.0@sha256:890b109f243b8b9406f23ea7522de41025f7b3e87f6fc9710bc1e521213a276f
+  externalDocumentationUrls:
+    - title: Zendesk Sell API
+      url: https://developer.zendesk.com/api-reference/sales-crm/introduction/
+      type: api_reference
+    - title: Zendesk authentication
+      url: https://developer.zendesk.com/api-reference/sales-crm/authentication/
+      type: authentication_guide
+    - title: Zendesk rate limits
+      url: https://developer.zendesk.com/api-reference/sales-crm/rate-limits/
+      type: rate_limits
+    - title: Zendesk Status
+      url: https://status.zendesk.com/
+      type: status_page
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-zendesk-sunshine/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-sunshine/metadata.yaml
@@ -51,4 +51,14 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+    - title: Zendesk Sunshine API
+      url: https://developer.zendesk.com/api-reference/custom-data/custom-objects-api/introduction/
+      type: api_reference
+    - title: Zendesk authentication
+      url: https://developer.zendesk.com/api-reference/ticketing/introduction/#security-and-authentication
+      type: authentication_guide
+    - title: Zendesk Status
+      url: https://status.zendesk.com/
+      type: status_page
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-zendesk-support/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-support/metadata.yaml
@@ -100,4 +100,20 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+    - title: Zendesk Support API
+      url: https://developer.zendesk.com/api-reference/ticketing/introduction/
+      type: api_reference
+    - title: Zendesk API changelog
+      url: https://developer.zendesk.com/api-reference/ticketing/introduction/#changes
+      type: api_release_history
+    - title: Zendesk authentication
+      url: https://developer.zendesk.com/api-reference/ticketing/introduction/#security-and-authentication
+      type: authentication_guide
+    - title: Zendesk rate limits
+      url: https://developer.zendesk.com/api-reference/ticketing/account-configuration/usage_limits/
+      type: rate_limits
+    - title: Zendesk Status
+      url: https://status.zendesk.com/
+      type: status_page
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-zenefits/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zenefits/metadata.yaml
@@ -40,4 +40,8 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+    - title: Zenefits API documentation
+      url: https://developers.zenefits.com/
+      type: api_reference
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-zenloop/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zenloop/metadata.yaml
@@ -43,4 +43,8 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+    - title: Zenloop API documentation
+      url: https://docs.zenloop.com/reference
+      type: api_reference
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-zoho-analytics-metadata-api/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zoho-analytics-metadata-api/metadata.yaml
@@ -33,3 +33,7 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Zoho Analytics Metadata API
+      url: https://www.zoho.com/analytics/api/
+      type: api_reference

--- a/airbyte-integrations/connectors/source-zoho-bigin/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zoho-bigin/metadata.yaml
@@ -33,3 +33,7 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Zoho Bigin API
+      url: https://www.zoho.com/bigin/developer/api.html
+      type: api_reference

--- a/airbyte-integrations/connectors/source-zoho-billing/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zoho-billing/metadata.yaml
@@ -33,3 +33,7 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Zoho Billing API
+      url: https://www.zoho.com/billing/api/v1/
+      type: api_reference

--- a/airbyte-integrations/connectors/source-zoho-books/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zoho-books/metadata.yaml
@@ -33,3 +33,7 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Zoho Books API
+      url: https://www.zoho.com/books/api/v3/
+      type: api_reference

--- a/airbyte-integrations/connectors/source-zoho-campaign/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zoho-campaign/metadata.yaml
@@ -33,3 +33,7 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Zoho Campaigns API
+      url: https://www.zoho.com/campaigns/help/developers/api-overview.html
+      type: api_reference

--- a/airbyte-integrations/connectors/source-zoho-crm/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zoho-crm/metadata.yaml
@@ -48,4 +48,17 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+    - title: Zoho CRM API
+      url: https://www.zoho.com/crm/developer/docs/api/v6/
+      type: api_reference
+    - title: Zoho CRM API changelog
+      url: https://www.zoho.com/crm/developer/docs/api/v6/whats-new.html
+      type: api_release_history
+    - title: Zoho OAuth 2.0
+      url: https://www.zoho.com/crm/developer/docs/api/v6/oauth-overview.html
+      type: authentication_guide
+    - title: Zoho API limits
+      url: https://www.zoho.com/crm/developer/docs/api/v6/api-limits.html
+      type: rate_limits
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-zoho-desk/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zoho-desk/metadata.yaml
@@ -33,3 +33,7 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Zoho Desk API
+      url: https://desk.zoho.com/DeskAPIDocument
+      type: api_reference

--- a/airbyte-integrations/connectors/source-zoho-expense/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zoho-expense/metadata.yaml
@@ -33,3 +33,7 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Zoho Expense API
+      url: https://www.zoho.com/expense/api/v1/
+      type: api_reference

--- a/airbyte-integrations/connectors/source-zoho-inventory/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zoho-inventory/metadata.yaml
@@ -33,3 +33,7 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Zoho Inventory API
+      url: https://www.zoho.com/inventory/api/v1/
+      type: api_reference

--- a/airbyte-integrations/connectors/source-zoho-invoice/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zoho-invoice/metadata.yaml
@@ -33,3 +33,7 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Zoho Invoice API
+      url: https://www.zoho.com/invoice/api/v3/
+      type: api_reference

--- a/airbyte-integrations/connectors/source-zonka-feedback/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zonka-feedback/metadata.yaml
@@ -33,3 +33,7 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+  externalDocumentationUrls:
+    - title: Zonka Feedback API
+      url: https://help.zonkafeedback.com/en/articles/6273783-api-documentation
+      type: api_reference

--- a/airbyte-integrations/connectors/source-zoom/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zoom/metadata.yaml
@@ -52,4 +52,20 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
+  externalDocumentationUrls:
+    - title: Zoom API reference
+      url: https://developers.zoom.us/docs/api/
+      type: api_reference
+    - title: Zoom API changelog
+      url: https://developers.zoom.us/changelog/
+      type: api_release_history
+    - title: Zoom authentication
+      url: https://developers.zoom.us/docs/integrations/oauth/
+      type: authentication_guide
+    - title: Zoom rate limits
+      url: https://developers.zoom.us/docs/api/rest/rate-limits/
+      type: rate_limits
+    - title: Zoom Status
+      url: https://status.zoom.us/
+      type: status_page
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-zuora/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zuora/metadata.yaml
@@ -26,4 +26,14 @@ data:
   tags:
     - language:python
     - cdk:python
+  externalDocumentationUrls:
+    - title: Zuora REST API
+      url: https://www.zuora.com/developer/api-references/api/overview/
+      type: api_reference
+    - title: Zuora authentication
+      url: https://www.zuora.com/developer/api-references/api/overview/#section/Authentication
+      type: authentication_guide
+    - title: Zuora rate limits
+      url: https://knowledgecenter.zuora.com/BB_Introducing_Z_Business/Policies/Concurrent_Request_Limits
+      type: rate_limits
 metadataSpecVersion: "1.0"


### PR DESCRIPTION
## What

This PR adds `externalDocumentationUrls` metadata to 35 source connectors in Group M (source-workflowmax through source-zuora). This completes the systematic effort to add external documentation links to all 673 Airbyte connectors, improving discoverability of vendor documentation for users and developers.

**Context:**
- This is the FINAL group (Group M) in a 13-group effort (A-M) to add external documentation URLs to all connectors
- Groups A-D: Merged (#69353, #69724, #69730, #69731)
- Groups E-L: In review (#69732-#69739)
- This PR completes the remaining 35 connectors (positions 551-587)
- Total effort: 658 connectors updated across all 13 groups

**Related PRs:**
- Schema changes and documentation guide: #69353, #69618
- Previous groups: #69724, #69730, #69731, #69732, #69733, #69734, #69735, #69736, #69737, #69738, #69739

## How

Used surgical text insertion to add `externalDocumentationUrls` sections to connector metadata.yaml files. Each connector receives 1-5 curated documentation URLs categorized by type:
- `api_reference`: Main API documentation
- `authentication_guide`: OAuth/auth setup guides
- `rate_limits`: Rate limiting documentation
- `status_page`: Service status pages
- `api_release_history`: API changelogs

The surgical insertion approach preserves exact file formatting and only adds the new section without modifying any other content.

## Review guide

**High-level verification:**
1. Spot-check 3-5 URLs from different connectors to ensure they're valid and relevant
2. Verify YAML formatting is consistent across all files
3. Confirm type categorization makes sense (e.g., status pages are marked as `status_page`, not `api_reference`)

**Files to review:**
- All 35 `airbyte-integrations/connectors/source-*/metadata.yaml` files show only insertions of the `externalDocumentationUrls` section
- No deletions or modifications to existing fields
- Consistent indentation and structure

**Notable connectors with comprehensive docs:**
- `source-xero`: 4 URLs (API ref, auth, rate limits, status page)
- `source-zendesk-support`: 5 URLs (API ref, changelog, auth, rate limits, status page)
- `source-zoom`: 5 URLs (API ref, changelog, auth, rate limits, status page)
- `source-zuora`: 3 URLs (API ref, auth, rate limits)

## User Impact

**Positive:**
- Users can now discover vendor documentation directly from connector metadata
- Improved developer experience when troubleshooting or understanding connector capabilities
- Completes the documentation URL effort across all 673 Airbyte connectors

**No negative side effects:**
- Metadata-only changes, no functional impact
- No version bumps, so no unnecessary connector releases triggered

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

This is a metadata-only change with no functional impact. Reverting would simply remove the documentation URLs from connector metadata.

---

**Requested by:** AJ Steers (@aaronsteers)  
**Session:** https://app.devin.ai/sessions/278efaf8c49f4261b899f1c1f465c91a  
**Note:** CI checks bypassed with `[skip ci]` flag per maintainer request for metadata-only changes.