### PR TITLE
fix(destination-bigquery): Handle InterruptedException in coroutine context during setup (do not merge)

### DIFF
--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/BigQueryCoroutineHelper.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/BigQueryCoroutineHelper.kt
@@ -12,16 +12,18 @@ import kotlinx.coroutines.withContext
 /**
  * Helper function for executing blocking BigQuery SDK calls within a coroutine context.
  *
- * This function addresses the issue where BigQuery SDK's blocking calls (like `getTable()`, `query()`)
- * use `AbstractFuture.get()` internally, which throws `InterruptedException` when the thread is
- * interrupted. When running in a coroutine context, if the coroutine is cancelled (e.g., due to
- * timeout or parent scope cancellation), the thread may be interrupted, causing the BigQuery SDK
- * to throw `BigQueryException` with `InterruptedException` as the cause.
+ * This function addresses the issue where BigQuery SDK's blocking calls (like `getTable()`,
+ * `query()`) use `AbstractFuture.get()` internally, which throws `InterruptedException` when the
+ * thread is interrupted. When running in a coroutine context, if the coroutine is cancelled (e.g.,
+ * due to timeout or parent scope cancellation), the thread may be interrupted, causing the BigQuery
+ * SDK to throw `BigQueryException` with `InterruptedException` as the cause.
  *
  * This helper:
  * 1. Ensures the blocking call runs on `Dispatchers.IO` (appropriate for blocking I/O operations)
  * 2. Converts `BigQueryException` caused by `InterruptedException` to `CancellationException`,
+ * ```
  *    allowing proper coroutine cancellation handling
+ * ```
  * 3. Also handles direct `InterruptedException` for cases like `Thread.sleep()` in polling loops
  *
  * Usage:

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/BigQueryCoroutineHelper.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/BigQueryCoroutineHelper.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.bigquery
+
+import com.google.cloud.bigquery.BigQueryException
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * Helper function for executing blocking BigQuery SDK calls within a coroutine context.
+ *
+ * This function addresses the issue where BigQuery SDK's blocking calls (like `getTable()`, `query()`)
+ * use `AbstractFuture.get()` internally, which throws `InterruptedException` when the thread is
+ * interrupted. When running in a coroutine context, if the coroutine is cancelled (e.g., due to
+ * timeout or parent scope cancellation), the thread may be interrupted, causing the BigQuery SDK
+ * to throw `BigQueryException` with `InterruptedException` as the cause.
+ *
+ * This helper:
+ * 1. Ensures the blocking call runs on `Dispatchers.IO` (appropriate for blocking I/O operations)
+ * 2. Converts `BigQueryException` caused by `InterruptedException` to `CancellationException`,
+ *    allowing proper coroutine cancellation handling
+ * 3. Also handles direct `InterruptedException` for cases like `Thread.sleep()` in polling loops
+ *
+ * Usage:
+ * ```kotlin
+ * val table = bigQueryCall { bigquery.getTable(tableId) }
+ * ```
+ *
+ * @param block The blocking BigQuery SDK call to execute
+ * @return The result of the BigQuery call
+ * @throws CancellationException if the call was interrupted due to coroutine cancellation
+ * @throws BigQueryException for other BigQuery-related errors
+ */
+internal suspend fun <T> bigQueryCall(block: () -> T): T =
+    withContext(Dispatchers.IO) {
+        try {
+            block()
+        } catch (e: InterruptedException) {
+            // Direct InterruptedException (e.g., from Thread.sleep in polling loops)
+            throw CancellationException("Interrupted during BigQuery call", e)
+        } catch (e: BigQueryException) {
+            // BigQuery SDK wraps InterruptedException in BigQueryException
+            if (e.cause is InterruptedException) {
+                throw CancellationException("BigQuery call was interrupted", e)
+            }
+            throw e
+        }
+    }

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/BigQueryCoroutineHelper.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/BigQueryCoroutineHelper.kt
@@ -42,10 +42,14 @@ internal suspend fun <T> bigQueryCall(block: () -> T): T =
             block()
         } catch (e: InterruptedException) {
             // Direct InterruptedException (e.g., from Thread.sleep in polling loops)
+            // Restore the interrupt status before converting to CancellationException
+            Thread.currentThread().interrupt()
             throw CancellationException("Interrupted during BigQuery call", e)
         } catch (e: BigQueryException) {
             // BigQuery SDK wraps InterruptedException in BigQueryException
             if (e.cause is InterruptedException) {
+                // Restore the interrupt status before converting to CancellationException
+                Thread.currentThread().interrupt()
                 throw CancellationException("BigQuery call was interrupted", e)
             }
             throw e

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/typing_deduping/direct_load_tables/BigqueryDirectLoadDatabaseInitialStatusGatherer.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/typing_deduping/direct_load_tables/BigqueryDirectLoadDatabaseInitialStatusGatherer.kt
@@ -13,6 +13,7 @@ import io.airbyte.cdk.load.orchestration.db.direct_load_table.DirectLoadInitialS
 import io.airbyte.cdk.load.orchestration.db.direct_load_table.DirectLoadTableStatus
 import io.airbyte.cdk.load.orchestration.db.legacy_typing_deduping.TableCatalog
 import io.airbyte.cdk.load.table.TableName
+import io.airbyte.integrations.destination.bigquery.bigQueryCall
 import io.airbyte.integrations.destination.bigquery.write.typing_deduping.toTableId
 import java.math.BigInteger
 import java.util.concurrent.ConcurrentHashMap
@@ -43,8 +44,8 @@ class BigqueryDirectLoadDatabaseInitialStatusGatherer(
         return map
     }
 
-    private fun getTableStatus(tableName: TableName): DirectLoadTableStatus? {
-        val table = bigquery.getTable(tableName.toTableId())
+    private suspend fun getTableStatus(tableName: TableName): DirectLoadTableStatus? {
+        val table = bigQueryCall { bigquery.getTable(tableName.toTableId()) }
         return table?.let { DirectLoadTableStatus(isEmpty = table.numRows == BigInteger.ZERO) }
     }
 }

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/typing_deduping/legacy_raw_tables/BigqueryTypingDedupingDatabaseInitialStatusGatherer.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/typing_deduping/legacy_raw_tables/BigqueryTypingDedupingDatabaseInitialStatusGatherer.kt
@@ -15,20 +15,23 @@ import io.airbyte.cdk.load.orchestration.db.legacy_typing_deduping.TableCatalog
 import io.airbyte.cdk.load.orchestration.db.legacy_typing_deduping.TypingDedupingDatabaseInitialStatus
 import io.airbyte.cdk.load.table.TableName
 import io.airbyte.cdk.load.table.TableSuffixes.TMP_TABLE_SUFFIX
+import io.airbyte.integrations.destination.bigquery.bigQueryCall
 
 class BigqueryTypingDedupingDatabaseInitialStatusGatherer(private val bq: BigQuery) :
     DatabaseInitialStatusGatherer<TypingDedupingDatabaseInitialStatus> {
-    private fun getInitialRawTableState(
+    private suspend fun getInitialRawTableState(
         rawTableName: TableName,
         suffix: String
     ): RawTableInitialStatus? {
-        bq.getTable(TableId.of(rawTableName.namespace, rawTableName.name + suffix))
+        val table =
+            bigQueryCall { bq.getTable(TableId.of(rawTableName.namespace, rawTableName.name + suffix)) }
         // Table doesn't exist. There are no unprocessed records, and no timestamp.
-        ?: return null
+            ?: return null
 
         val rawTableIdQuoted = """`${rawTableName.namespace}`.`${rawTableName.name}$suffix`"""
         val unloadedRecordTimestamp =
-            bq.query(
+            bigQueryCall {
+                bq.query(
                     QueryJobConfiguration.of(
                         """
                             SELECT TIMESTAMP_SUB(MIN(_airbyte_extracted_at), INTERVAL 1 MICROSECOND)
@@ -37,6 +40,7 @@ class BigqueryTypingDedupingDatabaseInitialStatusGatherer(private val bq: BigQue
                             """.trimIndent()
                     )
                 )
+            }
                 .iterateAll()
                 .iterator()
                 .next()
@@ -52,7 +56,8 @@ class BigqueryTypingDedupingDatabaseInitialStatusGatherer(private val bq: BigQue
         }
 
         val loadedRecordTimestamp =
-            bq.query(
+            bigQueryCall {
+                bq.query(
                     QueryJobConfiguration.of(
                         """
                     SELECT MAX(_airbyte_extracted_at)
@@ -60,6 +65,7 @@ class BigqueryTypingDedupingDatabaseInitialStatusGatherer(private val bq: BigQue
                     """.trimIndent()
                     )
                 )
+            }
                 .iterateAll()
                 .iterator()
                 .next()

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/typing_deduping/legacy_raw_tables/BigqueryTypingDedupingDatabaseInitialStatusGatherer.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/typing_deduping/legacy_raw_tables/BigqueryTypingDedupingDatabaseInitialStatusGatherer.kt
@@ -23,11 +23,8 @@ class BigqueryTypingDedupingDatabaseInitialStatusGatherer(private val bq: BigQue
         rawTableName: TableName,
         suffix: String
     ): RawTableInitialStatus? {
-        val table =
-            bigQueryCall {
-                bq.getTable(TableId.of(rawTableName.namespace, rawTableName.name + suffix))
-            }
-            // Table doesn't exist. There are no unprocessed records, and no timestamp.
+        // Table doesn't exist. There are no unprocessed records, and no timestamp.
+        bigQueryCall { bq.getTable(TableId.of(rawTableName.namespace, rawTableName.name + suffix)) }
             ?: return null
 
         val rawTableIdQuoted = """`${rawTableName.namespace}`.`${rawTableName.name}$suffix`"""


### PR DESCRIPTION
## What

Fixes a `BigQueryException` caused by `InterruptedException` that occurs during the setup phase when the connector attempts to gather the initial status of raw tables.

**Error observed:**
```
com.google.cloud.bigquery.BigQueryException: java.lang.InterruptedException
    at com.google.cloud.bigquery.BigQueryImpl.getTable(BigQueryImpl.java:874)
    at ...BigqueryDatabaseInitialStatusGatherer.isFinalTableEmpty(...)
    at ...BigqueryDatabaseInitialStatusGatherer.gatherInitialStatus(...)
    at ...TypingDedupingWriter.setup(...)
Caused by: java.lang.InterruptedException
    at com.google.common.util.concurrent.AbstractFuture.get(AbstractFuture.java:555)
```

**Root cause:** BigQuery SDK's blocking calls (`getTable()`, `query()`) use `AbstractFuture.get()` internally, which throws `InterruptedException` when the thread is interrupted. When running in a coroutine context, if the coroutine is cancelled (e.g., due to timeout or parent scope cancellation), the thread may be interrupted, causing the BigQuery SDK to wrap this as a `BigQueryException`. This was being treated as a hard failure rather than a cancellation.

## How

1. Created a `bigQueryCall()` helper function that:
   - Ensures blocking calls run on `Dispatchers.IO`
   - Restores thread interrupt status via `Thread.currentThread().interrupt()` before converting exceptions
   - Converts `BigQueryException` caused by `InterruptedException` to `CancellationException` for proper coroutine cancellation handling
   - Also handles direct `InterruptedException` for cases like `Thread.sleep()` in polling loops

2. Updated both initial status gatherer classes to use the helper:
   - `BigqueryDirectLoadDatabaseInitialStatusGatherer`
   - `BigqueryTypingDedupingDatabaseInitialStatusGatherer`

## Review guide

1. `BigQueryCoroutineHelper.kt` - New helper function with exception conversion logic. **Key review point:** Verify the exception handling logic correctly identifies cancellation scenarios vs. real BigQuery errors.
2. `BigqueryDirectLoadDatabaseInitialStatusGatherer.kt` - Changed `getTableStatus()` to `suspend` and wrapped BigQuery call
3. `BigqueryTypingDedupingDatabaseInitialStatusGatherer.kt` - Changed `getInitialRawTableState()` to `suspend` and wrapped all BigQuery calls (`getTable()` and `query()`)

**⚠️ CI Status:** SpotBugs lint check is failing. The `Thread.currentThread().interrupt()` pattern was added to properly restore interrupt status before throwing `CancellationException`, but SpotBugs is still reporting an issue. **Maintainer assistance needed** to identify the specific SpotBugs rule being violated (the HTML report is not accessible from CI logs).

**Questions for reviewers:**
- Are there other BigQuery blocking calls in the connector that should also use this pattern?
- Should we add unit tests for the `bigQueryCall` helper to verify exception conversion?
- What SpotBugs rule is being violated? The standard `InterruptedException` handling pattern has been applied.

## User Impact

Users experiencing `BigQueryException: java.lang.InterruptedException` errors during sync setup should no longer see these errors treated as hard failures. Instead, if the sync is being cancelled, it will be handled gracefully as a cancellation.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Requested by Vikram Srigada (@vikram661)
Link to Devin run: https://app.devin.ai/sessions/9c34c76d1de54fefa3cf25fe0e2d8509