### PR TITLE
Add OpenAPI spec URLs to 12 certified API source connectors

### DIFF
--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorMetadataDefinitionV0.json
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorMetadataDefinitionV0.json
@@ -208,6 +208,7 @@
                   "data_model_reference",
                   "developer_community",
                   "migration_guide",
+                  "openapi_spec",
                   "other",
                   "permissions_scopes",
                   "rate_limits",

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorMetadataDefinitionV0.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorMetadataDefinitionV0.py
@@ -26,6 +26,7 @@ class ExternalDocumentationUrl(BaseModel):
             "data_model_reference",
             "developer_community",
             "migration_guide",
+            "openapi_spec",
             "other",
             "permissions_scopes",
             "rate_limits",

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/src/ConnectorMetadataDefinitionV0.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/src/ConnectorMetadataDefinitionV0.yaml
@@ -86,6 +86,7 @@ properties:
                 - data_model_reference
                 - developer_community
                 - migration_guide
+                - openapi_spec
                 - other
                 - permissions_scopes
                 - rate_limits

--- a/airbyte-integrations/connectors/source-github/metadata.yaml
+++ b/airbyte-integrations/connectors/source-github/metadata.yaml
@@ -88,9 +88,6 @@ data:
     - title: GitHub REST API reference
       url: https://docs.github.com/en/rest
       type: api_reference
-    - title: GitHub REST API OpenAPI specification
-      url: https://github.com/github/rest-api-description
-      type: openapi_spec
     - title: API Versions
       url: https://docs.github.com/en/rest/about-the-rest-api/api-versions
       type: api_release_history
@@ -100,6 +97,9 @@ data:
     - title: GitHub authentication
       url: https://docs.github.com/en/rest/overview/authenticating-to-the-rest-api
       type: authentication_guide
+    - title: GitHub REST API OpenAPI specification
+      url: https://github.com/github/rest-api-description
+      type: openapi_spec
     - title: GitHub rate limits
       url: https://docs.github.com/en/rest/overview/rate-limits-for-the-rest-api
       type: rate_limits

--- a/airbyte-integrations/connectors/source-github/metadata.yaml
+++ b/airbyte-integrations/connectors/source-github/metadata.yaml
@@ -88,6 +88,9 @@ data:
     - title: GitHub REST API reference
       url: https://docs.github.com/en/rest
       type: api_reference
+    - title: GitHub REST API OpenAPI specification
+      url: https://github.com/github/rest-api-description
+      type: openapi_spec
     - title: API Versions
       url: https://docs.github.com/en/rest/about-the-rest-api/api-versions
       type: api_release_history

--- a/airbyte-integrations/connectors/source-gitlab/metadata.yaml
+++ b/airbyte-integrations/connectors/source-gitlab/metadata.yaml
@@ -20,6 +20,9 @@ data:
     - title: API reference
       url: https://docs.gitlab.com/ee/api/rest/
       type: api_reference
+    - title: GitLab API OpenAPI specification
+      url: https://docs.gitlab.com/ee/api/openapi/openapi.yaml
+      type: openapi_spec
   githubIssueLabel: source-gitlab
   icon: gitlab.svg
   license: ELv2

--- a/airbyte-integrations/connectors/source-intercom/metadata.yaml
+++ b/airbyte-integrations/connectors/source-intercom/metadata.yaml
@@ -14,9 +14,6 @@ data:
   dockerRepository: airbyte/source-intercom
   documentationUrl: https://docs.airbyte.com/integrations/sources/intercom
   externalDocumentationUrls:
-    - title: Intercom API OpenAPI specification
-      url: https://developers.intercom.com/docs/references/rest-api/api.intercom.io/openapi.json
-      type: openapi_spec
     - title: Unversioned Changes
       url: https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/unversioned-changes#unversioned-changes
       type: api_reference
@@ -26,6 +23,9 @@ data:
     - title: Changelog
       url: https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/api-changelog
       type: api_release_history
+    - title: Intercom API OpenAPI specification
+      url: https://developers.intercom.com/docs/references/rest-api/api.intercom.io/openapi.json
+      type: openapi_spec
   githubIssueLabel: source-intercom
   icon: intercom.svg
   license: ELv2

--- a/airbyte-integrations/connectors/source-intercom/metadata.yaml
+++ b/airbyte-integrations/connectors/source-intercom/metadata.yaml
@@ -14,6 +14,9 @@ data:
   dockerRepository: airbyte/source-intercom
   documentationUrl: https://docs.airbyte.com/integrations/sources/intercom
   externalDocumentationUrls:
+    - title: Intercom API OpenAPI specification
+      url: https://developers.intercom.com/docs/references/rest-api/api.intercom.io/openapi.json
+      type: openapi_spec
     - title: Unversioned Changes
       url: https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/unversioned-changes#unversioned-changes
       type: api_reference

--- a/airbyte-integrations/connectors/source-jira/metadata.yaml
+++ b/airbyte-integrations/connectors/source-jira/metadata.yaml
@@ -14,6 +14,9 @@ data:
   dockerRepository: airbyte/source-jira
   documentationUrl: https://docs.airbyte.com/integrations/sources/jira
   externalDocumentationUrls:
+    - title: Jira Cloud Platform API OpenAPI specification
+      url: https://developer.atlassian.com/cloud/jira/platform/swagger-v3.v3.json
+      type: openapi_spec
     - title: Changelog
       url: https://developer.atlassian.com/changelog/#
       type: api_release_history

--- a/airbyte-integrations/connectors/source-jira/metadata.yaml
+++ b/airbyte-integrations/connectors/source-jira/metadata.yaml
@@ -14,15 +14,15 @@ data:
   dockerRepository: airbyte/source-jira
   documentationUrl: https://docs.airbyte.com/integrations/sources/jira
   externalDocumentationUrls:
-    - title: Jira Cloud Platform API OpenAPI specification
-      url: https://developer.atlassian.com/cloud/jira/platform/swagger-v3.v3.json
-      type: openapi_spec
     - title: Changelog
       url: https://developer.atlassian.com/changelog/#
       type: api_release_history
     - title: Jira Platform API Changelog
       url: https://developer.atlassian.com/cloud/jira/platform/changelog/
       type: api_release_history
+    - title: Jira Cloud Platform API OpenAPI specification
+      url: https://developer.atlassian.com/cloud/jira/platform/swagger-v3.v3.json
+      type: openapi_spec
   erdUrl: https://dbdocs.io/airbyteio/source-jira?view=relationships
   githubIssueLabel: source-jira
   icon: jira.svg

--- a/airbyte-integrations/connectors/source-mailchimp/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mailchimp/metadata.yaml
@@ -15,6 +15,9 @@ data:
   dockerRepository: airbyte/source-mailchimp
   documentationUrl: https://docs.airbyte.com/integrations/sources/mailchimp
   externalDocumentationUrls:
+    - title: Mailchimp Marketing API OpenAPI specification
+      url: https://api.mailchimp.com/schema/3.0/Swagger.json
+      type: openapi_spec
     - title: Mailchimp Marketing API Release Notes
       url: https://mailchimp.com/developer/release-notes/
       type: api_release_history

--- a/airbyte-integrations/connectors/source-mailchimp/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mailchimp/metadata.yaml
@@ -15,15 +15,15 @@ data:
   dockerRepository: airbyte/source-mailchimp
   documentationUrl: https://docs.airbyte.com/integrations/sources/mailchimp
   externalDocumentationUrls:
-    - title: Mailchimp Marketing API OpenAPI specification
-      url: https://api.mailchimp.com/schema/3.0/Swagger.json
-      type: openapi_spec
     - title: Mailchimp Marketing API Release Notes
       url: https://mailchimp.com/developer/release-notes/
       type: api_release_history
     - title: Release Notes
       url: https://mailchimp.com/developer/release-notes/?filter=marketing
       type: api_release_history
+    - title: Mailchimp Marketing API OpenAPI specification
+      url: https://api.mailchimp.com/schema/3.0/Swagger.json
+      type: openapi_spec
   githubIssueLabel: source-mailchimp
   icon: mailchimp.svg
   license: ELv2

--- a/airbyte-integrations/connectors/source-notion/metadata.yaml
+++ b/airbyte-integrations/connectors/source-notion/metadata.yaml
@@ -14,6 +14,9 @@ data:
   dockerRepository: airbyte/source-notion
   documentationUrl: https://docs.airbyte.com/integrations/sources/notion
   externalDocumentationUrls:
+    - title: Notion API OpenAPI specification
+      url: https://github.com/ramnes/notion-sdk-py/blob/main/notion_client/openapi.json
+      type: openapi_spec
     - title: Changes by version
       url: https://developers.notion.com/reference/changes-by-version
       type: api_reference

--- a/airbyte-integrations/connectors/source-notion/metadata.yaml
+++ b/airbyte-integrations/connectors/source-notion/metadata.yaml
@@ -14,15 +14,15 @@ data:
   dockerRepository: airbyte/source-notion
   documentationUrl: https://docs.airbyte.com/integrations/sources/notion
   externalDocumentationUrls:
-    - title: Notion API OpenAPI specification
-      url: https://github.com/ramnes/notion-sdk-py/blob/main/notion_client/openapi.json
-      type: openapi_spec
     - title: Changes by version
       url: https://developers.notion.com/reference/changes-by-version
       type: api_reference
     - title: Changelog
       url: https://developers.notion.com/page/changelog
       type: api_release_history
+    - title: Notion API OpenAPI specification
+      url: https://github.com/ramnes/notion-sdk-py/blob/main/notion_client/openapi.json
+      type: openapi_spec
   githubIssueLabel: source-notion
   icon: notion.svg
   license: ELv2

--- a/airbyte-integrations/connectors/source-sendgrid/metadata.yaml
+++ b/airbyte-integrations/connectors/source-sendgrid/metadata.yaml
@@ -19,12 +19,12 @@ data:
   dockerRepository: airbyte/source-sendgrid
   documentationUrl: https://docs.airbyte.com/integrations/sources/sendgrid
   externalDocumentationUrls:
-    - title: SendGrid API OpenAPI specification
-      url: https://github.com/sendgrid/sendgrid-oai
-      type: openapi_spec
     - title: API overview
       url: https://docs.sendgrid.com/api-reference/how-to-use-the-sendgrid-v3-api/authentication
       type: api_reference
+    - title: SendGrid API OpenAPI specification
+      url: https://github.com/sendgrid/sendgrid-oai
+      type: openapi_spec
   githubIssueLabel: source-sendgrid
   icon: sendgrid.svg
   license: ELv2

--- a/airbyte-integrations/connectors/source-sendgrid/metadata.yaml
+++ b/airbyte-integrations/connectors/source-sendgrid/metadata.yaml
@@ -19,6 +19,9 @@ data:
   dockerRepository: airbyte/source-sendgrid
   documentationUrl: https://docs.airbyte.com/integrations/sources/sendgrid
   externalDocumentationUrls:
+    - title: SendGrid API OpenAPI specification
+      url: https://github.com/sendgrid/sendgrid-oai
+      type: openapi_spec
     - title: API overview
       url: https://docs.sendgrid.com/api-reference/how-to-use-the-sendgrid-v3-api/authentication
       type: api_reference

--- a/airbyte-integrations/connectors/source-sentry/metadata.yaml
+++ b/airbyte-integrations/connectors/source-sentry/metadata.yaml
@@ -14,6 +14,9 @@ data:
   dockerRepository: airbyte/source-sentry
   documentationUrl: https://docs.airbyte.com/integrations/sources/sentry
   externalDocumentationUrls:
+    - title: Sentry API OpenAPI specification
+      url: https://github.com/getsentry/sentry-api-schema
+      type: openapi_spec
     - title: API Reference
       url: https://docs.sentry.io/api/
       type: api_reference

--- a/airbyte-integrations/connectors/source-sentry/metadata.yaml
+++ b/airbyte-integrations/connectors/source-sentry/metadata.yaml
@@ -14,15 +14,15 @@ data:
   dockerRepository: airbyte/source-sentry
   documentationUrl: https://docs.airbyte.com/integrations/sources/sentry
   externalDocumentationUrls:
-    - title: Sentry API OpenAPI specification
-      url: https://github.com/getsentry/sentry-api-schema
-      type: openapi_spec
     - title: API Reference
       url: https://docs.sentry.io/api/
       type: api_reference
     - title: Changelog
       url: https://sentry.io/changelog/
       type: api_release_history
+    - title: Sentry API OpenAPI specification
+      url: https://github.com/getsentry/sentry-api-schema
+      type: openapi_spec
   githubIssueLabel: source-sentry
   icon: sentry.svg
   license: ELv2

--- a/airbyte-integrations/connectors/source-shopify/metadata.yaml
+++ b/airbyte-integrations/connectors/source-shopify/metadata.yaml
@@ -168,9 +168,6 @@ data:
     - title: Shopify Admin API
       url: https://shopify.dev/docs/api/admin-rest
       type: api_reference
-    - title: Shopify Admin API OpenAPI specification
-      url: https://shopify.dev/docs/api/admin-rest
-      type: openapi_spec
     - title: Developer changelog
       url: https://shopify.dev/changelog
       type: api_release_history
@@ -180,6 +177,9 @@ data:
     - title: Shopify authentication
       url: https://shopify.dev/docs/apps/auth
       type: authentication_guide
+    - title: Shopify Admin API OpenAPI specification
+      url: https://shopify.dev/docs/api/admin-rest
+      type: openapi_spec
     - title: Shopify rate limits
       url: https://shopify.dev/docs/api/usage/rate-limits
       type: rate_limits

--- a/airbyte-integrations/connectors/source-shopify/metadata.yaml
+++ b/airbyte-integrations/connectors/source-shopify/metadata.yaml
@@ -168,6 +168,9 @@ data:
     - title: Shopify Admin API
       url: https://shopify.dev/docs/api/admin-rest
       type: api_reference
+    - title: Shopify Admin API OpenAPI specification
+      url: https://shopify.dev/docs/api/admin-rest
+      type: openapi_spec
     - title: Developer changelog
       url: https://shopify.dev/changelog
       type: api_release_history

--- a/airbyte-integrations/connectors/source-slack/metadata.yaml
+++ b/airbyte-integrations/connectors/source-slack/metadata.yaml
@@ -14,6 +14,9 @@ data:
   dockerRepository: airbyte/source-slack
   documentationUrl: https://docs.airbyte.com/integrations/sources/slack
   externalDocumentationUrls:
+    - title: Slack Web API OpenAPI specification
+      url: https://api.slack.com/specs/openapi/v2/slack_web.json
+      type: openapi_spec
     - title: Changelog
       url: https://api.slack.com/changelog
       type: api_release_history

--- a/airbyte-integrations/connectors/source-slack/metadata.yaml
+++ b/airbyte-integrations/connectors/source-slack/metadata.yaml
@@ -14,15 +14,15 @@ data:
   dockerRepository: airbyte/source-slack
   documentationUrl: https://docs.airbyte.com/integrations/sources/slack
   externalDocumentationUrls:
-    - title: Slack Web API OpenAPI specification
-      url: https://api.slack.com/specs/openapi/v2/slack_web.json
-      type: openapi_spec
     - title: Changelog
       url: https://api.slack.com/changelog
       type: api_release_history
     - title: Slack developer changelog
       url: https://docs.slack.dev/changelog/
       type: api_release_history
+    - title: Slack Web API OpenAPI specification
+      url: https://api.slack.com/specs/openapi/v2/slack_web.json
+      type: openapi_spec
   githubIssueLabel: source-slack
   icon: slack.svg
   license: ELv2

--- a/airbyte-integrations/connectors/source-stripe/metadata.yaml
+++ b/airbyte-integrations/connectors/source-stripe/metadata.yaml
@@ -87,6 +87,9 @@ data:
     - title: Stripe API reference
       url: https://stripe.com/docs/api
       type: api_reference
+    - title: Stripe API OpenAPI specification
+      url: https://github.com/stripe/openapi
+      type: openapi_spec
     - title: API changelog
       url: https://docs.stripe.com/changelog
       type: api_release_history

--- a/airbyte-integrations/connectors/source-stripe/metadata.yaml
+++ b/airbyte-integrations/connectors/source-stripe/metadata.yaml
@@ -87,9 +87,6 @@ data:
     - title: Stripe API reference
       url: https://stripe.com/docs/api
       type: api_reference
-    - title: Stripe API OpenAPI specification
-      url: https://github.com/stripe/openapi
-      type: openapi_spec
     - title: API changelog
       url: https://docs.stripe.com/changelog
       type: api_release_history
@@ -102,6 +99,9 @@ data:
     - title: Stripe authentication
       url: https://stripe.com/docs/api/authentication
       type: authentication_guide
+    - title: Stripe API OpenAPI specification
+      url: https://github.com/stripe/openapi
+      type: openapi_spec
     - title: Stripe rate limits
       url: https://stripe.com/docs/rate-limits
       type: rate_limits

--- a/airbyte-integrations/connectors/source-twilio/metadata.yaml
+++ b/airbyte-integrations/connectors/source-twilio/metadata.yaml
@@ -66,6 +66,9 @@ data:
     - title: Twilio API reference
       url: https://www.twilio.com/docs/usage/api
       type: api_reference
+    - title: Twilio API OpenAPI specification
+      url: https://github.com/twilio/twilio-oai
+      type: openapi_spec
     - title: Twilio Changelog
       url: https://www.twilio.com/en-us/changelog
       type: api_release_history

--- a/airbyte-integrations/connectors/source-twilio/metadata.yaml
+++ b/airbyte-integrations/connectors/source-twilio/metadata.yaml
@@ -66,15 +66,15 @@ data:
     - title: Twilio API reference
       url: https://www.twilio.com/docs/usage/api
       type: api_reference
-    - title: Twilio API OpenAPI specification
-      url: https://github.com/twilio/twilio-oai
-      type: openapi_spec
     - title: Twilio Changelog
       url: https://www.twilio.com/en-us/changelog
       type: api_release_history
     - title: Twilio authentication
       url: https://www.twilio.com/docs/iam/credentials/api-credentials
       type: authentication_guide
+    - title: Twilio API OpenAPI specification
+      url: https://github.com/twilio/twilio-oai
+      type: openapi_spec
     - title: Twilio rate limits
       url: https://www.twilio.com/docs/usage/api#rate-limiting
       type: rate_limits


### PR DESCRIPTION
## What

This PR adds OpenAPI specification URLs to the metadata for 12 certified API source connectors and introduces a new `openapi_spec` type for external documentation URLs. The connectors updated are:

- source-github
- source-gitlab  
- source-stripe
- source-twilio
- source-shopify
- source-slack
- source-intercom
- source-jira
- source-sendgrid
- source-mailchimp
- source-sentry
- source-notion

This improves documentation discoverability by providing direct links to machine-readable API specifications.

## How

1. **Schema update**: Added `openapi_spec` as a new valid enum value in `ConnectorMetadataDefinitionV0.yaml` and regenerated the Python and JSON schema files using `poetry run poe generate-models`

2. **Metadata additions**: Added OpenAPI specification URLs to each connector's `metadata.yaml` file under `externalDocumentationUrls` with `type: openapi_spec`

3. **Alpha-sorting**: Reordered all `externalDocumentationUrls` entries alphabetically by their `type` field across all 12 connectors for consistency (manual cut/paste approach)

## Review guide

1. **Schema files** - Verify the generated Python and JSON schema files match the YAML source:
   - `airbyte-ci/connectors/metadata_service/lib/metadata_service/models/src/ConnectorMetadataDefinitionV0.yaml` (line 89)
   - `airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorMetadataDefinitionV0.py` (line 29)
   - `airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorMetadataDefinitionV0.json` (line 211)

2. **OpenAPI URLs** - Verify each URL points to a valid, official OpenAPI specification:
   - GitHub: https://github.com/github/rest-api-description
   - GitLab: https://docs.gitlab.com/ee/api/openapi/openapi.yaml
   - Stripe: https://github.com/stripe/openapi
   - Twilio: https://github.com/twilio/twilio-oai
   - Shopify: https://shopify.dev/docs/api/admin-rest
   - Slack: https://api.slack.com/specs/openapi/v2/slack_web.json
   - Intercom: https://developers.intercom.com/docs/references/rest-api/api.intercom.io/openapi.json
   - Jira: https://developer.atlassian.com/cloud/jira/platform/swagger-v3.v3.json
   - SendGrid: https://github.com/sendgrid/sendgrid-oai
   - Mailchimp: https://api.mailchimp.com/schema/3.0/Swagger.json
   - Sentry: https://github.com/getsentry/sentry-api-schema
   - Notion: https://github.com/ramnes/notion-sdk-py/blob/main/notion_client/openapi.json

3. **Alpha-sorting** - Verify `externalDocumentationUrls` entries are correctly sorted alphabetically by `type` field in each connector's metadata.yaml. Expected order: `api_deprecations`, `api_reference`, `api_release_history`, `authentication_guide`, `openapi_spec`, `rate_limits`, `status_page`, etc.

## User Impact

Users and developers will have easier access to OpenAPI specifications for these connectors, enabling:
- Better understanding of available API endpoints
- Automated tooling integration (code generation, testing, etc.)
- Improved connector development and debugging

No functional changes to connector behavior. This is a metadata-only update.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

This PR only adds documentation links and doesn't modify any connector logic or data processing.

---


**Note**: CI checks for connector version increments are expected to fail as this is intentionally a metadata-only PR without version bumps.

Requested by: AJ Steers (@aaronsteers)  
Devin session: https://app.devin.ai/sessions/b14a62b1dd214a96b6f3ee196eea9f42