### PR TITLE
chore: Sort externalDocumentationUrls by type then title (do not merge)

### DIFF
--- a/airbyte-integrations/connectors/destination-astra/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-astra/metadata.yaml
@@ -48,10 +48,10 @@ data:
     - title: DataStax Astra documentation
       url: https://docs.datastax.com/en/astra-serverless/docs/
       type: api_reference
-    - title: CQL reference
-      url: https://docs.datastax.com/en/cql-oss/3.x/cql/cql_reference/cqlReferenceTOC.html
-      type: sql_reference
     - title: Authentication
       url: https://docs.datastax.com/en/astra-serverless/docs/manage/org/manage-tokens.html
       type: authentication_guide
+    - title: CQL reference
+      url: https://docs.datastax.com/en/cql-oss/3.x/cql/cql_reference/cqlReferenceTOC.html
+      type: sql_reference
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-bigquery-denormalized/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-bigquery-denormalized/metadata.yaml
@@ -36,10 +36,10 @@ data:
     - title: BigQuery documentation
       url: https://cloud.google.com/bigquery/docs
       type: api_reference
-    - title: Standard SQL reference
-      url: https://cloud.google.com/bigquery/docs/reference/standard-sql
-      type: sql_reference
     - title: Service account authentication
       url: https://cloud.google.com/iam/docs/service-accounts
       type: authentication_guide
+    - title: Standard SQL reference
+      url: https://cloud.google.com/bigquery/docs/reference/standard-sql
+      type: sql_reference
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-bigquery/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-bigquery/metadata.yaml
@@ -88,9 +88,6 @@ data:
     - title: Release notes
       url: https://cloud.google.com/bigquery/docs/release-notes
       type: api_release_history
-    - title: Standard SQL reference
-      url: https://cloud.google.com/bigquery/docs/reference/standard-sql
-      type: sql_reference
     - title: Service account authentication
       url: https://cloud.google.com/iam/docs/service-accounts
       type: authentication_guide
@@ -100,6 +97,9 @@ data:
     - title: Quotas and limits
       url: https://cloud.google.com/bigquery/quotas
       type: rate_limits
+    - title: Standard SQL reference
+      url: https://cloud.google.com/bigquery/docs/reference/standard-sql
+      type: sql_reference
     - title: Google Cloud Status
       url: https://status.cloud.google.com/
       type: status_page

--- a/airbyte-integrations/connectors/destination-cassandra/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-cassandra/metadata.yaml
@@ -25,10 +25,10 @@ data:
     - title: Cassandra documentation
       url: https://cassandra.apache.org/doc/latest/
       type: api_reference
-    - title: CQL reference
-      url: https://cassandra.apache.org/doc/latest/cassandra/cql/
-      type: sql_reference
     - title: Authentication
       url: https://cassandra.apache.org/doc/latest/cassandra/configuration/cass_yaml_file.html#authenticator
       type: authentication_guide
+    - title: CQL reference
+      url: https://cassandra.apache.org/doc/latest/cassandra/cql/
+      type: sql_reference
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
@@ -54,13 +54,13 @@ data:
     - title: ClickHouse documentation
       url: https://clickhouse.com/docs
       type: api_reference
-    - title: SQL reference
-      url: https://clickhouse.com/docs/en/sql-reference
-      type: sql_reference
-    - title: User authentication
-      url: https://clickhouse.com/docs/en/operations/access-rights
-      type: authentication_guide
     - title: Changelog
       url: https://clickhouse.com/docs/whats-new/changelog
       type: api_release_history
+    - title: User authentication
+      url: https://clickhouse.com/docs/en/operations/access-rights
+      type: authentication_guide
+    - title: SQL reference
+      url: https://clickhouse.com/docs/en/sql-reference
+      type: sql_reference
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-databricks/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-databricks/metadata.yaml
@@ -78,15 +78,15 @@ data:
     - title: Release notes
       url: https://docs.databricks.com/release-notes/index.html
       type: api_release_history
-    - title: SQL reference
-      url: https://docs.databricks.com/sql/language-manual/index.html
-      type: sql_reference
     - title: Authentication
       url: https://docs.databricks.com/dev-tools/auth.html
       type: authentication_guide
     - title: Access control
       url: https://docs.databricks.com/security/access-control/index.html
       type: permissions_scopes
+    - title: SQL reference
+      url: https://docs.databricks.com/sql/language-manual/index.html
+      type: sql_reference
     - title: Databricks Status
       url: https://status.databricks.com/
       type: status_page

--- a/airbyte-integrations/connectors/destination-firebolt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-firebolt/metadata.yaml
@@ -38,10 +38,10 @@ data:
     - title: Firebolt documentation
       url: https://docs.firebolt.io/
       type: api_reference
-    - title: SQL reference
-      url: https://docs.firebolt.io/sql_reference/
-      type: sql_reference
     - title: Authentication
       url: https://docs.firebolt.io/godocs/Overview/managing-your-organization/service-accounts.html
       type: authentication_guide
+    - title: SQL reference
+      url: https://docs.firebolt.io/sql_reference/
+      type: sql_reference
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-gcs/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-gcs/metadata.yaml
@@ -47,6 +47,9 @@ data:
     - title: Cloud Storage documentation
       url: https://cloud.google.com/storage/docs
       type: api_reference
+    - title: Google Cloud Release Notes
+      url: https://cloud.google.com/release-notes
+      type: api_release_history
     - title: Service account authentication
       url: https://cloud.google.com/iam/docs/service-accounts
       type: authentication_guide
@@ -59,7 +62,4 @@ data:
     - title: Google Cloud Status
       url: https://status.cloud.google.com/
       type: status_page
-    - title: Google Cloud Release Notes
-      url: https://cloud.google.com/release-notes
-      type: api_release_history
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-hubspot/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-hubspot/metadata.yaml
@@ -33,6 +33,9 @@ data:
     - title: HubSpot API documentation
       url: https://developers.hubspot.com/docs/api/overview
       type: api_reference
+    - title: HubSpot Developer Changelog
+      url: https://developers.hubspot.com/changelog
+      type: api_release_history
     - title: OAuth
       url: https://developers.hubspot.com/docs/api/oauth-quickstart-guide
       type: authentication_guide
@@ -42,7 +45,4 @@ data:
     - title: HubSpot Status
       url: https://status.hubspot.com/
       type: status_page
-    - title: HubSpot Developer Changelog
-      url: https://developers.hubspot.com/changelog
-      type: api_release_history
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-milvus/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-milvus/metadata.yaml
@@ -57,10 +57,10 @@ data:
     - title: Milvus documentation
       url: https://milvus.io/docs
       type: api_reference
-    - title: Authentication
-      url: https://milvus.io/docs/authenticate.md
-      type: authentication_guide
     - title: Release notes
       url: https://milvus.io/docs/release_notes.md
       type: api_release_history
+    - title: Authentication
+      url: https://milvus.io/docs/authenticate.md
+      type: authentication_guide
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-mongodb/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mongodb/metadata.yaml
@@ -32,6 +32,9 @@ data:
     - title: MongoDB documentation
       url: https://www.mongodb.com/docs/
       type: api_reference
+    - title: Release Notes
+      url: https://www.mongodb.com/docs/manual/release-notes/
+      type: api_release_history
     - title: Authentication
       url: https://www.mongodb.com/docs/manual/core/authentication/
       type: authentication_guide
@@ -41,7 +44,4 @@ data:
     - title: MongoDB Status
       url: https://status.mongodb.com/
       type: status_page
-    - title: Release Notes
-      url: https://www.mongodb.com/docs/manual/release-notes/
-      type: api_release_history
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-mssql/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mssql/metadata.yaml
@@ -50,16 +50,16 @@ data:
     - title: SQL Server documentation
       url: https://learn.microsoft.com/en-us/sql/sql-server/
       type: api_reference
-    - title: Transact-SQL reference
-      url: https://learn.microsoft.com/en-us/sql/t-sql/language-reference
-      type: sql_reference
+    - title: SQL Server 2022 release notes
+      url: https://learn.microsoft.com/en-us/sql/sql-server/sql-server-2022-release-notes
+      type: api_release_history
     - title: Authentication and authorization
       url: https://learn.microsoft.com/en-us/sql/relational-databases/security/authentication-access/getting-started-with-database-engine-permissions
       type: authentication_guide
     - title: Permissions
       url: https://learn.microsoft.com/en-us/sql/relational-databases/security/permissions-database-engine
       type: permissions_scopes
-    - title: SQL Server 2022 release notes
-      url: https://learn.microsoft.com/en-us/sql/sql-server/sql-server-2022-release-notes
-      type: api_release_history
+    - title: Transact-SQL reference
+      url: https://learn.microsoft.com/en-us/sql/t-sql/language-reference
+      type: sql_reference
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-mysql-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mysql-strict-encrypt/metadata.yaml
@@ -48,13 +48,13 @@ data:
     - title: MySQL documentation
       url: https://dev.mysql.com/doc/
       type: api_reference
-    - title: SQL statement syntax
-      url: https://dev.mysql.com/doc/refman/8.0/en/sql-statements.html
-      type: sql_reference
     - title: Access control and account management
       url: https://dev.mysql.com/doc/refman/8.0/en/access-control.html
       type: authentication_guide
     - title: GRANT statement
       url: https://dev.mysql.com/doc/refman/8.0/en/grant.html
       type: permissions_scopes
+    - title: SQL statement syntax
+      url: https://dev.mysql.com/doc/refman/8.0/en/sql-statements.html
+      type: sql_reference
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-mysql/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mysql/metadata.yaml
@@ -60,16 +60,16 @@ data:
     - title: MySQL documentation
       url: https://dev.mysql.com/doc/
       type: api_reference
-    - title: SQL statement syntax
-      url: https://dev.mysql.com/doc/refman/8.0/en/sql-statements.html
-      type: sql_reference
+    - title: MySQL Release Notes
+      url: https://dev.mysql.com/doc/relnotes/mysql/en/
+      type: api_release_history
     - title: Access control and account management
       url: https://dev.mysql.com/doc/refman/8.0/en/access-control.html
       type: authentication_guide
     - title: GRANT statement
       url: https://dev.mysql.com/doc/refman/8.0/en/grant.html
       type: permissions_scopes
-    - title: MySQL Release Notes
-      url: https://dev.mysql.com/doc/relnotes/mysql/en/
-      type: api_release_history
+    - title: SQL statement syntax
+      url: https://dev.mysql.com/doc/refman/8.0/en/sql-statements.html
+      type: sql_reference
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-oracle-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-oracle-strict-encrypt/metadata.yaml
@@ -39,13 +39,13 @@ data:
     - title: Oracle Database documentation
       url: https://docs.oracle.com/en/database/
       type: api_reference
-    - title: SQL language reference
-      url: https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/
-      type: sql_reference
     - title: Database authentication
       url: https://docs.oracle.com/en/database/oracle/oracle-database/19/dbseg/configuring-authentication.html
       type: authentication_guide
     - title: Managing security
       url: https://docs.oracle.com/en/database/oracle/oracle-database/19/dbseg/
       type: permissions_scopes
+    - title: SQL language reference
+      url: https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/
+      type: sql_reference
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-oracle/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-oracle/metadata.yaml
@@ -49,16 +49,16 @@ data:
     - title: Oracle Database documentation
       url: https://docs.oracle.com/en/database/
       type: api_reference
-    - title: SQL language reference
-      url: https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/
-      type: sql_reference
+    - title: Oracle Database Release Notes
+      url: https://docs.oracle.com/en/database/oracle/oracle-database/
+      type: api_release_history
     - title: Database authentication
       url: https://docs.oracle.com/en/database/oracle/oracle-database/19/dbseg/configuring-authentication.html
       type: authentication_guide
     - title: Managing security
       url: https://docs.oracle.com/en/database/oracle/oracle-database/19/dbseg/
       type: permissions_scopes
-    - title: Oracle Database Release Notes
-      url: https://docs.oracle.com/en/database/oracle/oracle-database/
-      type: api_release_history
+    - title: SQL language reference
+      url: https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/
+      type: sql_reference
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-pgvector/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-pgvector/metadata.yaml
@@ -51,10 +51,10 @@ data:
             type: GSM
             alias: airbyte-connector-testing-secret-store
   externalDocumentationUrls:
-    - title: pgvector documentation
-      url: https://github.com/pgvector/pgvector
-      type: api_reference
     - title: PostgreSQL documentation
       url: https://www.postgresql.org/docs/current/
+      type: api_reference
+    - title: pgvector documentation
+      url: https://github.com/pgvector/pgvector
       type: api_reference
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-pinecone/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-pinecone/metadata.yaml
@@ -61,15 +61,15 @@ data:
     - title: Pinecone documentation
       url: https://docs.pinecone.io/
       type: api_reference
+    - title: Release notes
+      url: https://docs.pinecone.io/release-notes
+      type: api_release_history
     - title: Authentication
       url: https://docs.pinecone.io/guides/get-started/authentication
       type: authentication_guide
     - title: Rate limits
       url: https://docs.pinecone.io/troubleshooting/rate-limits
       type: rate_limits
-    - title: Release notes
-      url: https://docs.pinecone.io/release-notes
-      type: api_release_history
     - title: Pinecone Status
       url: https://status.pinecone.io/
       type: status_page

--- a/airbyte-integrations/connectors/destination-postgres-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-postgres-strict-encrypt/metadata.yaml
@@ -42,13 +42,13 @@ data:
     - title: PostgreSQL documentation
       url: https://www.postgresql.org/docs/current/
       type: api_reference
-    - title: SQL commands
-      url: https://www.postgresql.org/docs/current/sql-commands.html
-      type: sql_reference
     - title: Client authentication
       url: https://www.postgresql.org/docs/current/client-authentication.html
       type: authentication_guide
     - title: Database roles and privileges
       url: https://www.postgresql.org/docs/current/user-manag.html
       type: permissions_scopes
+    - title: SQL commands
+      url: https://www.postgresql.org/docs/current/sql-commands.html
+      type: sql_reference
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-postgres/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-postgres/metadata.yaml
@@ -51,16 +51,16 @@ data:
     - title: PostgreSQL documentation
       url: https://www.postgresql.org/docs/current/
       type: api_reference
-    - title: SQL commands
-      url: https://www.postgresql.org/docs/current/sql-commands.html
-      type: sql_reference
+    - title: Release Notes
+      url: https://www.postgresql.org/docs/release/
+      type: api_release_history
     - title: Client authentication
       url: https://www.postgresql.org/docs/current/client-authentication.html
       type: authentication_guide
     - title: Database roles and privileges
       url: https://www.postgresql.org/docs/current/user-manag.html
       type: permissions_scopes
-    - title: Release Notes
-      url: https://www.postgresql.org/docs/release/
-      type: api_release_history
+    - title: SQL commands
+      url: https://www.postgresql.org/docs/current/sql-commands.html
+      type: sql_reference
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-qdrant/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-qdrant/metadata.yaml
@@ -44,10 +44,10 @@ data:
     - title: Qdrant documentation
       url: https://qdrant.tech/documentation/
       type: api_reference
-    - title: Authentication
-      url: https://qdrant.tech/documentation/guides/security/
-      type: authentication_guide
     - title: Release notes
       url: https://github.com/qdrant/qdrant/releases
       type: api_release_history
+    - title: Authentication
+      url: https://qdrant.tech/documentation/guides/security/
+      type: authentication_guide
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-redis/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-redis/metadata.yaml
@@ -31,10 +31,10 @@ data:
     - title: Redis documentation
       url: https://redis.io/docs/
       type: api_reference
-    - title: Redis ACL
-      url: https://redis.io/docs/management/security/acl/
-      type: permissions_scopes
     - title: Release notes
       url: https://redis.io/docs/about/releases/
       type: api_release_history
+    - title: Redis ACL
+      url: https://redis.io/docs/management/security/acl/
+      type: permissions_scopes
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-redshift/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-redshift/metadata.yaml
@@ -92,12 +92,12 @@ data:
   tags:
     - language:java
   externalDocumentationUrls:
+    - title: Cluster versions
+      url: https://docs.aws.amazon.com/redshift/latest/mgmt/cluster-versions.html
+      type: api_release_history
     - title: Release notes
       url: https://docs.aws.amazon.com/redshift/latest/mgmt/release-notes.html
       type: api_release_history
-    - title: SQL reference
-      url: https://docs.aws.amazon.com/redshift/latest/dg/c_SQL_reference.html
-      type: sql_reference
     - title: Database authentication
       url: https://docs.aws.amazon.com/redshift/latest/mgmt/generating-user-credentials.html
       type: authentication_guide
@@ -107,10 +107,10 @@ data:
     - title: Quotas and limits
       url: https://docs.aws.amazon.com/redshift/latest/mgmt/amazon-redshift-limits.html
       type: rate_limits
+    - title: SQL reference
+      url: https://docs.aws.amazon.com/redshift/latest/dg/c_SQL_reference.html
+      type: sql_reference
     - title: AWS Service Health Dashboard
       url: https://health.aws.amazon.com/health/status
       type: status_page
-    - title: Cluster versions
-      url: https://docs.aws.amazon.com/redshift/latest/mgmt/cluster-versions.html
-      type: api_release_history
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-rockset/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-rockset/metadata.yaml
@@ -21,11 +21,11 @@ data:
     ql: 100
   supportLevel: archived
   externalDocumentationUrls:
-    - title: Rockset documentation
-      url: https://rockset.com/docs/
-      type: api_reference
     - title: API reference
       url: https://rockset.com/docs/rest-api/
+      type: api_reference
+    - title: Rockset documentation
+      url: https://rockset.com/docs/
       type: api_reference
     - title: Authentication
       url: https://rockset.com/docs/rest-api/#authentication

--- a/airbyte-integrations/connectors/destination-scylla/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-scylla/metadata.yaml
@@ -25,10 +25,10 @@ data:
     - title: ScyllaDB documentation
       url: https://docs.scylladb.com/
       type: api_reference
-    - title: CQL reference
-      url: https://docs.scylladb.com/stable/cql/
-      type: sql_reference
     - title: Authentication
       url: https://docs.scylladb.com/stable/operating-scylla/security/authentication.html
       type: authentication_guide
+    - title: CQL reference
+      url: https://docs.scylladb.com/stable/cql/
+      type: sql_reference
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-singlestore/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-singlestore/metadata.yaml
@@ -22,10 +22,10 @@ data:
     - title: SingleStore documentation
       url: https://docs.singlestore.com/
       type: api_reference
-    - title: SQL reference
-      url: https://docs.singlestore.com/db/latest/reference/sql-reference/
-      type: sql_reference
     - title: Authentication
       url: https://docs.singlestore.com/db/latest/security/authentication/
       type: authentication_guide
+    - title: SQL reference
+      url: https://docs.singlestore.com/db/latest/reference/sql-reference/
+      type: sql_reference
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-snowflake-cortex/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-snowflake-cortex/metadata.yaml
@@ -55,10 +55,10 @@ data:
     - title: Snowflake Cortex documentation
       url: https://docs.snowflake.com/en/user-guide/snowflake-cortex
       type: api_reference
-    - title: Snowflake SQL reference
-      url: https://docs.snowflake.com/en/sql-reference
-      type: sql_reference
     - title: Key pair authentication
       url: https://docs.snowflake.com/en/user-guide/key-pair-auth
       type: authentication_guide
+    - title: Snowflake SQL reference
+      url: https://docs.snowflake.com/en/sql-reference
+      type: sql_reference
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-snowflake/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-snowflake/metadata.yaml
@@ -90,19 +90,19 @@ data:
     - title: Release notes
       url: https://docs.snowflake.com/en/release-notes
       type: api_release_history
-    - title: SQL reference
-      url: https://docs.snowflake.com/en/sql-reference
-      type: sql_reference
+    - title: Snowflake server release notes and feature updates
+      url: https://docs.snowflake.com/en/release-notes/new-features
+      type: api_release_history
     - title: Key pair authentication
       url: https://docs.snowflake.com/en/user-guide/key-pair-auth
       type: authentication_guide
     - title: Access control
       url: https://docs.snowflake.com/en/user-guide/security-access-control
       type: permissions_scopes
+    - title: SQL reference
+      url: https://docs.snowflake.com/en/sql-reference
+      type: sql_reference
     - title: Snowflake Status
       url: https://status.snowflake.com/
       type: status_page
-    - title: Snowflake server release notes and feature updates
-      url: https://docs.snowflake.com/en/release-notes/new-features
-      type: api_release_history
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-weaviate/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-weaviate/metadata.yaml
@@ -61,10 +61,10 @@ data:
     - title: Weaviate documentation
       url: https://weaviate.io/developers/weaviate
       type: api_reference
-    - title: Authentication
-      url: https://weaviate.io/developers/weaviate/configuration/authentication
-      type: authentication_guide
     - title: Release notes
       url: https://weaviate.io/developers/weaviate/release-notes
       type: api_release_history
+    - title: Authentication
+      url: https://weaviate.io/developers/weaviate/configuration/authentication
+      type: authentication_guide
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-yugabytedb/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-yugabytedb/metadata.yaml
@@ -25,10 +25,10 @@ data:
     - title: YugabyteDB documentation
       url: https://docs.yugabyte.com/
       type: api_reference
-    - title: YSQL reference
-      url: https://docs.yugabyte.com/preview/api/ysql/
-      type: sql_reference
     - title: Authentication
       url: https://docs.yugabyte.com/preview/secure/authentication/
       type: authentication_guide
+    - title: YSQL reference
+      url: https://docs.yugabyte.com/preview/api/ysql/
+      type: sql_reference
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-adobe-commerce-magento/metadata.yaml
+++ b/airbyte-integrations/connectors/source-adobe-commerce-magento/metadata.yaml
@@ -37,9 +37,9 @@ data:
     - title: REST API reference
       url: https://developer.adobe.com/commerce/webapi/rest/
       type: api_reference
-    - title: Authentication
-      url: https://developer.adobe.com/commerce/webapi/get-started/authentication/
-      type: authentication_guide
     - title: Release notes
       url: https://experienceleague.adobe.com/docs/commerce-operations/release/notes/overview.html
       type: api_release_history
+    - title: Authentication
+      url: https://developer.adobe.com/commerce/webapi/get-started/authentication/
+      type: authentication_guide

--- a/airbyte-integrations/connectors/source-amazon-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-amazon-ads/metadata.yaml
@@ -115,19 +115,19 @@ data:
             type: GSM
             alias: airbyte-connector-testing-secret-store
   externalDocumentationUrls:
+    - title: Deprecations
+      url: https://advertising.amazon.com/API/docs/en-us/release-notes/deprecations
+      type: api_deprecations
     - title: Advertising API
       url: https://advertising.amazon.com/API/docs/en-us
       type: api_reference
+    - title: All releases
+      url: https://advertising.amazon.com/API/docs/en-us/release-notes/index
+      type: api_release_history
     - title: Authorization
       url: https://advertising.amazon.com/API/docs/en-us/get-started/authorization
       type: authentication_guide
     - title: Rate limits
       url: https://advertising.amazon.com/API/docs/en-us/get-started/developer-notes#rate-limiting
       type: rate_limits
-    - title: All releases
-      url: https://advertising.amazon.com/API/docs/en-us/release-notes/index
-      type: api_release_history
-    - title: Deprecations
-      url: https://advertising.amazon.com/API/docs/en-us/release-notes/deprecations
-      type: api_deprecations
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/metadata.yaml
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/metadata.yaml
@@ -76,19 +76,19 @@ data:
             type: GSM
             alias: airbyte-connector-testing-secret-store
   externalDocumentationUrls:
+    - title: SP-API Deprecation Schedule
+      url: https://developer-docs.amazon.com/sp-api/docs/sp-api-deprecations
+      type: api_deprecations
     - title: SP-API documentation
       url: https://developer-docs.amazon.com/sp-api/
       type: api_reference
+    - title: SP-API Release Notes
+      url: https://developer-docs.amazon.com/sp-api/docs/sp-api-release-notes
+      type: api_release_history
     - title: Authorization
       url: https://developer-docs.amazon.com/sp-api/docs/authorizing-selling-partner-api-applications
       type: authentication_guide
     - title: Usage plans and rate limits
       url: https://developer-docs.amazon.com/sp-api/docs/usage-plans-and-rate-limits-in-the-sp-api
       type: rate_limits
-    - title: SP-API Release Notes
-      url: https://developer-docs.amazon.com/sp-api/docs/sp-api-release-notes
-      type: api_release_history
-    - title: SP-API Deprecation Schedule
-      url: https://developer-docs.amazon.com/sp-api/docs/sp-api-deprecations
-      type: api_deprecations
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-bigquery/metadata.yaml
+++ b/airbyte-integrations/connectors/source-bigquery/metadata.yaml
@@ -41,13 +41,13 @@ data:
     - title: BigQuery REST API
       url: https://cloud.google.com/bigquery/docs/reference/rest
       type: api_reference
+    - title: Release notes
+      url: https://cloud.google.com/bigquery/docs/release-notes
+      type: api_release_history
     - title: Authentication
       url: https://cloud.google.com/bigquery/docs/authentication
       type: authentication_guide
     - title: Quotas and limits
       url: https://cloud.google.com/bigquery/quotas
       type: rate_limits
-    - title: Release notes
-      url: https://cloud.google.com/bigquery/docs/release-notes
-      type: api_release_history
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-bing-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-bing-ads/metadata.yaml
@@ -20,11 +20,11 @@ data:
   dockerRepository: airbyte/source-bing-ads
   documentationUrl: https://docs.airbyte.com/integrations/sources/bing-ads
   externalDocumentationUrls:
-    - title: Release notes
-      url: https://learn.microsoft.com/en-us/advertising/guides/release-notes?view=bingads-13
-      type: api_release_history
     - title: Bing Ads API Release Notes
       url: https://learn.microsoft.com/en-us/advertising/guides/release-notes
+      type: api_release_history
+    - title: Release notes
+      url: https://learn.microsoft.com/en-us/advertising/guides/release-notes?view=bingads-13
       type: api_release_history
   erdUrl: https://dbdocs.io/airbyteio/source-bing-ads?view=relationships
   githubIssueLabel: source-bing-ads

--- a/airbyte-integrations/connectors/source-braintree/metadata.yaml
+++ b/airbyte-integrations/connectors/source-braintree/metadata.yaml
@@ -44,6 +44,9 @@ data:
             type: GSM
             alias: airbyte-connector-testing-secret-store
   externalDocumentationUrls:
+    - title: Server SDK Deprecation Policy
+      url: https://developer.paypal.com/braintree/docs/reference/general/server-sdk-deprecation-policy
+      type: api_deprecations
     - title: Braintree API reference
       url: https://developer.paypal.com/braintree/docs/reference/overview
       type: api_reference
@@ -56,7 +59,4 @@ data:
     - title: Braintree Status
       url: https://status.braintreepayments.com/
       type: status_page
-    - title: Server SDK Deprecation Policy
-      url: https://developer.paypal.com/braintree/docs/reference/general/server-sdk-deprecation-policy
-      type: api_deprecations
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-clickhouse/metadata.yaml
+++ b/airbyte-integrations/connectors/source-clickhouse/metadata.yaml
@@ -36,13 +36,13 @@ data:
     - title: ClickHouse HTTP interface
       url: https://clickhouse.com/docs/en/interfaces/http
       type: api_reference
+    - title: Changelog
+      url: https://clickhouse.com/docs/whats-new/changelog
+      type: api_release_history
     - title: ClickHouse authentication
       url: https://clickhouse.com/docs/en/operations/access-rights
       type: authentication_guide
     - title: ClickHouse SQL reference
       url: https://clickhouse.com/docs/en/sql-reference
       type: sql_reference
-    - title: Changelog
-      url: https://clickhouse.com/docs/whats-new/changelog
-      type: api_release_history
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-cockroachdb/metadata.yaml
+++ b/airbyte-integrations/connectors/source-cockroachdb/metadata.yaml
@@ -30,16 +30,16 @@ data:
   tags:
     - language:java
   externalDocumentationUrls:
-    - title: CockroachDB SQL reference
-      url: https://www.cockroachlabs.com/docs/stable/sql-statements
-      type: sql_reference
-    - title: CockroachDB authentication
-      url: https://www.cockroachlabs.com/docs/stable/authentication
-      type: authentication_guide
-    - title: CockroachDB Status
-      url: https://status.cockroachlabs.com/
-      type: status_page
     - title: CockroachDB Releases
       url: https://www.cockroachlabs.com/docs/releases/
       type: api_release_history
+    - title: CockroachDB authentication
+      url: https://www.cockroachlabs.com/docs/stable/authentication
+      type: authentication_guide
+    - title: CockroachDB SQL reference
+      url: https://www.cockroachlabs.com/docs/stable/sql-statements
+      type: sql_reference
+    - title: CockroachDB Status
+      url: https://status.cockroachlabs.com/
+      type: status_page
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-couchbase/metadata.yaml
+++ b/airbyte-integrations/connectors/source-couchbase/metadata.yaml
@@ -45,10 +45,10 @@ data:
   connectorBuildOptions:
     baseImage: docker.io/airbyte/python-connector-base:4.0.0@sha256:d9894b6895923b379f3006fa251147806919c62b7d9021b5cd125bb67d7bbe22
   externalDocumentationUrls:
-    - title: Couchbase SQL++ reference
-      url: https://docs.couchbase.com/server/current/n1ql/n1ql-language-reference/index.html
-      type: sql_reference
     - title: Couchbase authentication
       url: https://docs.couchbase.com/server/current/learn/security/authentication.html
       type: authentication_guide
+    - title: Couchbase SQL++ reference
+      url: https://docs.couchbase.com/server/current/n1ql/n1ql-language-reference/index.html
+      type: sql_reference
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-db2/metadata.yaml
+++ b/airbyte-integrations/connectors/source-db2/metadata.yaml
@@ -30,10 +30,10 @@ data:
   tags:
     - language:java
   externalDocumentationUrls:
-    - title: IBM Db2 SQL reference
-      url: https://www.ibm.com/docs/en/db2/11.5?topic=reference-sql
-      type: sql_reference
     - title: IBM Db2 authentication
       url: https://www.ibm.com/docs/en/db2/11.5?topic=security-authentication
       type: authentication_guide
+    - title: IBM Db2 SQL reference
+      url: https://www.ibm.com/docs/en/db2/11.5?topic=reference-sql
+      type: sql_reference
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-dremio/metadata.yaml
+++ b/airbyte-integrations/connectors/source-dremio/metadata.yaml
@@ -44,10 +44,10 @@ data:
     - title: Dremio REST API
       url: https://docs.dremio.com/software/rest-api/
       type: api_reference
-    - title: Dremio SQL reference
-      url: https://docs.dremio.com/software/sql-reference/
-      type: sql_reference
     - title: Dremio authentication
       url: https://docs.dremio.com/software/rest-api/authentication/
       type: authentication_guide
+    - title: Dremio SQL reference
+      url: https://docs.dremio.com/software/sql-reference/
+      type: sql_reference
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-elasticsearch/metadata.yaml
+++ b/airbyte-integrations/connectors/source-elasticsearch/metadata.yaml
@@ -30,13 +30,13 @@ data:
     - title: Elasticsearch REST APIs
       url: https://www.elastic.co/guide/en/elasticsearch/reference/current/rest-apis.html
       type: api_reference
+    - title: Elasticsearch Release Notes
+      url: https://www.elastic.co/docs/release-notes/elasticsearch
+      type: api_release_history
     - title: Elasticsearch authentication
       url: https://www.elastic.co/guide/en/elasticsearch/reference/current/setting-up-authentication.html
       type: authentication_guide
     - title: Elastic Cloud Status
       url: https://status.elastic.co/
       type: status_page
-    - title: Elasticsearch Release Notes
-      url: https://www.elastic.co/docs/release-notes/elasticsearch
-      type: api_release_history
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-github/metadata.yaml
+++ b/airbyte-integrations/connectors/source-github/metadata.yaml
@@ -82,9 +82,15 @@ data:
             type: GSM
             alias: airbyte-connector-testing-secret-store
   externalDocumentationUrls:
+    - title: Breaking changes
+      url: https://docs.github.com/en/rest/about-the-rest-api/breaking-changes
+      type: api_deprecations
     - title: GitHub REST API reference
       url: https://docs.github.com/en/rest
       type: api_reference
+    - title: API Versions
+      url: https://docs.github.com/en/rest/about-the-rest-api/api-versions
+      type: api_release_history
     - title: GitHub API changelog
       url: https://github.blog/changelog/label/api/
       type: api_release_history
@@ -97,10 +103,4 @@ data:
     - title: GitHub Status
       url: https://www.githubstatus.com/
       type: status_page
-    - title: API Versions
-      url: https://docs.github.com/en/rest/about-the-rest-api/api-versions
-      type: api_release_history
-    - title: Breaking changes
-      url: https://docs.github.com/en/rest/about-the-rest-api/breaking-changes
-      type: api_deprecations
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-gitlab/metadata.yaml
+++ b/airbyte-integrations/connectors/source-gitlab/metadata.yaml
@@ -14,12 +14,12 @@ data:
   dockerRepository: airbyte/source-gitlab
   documentationUrl: https://docs.airbyte.com/integrations/sources/gitlab
   externalDocumentationUrls:
-    - title: API reference
-      url: https://docs.gitlab.com/ee/api/rest/
-      type: api_reference
     - title: Future REST API deprecations and removals
       url: https://docs.gitlab.com/ee/api/rest/deprecations.html
       type: api_deprecations
+    - title: API reference
+      url: https://docs.gitlab.com/ee/api/rest/
+      type: api_reference
   githubIssueLabel: source-gitlab
   icon: gitlab.svg
   license: ELv2

--- a/airbyte-integrations/connectors/source-google-sheets/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-sheets/metadata.yaml
@@ -14,11 +14,11 @@ data:
   dockerRepository: airbyte/source-google-sheets
   documentationUrl: https://docs.airbyte.com/integrations/sources/google-sheets
   externalDocumentationUrls:
-    - title: Release notes
-      url: https://developers.google.com/sheets/docs/release-notes
-      type: api_release_history
     - title: Google Workspace developer release notes
       url: https://developers.google.com/workspace/release-notes
+      type: api_release_history
+    - title: Release notes
+      url: https://developers.google.com/sheets/docs/release-notes
       type: api_release_history
   githubIssueLabel: source-google-sheets
   icon: google-sheets.svg

--- a/airbyte-integrations/connectors/source-instagram/metadata.yaml
+++ b/airbyte-integrations/connectors/source-instagram/metadata.yaml
@@ -56,11 +56,11 @@ data:
       - user_lifetime_insights
   documentationUrl: https://docs.airbyte.com/integrations/sources/instagram
   externalDocumentationUrls:
-    - title: Release notes
-      url: https://developers.facebook.com/docs/instagram-api/changelog
-      type: api_release_history
     - title: Instagram Platform Changelog
       url: https://developers.facebook.com/docs/instagram-platform/changelog
+      type: api_release_history
+    - title: Release notes
+      url: https://developers.facebook.com/docs/instagram-api/changelog
       type: api_release_history
   erdUrl: https://dbdocs.io/airbyteio/source-instagram?view=relationships
   tags:

--- a/airbyte-integrations/connectors/source-intercom/metadata.yaml
+++ b/airbyte-integrations/connectors/source-intercom/metadata.yaml
@@ -14,14 +14,14 @@ data:
   dockerRepository: airbyte/source-intercom
   documentationUrl: https://docs.airbyte.com/integrations/sources/intercom
   externalDocumentationUrls:
-    - title: Changelog
-      url: https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/api-changelog
-      type: api_release_history
     - title: Unversioned Changes
       url: https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/unversioned-changes#unversioned-changes
       type: api_reference
     - title: API Changelog
       url: https://developers.intercom.com/docs/references/changelog
+      type: api_release_history
+    - title: Changelog
+      url: https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/api-changelog
       type: api_release_history
   githubIssueLabel: source-intercom
   icon: intercom.svg

--- a/airbyte-integrations/connectors/source-mailchimp/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mailchimp/metadata.yaml
@@ -15,11 +15,11 @@ data:
   dockerRepository: airbyte/source-mailchimp
   documentationUrl: https://docs.airbyte.com/integrations/sources/mailchimp
   externalDocumentationUrls:
-    - title: Release Notes
-      url: https://mailchimp.com/developer/release-notes/?filter=marketing
-      type: api_release_history
     - title: Mailchimp Marketing API Release Notes
       url: https://mailchimp.com/developer/release-notes/
+      type: api_release_history
+    - title: Release Notes
+      url: https://mailchimp.com/developer/release-notes/?filter=marketing
       type: api_release_history
   githubIssueLabel: source-mailchimp
   icon: mailchimp.svg

--- a/airbyte-integrations/connectors/source-mongodb-v2/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mongodb-v2/metadata.yaml
@@ -95,10 +95,10 @@ data:
     - title: MongoDB documentation
       url: https://www.mongodb.com/docs/
       type: api_reference
-    - title: MongoDB authentication
-      url: https://www.mongodb.com/docs/manual/core/authentication/
-      type: authentication_guide
     - title: Release Notes
       url: https://www.mongodb.com/docs/manual/release-notes/
       type: api_release_history
+    - title: MongoDB authentication
+      url: https://www.mongodb.com/docs/manual/core/authentication/
+      type: authentication_guide
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-mssql/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mssql/metadata.yaml
@@ -54,10 +54,10 @@ data:
     - title: SQL Server documentation
       url: https://learn.microsoft.com/en-us/sql/sql-server/
       type: api_reference
-    - title: SQL Server authentication
-      url: https://learn.microsoft.com/en-us/sql/relational-databases/security/choose-an-authentication-mode
-      type: authentication_guide
     - title: SQL Server 2022 release notes
       url: https://learn.microsoft.com/en-us/sql/sql-server/sql-server-2022-release-notes
       type: api_release_history
+    - title: SQL Server authentication
+      url: https://learn.microsoft.com/en-us/sql/relational-databases/security/choose-an-authentication-mode
+      type: authentication_guide
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-mysql/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mysql/metadata.yaml
@@ -82,10 +82,10 @@ data:
     - title: MySQL documentation
       url: https://dev.mysql.com/doc/
       type: api_reference
-    - title: MySQL authentication
-      url: https://dev.mysql.com/doc/refman/8.0/en/access-control.html
-      type: authentication_guide
     - title: MySQL Release Notes
       url: https://dev.mysql.com/doc/relnotes/mysql/en/
       type: api_release_history
+    - title: MySQL authentication
+      url: https://dev.mysql.com/doc/refman/8.0/en/access-control.html
+      type: authentication_guide
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-oracle/metadata.yaml
+++ b/airbyte-integrations/connectors/source-oracle/metadata.yaml
@@ -42,10 +42,10 @@ data:
     - title: Oracle Database documentation
       url: https://docs.oracle.com/en/database/
       type: api_reference
-    - title: Oracle authentication
-      url: https://docs.oracle.com/en/database/oracle/oracle-database/19/dbseg/introduction-to-oracle-database-security.html
-      type: authentication_guide
     - title: Oracle Database Release Notes
       url: https://docs.oracle.com/en/database/oracle/oracle-database/
       type: api_release_history
+    - title: Oracle authentication
+      url: https://docs.oracle.com/en/database/oracle/oracle-database/19/dbseg/introduction-to-oracle-database-security.html
+      type: authentication_guide
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-pipedrive/metadata.yaml
+++ b/airbyte-integrations/connectors/source-pipedrive/metadata.yaml
@@ -68,13 +68,13 @@ data:
     - title: Pipedrive API reference
       url: https://developers.pipedrive.com/docs/api/v1
       type: api_reference
+    - title: Changelog
+      url: https://developers.pipedrive.com/changelog
+      type: api_release_history
     - title: Pipedrive authentication
       url: https://pipedrive.readme.io/docs/core-api-concepts-authentication
       type: authentication_guide
     - title: Pipedrive rate limits
       url: https://pipedrive.readme.io/docs/core-api-concepts-rate-limiting
       type: rate_limits
-    - title: Changelog
-      url: https://developers.pipedrive.com/changelog
-      type: api_release_history
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-postgres/metadata.yaml
+++ b/airbyte-integrations/connectors/source-postgres/metadata.yaml
@@ -68,10 +68,10 @@ data:
     - title: PostgreSQL documentation
       url: https://www.postgresql.org/docs/
       type: api_reference
-    - title: PostgreSQL authentication
-      url: https://www.postgresql.org/docs/current/auth-methods.html
-      type: authentication_guide
     - title: Release Notes
       url: https://www.postgresql.org/docs/release/
       type: api_release_history
+    - title: PostgreSQL authentication
+      url: https://www.postgresql.org/docs/current/auth-methods.html
+      type: authentication_guide
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-quickbooks/metadata.yaml
+++ b/airbyte-integrations/connectors/source-quickbooks/metadata.yaml
@@ -75,13 +75,13 @@ data:
     - title: QuickBooks Online API
       url: https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/account
       type: api_reference
+    - title: QuickBooks Online API Changelog
+      url: https://developer.intuit.com/app/developer/qbo/docs/changelog
+      type: api_release_history
     - title: QuickBooks authentication
       url: https://developer.intuit.com/app/developer/qbo/docs/develop/authentication-and-authorization
       type: authentication_guide
     - title: QuickBooks rate limits
       url: https://developer.intuit.com/app/developer/qbo/docs/develop/troubleshooting/error-codes#rate-limits
       type: rate_limits
-    - title: QuickBooks Online API Changelog
-      url: https://developer.intuit.com/app/developer/qbo/docs/changelog
-      type: api_release_history
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-salesforce/metadata.yaml
+++ b/airbyte-integrations/connectors/source-salesforce/metadata.yaml
@@ -17,11 +17,11 @@ data:
   dockerRepository: airbyte/source-salesforce
   documentationUrl: https://docs.airbyte.com/integrations/sources/salesforce
   externalDocumentationUrls:
-    - title: Winter 2026 release notes - API
-      url: https://help.salesforce.com/s/articleView?id=release-notes.salesforce_release_notes.htm&release=258&type=5
-      type: api_release_history
     - title: REST API Release Notes
       url: https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/rest_rns.htm
+      type: api_release_history
+    - title: Winter 2026 release notes - API
+      url: https://help.salesforce.com/s/articleView?id=release-notes.salesforce_release_notes.htm&release=258&type=5
       type: api_release_history
   githubIssueLabel: source-salesforce
   icon: salesforce.svg

--- a/airbyte-integrations/connectors/source-shopify/metadata.yaml
+++ b/airbyte-integrations/connectors/source-shopify/metadata.yaml
@@ -168,6 +168,9 @@ data:
     - title: Shopify Admin API
       url: https://shopify.dev/docs/api/admin-rest
       type: api_reference
+    - title: Developer changelog
+      url: https://shopify.dev/changelog
+      type: api_release_history
     - title: Shopify API changelog
       url: https://shopify.dev/docs/api/release-notes
       type: api_release_history
@@ -180,7 +183,4 @@ data:
     - title: Shopify Status
       url: https://www.shopifystatus.com/
       type: status_page
-    - title: Developer changelog
-      url: https://shopify.dev/changelog
-      type: api_release_history
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-snowflake/metadata.yaml
+++ b/airbyte-integrations/connectors/source-snowflake/metadata.yaml
@@ -46,13 +46,13 @@ data:
     - title: Snowflake documentation
       url: https://docs.snowflake.com/
       type: api_reference
+    - title: Snowflake server release notes and feature updates
+      url: https://docs.snowflake.com/en/release-notes/new-features
+      type: api_release_history
     - title: Snowflake authentication
       url: https://docs.snowflake.com/en/user-guide/admin-user-management
       type: authentication_guide
     - title: Snowflake Status
       url: https://status.snowflake.com/
       type: status_page
-    - title: Snowflake server release notes and feature updates
-      url: https://docs.snowflake.com/en/release-notes/new-features
-      type: api_release_history
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-square/metadata.yaml
+++ b/airbyte-integrations/connectors/source-square/metadata.yaml
@@ -56,6 +56,9 @@ data:
     - title: Square API reference
       url: https://developer.squareup.com/reference/square
       type: api_reference
+    - title: Square API Release Notes
+      url: https://developer.squareup.com/docs/release-notes
+      type: api_release_history
     - title: Square API changelog
       url: https://developer.squareup.com/docs/changelog
       type: api_release_history
@@ -68,7 +71,4 @@ data:
     - title: Square Status
       url: https://www.issquareup.com/
       type: status_page
-    - title: Square API Release Notes
-      url: https://developer.squareup.com/docs/release-notes
-      type: api_release_history
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-stripe/metadata.yaml
+++ b/airbyte-integrations/connectors/source-stripe/metadata.yaml
@@ -87,6 +87,12 @@ data:
     - title: Stripe API reference
       url: https://stripe.com/docs/api
       type: api_reference
+    - title: API changelog
+      url: https://docs.stripe.com/changelog
+      type: api_release_history
+    - title: API upgrades
+      url: https://docs.stripe.com/upgrades
+      type: api_release_history
     - title: Stripe API changelog
       url: https://stripe.com/docs/upgrades
       type: api_release_history
@@ -99,10 +105,4 @@ data:
     - title: Stripe Status
       url: https://status.stripe.com/
       type: status_page
-    - title: API upgrades
-      url: https://docs.stripe.com/upgrades
-      type: api_release_history
-    - title: API changelog
-      url: https://docs.stripe.com/changelog
-      type: api_release_history
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-surveymonkey/metadata.yaml
+++ b/airbyte-integrations/connectors/source-surveymonkey/metadata.yaml
@@ -56,13 +56,13 @@ data:
     - title: SurveyMonkey API reference
       url: https://developer.surveymonkey.com/api/v3/
       type: api_reference
+    - title: SurveyMonkey API Changelog
+      url: https://developer.surveymonkey.com/api/v3/#changelog
+      type: api_release_history
     - title: SurveyMonkey authentication
       url: https://developer.surveymonkey.com/api/v3/#authentication
       type: authentication_guide
     - title: SurveyMonkey rate limits
       url: https://developer.surveymonkey.com/api/v3/#rate-limits
       type: rate_limits
-    - title: SurveyMonkey API Changelog
-      url: https://developer.surveymonkey.com/api/v3/#changelog
-      type: api_release_history
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-twilio/metadata.yaml
+++ b/airbyte-integrations/connectors/source-twilio/metadata.yaml
@@ -66,6 +66,9 @@ data:
     - title: Twilio API reference
       url: https://www.twilio.com/docs/usage/api
       type: api_reference
+    - title: Twilio Changelog
+      url: https://www.twilio.com/en-us/changelog
+      type: api_release_history
     - title: Twilio authentication
       url: https://www.twilio.com/docs/iam/credentials/api-credentials
       type: authentication_guide
@@ -75,7 +78,4 @@ data:
     - title: Twilio Status
       url: https://status.twilio.com/
       type: status_page
-    - title: Twilio Changelog
-      url: https://www.twilio.com/en-us/changelog
-      type: api_release_history
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-zendesk-support/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-support/metadata.yaml
@@ -104,6 +104,9 @@ data:
     - title: Zendesk Support API
       url: https://developer.zendesk.com/api-reference/ticketing/introduction/
       type: api_reference
+    - title: API Changelog
+      url: https://developer.zendesk.com/api-reference/changelog/changelog/
+      type: api_release_history
     - title: Zendesk API changelog
       url: https://developer.zendesk.com/api-reference/ticketing/introduction/#changes
       type: api_release_history
@@ -116,7 +119,4 @@ data:
     - title: Zendesk Status
       url: https://status.zendesk.com/
       type: status_page
-    - title: API Changelog
-      url: https://developer.zendesk.com/api-reference/changelog/changelog/
-      type: api_release_history
 metadataSpecVersion: "1.0"


### PR DESCRIPTION
## What

This PR sorts the `externalDocumentationUrls` entries in connector metadata.yaml files alphabetically by `type` field first, then by `title` field within each type group. This improves consistency and makes it easier to find specific documentation types across connectors.

**Note**: This is a draft PR showing progress on 17 of 63 files that need sorting. More commits will be added to complete the remaining files.

Requested by AJ Steers (@aaronsteers)
Link to Devin run: https://app.devin.ai/sessions/587a880e1f674292ab4daf4e67fc9c90

## How

Manual reordering of YAML array entries in metadata.yaml files. YAML libraries were not used to preserve comments and formatting. Each file's `externalDocumentationUrls` section was manually sorted by:
1. Primary sort: `type` field (alphabetically)
2. Secondary sort: `title` field (alphabetically within each type group)

## Review guide

**Critical items to verify**:
1. YAML syntax is valid in all modified files (no indentation errors, missing colons, etc.)
2. No content changes - all URLs, titles, and type values remain identical to before
3. Comments are preserved in their correct locations
4. Sorting is correct: entries are grouped by type alphabetically, then sorted by title within each type

**Files modified so far** (17/63):
- Destinations: astra, bigquery, bigquery-denormalized, cassandra, clickhouse, databricks, firebolt, gcs, hubspot, mongodb, mssql, mysql, mysql-strict-encrypt, oracle, postgres, redis
- Sources: github

**Example of sorting applied**:
```yaml
# Before:
- title: API docs
  type: api_reference
- title: Auth guide  
  type: authentication_guide
- title: Release notes
  type: api_release_history

# After (sorted by type, then title):
- title: API docs
  type: api_reference
- title: Release notes
  type: api_release_history
- title: Auth guide
  type: authentication_guide
```

## User Impact

No functional impact. This is a metadata organization change that improves consistency across connector documentation references.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

This change only affects metadata organization and can be safely reverted without any functional impact.