### PR TITLE
docs(bulk-cdk): Add API documentation links to README and CONTRIBUTING

### DIFF
--- a/airbyte-cdk/bulk/CONTRIBUTING.md
+++ b/airbyte-cdk/bulk/CONTRIBUTING.md
@@ -29,7 +29,9 @@ sdk default java 21.0.9-zulu
 
 The Kotlin Bulk CDK uses [Dokka](https://kotlinlang.org/docs/dokka-introduction.html) to generate API documentation from KDoc comments.
 
-### Generate Documentation
+**Published Documentation**: The latest API documentation is available at https://airbyte-kotlin-cdk.vercel.app/
+
+### Generate Documentation Locally
 
 ```bash
 ./gradlew :airbyte-cdk:bulk:docsGenerate

--- a/airbyte-cdk/bulk/README.md
+++ b/airbyte-cdk/bulk/README.md
@@ -4,7 +4,8 @@ The Bulk CDK is the "new java CDK" that's currently incubating.
 As the name suggests, its purpose is to help develop connectors which extract or load data in bulk.
 The Bulk CDK is written in Kotlin and uses the Micronaut framework for dependency injection.
 
-**Documentation**: [API Reference](https://airbyte-kotlin-cdk.vercel.app/) | **Contributing**: See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, building, testing, and documentation generation instructions.
+- **API Reference Docs**: [Kotlin CDK API Reference](https://airbyte-kotlin-cdk.vercel.app/)
+- **Contributing**: See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Structure
 

--- a/airbyte-cdk/bulk/README.md
+++ b/airbyte-cdk/bulk/README.md
@@ -4,7 +4,7 @@ The Bulk CDK is the "new java CDK" that's currently incubating.
 As the name suggests, its purpose is to help develop connectors which extract or load data in bulk.
 The Bulk CDK is written in Kotlin and uses the Micronaut framework for dependency injection.
 
-**Contributing**: See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, building, testing, and documentation generation instructions.
+**Documentation**: [API Reference](https://airbyte-kotlin-cdk.vercel.app/) | **Contributing**: See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, building, testing, and documentation generation instructions.
 
 ## Structure
 


### PR DESCRIPTION
## What

Adds links to the published Kotlin Bulk CDK API documentation in README.md and CONTRIBUTING.md to make the documentation easily discoverable for developers.

The documentation is published at https://airbyte-kotlin-cdk.vercel.app/ via the Dokka workflow set up in PR #69809 and PR #69810.

Requested by @aaronsteers in [Devin session](https://app.devin.ai/sessions/f46b19703bd848dbad2c58cb105d470a).

## How

- **README.md**: Added documentation link at the top alongside the Contributing link in the format: `**Documentation**: [API Reference](https://airbyte-kotlin-cdk.vercel.app/)`
- **CONTRIBUTING.md**: Added a "Published Documentation" note in the "Generating Documentation" section before the "Generate Documentation Locally" subsection

## Review guide

1. **Verify the documentation URL works**: Visit https://airbyte-kotlin-cdk.vercel.app/ to confirm the documentation is live and rendering correctly
2. **`airbyte-cdk/bulk/README.md` (line 7)**: Check that the documentation link placement makes sense at the top of the README
3. **`airbyte-cdk/bulk/CONTRIBUTING.md` (lines 32-34)**: Check that the published documentation link is appropriately placed in the "Generating Documentation" section

## User Impact

**Positive:**
- Developers can now easily find the published API documentation from the README and CONTRIBUTING files
- Reduces friction for developers looking for API reference documentation

**Neutral:**
- The documentation URL is hardcoded; if the Vercel project name changes in the future, these links will need to be updated

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Reverting will simply remove the documentation links from README and CONTRIBUTING files. The documentation will still be accessible directly via Vercel, just not linked from these files.