### PR TITLE
chore(connectors_qa): Improve version increment check messages for clarity

### DIFF
--- a/airbyte-ci/connectors/connectors_qa/src/connectors_qa/checks/version.py
+++ b/airbyte-ci/connectors/connectors_qa/src/connectors_qa/checks/version.py
@@ -97,7 +97,8 @@ class CheckVersionIncrement(Check):
                 return self.fail(
                     connector,
                     f"The dockerImageTag in {consts.METADATA_FILE_NAME} was not incremented. "
-                    f"Master version is {master_version}, current version is {current_version}",
+                    f"Master version is {master_version}, current version is {current_version}. "
+                    f"Ignore this message if you do not intend to re-release the connector.",
                 )
 
             if self._are_both_versions_release_candidates(master_version, current_version):

--- a/airbyte-ci/connectors/connectors_qa/src/connectors_qa/checks/version.py
+++ b/airbyte-ci/connectors/connectors_qa/src/connectors_qa/checks/version.py
@@ -93,7 +93,15 @@ class CheckVersionIncrement(Check):
             current_version = self._get_current_connector_version(connector)
 
             # Require a version increment
-            if current_version <= master_version:
+            if current_version < master_version:
+                return self.fail(
+                    connector,
+                    f"The dockerImageTag in {consts.METADATA_FILE_NAME} appears to be lower than the "
+                    f"version on the default branch. Master version is {master_version}, current "
+                    f"version is {current_version}. "
+                    f"Update your PR branch from the default branch to get the latest connector version.",
+                )
+            if current_version == master_version:
                 return self.fail(
                     connector,
                     f"The dockerImageTag in {consts.METADATA_FILE_NAME} was not incremented. "

--- a/airbyte-ci/connectors/connectors_qa/tests/unit_tests/test_checks/test_version.py
+++ b/airbyte-ci/connectors/connectors_qa/tests/unit_tests/test_checks/test_version.py
@@ -37,7 +37,7 @@ class TestVersionIncrementCheck:
         assert result.status == CheckStatus.FAILED
         assert (
             result.message
-            == f"The dockerImageTag in {consts.METADATA_FILE_NAME} was not incremented. Master version is 1.0.0, current version is 1.0.0"
+            == f"The dockerImageTag in {consts.METADATA_FILE_NAME} was not incremented. Master version is 1.0.0, current version is 1.0.0. Ignore this message if you do not intend to re-release the connector."
         )
 
     def test_validate_success_rc_increment(self, mock_connector, mocker):

--- a/airbyte-ci/connectors/connectors_qa/tests/unit_tests/test_checks/test_version.py
+++ b/airbyte-ci/connectors/connectors_qa/tests/unit_tests/test_checks/test_version.py
@@ -40,6 +40,15 @@ class TestVersionIncrementCheck:
             == f"The dockerImageTag in {consts.METADATA_FILE_NAME} was not incremented. Master version is 1.0.0, current version is 1.0.0. Ignore this message if you do not intend to re-release the connector."
         )
 
+    def test_validate_failure_decrement(self, mock_connector, mocker):
+        version_increment_check = self._get_version_increment_check(mocker, master_version="1.1.0", current_version="1.0.0")
+        result = version_increment_check._run(mock_connector)
+        assert result.status == CheckStatus.FAILED
+        assert (
+            result.message
+            == f"The dockerImageTag in {consts.METADATA_FILE_NAME} appears to be lower than the version on the default branch. Master version is 1.1.0, current version is 1.0.0. Update your PR branch from the default branch to get the latest connector version."
+        )
+
     def test_validate_success_rc_increment(self, mock_connector, mocker):
         version_increment_check = self._get_version_increment_check(mocker, master_version="1.0.1-rc.1", current_version="1.0.1-rc.2")
         result = version_increment_check._run(mock_connector)


### PR DESCRIPTION
## What

Updates the version increment check failure messages in QA checks to provide clearer guidance to users:
1. When version is not incremented (same as master): tells users they can ignore if not re-releasing
2. When version appears decremented (lower than master): suggests updating the PR branch from the default branch

This addresses feedback from [this Slack conversation](https://airbytehq-team.slack.com/archives/C09UDKZHQ5Q/p1764608852349439?thread_ts=1764608648.207459&cid=C09UDKZHQ5Q) where it was noted that a low-tech fix would be to add a note to the failure message itself.

## How

Split the original `current_version <= master_version` condition into two separate cases:
- `current_version < master_version`: New message indicating the version appears lower than the default branch, suggesting to update the PR branch
- `current_version == master_version`: Message noting the version was not incremented, with guidance that it can be ignored if not re-releasing

## Review guide

1. `airbyte-ci/connectors/connectors_qa/src/connectors_qa/checks/version.py` - Logic split and updated messages
2. `airbyte-ci/connectors/connectors_qa/tests/unit_tests/test_checks/test_version.py` - Updated existing test and added new `test_validate_failure_decrement` test

### Suggested review checklist
- [ ] Verify the logic split from `<=` to separate `<` and `==` checks is correct
- [ ] Confirm message wording is clear and actionable for users

## User Impact

Users who see the version increment check failure will now receive more specific guidance:
- If their version matches master, they'll know they can ignore the message if not planning to re-release
- If their version is lower than master (likely due to an outdated branch), they'll be prompted to update from the default branch

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Requested by AJ Steers (@aaronsteers)

Link to Devin run: https://app.devin.ai/sessions/37dcaf034ff449848056084cbafc706d