### PR TITLE
Allow socket count to be overridden in CDK.

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/config/InputBeanFactory.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/config/InputBeanFactory.kt
@@ -40,9 +40,23 @@ import kotlinx.coroutines.flow.Flow
 @Factory
 class InputBeanFactory {
     @Requires(property = "airbyte.destination.core.data-channel.medium", value = "SOCKET")
+    @Named("socketPaths")
+    @Singleton
+    fun socketPaths(
+        @Value("\${airbyte.destination.core.data-channel.count-override}") count: Int?,
+        @Value("\${airbyte.destination.core.data-channel.socket-paths}") socketPaths: List<String>,
+    ): List<String> {
+        return if (count != null) {
+            socketPaths.take(count)
+        } else {
+            socketPaths
+        }
+    }
+
+    @Requires(property = "airbyte.destination.core.data-channel.medium", value = "SOCKET")
     @Singleton
     fun sockets(
-        @Value("\${airbyte.destination.core.data-channel.socket-paths}") socketPaths: List<String>,
+        @Named("socketPaths") socketPaths: List<String>,
         @Value("\${airbyte.destination.core.data-channel.socket-buffer-size-bytes}")
         bufferSizeBytes: Int,
         @Value("\${airbyte.destination.core.data-channel.socket-connection-timeout-ms}")


### PR DESCRIPTION
Allows socket count to be overridden for GCS data lake or other dests which need to specify socket count