### PR TITLE
fix(bulk-cdk): Add checkout step to detect-changes job in Dokka workflow

### DIFF
--- a/.github/workflows/kotlin-bulk-cdk-dokka-publish.yml
+++ b/.github/workflows/kotlin-bulk-cdk-dokka-publish.yml
@@ -22,6 +22,11 @@ jobs:
     name: Detect Kotlin Bulk CDK Changes
     runs-on: ubuntu-24.04
     steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Detect Changes
         id: detect-changes
         uses: dorny/paths-filter@v3.0.2


### PR DESCRIPTION
## What

Fixes the Kotlin Bulk CDK Documentation workflow failing on master branch with error:
```
fatal: not a git repository (or any of the parent directories): .git
##[error]The process '/usr/bin/git' failed with exit code 128
```

**Failed run:** https://github.com/airbytehq/airbyte/actions/runs/19578468640

**Requested by:** AJ Steers (@aaronsteers)  
**Devin session:** https://app.devin.ai/sessions/f46b19703bd848dbad2c58cb105d470a

## How

Added `actions/checkout@v4` step with `fetch-depth: 0` to the `detect-changes` job before running `dorny/paths-filter@v3.0.2`.

**Root cause:** The `dorny/paths-filter` action behaves differently on `pull_request` vs `push` events:
- On `pull_request` events: Uses GitHub API to detect changes (no local git repo needed)
- On `push` events: Runs git commands locally (requires a checked-out repository)

The workflow worked on PRs but failed on master because the `detect-changes` job had no checkout step.

## Review guide

1. **`.github/workflows/kotlin-bulk-cdk-dokka-publish.yml` lines 25-28**: Verify the checkout step is correctly placed before the paths-filter action
2. **`fetch-depth: 0`**: Confirm this is appropriate for paths-filter to detect changes (it needs git history)
3. **Potential issue**: Verify that the GitHub variable `VERCEL_KOTLIN_CDK_PROJECT_ID` is configured in the repository settings (line 86, 90). If not configured, the Vercel deployment will silently skip.

## User Impact

**Positive:**
- The Kotlin Bulk CDK documentation workflow will now run successfully on master branch pushes
- Documentation will be automatically deployed to production on master merges

**Negative:**
- None expected. The checkout step adds minimal overhead (~1-2 seconds)

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Reverting would return the workflow to its broken state on master, but would not affect any other functionality. The workflow would continue to work on PRs (using GitHub API) but fail on master pushes.