### PR TITLE
fix: correct regression test report path for LLM evaluation

### DIFF
--- a/.github/workflows/run-regression-tests-command.yml
+++ b/.github/workflows/run-regression-tests-command.yml
@@ -218,12 +218,26 @@ jobs:
           s3_build_cache_secret_key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
           subcommand: connectors ${{ env.USE_LOCAL_CDK_FLAG }} ${{ inputs.connector_filter }} test --only-step connector_live_tests --connector_live_tests.test-suite=regression --connector_live_tests.connection-id=${{ github.event.inputs.connection_id }} --connector_live_tests.pr-url="https://github.com/airbytehq/airbyte/pull/${{ github.event.inputs.pr }}" ${{ env.READ_WITH_STATE_FLAG }} ${{ env.DISABLE_PROXY_FLAG }} ${{ env.STREAM_PARAMS }} ${{ env.CONNECTION_SUBSET }} ${{ env.CONTROL_VERSION }} --global-status-check-context="Regression Tests" --global-status-check-description='Running regression tests'
 
-      - name: Upload regression test report
+      - name: Locate regression test report
         if: always() && github.event_name == 'workflow_dispatch'
+        id: locate-report
+        run: |
+          # Find the most recent report.html file in /tmp/live_tests_artifacts/
+          REPORT_PATH=$(find /tmp/live_tests_artifacts -name "report.html" -type f -printf '%T@ %p\n' 2>/dev/null | sort -n | tail -1 | cut -f2- -d" ")
+          if [ -n "$REPORT_PATH" ]; then
+            echo "report_path=$REPORT_PATH" >> "$GITHUB_OUTPUT"
+            echo "Found report at: $REPORT_PATH"
+          else
+            echo "report_path=" >> "$GITHUB_OUTPUT"
+            echo "No report.html found in /tmp/live_tests_artifacts/"
+          fi
+
+      - name: Upload regression test report
+        if: always() && github.event_name == 'workflow_dispatch' && steps.locate-report.outputs.report_path != ''
         uses: actions/upload-artifact@v4
         with:
           name: regression-test-report
-          path: /tmp/regression_tests_artifacts/report.html
+          path: ${{ steps.locate-report.outputs.report_path }}
           if-no-files-found: ignore
 
       - name: Append regression outcome
@@ -235,7 +249,7 @@ jobs:
           edit-mode: append
           body: |
             > Regression tests: ${{ steps.run-regression-tests.outcome == 'success' && '✅ PASSED' || steps.run-regression-tests.outcome == 'failure' && '❌ FAILED' || steps.run-regression-tests.outcome == 'cancelled' && '⚠️ CANCELLED' || steps.run-regression-tests.outcome == 'skipped' && '⏭️ SKIPPED' || '❓ UNKNOWN' }}
-            > Report: ${{ hashFiles('/tmp/regression_tests_artifacts/report.html') != '' && 'artifact `regression-test-report` available in the run' || 'not generated' }}
+            > Report: ${{ steps.locate-report.outputs.report_path != '' && 'artifact `regression-test-report` available in the run' || 'not generated' }}
 
       - name: Install live-tests dependencies for LLM evaluation
         if: always() && github.event_name == 'workflow_dispatch'
@@ -252,7 +266,7 @@ jobs:
           echo "Ollama server started and model pulled"
 
       - name: Evaluate Regression Test Report with LLM
-        if: always() && github.event_name == 'workflow_dispatch'
+        if: always() && github.event_name == 'workflow_dispatch' && steps.locate-report.outputs.report_path != ''
         id: llm-eval
         continue-on-error: true
         working-directory: airbyte-ci/connectors/live-tests
@@ -265,18 +279,16 @@ jobs:
           echo "ran=false" >> "$GITHUB_OUTPUT"
           echo "result=error" >> "$GITHUB_OUTPUT"
 
-          # Find the most recent report.html file in /tmp/regression_tests_artifacts/
-          REPORT_PATH=$(find /tmp/regression_tests_artifacts -name "report.html" -type f -printf '%T@ %p\n' | sort -n | tail -1 | cut -f2- -d" ")
+          REPORT_PATH="${{ steps.locate-report.outputs.report_path }}"
 
           if [ -z "$REPORT_PATH" ]; then
-            echo "Error: No report.html found in /tmp/regression_tests_artifacts/" >&2
+            echo "Error: No report path provided from locate-report step" >&2
             echo "## ⚠️ LLM Evaluation Skipped" >> "$GITHUB_STEP_SUMMARY"
             echo "No regression test report found. The tests may have failed to generate a report." >> "$GITHUB_STEP_SUMMARY"
             exit 1
           fi
 
-          echo "Found report at: $REPORT_PATH"
-          echo "Running LLM evaluation..."
+          echo "Evaluating report at: $REPORT_PATH"
 
           # Run the evaluation script
           OUT_JSON="$RUNNER_TEMP/llm_eval.json"


### PR DESCRIPTION
## What

Fixes the regression test report path for LLM evaluation in the `run-regression-tests-command.yml` workflow. The workflow was looking for reports at `/tmp/regression_tests_artifacts/report.html` but the live-tests framework actually saves them to `/tmp/live_tests_artifacts/session_{run_id}/report.html`.

This caused the LLM evaluation step to fail with "No report.html found" as seen in [workflow run 19556935801](https://github.com/airbytehq/airbyte/actions/runs/19556935801).

Related to PR #68673 (LLM evaluation feature) tested on PR #69782.

## How

1. **Added "Locate regression test report" step** - Uses `find` to dynamically locate the most recent `report.html` file under `/tmp/live_tests_artifacts/` and outputs the path to `steps.locate-report.outputs.report_path`

2. **Updated three dependent steps:**
   - "Upload regression test report" - Now uses the dynamically located path instead of hardcoded path
   - "Append regression outcome" - Checks `steps.locate-report.outputs.report_path` instead of `hashFiles()` with hardcoded path  
   - "Evaluate Regression Test Report with LLM" - Uses the located path and only runs if report was found

The path `/tmp/live_tests_artifacts/` comes from `MAIN_OUTPUT_DIRECTORY` constant in `airbyte-ci/connectors/live-tests/src/live_tests/conftest.py:53`.

## Review guide

1. **`.github/workflows/run-regression-tests-command.yml` lines 221-233** - New "Locate regression test report" step
   - ⚠️ **Critical**: Verify the `find` command logic is correct and will work on GitHub Actions runners
   - The `-printf '%T@ %p\n'` syntax is GNU find specific but should work on Ubuntu runners
   - Takes most recent report by modification time if multiple exist

2. **Lines 236, 269** - Updated conditionals
   - Upload and LLM eval steps now check `steps.locate-report.outputs.report_path != ''`
   - This prevents these steps from running when no report is found

3. **Lines 240, 252, 282** - Updated path references
   - All three steps now use `${{ steps.locate-report.outputs.report_path }}` instead of hardcoded paths

## User Impact

**Positive:**
- LLM evaluation will now actually run on regression test reports (previously failed to find report)
- PR comments will correctly show whether report was generated and include LLM evaluation results

**Potential risks:**
- ⚠️ **This change is untested in a real workflow run** - based on code investigation but needs validation
- If multiple sessions exist, takes the most recent report (should be correct but could be fragile)
- If live-tests framework changes `MAIN_OUTPUT_DIRECTORY` in the future, this will break

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Reverting would just restore the broken behavior (report not found). The LLM evaluation feature would fail as it did before, but the core regression tests themselves would continue to work.

---

**Link to Devin run:** https://app.devin.ai/sessions/4068a8bea50145d2b1f11315f06fa213  
**Requested by:** AJ Steers (@aaronsteers)