### PR TITLE
Fix(Source-Notion): Recursion Depth Leak 

### DIFF
--- a/airbyte-integrations/connectors/source-notion/components.py
+++ b/airbyte-integrations/connectors/source-notion/components.py
@@ -85,6 +85,7 @@ class BlocksRetriever(SimpleRetriever):
                     cursor_slice=stream_slice.cursor_slice,
                 )
                 yield from self.read_records(records_schema, child_stream_slice)
+                self.current_block_depth -= 1
 
             if "parent" in stream_data:
                 stream_data["parent"]["sequence_number"] = sequence_number

--- a/airbyte-integrations/connectors/source-notion/metadata.yaml
+++ b/airbyte-integrations/connectors/source-notion/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 6e00b415-b02e-4160-bf02-58176a0ae687
-  dockerImageTag: 3.3.6
+  dockerImageTag: 3.3.7
   dockerRepository: airbyte/source-notion
   documentationUrl: https://docs.airbyte.com/integrations/sources/notion
   externalDocumentationUrls:

--- a/airbyte-integrations/connectors/source-notion/unit_tests/test_components.py
+++ b/airbyte-integrations/connectors/source-notion/unit_tests/test_components.py
@@ -99,7 +99,7 @@ state_test_records = [
 ]
 
 
-def test_blocks_retriever_depth_counter_bug(components_module):
+def test_blocks_retriever_depth_restored_after_children(components_module):
     """
     Test to verify that current_block_depth is correctly incremented and decremented during recursive calls.
 

--- a/airbyte-integrations/connectors/source-notion/unit_tests/test_components.py
+++ b/airbyte-integrations/connectors/source-notion/unit_tests/test_components.py
@@ -102,13 +102,13 @@ state_test_records = [
 def test_blocks_retriever_depth_counter_bug(components_module):
     """
     Test to verify that current_block_depth is correctly incremented and decremented during recursive calls.
-    
+
     This test creates a scenario with two sibling blocks at the same level, both having children:
     - Block A (has_children=True)
       - Block A1 (has_children=False)
-    - Block B (has_children=True)  
+    - Block B (has_children=True)
       - Block B1 (has_children=False)
-    
+
     The depth counter should properly increment when entering a child level and decrement when
     returning to the parent level. This ensures sibling blocks are processed at the correct depth.
     """
@@ -125,14 +125,22 @@ def test_blocks_retriever_depth_counter_bug(components_module):
     retriever._paginator = MagicMock()
     depth_tracker = []
 
-    block_a = Record(data={"id": "block-a", "has_children": True}, stream_name="blocks", associated_slice=StreamSlice(partition={}, cursor_slice={}))
-    block_a1 = Record(data={"id": "block-a1", "has_children": False}, stream_name="blocks", associated_slice=StreamSlice(partition={}, cursor_slice={}))
-    block_b = Record(data={"id": "block-b", "has_children": True}, stream_name="blocks", associated_slice=StreamSlice(partition={}, cursor_slice={}))
-    block_b1 = Record(data={"id": "block-b1", "has_children": False}, stream_name="blocks", associated_slice=StreamSlice(partition={}, cursor_slice={}))
-    
+    block_a = Record(
+        data={"id": "block-a", "has_children": True}, stream_name="blocks", associated_slice=StreamSlice(partition={}, cursor_slice={})
+    )
+    block_a1 = Record(
+        data={"id": "block-a1", "has_children": False}, stream_name="blocks", associated_slice=StreamSlice(partition={}, cursor_slice={})
+    )
+    block_b = Record(
+        data={"id": "block-b", "has_children": True}, stream_name="blocks", associated_slice=StreamSlice(partition={}, cursor_slice={})
+    )
+    block_b1 = Record(
+        data={"id": "block-b1", "has_children": False}, stream_name="blocks", associated_slice=StreamSlice(partition={}, cursor_slice={})
+    )
+
     def mock_super_read_records(self, records_schema, stream_slice=None):
         depth_tracker.append(retriever.current_block_depth)
-        
+
         if stream_slice is None or not stream_slice.partition:
             yield block_a
             yield block_b
@@ -140,8 +148,8 @@ def test_blocks_retriever_depth_counter_bug(components_module):
             yield block_a1
         elif stream_slice.partition.get("block_id") == "block-b":
             yield block_b1
-    
-    with patch.object(SimpleRetriever, 'read_records', mock_super_read_records):
+
+    with patch.object(SimpleRetriever, "read_records", mock_super_read_records):
         stream_slice = StreamSlice(partition={}, cursor_slice={})
         results = list(retriever.read_records({}, stream_slice))
 

--- a/docs/integrations/sources/notion.md
+++ b/docs/integrations/sources/notion.md
@@ -119,7 +119,7 @@ The connector is restricted by Notion [request limits](https://developers.notion
 
 | Version     | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:------------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 3.3.7 | 2025-11-20 | [69375](https://github.com/airbytehq/airbyte/pull/69780) | Fix bug in current_block_depth |
+| 3.3.7 | 2025-11-24 | [69375](https://github.com/airbytehq/airbyte/pull/69780) | Fix bug in current_block_depth |
 | 3.3.6 | 2025-11-18 | [69375](https://github.com/airbytehq/airbyte/pull/69375) | Update dependencies |
 | 3.3.5 | 2025-10-29 | [68750](https://github.com/airbytehq/airbyte/pull/68750) | Update dependencies |
 | 3.3.4 | 2025-10-21 | [68399](https://github.com/airbytehq/airbyte/pull/68399) | Update dependencies |

--- a/docs/integrations/sources/notion.md
+++ b/docs/integrations/sources/notion.md
@@ -119,6 +119,7 @@ The connector is restricted by Notion [request limits](https://developers.notion
 
 | Version     | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:------------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 3.3.7 | 2025-11-20 | [69375](https://github.com/airbytehq/airbyte/pull/69780) | Fix bug in current_block_depth |
 | 3.3.6 | 2025-11-18 | [69375](https://github.com/airbytehq/airbyte/pull/69375) | Update dependencies |
 | 3.3.5 | 2025-10-29 | [68750](https://github.com/airbytehq/airbyte/pull/68750) | Update dependencies |
 | 3.3.4 | 2025-10-21 | [68399](https://github.com/airbytehq/airbyte/pull/68399) | Update dependencies |

--- a/docs/integrations/sources/notion.md
+++ b/docs/integrations/sources/notion.md
@@ -119,7 +119,7 @@ The connector is restricted by Notion [request limits](https://developers.notion
 
 | Version     | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:------------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 3.3.7 | 2025-11-24 | [69375](https://github.com/airbytehq/airbyte/pull/69780) | Fix bug in current_block_depth |
+| 3.3.7 | 2025-11-24 | [69375](https://github.com/airbytehq/airbyte/pull/69780) | Fix bug in current_block_depth  |
 | 3.3.6 | 2025-11-18 | [69375](https://github.com/airbytehq/airbyte/pull/69375) | Update dependencies |
 | 3.3.5 | 2025-10-29 | [68750](https://github.com/airbytehq/airbyte/pull/68750) | Update dependencies |
 | 3.3.4 | 2025-10-21 | [68399](https://github.com/airbytehq/airbyte/pull/68399) | Update dependencies |


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->
Fix depth counter bug in BlocksRetriever that caused current_block_depth to accumulate incorrectly across sibling blocks with children.

The BlocksRetriever.read_records() method increments current_block_depth when processing blocks with children, but was never decrementing it after the recursive call completes. This causes the depth counter to keep growing instead of returning to the parent level.

Impact of the bug:

source INFO Reached max block depth limit. Exiting.
When processing multiple sibling blocks that have children, the depth counter would incorrectly accumulate
Could prematurely hit the MAX_BLOCK_DEPTH limit (30) and stop retrieving valid nested blocks
Example: Processing 30 sibling blocks with children would incorrectly reach depth 30, even though the actual nesting depth is only 1
## How
<!--
* Describe how code changes achieve the solution.
-->
Added self.current_block_depth -= 1 after the recursive yield from self.read_records() call in components.py line 88 to properly restore the depth counter when returning from child block processing.
## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X ] YES 💚
- [ ] NO ❌
