### PR TITLE
fix(bulk-cdk): Remove alias-domains and add documentation links

### DIFF
--- a/.github/workflows/kotlin-bulk-cdk-dokka-publish.yml
+++ b/.github/workflows/kotlin-bulk-cdk-dokka-publish.yml
@@ -149,8 +149,6 @@ jobs:
           vercel-project-id: ${{ env.VERCEL_PROJECT_ID }}
           working-directory: docs-output
           vercel-args: ${{ github.ref == 'refs/heads/master' && '--prod' || '' }}
-          alias-domains: |
-            ${{ github.ref == 'refs/heads/master' && 'bulk-cdk-docs.vercel.app' || '' }}
 
       - name: Authenticate as GitHub App
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
## What

Fixes production deployment failures in the Kotlin Bulk CDK Dokka workflow and adds links to the published API documentation.

**Problem**: Production deployments were failing with "Deployment not found" errors when trying to assign a custom alias domain that didn't match the actual Vercel project configuration.

**Root cause**: The workflow was trying to assign `bulk-cdk-docs.vercel.app` as an alias, but the actual Vercel project is configured with `airbyte-kotlin-cdk.vercel.app` which is automatically assigned by Vercel for production deployments.

Fixes production deployment failure: https://github.com/airbytehq/airbyte/actions/runs/19580022813

Requested by @aaronsteers in [Devin session](https://app.devin.ai/sessions/f46b19703bd848dbad2c58cb105d470a).

## How

**Workflow fix:**
- Removed the `alias-domains` configuration from `.github/workflows/kotlin-bulk-cdk-dokka-publish.yml`
- Vercel automatically assigns `airbyte-kotlin-cdk.vercel.app` as the production alias, so the explicit configuration was redundant and causing failures

**Documentation links:**
- Added link to published API documentation (https://airbyte-kotlin-cdk.vercel.app/) in `README.md` at the top alongside the Contributing link
- Added link to published API documentation in `CONTRIBUTING.md` in the "Generating Documentation" section

## Review guide

1. **`.github/workflows/kotlin-bulk-cdk-dokka-publish.yml` (lines 149-153)** - **Most critical**: Verify that removing `alias-domains` is the correct fix:
   - Is `airbyte-kotlin-cdk.vercel.app` the intended production URL? (This is what Vercel automatically assigns)
   - Should we instead add `bulk-cdk-docs.vercel.app` to the Vercel project settings and keep the alias configuration?
   - The removal assumes Vercel's automatic aliasing is sufficient

2. **`airbyte-cdk/bulk/README.md` (line 7)** - Check that the documentation link placement makes sense:
   - Added at the top alongside Contributing link
   - Format: `**Documentation**: [API Reference](https://airbyte-kotlin-cdk.vercel.app/)`

3. **`airbyte-cdk/bulk/CONTRIBUTING.md` (lines 32-34)** - Check that the documentation link placement makes sense:
   - Added in the "Generating Documentation" section before "Generate Documentation Locally"
   - Provides context that published docs are available before showing how to generate locally

## User Impact

**Positive:**
- Production deployments will succeed (previously failing on alias assignment)
- Users can now easily find the published API documentation from README and CONTRIBUTING files
- Documentation is accessible at https://airbyte-kotlin-cdk.vercel.app/

**Neutral:**
- Production docs URL is `airbyte-kotlin-cdk.vercel.app` (matches the Vercel project name)
- If a different vanity domain is desired in the future, it would need to be added to Vercel project settings first

**Potential risks:**
- If the Vercel project name changes in the future, the hardcoded documentation links will break
- The domain mismatch between the original plan (`bulk-cdk-docs.vercel.app`) and actual implementation (`airbyte-kotlin-cdk.vercel.app`) suggests there may have been miscommunication about the intended production URL

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Reverting will re-introduce the alias assignment failure in production deployments and remove the documentation links, but won't break core functionality. The documentation will still be accessible directly via Vercel, just not linked from the README/CONTRIBUTING files.