### PR TITLE
feat(bulk-cdk): Enable force-publish via workflow_dispatch

### DIFF
--- a/.github/workflows/kotlin-bulk-cdk-dokka-publish.yml
+++ b/.github/workflows/kotlin-bulk-cdk-dokka-publish.yml
@@ -42,7 +42,8 @@ jobs:
     name: Build Kotlin Bulk CDK Documentation
     runs-on: ubuntu-24.04
     needs: detect-changes
-    if: needs.detect-changes.outputs.changed == 'true'
+    # Build docs if changes detected OR if manually triggered via workflow_dispatch
+    if: needs.detect-changes.outputs.changed == 'true' || github.event_name == 'workflow_dispatch'
 
     steps:
       - name: Checkout Repository
@@ -81,12 +82,14 @@ jobs:
   vercel-preview:
     name: Deploy Docs to Vercel (Preview)
     needs: [detect-changes, build-docs]
-    # Only deploy for non-fork PRs and master branch, and when Vercel project is configured
+    # Deploy for: non-fork PRs, master branch pushes, OR manual workflow_dispatch
+    # Always require Vercel project to be configured
     if: >
-      needs.detect-changes.outputs.changed == 'true'
+      (needs.detect-changes.outputs.changed == 'true' || github.event_name == 'workflow_dispatch')
       && (
         github.event_name == 'push'
         || github.event.pull_request.head.repo.full_name == github.repository
+        || github.event_name == 'workflow_dispatch'
       )
       && vars.VERCEL_KOTLIN_CDK_PROJECT_ID != ''
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## What

Enables manual triggering of the Kotlin Bulk CDK documentation build and deployment via `workflow_dispatch`. This allows force-publishing documentation even when no Bulk CDK files have changed, which is useful for:
- Re-publishing after fixing workflow issues (like the recent master branch failure in #69806)
- Updating documentation after Vercel configuration changes
- Manual deployments when needed

Related to #69752 (original Dokka implementation) and #69806 (master branch fix).

## How

Updated the conditional logic in two jobs:
1. **build-docs**: Added `|| github.event_name == 'workflow_dispatch'` to the if condition so docs are built when manually triggered
2. **vercel-preview**: Added `|| github.event_name == 'workflow_dispatch'` to both parts of the if condition so deployment happens when manually triggered

The workflow will now trigger on:
- Pull requests with Bulk CDK changes (existing behavior)
- Pushes to master with Bulk CDK changes (existing behavior)
- Manual workflow_dispatch events (new behavior)

## Review guide

1. **`.github/workflows/kotlin-bulk-cdk-dokka-publish.yml`** - Review the conditional logic:
   - Line 45-46: `build-docs` job condition now includes workflow_dispatch
   - Lines 87-93: `vercel-preview` job condition now includes workflow_dispatch in both OR clauses
   - Verify the logic correctly handles all three trigger types (push, pull_request, workflow_dispatch)
   - Confirm the Vercel project ID guard (`vars.VERCEL_KOTLIN_CDK_PROJECT_ID != ''`) still protects against misconfiguration

## User Impact

**Positive:**
- Maintainers can manually trigger documentation builds and deployments without making code changes
- Fixes the issue where workflow fixes don't automatically re-publish docs

**Potential issues:**
- ⚠️ **Cannot test in CI**: This PR only changes the workflow file, so the Dokka build won't run in CI (path filter). Manual testing via workflow_dispatch will be needed after merge.
- ⚠️ **Requires Vercel setup**: The `VERCEL_KOTLIN_CDK_PROJECT_ID` variable must be configured in repository settings for deployments to work.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

This only adds an additional trigger condition. Reverting would remove the manual trigger capability but wouldn't break existing automated deployments.

---

**Link to Devin run**: https://app.devin.ai/sessions/f46b19703bd848dbad2c58cb105d470a  
**Requested by**: AJ Steers (@aaronsteers)