### PR TITLE
perf(bulk-cdk): Optimize checkout operations in Dokka workflow

### DIFF
--- a/.github/workflows/kotlin-bulk-cdk-dokka-publish.yml
+++ b/.github/workflows/kotlin-bulk-cdk-dokka-publish.yml
@@ -40,7 +40,6 @@ jobs:
         if: github.event_name != 'workflow_dispatch'
         uses: dorny/paths-filter@v3.0.2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           filters: |
             bulk-cdk:
               - 'airbyte-cdk/bulk/**'

--- a/.github/workflows/kotlin-bulk-cdk-dokka-publish.yml
+++ b/.github/workflows/kotlin-bulk-cdk-dokka-publish.yml
@@ -21,22 +21,29 @@ jobs:
   detect-changes:
     name: Detect Kotlin Bulk CDK Changes
     runs-on: ubuntu-24.04
+    outputs:
+      changed: ${{ steps.set-changed.outputs.changed || steps.detect-changes.outputs.bulk-cdk }}
     steps:
-      - name: Checkout Repository
+      - name: Manual trigger - mark as changed
+        id: set-changed
+        if: github.event_name == 'workflow_dispatch'
+        run: echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout Repository (push only, shallow)
+        if: github.event_name == 'push'
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 2
 
-      - name: Detect Changes
+      - name: Detect Changes (PR via API, push via git)
         id: detect-changes
+        if: github.event_name != 'workflow_dispatch'
         uses: dorny/paths-filter@v3.0.2
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           filters: |
             bulk-cdk:
               - 'airbyte-cdk/bulk/**'
-
-    outputs:
-      changed: ${{ steps.detect-changes.outputs.bulk-cdk }}
 
   build-docs:
     name: Build Kotlin Bulk CDK Documentation
@@ -49,7 +56,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.head_ref || github.ref }}
 

--- a/.github/workflows/kotlin-bulk-cdk-dokka-publish.yml
+++ b/.github/workflows/kotlin-bulk-cdk-dokka-publish.yml
@@ -21,21 +21,21 @@ jobs:
   detect-changes:
     name: Detect Kotlin Bulk CDK Changes
     runs-on: ubuntu-24.04
-    outputs:
-      changed: ${{ steps.set-changed.outputs.changed || steps.detect-changes.outputs.bulk-cdk }}
     steps:
-      - name: Manual trigger - mark as changed
+      - name: Force 'changed=true' [Manual Trigger]
         id: set-changed
         if: github.event_name == 'workflow_dispatch'
         run: echo "changed=true" >> "$GITHUB_OUTPUT"
 
-      - name: Checkout Repository (push only, shallow)
+      - name: Checkout Repository [Push Trigger]
         if: github.event_name == 'push'
         uses: actions/checkout@v4
         with:
           fetch-depth: 2
 
-      - name: Detect Changes (PR via API, push via git)
+      - name: Detect Changes
+        # PR triggers will use API (don't require pre-checkout.)
+        # Push triggers will require the checked-out code.
         id: detect-changes
         if: github.event_name != 'workflow_dispatch'
         uses: dorny/paths-filter@v3.0.2
@@ -43,6 +43,9 @@ jobs:
           filters: |
             bulk-cdk:
               - 'airbyte-cdk/bulk/**'
+
+    outputs:
+      changed: ${{ steps.set-changed.outputs.changed || steps.detect-changes.outputs.bulk-cdk }}
 
   build-docs:
     name: Build Kotlin Bulk CDK Documentation


### PR DESCRIPTION
## What

Optimizes git checkout operations in the Kotlin Bulk CDK Dokka documentation workflow to significantly reduce execution time and fixes production deployment failures caused by alias domain misconfiguration.

Requested by @aaronsteers in [Devin session](https://app.devin.ai/sessions/f46b19703bd848dbad2c58cb105d470a).

## How

**detect-changes job optimizations:**
- **workflow_dispatch**: Skip checkout entirely, set `changed=true` directly via early step
- **push on master**: Use `fetch-depth: 2` (only need current + previous commit for change detection)
- **pull_request**: No checkout needed (dorny/paths-filter uses GitHub API)
- Updated job outputs to use OR expression: `${{ steps.set-changed.outputs.changed || steps.detect-changes.outputs.bulk-cdk }}` to handle skipped steps

**build-docs job optimization:**
- Changed `fetch-depth` from `0` to `1` (only need current commit to build docs)

**Production deployment fix:**
- Removed `alias-domains` configuration that was trying to assign `bulk-cdk-docs.vercel.app`
- The actual Vercel project uses `airbyte-kotlin-cdk.vercel.app` which is automatically assigned for production
- The hardcoded alias was causing "Deployment not found" errors during production deployments

## Review guide

1. **`.github/workflows/kotlin-bulk-cdk-dokka-publish.yml` (lines 21-46)** - **Most critical**: Verify the conditional logic in detect-changes job:
   - Does the output expression `steps.set-changed.outputs.changed || steps.detect-changes.outputs.bulk-cdk` correctly handle all three trigger types?
   - Will the OR expression work correctly when one step is skipped (e.g., when `set-changed` runs but `detect-changes` is skipped)?
   - Is `fetch-depth: 2` sufficient for push events, especially with merge commits? (Trade-off: speed vs. completeness)

2. **`.github/workflows/kotlin-bulk-cdk-dokka-publish.yml` (lines 55-60)** - Verify `fetch-depth: 1` is sufficient for building docs (should be fine since we only need current code)

3. **`.github/workflows/kotlin-bulk-cdk-dokka-publish.yml` (lines 139-148)** - Confirm removing `alias-domains` is correct:
   - Vercel automatically assigns `airbyte-kotlin-cdk.vercel.app` for production
   - The removed alias (`bulk-cdk-docs.vercel.app`) was causing deployment failures
   - Is `airbyte-kotlin-cdk.vercel.app` the intended production URL?

## User Impact

**Positive:**
- Significantly faster workflow execution by avoiding full history fetches
- detect-changes job will be nearly instant for workflow_dispatch triggers
- Production deployments will succeed (previously failing on alias assignment)
- Reduced GitHub Actions minutes usage

**Neutral:**
- Production docs URL remains `airbyte-kotlin-cdk.vercel.app` (no change from current behavior)

**Potential risks:**
- If `fetch-depth: 2` is insufficient for certain merge commit scenarios on master, change detection might miss some changes (unlikely for typical fast-forward merges)
- The conditional logic in detect-changes hasn't been tested in all three scenarios (workflow_dispatch, push, pull_request) in the live environment

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

This only optimizes checkout operations and fixes a deployment configuration issue. Reverting will restore the slower full-history fetches and re-introduce the alias assignment failure, but won't break core functionality.