### PR TITLE
exclude data activation destinations from upgrade tests

### DIFF
--- a/.github/workflows/cdk-connector-compatibility-test.yml
+++ b/.github/workflows/cdk-connector-compatibility-test.yml
@@ -7,6 +7,15 @@ on:
   schedule:
     - cron: "0 12 * * *"
   workflow_call:
+    inputs:
+      upgradeCdkGradleParams:
+        type: string
+        description: |
+          Additional parameters to pass into the `./gradlew upgradeCdk` call.
+          For example, `-x :airbyte-integrations:connectors:destination-hubspot:upgradeCdk` would allow you
+          to exclude destination-hubspot from being tested.
+        required: false
+        default: ""
 
 jobs:
   generate-matrix:

--- a/.github/workflows/cdk-connector-compatibility-test.yml
+++ b/.github/workflows/cdk-connector-compatibility-test.yml
@@ -98,7 +98,7 @@ jobs:
 
       - name: Run CDK upgrade # Run tests against local CDK version
         if: matrix.connector
-        run: ./gradlew upgradeCdk --cdkVersion=local
+        run: ./gradlew upgradeCdk --cdkVersion=local ${{ inputs.upgradeCdkGradleParams }}
 
       - name: Run Unit Tests
         id: run-unit-tests

--- a/.github/workflows/cdk-connector-compatibility-test.yml
+++ b/.github/workflows/cdk-connector-compatibility-test.yml
@@ -45,6 +45,8 @@ jobs:
       GCP_GSM_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}
       GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID || vars.GCP_PROJECT_ID }}
       DD_TAGS: "connector.name:${{ matrix.connector }}"
+      # Exclude data activation destinations by default
+      UPGRADE_CDK_GRADLE_PARAMS: ${{ inputs.upgradeCdkGradleParams || '-x :airbyte-integrations:connectors:destination-hubspot:upgradeCdk :airbyte-integrations:connectors:destination-customer-io:upgradeCdk' }}
 
     strategy:
       matrix:
@@ -98,7 +100,7 @@ jobs:
 
       - name: Run CDK upgrade # Run tests against local CDK version
         if: matrix.connector
-        run: ./gradlew upgradeCdk --cdkVersion=local ${{ inputs.upgradeCdkGradleParams }}
+        run: ./gradlew upgradeCdk --cdkVersion=local $UPGRADE_CDK_GRADLE_PARAMS
 
       - name: Run Unit Tests
         id: run-unit-tests


### PR DESCRIPTION
see also https://github.com/airbytehq/airbyte-enterprise/pull/314 - we need to add a param for the enterprise repo.

there's probably more elegant ways to do this (e.g. parse metadata.yaml to check for `connectorSubtype: api` + `connectorType: destination`) but that would be a lot more work for no real benefit :shrug: happy to point claude at that, if we think it's useful, but IMO this is sufficient

completely untested :P going to just let the cron run overnight and hope it works