### PR TITLE
Fixed the source-rss connector path - preventing it from adding trail…

### DIFF
--- a/airbyte-integrations/connectors/source-rss/source_rss/manifest.yaml
+++ b/airbyte-integrations/connectors/source-rss/source_rss/manifest.yaml
@@ -37,7 +37,7 @@ definitions:
       schema:
         $ref: "#/definitions/items_schema"
     $parameters:
-      path: "/"
+      path: ""
     incremental_sync:
       type: DatetimeBasedCursor
       cursor_field: published


### PR DESCRIPTION
## What
Fixed the source-rss connector path - preventing it from adding trailing '/' unnecessarily
This issue has been recognized for over one year, and an invitation was made in [Issue 45389](https://github.com/airbytehq/airbyte/issues/45389) for the "community" to identify the issue and offer a solution. 

This problem is exemplified by an RSS URL such as: 

* https://www.cyber.gc.ca/api/cccs/atom/v1/get?feed=alerts_advisories

When the `source-rss` connector automatically appends a `/` at the end (https://www.cyber.gc.ca/api/cccs/atom/v1/get?feed=alerts_advisories/),  it returns a failed status: 

```
<feed xml:lang="en">
<id>https://cyber.gc.ca/&lang=en</id>
<link rel="self" href="https://cyber.gc.ca/&lang=en"/>
<title>404 - ERROR</title>
<updated/>
</feed>
```

The user should be able to enter the correct URL and it should be used without modification. 

## How
modified the `manifest.yaml` file to change `path: "/"` to `path: ""`.

## User Impact
The end result is that the Airbyte installation will import RSS feeds properly out of the box.

