### PR TITLE
ci(fix): reduce workflow inputs from 12/11 to 10 to comply with GitHub limit

### DIFF
--- a/.github/workflows/run-live-tests-command.yml
+++ b/.github/workflows/run-live-tests-command.yml
@@ -64,13 +64,16 @@ on:
         description: Disable proxy for requests
         default: "false"
         type: boolean
-      connection_subset:
-        description: The subset of connections to select from.
-        default: "sandboxes"
-        type: choice
-        options:
-          - sandboxes
-          - all
+
+      # Workaround: GitHub currently supports a max of 10 inputs for workflow_dispatch events.
+      # We need to consolidate some inputs to stay within this limit.
+      # connection_subset:
+      #   description: The subset of connections to select from.
+      #   default: "sandboxes"
+      #   type: choice
+      #   options:
+      #     - sandboxes
+      #     - all
 
 jobs:
   live_tests:
@@ -146,7 +149,10 @@ jobs:
       - name: Setup Connection Subset Option
         if: github.event_name == 'workflow_dispatch'
         run: |
-          echo "CONNECTION_SUBSET=--connector_live_tests.connection-subset=${{ github.event.inputs.connection_subset }}" >> $GITHUB_ENV
+          echo "CONNECTION_SUBSET=--connector_live_tests.connection-subset=sandboxes" >> $GITHUB_ENV
+        # TODO: re-enable when we have resolved the more-than-10-inputs issue in workflow_dispatch.
+        # run: |
+        #   echo "CONNECTION_SUBSET=--connector_live_tests.connection-subset=${{ github.event.inputs.connection_subset }}" >> $GITHUB_ENV
 
       # NOTE: We still use a PAT here (rather than a GitHub App) because the workflow needs
       # permissions to add commits to our main repo as well as forks. This will only work on

--- a/.github/workflows/run-live-tests-command.yml
+++ b/.github/workflows/run-live-tests-command.yml
@@ -1,4 +1,4 @@
-name: Connector CI - Run Live Validation Tests
+name: On-Demand Live Connector Validation Tests
 
 concurrency:
   # This is the name of the concurrency group. It is used to prevent concurrent runs of the same workflow.

--- a/.github/workflows/run-regression-tests-command.yml
+++ b/.github/workflows/run-regression-tests-command.yml
@@ -1,4 +1,4 @@
-name: Connector Ops CI - Run Regression Tests
+name: On-Demand Connector Regression Tests
 
 concurrency:
   # This is the name of the concurrency group. It is used to prevent concurrent runs of the same workflow.
@@ -64,17 +64,20 @@ on:
         description: Disable proxy for requests
         default: "false"
         type: boolean
-      connection_subset:
-        description: The subset of connections to select from.
-        default: "sandboxes"
-        type: choice
-        options:
-          - sandboxes
-          - all
-      control_version:
-        description: The version to use as a control version. This is useful when the version defined in the cloud registry does not have a lot of usage (either because a progressive rollout is underway or because a new version has just been released).
-        required: false
-        type: string
+
+      # Workaround: GitHub currently supports a max of 10 inputs for workflow_dispatch events.
+      # We need to consolidate some inputs to stay within this limit.
+      # connection_subset:
+      #   description: The subset of connections to select from.
+      #   default: "sandboxes"
+      #   type: choice
+      #   options:
+      #     - sandboxes
+      #     - all
+      # control_version:
+      #   description: The version to use as a control version. This is useful when the version defined in the cloud registry does not have a lot of usage (either because a progressive rollout is underway or because a new version has just been released).
+      #   required: false
+      #   type: string
 
 jobs:
   regression_tests:
@@ -158,16 +161,22 @@ jobs:
       - name: Setup Connection Subset Option
         if: github.event_name == 'workflow_dispatch'
         run: |
-          echo "CONNECTION_SUBSET=--connector_live_tests.connection-subset=${{ github.event.inputs.connection_subset }}" >> $GITHUB_ENV
+          echo "CONNECTION_SUBSET=--connector_live_tests.connection-subset=sandboxes" >> $GITHUB_ENV
+        # TODO: re-enable when we have resolved the more-than-10-inputs issue in workflow_dispatch.
+        # run: |
+        #   echo "CONNECTION_SUBSET=--connector_live_tests.connection-subset=${{ github.event.inputs.connection_subset }}" >> $GITHUB_ENV
 
       - name: Setup Control Version
         if: github.event_name == 'workflow_dispatch'
         run: |
-          if [ -n "${{ github.event.inputs.control_version }}" ]; then
-            echo "CONTROL_VERSION=--connector_live_tests.control-version=${{ github.event.inputs.control_version }}" >> $GITHUB_ENV
-          else
-            echo "CONTROL_VERSION=" >> $GITHUB_ENV
-          fi
+          echo "CONTROL_VERSION=" >> $GITHUB_ENV
+        # TODO: re-enable when we have resolved the more-than-10-inputs issue in workflow_dispatch.
+        # run: |
+        #   if [ -n "${{ github.event.inputs.control_version }}" ]; then
+        #     echo "CONTROL_VERSION=--connector_live_tests.control-version=${{ github.event.inputs.control_version }}" >> $GITHUB_ENV
+        #   else
+        #     echo "CONTROL_VERSION=" >> $GITHUB_ENV
+        #   fi
 
       # NOTE: We still use a PAT here (rather than a GitHub App) because the workflow needs
       # permissions to add commits to our main repo as well as forks. This will only work on


### PR DESCRIPTION
## What

Fixes a GitHub Actions limitation where `workflow_dispatch` events support a maximum of 10 inputs. Both the live tests and regression tests workflows exceeded this limit, causing workflow dispatch failures.

**Requested by:** @aaronsteers
**Devin Session:** https://app.devin.ai/sessions/485dd65d48114a1cb9ad09683ba6a059

## How

Applied a temporary workaround to both workflows:

1. **`run-regression-tests-command.yml`**: Reduced from 12 to 10 inputs by commenting out:
   - `connection_subset` (hardcoded to default: "sandboxes")
   - `control_version` (hardcoded to default: empty)

2. **`run-live-tests-command.yml`**: Reduced from 11 to 10 inputs by commenting out:
   - `connection_subset` (hardcoded to default: "sandboxes")

The commented-out inputs are preserved with TODO comments for future restoration when the GitHub limitation is resolved or a better solution is found.

## Review guide

1. **`.github/workflows/run-regression-tests-command.yml`**
   - Lines 67-80: Verify `connection_subset` and `control_version` inputs are properly commented out
   - Lines 164-179: Confirm hardcoded defaults match previous defaults ("sandboxes" and empty string)
   - Count total inputs: should be exactly 10

2. **`.github/workflows/run-live-tests-command.yml`**
   - Lines 67-76: Verify `connection_subset` input is properly commented out
   - Lines 152-155: Confirm hardcoded default matches previous default ("sandboxes")
   - Count total inputs: should be exactly 10

## User Impact

**Positive:**
- Workflows can now be triggered via workflow_dispatch without hitting the 10-input limit
- Workflow names updated to be more descriptive ("On-Demand" prefix)

**Negative (Temporary):**
- Users cannot select "all" for `connection_subset` (forced to "sandboxes")
- Users cannot specify a custom `control_version` in regression tests
- This is a temporary limitation until the GitHub platform issue is resolved

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

This is a pure workflow configuration change with no code dependencies. Reverting would restore the previous functionality but re-introduce the 10-input limit error.