### PR TITLE
chore: rework docs numbering

### DIFF
--- a/connector-writer/destination/step-by-step/0-introduction.md
+++ b/connector-writer/destination/step-by-step/0-introduction.md
@@ -22,28 +22,28 @@
 **Timeline:** 2-3 days
 
 **Steps:**
-1. **1-getting-started.md** (Phases 0-1, ~4 hours)
+1. **1-getting-started.md** (Setup Phases 1-2, ~4 hours)
    - Project scaffolding and build setup
    - Spec operation implementation
    - **Milestone:** `./destination-{db} --spec` works
 
-2. **2-database-setup.md** (Phases 2-5, ~6 hours)
-   - Database connectivity and basic operations
-   - Namespace and table operations
+2. **2-database-setup.md** (Database Phases 1-2, ~6 hours)
+   - Database connectivity and all table operations
    - Check operation implementation
    - **Milestone:** `./destination-{db} --check --config config.json` works
 
-3. **3-write-infrastructure.md** (Phases 6-7, ~4 hours)
+3. **3-write-infrastructure.md** (Infrastructure Phases 1-2, ~4 hours)
    - Name generators and DI setup
    - Write operation infrastructure
    - Understanding test contexts
    - **Milestone:** DI configured, ready for business logic
 
-4. **4-write-operations.md** (Phases 8-11, ~8 hours)
+4. **4-write-operations.md** (Write Phases 1-4, ~8 hours)
    - InsertBuffer, Aggregate, Writer implementation
    - Append mode (direct writes)
    - Generation ID support
    - Overwrite mode (atomic swap)
+   - Copy operation
    - **Milestone:** `./destination-{db} --write` works with append + overwrite modes
 
 **Result:** Working connector suitable for PoC and simple use cases
@@ -59,14 +59,14 @@
 **Steps:**
 1-4. Complete Fast Path (above)
 
-5. **5-advanced-features.md** (Phases 12-15, ~12 hours)
+5. **5-advanced-features.md** (Advanced Phases 1-4, ~12 hours)
    - Schema evolution (automatic column add/drop/modify)
    - Dedupe mode (MERGE with primary key)
    - CDC support (hard/soft deletes)
    - Optimization and polish
    - **Milestone:** Full-featured, production-ready connector
 
-6. **6-testing.md** (~2 hours)
+6. **6-testing.md** (Testing Phase 1, ~2 hours)
    - Run BasicFunctionalityIntegrationTest
    - Validate all sync modes
    - Test schema evolution and CDC
@@ -98,12 +98,12 @@
 
 | Guide | Phases | What Works | Lines | Time | Prerequisites |
 |-------|--------|------------|-------|------|---------------|
-| **1-getting-started.md** | 0-1 | --spec | ~626 | 4h | None |
-| **2-database-setup.md** | 2-5 | --check | ~902 | 6h | Guide 1 |
-| **3-write-infrastructure.md** | 6-7 | DI ready | ~855 | 4h | Guide 2 |
-| **4-write-operations.md** | 8-11 | --write (append, overwrite) | ~869 | 8h | Guide 3 |
-| **5-advanced-features.md** | 12-15 | All features | ~1020 | 12h | Guide 4 |
-| **6-testing.md** | Tests | All tests pass | ~878 | 2h | Guide 5 |
+| **1-getting-started.md** | Setup 1-2 | --spec | ~626 | 4h | None |
+| **2-database-setup.md** | Database 1-2 | --check | ~1180 | 6h | Guide 1 |
+| **3-write-infrastructure.md** | Infrastructure 1-2 | DI ready | ~600 | 4h | Guide 2 |
+| **4-write-operations.md** | Write 1-4 | --write (append, overwrite) | ~780 | 8h | Guide 3 |
+| **5-advanced-features.md** | Advanced 1-4 | All features | ~900 | 12h | Guide 4 |
+| **6-testing.md** | Testing 1 | All tests pass | ~730 | 2h | Guide 5 |
 | **7-troubleshooting.md** | Reference | Debug help | ~280 | As needed | Any |
 
 ---
@@ -234,7 +234,7 @@ Platform → stdin → Lifecycle → Writer.setup()
 - Look at destination-snowflake or destination-clickhouse for examples
 
 **Common pitfalls:**
-- Not reading test contexts section (causes confusion in Phase 7)
+- Not reading test contexts section (causes confusion in Infrastructure Phase 2)
 - Missing DI registration (causes "No bean found" errors)
 - Skipping CDK version pinning (causes build issues)
 - Not understanding StreamLoader variants (causes wrong finalization)

--- a/connector-writer/destination/step-by-step/1-getting-started.md
+++ b/connector-writer/destination/step-by-step/1-getting-started.md
@@ -11,13 +11,13 @@
 
 ---
 
-## Phase 0: Scaffolding
+## Setup Phase 1: Scaffolding
 
 **Goal:** Empty project structure that builds
 
 **Checkpoint:** Project compiles
 
-### Step 0.1: Create Directory Structure
+### Setup Step 1: Create Directory Structure
 
 ```bash
 cd airbyte-integrations/connectors
@@ -34,7 +34,7 @@ mkdir check client config dataflow spec write
 mkdir write/load write/transform
 ```
 
-### Step 0.2: Create gradle.properties with CDK Version Pin
+### Setup Step 2: Create gradle.properties with CDK Version Pin
 
 **File:** `destination-{db}/gradle.properties`
 
@@ -56,7 +56,7 @@ cdkVersion=0.1.76
 ./gradlew destination-{db}:upgradeCdk --cdkVersion=0.1.76
 ```
 
-### Step 0.3: Create build.gradle.kts
+### Setup Step 3: Create build.gradle.kts
 
 **File:** `destination-{db}/build.gradle.kts`
 
@@ -88,7 +88,7 @@ dependencies {
 
 **No need to manually declare CDK dependencies** - the plugin handles it
 
-### Step 0.4: Create metadata.yaml
+### Setup Step 4: Create metadata.yaml
 
 **File:** `destination-{db}/metadata.yaml`
 
@@ -145,7 +145,7 @@ metadataSpecVersion: "1.0"
 grep "baseImage:" airbyte-integrations/connectors/destination-*/metadata.yaml | sort | uniq -c | sort -rn | head -3
 ```
 
-### Step 0.5: Configure Docker Build in build.gradle.kts
+### Setup Step 5: Configure Docker Build in build.gradle.kts
 
 **File:** Update `destination-{db}/build.gradle.kts`
 
@@ -181,7 +181,7 @@ dependencies {
 - `io.airbyte.gradle.docker`: Provides Docker build tasks
 - `airbyte-connector-docker-convention`: Reads metadata.yaml, generates build args
 
-### Step 0.6: Create Main Entry Point
+### Setup Step 6: Create Main Entry Point
 
 **File:** `destination-{db}/src/main/kotlin/.../​{DB}Destination.kt`
 
@@ -197,7 +197,7 @@ fun main(args: Array<String>) {
 
 **That's it!** The framework handles everything else.
 
-### Step 0.7: Verify Build
+### Setup Step 7: Verify Build
 
 ```bash
 $ ./gradlew :destination-{db}:build
@@ -211,7 +211,7 @@ $ ./gradlew :destination-{db}:build
 - Micronaut scanning issues? Ensure `@Singleton` annotations present
 - metadata.yaml syntax errors? Validate YAML format
 
-### Step 0.8: Create application-connector.yml
+### Setup Step 8: Create application-connector.yml
 
 **File:** `src/main/resources/application-connector.yml`
 
@@ -257,7 +257,7 @@ Failed to inject value for parameter [fileTransferEnabled]
 - ✅ `mappers.namespace-mapping-config-path`: Namespace mapping file path (empty for identity)
 - ✅ `file-transfer.enabled`: Whether connector transfers files (false for databases)
 
-### Step 0.9: Build Docker Image
+### Setup Step 9: Build Docker Image
 
 ```bash
 $ ./gradlew :destination-{db}:assemble
@@ -291,13 +291,13 @@ airbyte/destination-{db}    0.1.0    abc123def456    2 minutes ago    500MB
 
 ---
 
-## Phase 1: Spec Operation
+## Setup Phase 2: Spec Operation
 
 **Goal:** Implement --spec operation (returns connector configuration schema)
 
 **Checkpoint:** Spec test passes
 
-### Step 1.1: Understand Configuration Classes
+### Setup Step 1: Understand Configuration Classes
 
 **Two classes work together for configuration:**
 
@@ -317,7 +317,7 @@ ConfigurationFactory parses JSON → Configuration object
 Your code uses Configuration object
 ```
 
-### Step 1.2: Create Specification Class
+### Setup Step 2: Create Specification Class
 
 **Purpose:** Defines the configuration form users fill in Airbyte UI
 
@@ -361,7 +361,7 @@ open class {DB}Specification : ConfigurationSpecification() {
 - `@JsonSchemaTitle("Title")` - Label in UI (optional, defaults to property name)
 - `@JsonSchemaInject(json = """{"airbyte_secret": true}""")` - Mark as secret (passwords, API keys)
 
-### Step 1.3: Create Configuration and Factory
+### Setup Step 3: Create Configuration and Factory
 
 **Purpose:** Runtime configuration object your code actually uses
 
@@ -411,7 +411,7 @@ class {DB}ConfigurationFactory :
 - Specification = What users configure
 - Configuration = What your code uses
 
-### Step 1.4: Create Specification Extension
+### Setup Step 4: Create Specification Extension
 
 **Purpose:** Declares what sync modes your connector supports
 
@@ -443,7 +443,7 @@ class {DB}SpecificationExtension : DestinationSpecificationExtension {
 }
 ```
 
-### Step 1.5: Configure Documentation URL
+### Setup Step 5: Configure Documentation URL
 
 **File:** `src/main/resources/application.yml`
 
@@ -472,7 +472,7 @@ airbyteBulkConnector {
 
 **Default:** If not specified, uses placeholder URL
 
-### Step 1.6: Create Expected Spec Test File
+### Setup Step 6: Create Expected Spec Test File
 
 **File:** `src/test-integration/resources/expected-spec-oss.json`
 
@@ -539,7 +539,7 @@ airbyteBulkConnector {
 2. Copying output to this file
 3. Using it for regression testing
 
-### Step 1.7: Create Spec Test
+### Setup Step 7: Create Spec Test
 
 **File:** `src/test-integration/kotlin/.../spec/{DB}SpecTest.kt`
 
@@ -557,7 +557,7 @@ class {DB}SpecTest : SpecTest()
 - Matches expected-spec-oss.json (snapshot test)
 - If Cloud-specific: Matches expected-spec-cloud.json
 
-### Step 1.8: Generate and Validate Spec
+### Setup Step 8: Generate and Validate Spec
 
 **Run spec operation to generate the JSON schema:**
 
@@ -590,7 +590,7 @@ mkdir -p src/test-integration/resources
 
 **Tip:** Use `jq` to format: `./gradlew :destination-{db}:run --args='--spec' | jq .spec > expected-spec-oss.json`
 
-### Step 1.9: Run Spec Test
+### Setup Step 9: Run Spec Test
 
 ```bash
 $ ./gradlew :destination-{db}:integrationTestSpecOss

--- a/connector-writer/destination/step-by-step/2-database-setup.md
+++ b/connector-writer/destination/step-by-step/2-database-setup.md
@@ -1,24 +1,54 @@
-# Database Setup: Connectivity, Operations, and Check
+# Database Setup: TableOperationsClient & Check
 
-**Prerequisites:** Complete [1-getting-started.md](./1-getting-started.md) - Your connector's `--spec` operation must be working.
+**Prerequisites:** Complete Setup Phase 2 (Spec Operation) from [1-getting-started.md](./1-getting-started.md)
 
 ## What You'll Build
 
 After completing this guide, your connector will have:
-- Database connectivity
-- Namespace operations
-- Basic table operations (create, drop, count)
+- Complete `TableOperationsClient` implementation (all database operations)
+- Full test coverage via `TableOperationsSuite` (5 tests passing)
 - `--check` operation working
+- Ready for Infrastructure Phase 1 (Name Generators)
+
+## Phase Overview
+
+This file contains two phases:
+
+1. **Database Phase 1: TableOperationsClient Implementation**
+   - Create database connection and operations
+   - Implement all namespace and table operations
+   - 5 component tests passing
+
+2. **Database Phase 2: Check Operation**
+   - Validate database connection and permissions
+   - Integration test for `--check` command
 
 ---
 
-## Phase 2: Database Connectivity
+## Database Phase 1: TableOperationsClient Implementation
 
-**Goal:** Establish database connection
+**Goal:** Implement complete database operations interface in one cohesive phase
 
-**Checkpoint:** Can connect to database and execute simple query
+**Why one phase?** TableOperationsClient is a single cohesive interface. Implementing all methods together:
+- ✅ Follows natural coding flow (related methods use same patterns)
+- ✅ Clear completion criteria (all TableOperationsSuite tests pass)
+- ✅ No confusion about "which tests to enable when"
+- ✅ Single validation point
 
-### Step 2.1: Create BeanFactory with DataSource
+**What you'll implement:**
+1. **Infrastructure:** DataSource, test setup, SqlGenerator skeleton
+2. **Namespace operations:** CREATE/DROP schemas
+3. **Table operations:** CREATE/DROP/COUNT tables
+4. **Test utilities:** Insert/read for test verification
+5. **Full test suite:** All 5 TableOperationsSuite tests
+
+**Checkpoint:** All TableOperationsSuite tests passing (5 tests)
+
+---
+
+### Database Step 1: Create Infrastructure Setup
+
+#### Part A: Create BeanFactory with DataSource
 
 **File:** `{DB}BeanFactory.kt`
 
@@ -31,6 +61,7 @@ import io.micronaut.context.annotation.Factory
 import io.micronaut.context.annotation.Requires
 import io.micronaut.context.annotation.Singleton
 import javax.sql.DataSource
+import com.zaxxer.hikari.HikariDataSource
 
 @Factory
 class {DB}BeanFactory {
@@ -57,6 +88,14 @@ class {DB}BeanFactory {
         }
 
         // For non-JDBC: Create your native client here
+        // Example (ClickHouse):
+        // return ClickHouseDataSource(
+        //     "http://${config.hostname}:${config.port}/${config.database}",
+        //     Properties().apply {
+        //         setProperty("user", config.username)
+        //         setProperty("password", config.password)
+        //     }
+        // )
     }
 
     @Singleton
@@ -77,7 +116,16 @@ class {DB}BeanFactory {
 }
 ```
 
-### Step 2.2: Add Testcontainers Dependency
+**What this does:**
+- **configuration:** Loads config from `--config` file
+- **dataSource:** Creates connection pool for `--check` and `--write` operations
+- **emptyDataSource:** Dummy DataSource for `--spec` operation (no connection needed)
+
+**Database-specific adjustments:**
+- **JDBC (Postgres, MySQL):** Use HikariCP as shown
+- **Native clients (ClickHouse, BigQuery):** Replace with native client instantiation
+
+#### Part B: Add Testcontainers Dependency
 
 **File:** Update `build.gradle.kts`
 
@@ -87,19 +135,18 @@ dependencies {
 
     // Testcontainers for automated testing (recommended)
     testImplementation("org.testcontainers:testcontainers:1.19.0")
-    testImplementation("org.testcontainers:{db}:1.19.0")  // e.g., postgresql, mysql, etc.
-    // Or for databases without specific module:
+    testImplementation("org.testcontainers:{db}:1.19.0")  // e.g., postgresql, mysql, clickhouse
+
+    // For databases without specific Testcontainers module:
     // testImplementation("org.testcontainers:jdbc:1.19.0")
 }
 ```
 
 **Check available modules:** https://www.testcontainers.org/modules/databases/
 
-### Step 2.3: Create Test Configuration with Testcontainers
+#### Part C: Create Test Configuration with Testcontainers
 
 **File:** `src/test-integration/kotlin/.../component/{DB}TestConfigFactory.kt`
-
-**Primary approach (Testcontainers - recommended):**
 
 ```kotlin
 package io.airbyte.integrations.destination.{db}.component
@@ -128,9 +175,14 @@ class {DB}TestConfigFactory {
         // Example for MySQL:
         // val container = MySQLContainer("mysql:8.0")
         //     .withDatabaseName("test")
+        //     .withUsername("test")
+        //     .withPassword("test")
 
-        // Example for generic JDBC:
-        // val container = JdbcDatabaseContainer("{db}:latest")
+        // Example for ClickHouse:
+        // val container = ClickHouseContainer("clickhouse/clickhouse-server:latest")
+        //     .withDatabaseName("test")
+        //     .withUsername("default")
+        //     .withPassword("")
 
         container.start()
         return container
@@ -160,7 +212,7 @@ class {DB}TestConfigFactory {
 }
 ```
 
-**Alternative: Environment variables (for local development)**
+**Alternative: Environment variables** (for local development with existing database)
 
 ```kotlin
 @Singleton
@@ -177,290 +229,22 @@ fun testConfig(): {DB}Configuration {
 ```
 
 **Why Testcontainers (recommended)?**
-- ✅ Isolated test environment (no conflicts with other tests)
+- ✅ Isolated test environment (no conflicts)
 - ✅ Works in CI without setup
 - ✅ Reproducible across machines
 - ✅ Automatic cleanup
-- ✅ No manual database installation needed
+- ✅ No manual database installation
 
-**When to use environment variables?**
-- Local development with existing database
-- Database not supported by Testcontainers
-- Debugging against specific database version
-
-### Step 2.4: Create Minimal Test Client
-
-**File:** `src/test-integration/kotlin/.../component/{DB}TestTableOperationsClient.kt`
-
-```kotlin
-package io.airbyte.integrations.destination.{db}.component
-
-import io.airbyte.cdk.load.component.TestTableOperationsClient
-import io.airbyte.cdk.load.data.AirbyteValue
-import io.airbyte.cdk.load.table.TableName
-import io.micronaut.context.annotation.Requires
-import io.micronaut.context.annotation.Singleton
-import javax.sql.DataSource
-
-@Requires(env = ["component"])
-@Singleton
-class {DB}TestTableOperationsClient(
-    private val dataSource: DataSource,
-) : TestTableOperationsClient {
-
-    override suspend fun ping() {
-        dataSource.connection.use { connection ->
-            connection.createStatement().use { statement ->
-                statement.executeQuery("SELECT 1")
-            }
-        }
-    }
-
-    override suspend fun dropNamespace(namespace: String) {
-        // Implement in Phase 2
-        TODO("Implement in Phase 2")
-    }
-
-    override suspend fun insertRecords(
-        table: TableName,
-        records: List<Map<String, AirbyteValue>>
-    ) {
-        // Implement in Phase 3
-        TODO("Implement in Phase 3")
-    }
-
-    override suspend fun readTable(table: TableName): List<Map<String, Any>> {
-        // Implement in Phase 3
-        TODO("Implement in Phase 3")
-    }
-}
-```
-
-### Step 2.5: Create TableOperationsTest (Minimal)
-
-**File:** `src/test-integration/kotlin/.../component/{DB}TableOperationsTest.kt`
-
-```kotlin
-package io.airbyte.integrations.destination.{db}.component
-
-import io.airbyte.cdk.load.component.TableOperationsClient
-import io.airbyte.cdk.load.component.TableOperationsSuite
-import io.airbyte.cdk.load.component.TestTableOperationsClient
-import io.micronaut.test.extensions.junit5.annotation.MicronautTest
-import org.junit.jupiter.api.Test
-
-@MicronautTest(environments = ["component"])
-class {DB}TableOperationsTest(
-    override val client: TableOperationsClient,
-    override val testClient: TestTableOperationsClient,
-) : TableOperationsSuite {
-
-    @Test
-    override fun `connect to database`() {
-        super.`connect to database`()
-    }
-
-    // Other tests commented out for now - implement in later phases
-    // @Test
-    // override fun `create and drop namespaces`() { super.`create and drop namespaces`() }
-}
-```
-
-### Step 2.6: Validate Connection
-
-**Validate:**
+**Validate infrastructure setup:**
 ```bash
-$ ./gradlew :destination-{db}:testComponentConnectToDatabase  # 1 test should pass
-$ ./gradlew :destination-{db}:componentTest  # Regression check
+$ ./gradlew :destination-{db}:compileKotlin
 ```
 
-**Troubleshooting:**
-- Connection refused? Check hostname/port in test config
-- Authentication failed? Verify username/password
-- Database doesn't exist? Create test database first or use Testcontainers
-- Timeout? Check firewall/network connectivity
-
-✅ **Checkpoint:** Can connect to database + all previous phases still work
+Expected: BUILD SUCCESSFUL
 
 ---
 
----
-
-## Phase 3: Namespace Operations
-
-**Goal:** Create and drop schemas/databases
-
-**Checkpoint:** Can manage namespaces
-
-### Step 3.1: Create SQL Generator (Namespace Methods)
-
-**File:** `client/{DB}SqlGenerator.kt`
-
-```kotlin
-package io.airbyte.integrations.destination.{db}.client
-
-import io.airbyte.cdk.load.table.TableName
-import io.github.oshai.kotlinlogging.KotlinLogging
-import io.micronaut.context.annotation.Singleton
-
-private val log = KotlinLogging.logger {}
-
-fun String.andLog(): String {
-    log.info { this.trim() }
-    return this
-}
-
-@Singleton
-class {DB}SqlGenerator {
-
-    fun createNamespace(namespace: String): String {
-        // Postgres/MySQL: CREATE SCHEMA
-        return "CREATE SCHEMA IF NOT EXISTS ${namespace.quote()}".andLog()
-
-        // Or for databases without schemas:
-        return "CREATE DATABASE IF NOT EXISTS ${namespace.quote()}".andLog()
-    }
-
-    fun namespaceExists(namespace: String): String {
-        // Postgres:
-        return """
-            SELECT schema_name
-            FROM information_schema.schemata
-            WHERE schema_name = '${namespace}'
-        """.trimIndent().andLog()
-
-        // Or query your DB's system catalog
-    }
-
-    private fun String.quote() = "\"$this\""  // Or backticks, brackets, etc.
-
-    private fun fullyQualifiedName(tableName: TableName) =
-        "${tableName.namespace.quote()}.${tableName.name.quote()}"
-}
-```
-
-### Step 2.2: Create Database Client (Namespace Methods)
-
-**File:** `client/{DB}AirbyteClient.kt`
-
-```kotlin
-package io.airbyte.integrations.destination.{db}.client
-
-import io.airbyte.cdk.load.component.TableOperationsClient
-import io.airbyte.cdk.load.component.TableSchemaEvolutionClient
-import io.airbyte.integrations.destination.{db}.spec.{DB}Configuration
-import io.micronaut.context.annotation.Singleton
-import javax.sql.DataSource
-
-@Singleton
-class {DB}AirbyteClient(
-    private val dataSource: DataSource,
-    private val sqlGenerator: {DB}SqlGenerator,
-    private val config: {DB}Configuration,
-) : TableOperationsClient, TableSchemaEvolutionClient {
-
-    override suspend fun createNamespace(namespace: String) {
-        execute(sqlGenerator.createNamespace(namespace))
-    }
-
-    override suspend fun namespaceExists(namespace: String): Boolean {
-        return dataSource.connection.use { connection ->
-            connection.createStatement().use { statement ->
-                val rs = statement.executeQuery(sqlGenerator.namespaceExists(namespace))
-                rs.next()  // Returns true if namespace exists
-            }
-        }
-    }
-
-    private fun execute(sql: String) {
-        dataSource.connection.use { connection ->
-            connection.createStatement().use { statement ->
-                statement.execute(sql)
-            }
-        }
-    }
-
-    // Stub other methods for now
-    override suspend fun createTable(...) = TODO("Phase 3")
-    override suspend fun dropTable(...) = TODO("Phase 3")
-    override suspend fun tableExists(...) = TODO("Phase 3")
-    override suspend fun countTable(...) = TODO("Phase 3")
-    override suspend fun getGenerationId(...) = TODO("Phase 3")
-    override suspend fun copyTable(...) = TODO("Phase 7")
-    override suspend fun overwriteTable(...) = TODO("Phase 6")
-    override suspend fun upsertTable(...) = TODO("Phase 9")
-    override suspend fun discoverSchema(...) = TODO("Phase 8")
-    override fun computeSchema(...) = TODO("Phase 8")
-    override suspend fun ensureSchemaMatches(...) = TODO("Phase 8")
-    override suspend fun applyChangeset(...) = TODO("Phase 8")
-}
-```
-
-### Step 2.3: Update Test Client
-
-**File:** Update `{DB}TestTableOperationsClient.kt`
-
-```kotlin
-override suspend fun dropNamespace(namespace: String) {
-    dataSource.connection.use { connection ->
-        connection.createStatement().use { statement ->
-            // Postgres/MySQL:
-            statement.execute("DROP SCHEMA IF EXISTS \"${namespace}\" CASCADE")
-
-            // Or for databases without schemas:
-            statement.execute("DROP DATABASE IF EXISTS `${namespace}`")
-        }
-    }
-}
-```
-
-### Step 2.4: Register Client in BeanFactory
-
-**File:** Update `{DB}BeanFactory.kt`
-
-```kotlin
-@Singleton
-fun client(
-    dataSource: DataSource,
-    sqlGenerator: {DB}SqlGenerator,
-    config: {DB}Configuration,
-): {DB}AirbyteClient {
-    return {DB}AirbyteClient(dataSource, sqlGenerator, config)
-}
-```
-
-### Step 2.5: Enable Test in TableOperationsTest
-
-**File:** Update `{DB}TableOperationsTest.kt`
-
-```kotlin
-@Test
-override fun `create and drop namespaces`() {
-    super.`create and drop namespaces`()
-}
-```
-
-### Step 2.6: Validate
-
-**Validate:**
-```bash
-$ ./gradlew :destination-{db}:testComponentCreateAndDropNamespaces  # 1 test should pass
-$ ./gradlew :destination-{db}:componentTest  # 2 tests should pass
-```
-
-✅ **Checkpoint:** Can manage namespaces + all previous phases still work
-
----
-
----
-
-## Phase 4: Basic Table Operations
-
-**Goal:** Create tables, insert data, count rows
-
-**Checkpoint:** Can perform basic table CRUD
-
-### Step 4.1: Create Column Utilities
+### Database Step 2: Create ColumnUtils (Type Mapping)
 
 **File:** `client/{DB}ColumnUtils.kt`
 
@@ -497,243 +281,706 @@ class {DB}ColumnUtils {
 }
 ```
 
-**Database-specific adjustments:**
-- **Snowflake:** `VARCHAR` (no length), `VARIANT` for JSON
-- **ClickHouse:** `String`, `Nullable()` wrapper, `DateTime64(3)`
-- **MySQL:** `VARCHAR(65535)`, `JSON` type
-- **BigQuery:** `STRING`, `JSON`, specific types
+**Database-specific type mapping:**
 
-### Step 3.2: Add Table Methods to SQL Generator
+| Database | String | Integer | Number | JSON | Timestamp | Nullable |
+|----------|--------|---------|--------|------|-----------|----------|
+| **Postgres** | TEXT | BIGINT | DECIMAL(38,9) | JSONB | TIMESTAMPTZ | NULL suffix |
+| **MySQL** | VARCHAR(65535) | BIGINT | DECIMAL(38,9) | JSON | TIMESTAMP | NULL suffix |
+| **Snowflake** | VARCHAR | NUMBER(38,0) | FLOAT | VARIANT | TIMESTAMP_TZ | NULL suffix |
+| **ClickHouse** | String | Int64 | Decimal(38,9) | String | DateTime64(3) | Nullable() wrapper |
+| **BigQuery** | STRING | INT64 | NUMERIC | JSON | TIMESTAMP | nullable field |
 
-**File:** Update `{DB}SqlGenerator.kt`
+**Adjust toDialectType() for your database** - Use table above as reference.
+
+**Validate compilation:**
+```bash
+$ ./gradlew :destination-{db}:compileKotlin
+```
+
+---
+
+### Database Step 3: Create SqlGenerator (All Operations)
+
+**File:** `client/{DB}SqlGenerator.kt`
+
+**Why implement all operations now?** SQL generation is pure logic with no I/O. All methods follow the same pattern (string building + logging). Natural to write together.
 
 ```kotlin
-fun createTable(
-    stream: DestinationStream,
-    tableName: TableName,
-    columnMapping: ColumnNameMapping,
-    replace: Boolean
-): String {
-    val replaceClause = if (replace) "OR REPLACE " else ""
+package io.airbyte.integrations.destination.{db}.client
 
-    val columnDeclarations = stream.schema.asColumns()
-        .filter { (name, _) -> name !in AIRBYTE_META_COLUMNS }
-        .map { (name, type) ->
-            val mappedName = columnMapping[name]!!
-            columnUtils.formatColumn(mappedName, type.type, type.nullable)
-        }
-        .joinToString(",\n  ")
+import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.table.ColumnNameMapping
+import io.airbyte.cdk.load.table.TableName
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.micronaut.context.annotation.Singleton
 
-    return """
-        CREATE ${replaceClause}TABLE ${fullyQualifiedName(tableName)} (
-          "_airbyte_raw_id" VARCHAR NOT NULL,
-          "_airbyte_extracted_at" TIMESTAMP NOT NULL,
-          "_airbyte_meta" JSONB NOT NULL,
-          "_airbyte_generation_id" BIGINT,
-          $columnDeclarations
+private val log = KotlinLogging.logger {}
+
+// Extension function for SQL logging
+fun String.andLog(): String {
+    log.info { this.trim() }
+    return this
+}
+
+@Singleton
+class {DB}SqlGenerator(
+    private val columnUtils: {DB}ColumnUtils,
+) {
+
+    // ========================================
+    // NAMESPACE OPERATIONS
+    // ========================================
+
+    fun createNamespace(namespace: String): String {
+        // Postgres/MySQL: CREATE SCHEMA
+        return "CREATE SCHEMA IF NOT EXISTS ${namespace.quote()}".andLog()
+
+        // Or for databases with CREATE DATABASE:
+        // return "CREATE DATABASE IF NOT EXISTS ${namespace.quote()}".andLog()
+    }
+
+    fun namespaceExists(namespace: String): String {
+        // Postgres/MySQL:
+        return """
+            SELECT schema_name
+            FROM information_schema.schemata
+            WHERE schema_name = '$namespace'
+        """.trimIndent().andLog()
+
+        // ClickHouse:
+        // return """
+        //     SELECT name
+        //     FROM system.databases
+        //     WHERE name = '$namespace'
+        // """.trimIndent().andLog()
+
+        // Or query your DB's system catalog
+    }
+
+    // ========================================
+    // TABLE OPERATIONS
+    // ========================================
+
+    fun createTable(
+        stream: DestinationStream,
+        tableName: TableName,
+        columnMapping: ColumnNameMapping,
+        replace: Boolean
+    ): String {
+        val replaceClause = if (replace) "OR REPLACE " else ""
+
+        val columnDeclarations = stream.schema.asColumns()
+            .filter { (name, _) -> name !in AIRBYTE_META_COLUMNS }
+            .map { (name, type) ->
+                val mappedName = columnMapping[name]!!
+                columnUtils.formatColumn(mappedName, type.type, type.nullable)
+            }
+            .joinToString(",\n  ")
+
+        return """
+            CREATE ${replaceClause}TABLE ${fullyQualifiedName(tableName)} (
+              "_airbyte_raw_id" VARCHAR NOT NULL,
+              "_airbyte_extracted_at" TIMESTAMP NOT NULL,
+              "_airbyte_meta" JSONB NOT NULL,
+              "_airbyte_generation_id" BIGINT,
+              $columnDeclarations
+            )
+        """.trimIndent().andLog()
+    }
+
+    fun dropTable(tableName: TableName): String {
+        return "DROP TABLE IF EXISTS ${fullyQualifiedName(tableName)}".andLog()
+    }
+
+    fun countTable(tableName: TableName): String {
+        return """
+            SELECT COUNT(*) AS count
+            FROM ${fullyQualifiedName(tableName)}
+        """.trimIndent().andLog()
+    }
+
+    fun getGenerationId(tableName: TableName): String {
+        return """
+            SELECT "_airbyte_generation_id" AS generation_id
+            FROM ${fullyQualifiedName(tableName)}
+            LIMIT 1
+        """.trimIndent().andLog()
+    }
+
+    // ========================================
+    // HELPER METHODS
+    // ========================================
+
+    private fun String.quote(): String {
+        // Postgres/Snowflake: double quotes
+        return "\"$this\""
+
+        // MySQL: backticks
+        // return "`$this`"
+
+        // SQL Server: square brackets
+        // return "[$this]"
+    }
+
+    private fun fullyQualifiedName(tableName: TableName): String {
+        return "${tableName.namespace.quote()}.${tableName.name.quote()}"
+    }
+
+    companion object {
+        private val AIRBYTE_META_COLUMNS = setOf(
+            "_airbyte_raw_id",
+            "_airbyte_extracted_at",
+            "_airbyte_meta",
+            "_airbyte_generation_id"
         )
-    """.trimIndent().andLog()
-}
-
-fun dropTable(tableName: TableName): String {
-    return "DROP TABLE IF EXISTS ${fullyQualifiedName(tableName)}".andLog()
-}
-
-fun countTable(tableName: TableName): String {
-    return """
-        SELECT COUNT(*) AS count
-        FROM ${fullyQualifiedName(tableName)}
-    """.trimIndent().andLog()
-}
-
-fun getGenerationId(tableName: TableName): String {
-    return """
-        SELECT "_airbyte_generation_id" AS generation_id
-        FROM ${fullyQualifiedName(tableName)}
-        LIMIT 1
-    """.trimIndent().andLog()
-}
-
-private val AIRBYTE_META_COLUMNS = setOf(
-    "_airbyte_raw_id",
-    "_airbyte_extracted_at",
-    "_airbyte_meta",
-    "_airbyte_generation_id"
-)
-```
-
-### Step 3.3: Implement Table Operations in Client
-
-**File:** Update `{DB}AirbyteClient.kt`
-
-```kotlin
-override suspend fun createTable(
-    stream: DestinationStream,
-    tableName: TableName,
-    columnNameMapping: ColumnNameMapping,
-    replace: Boolean
-) {
-    execute(sqlGenerator.createTable(stream, tableName, columnNameMapping, replace))
-}
-
-override suspend fun dropTable(tableName: TableName) {
-    execute(sqlGenerator.dropTable(tableName))
-}
-
-override suspend fun tableExists(table: TableName): Boolean {
-    return countTable(table) != null
-}
-
-override suspend fun countTable(tableName: TableName): Long? =
-    try {
-        dataSource.connection.use { connection ->
-            connection.createStatement().use { statement ->
-                val rs = statement.executeQuery(sqlGenerator.countTable(tableName))
-                if (rs.next()) rs.getLong("count") else 0L
-            }
-        }
-    } catch (e: SQLException) {
-        log.debug(e) { "Table ${tableName} does not exist. Returning null." }
-        null  // Expected - table doesn't exist
-    }
-
-override suspend fun getGenerationId(tableName: TableName): Long {
-    try {
-        dataSource.connection.use { connection ->
-            connection.createStatement().use { statement ->
-                val rs = statement.executeQuery(sqlGenerator.getGenerationId(tableName))
-                if (rs.next()) {
-                    rs.getLong("generation_id") ?: 0L
-                } else {
-                    0L
-                }
-            }
-        }
-    } catch (e: SQLException) {
-        log.debug(e) { "Failed to retrieve generation ID, returning 0" }
-        return 0L
     }
 }
 ```
 
-### Step 3.4: Implement Test Client Insert/Read
+**Key points:**
+- **All operations in one file:** Namespace + table operations use same patterns
+- **Always call .andLog():** SQL logging is critical for debugging
+- **Database-specific quoting:** Adjust quote() method for your database
+- **Metadata columns:** Always included, filtered from user columns
 
-**File:** Update `{DB}TestTableOperationsClient.kt`
+**Validate SQL strings (manual check):**
+```bash
+# Copy-paste generated SQL to your database console
+# Verify syntax is correct for your database
+```
+
+**Validate compilation:**
+```bash
+$ ./gradlew :destination-{db}:compileKotlin
+```
+
+---
+
+### Database Step 4: Create Client (All Operations)
+
+**File:** `client/{DB}AirbyteClient.kt`
+
+**Why implement all operations now?** Client just delegates to SqlGenerator + executes. Straightforward pattern repeated for each method.
 
 ```kotlin
-override suspend fun insertRecords(
-    table: TableName,
-    records: List<Map<String, AirbyteValue>>
-) {
-    if (records.isEmpty()) return
+package io.airbyte.integrations.destination.{db}.client
 
-    dataSource.connection.use { connection ->
-        records.forEach { record ->
-            val columns = record.keys.joinToString(", ") { "\"$it\"" }
-            val placeholders = record.keys.joinToString(", ") { "?" }
-            val sql = """
-                INSERT INTO "${table.namespace}"."${table.name}" ($columns)
-                VALUES ($placeholders)
-            """
+import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.component.TableOperationsClient
+import io.airbyte.cdk.load.component.TableSchemaEvolutionClient
+import io.airbyte.cdk.load.table.ColumnNameMapping
+import io.airbyte.cdk.load.table.TableName
+import io.airbyte.integrations.destination.{db}.spec.{DB}Configuration
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.micronaut.context.annotation.Singleton
+import java.sql.SQLException
+import javax.sql.DataSource
 
-            connection.prepareStatement(sql).use { statement ->
-                record.values.forEachIndexed { index, value ->
-                    setParameter(statement, index + 1, value)
-                }
-                statement.executeUpdate()
+private val log = KotlinLogging.logger {}
+
+@Singleton
+class {DB}AirbyteClient(
+    private val dataSource: DataSource,
+    private val sqlGenerator: {DB}SqlGenerator,
+    private val config: {DB}Configuration,
+) : TableOperationsClient, TableSchemaEvolutionClient {
+
+    // ========================================
+    // NAMESPACE OPERATIONS
+    // ========================================
+
+    override suspend fun createNamespace(namespace: String) {
+        execute(sqlGenerator.createNamespace(namespace))
+    }
+
+    override suspend fun namespaceExists(namespace: String): Boolean {
+        return dataSource.connection.use { connection ->
+            connection.createStatement().use { statement ->
+                val rs = statement.executeQuery(sqlGenerator.namespaceExists(namespace))
+                rs.next()  // Returns true if namespace exists
             }
         }
     }
-}
 
-override suspend fun readTable(table: TableName): List<Map<String, Any>> {
-    val results = mutableListOf<Map<String, Any>>()
+    // ========================================
+    // TABLE OPERATIONS
+    // ========================================
 
-    dataSource.connection.use { connection ->
-        val sql = "SELECT * FROM \"${table.namespace}\".\"${table.name}\""
-        connection.createStatement().use { statement ->
-            val rs = statement.executeQuery(sql)
-            val metadata = rs.metaData
+    override suspend fun createTable(
+        stream: DestinationStream,
+        tableName: TableName,
+        columnNameMapping: ColumnNameMapping,
+        replace: Boolean
+    ) {
+        execute(sqlGenerator.createTable(stream, tableName, columnNameMapping, replace))
+    }
 
-            while (rs.next()) {
-                val row = mutableMapOf<String, Any>()
-                for (i in 1..metadata.columnCount) {
-                    val columnName = metadata.getColumnName(i)
-                    val value = rs.getObject(i)
-                    if (value != null) {
-                        row[columnName] = value
+    override suspend fun dropTable(tableName: TableName) {
+        execute(sqlGenerator.dropTable(tableName))
+    }
+
+    override suspend fun tableExists(table: TableName): Boolean {
+        return countTable(table) != null
+    }
+
+    override suspend fun countTable(tableName: TableName): Long? =
+        try {
+            dataSource.connection.use { connection ->
+                connection.createStatement().use { statement ->
+                    val rs = statement.executeQuery(sqlGenerator.countTable(tableName))
+                    if (rs.next()) rs.getLong("count") else 0L
+                }
+            }
+        } catch (e: SQLException) {
+            log.debug(e) { "Table ${tableName.toPrettyString()} does not exist. Returning null." }
+            null  // Expected - table doesn't exist
+        }
+
+    override suspend fun getGenerationId(tableName: TableName): Long =
+        try {
+            dataSource.connection.use { connection ->
+                connection.createStatement().use { statement ->
+                    val rs = statement.executeQuery(sqlGenerator.getGenerationId(tableName))
+                    if (rs.next()) {
+                        rs.getLong("generation_id") ?: 0L
+                    } else {
+                        0L
                     }
                 }
-                results.add(row)
+            }
+        } catch (e: SQLException) {
+            log.debug(e) { "Failed to retrieve generation ID, returning 0" }
+            0L
+        }
+
+    // ========================================
+    // HELPER METHODS
+    // ========================================
+
+    private fun execute(sql: String) {
+        dataSource.connection.use { connection ->
+            connection.createStatement().use { statement ->
+                statement.execute(sql)
             }
         }
     }
 
-    return results
-}
+    // ========================================
+    // STUB METHODS (Implement in later phases)
+    // ========================================
 
-private fun setParameter(statement: PreparedStatement, index: Int, value: AirbyteValue) {
-    when (value) {
-        is StringValue -> statement.setString(index, value.value)
-        is IntegerValue -> statement.setLong(index, value.value)
-        is NumberValue -> statement.setBigDecimal(index, value.value)
-        is BooleanValue -> statement.setBoolean(index, value.value)
-        is TimestampValue -> statement.setTimestamp(index, Timestamp.from(value.value))
-        is DateValue -> statement.setDate(index, Date.valueOf(value.value))
-        is ObjectValue -> statement.setString(index, value.toJson())  // JSON as string
-        is ArrayValue -> statement.setString(index, value.toJson())   // JSON as string
-        is NullValue -> statement.setNull(index, Types.VARCHAR)
-        else -> statement.setString(index, value.toString())
+    override suspend fun copyTable(
+        columnMapping: ColumnNameMapping,
+        source: TableName,
+        target: TableName
+    ) = TODO("Phase 11: Implement copyTable")
+
+    override suspend fun overwriteTable(
+        source: TableName,
+        target: TableName
+    ) = TODO("Phase 10: Implement overwriteTable")
+
+    override suspend fun upsertTable(
+        stream: DestinationStream,
+        columnMapping: ColumnNameMapping,
+        source: TableName,
+        target: TableName
+    ) = TODO("Phase 13: Implement upsertTable")
+
+    override suspend fun discoverSchema(tableName: TableName) =
+        TODO("Phase 12: Implement discoverSchema")
+
+    override fun computeSchema(
+        stream: DestinationStream,
+        columnMapping: ColumnNameMapping
+    ) = TODO("Phase 12: Implement computeSchema")
+
+    override suspend fun ensureSchemaMatches(
+        stream: DestinationStream,
+        tableName: TableName,
+        columnMapping: ColumnNameMapping
+    ) = TODO("Phase 12: Implement ensureSchemaMatches")
+
+    override suspend fun applyChangeset(
+        stream: DestinationStream,
+        columnMapping: ColumnNameMapping,
+        tableName: TableName,
+        expectedColumns: Collection<Pair<String, io.airbyte.cdk.load.table.ColumnType>>,
+        changeset: io.airbyte.cdk.load.table.ColumnChangeset
+    ) = TODO("Phase 12: Implement applyChangeset")
+}
+```
+
+**Key points:**
+- **Pattern:** All methods delegate to SqlGenerator, then execute SQL
+- **Error handling:** countTable returns null if table doesn't exist (expected, not error)
+- **Logging:** Use lazy evaluation `log.debug { }` not `log.debug("")`
+- **TODO stubs:** Methods for later phases clearly marked
+
+**Register client in BeanFactory:**
+
+**File:** Update `{DB}BeanFactory.kt`
+
+```kotlin
+@Singleton
+fun client(
+    dataSource: DataSource,
+    sqlGenerator: {DB}SqlGenerator,
+    config: {DB}Configuration,
+): TableOperationsClient {
+    return {DB}AirbyteClient(dataSource, sqlGenerator, config)
+}
+```
+
+**Validate compilation:**
+```bash
+$ ./gradlew :destination-{db}:compileKotlin
+```
+
+Expected: BUILD SUCCESSFUL with no errors
+
+---
+
+### Database Step 5: Implement Test Client (Insert/Read for Verification)
+
+**File:** `src/test-integration/kotlin/.../component/{DB}TestTableOperationsClient.kt`
+
+```kotlin
+package io.airbyte.integrations.destination.{db}.component
+
+import io.airbyte.cdk.load.component.TestTableOperationsClient
+import io.airbyte.cdk.load.data.*
+import io.airbyte.cdk.load.table.TableName
+import io.micronaut.context.annotation.Requires
+import io.micronaut.context.annotation.Singleton
+import java.sql.Date
+import java.sql.PreparedStatement
+import java.sql.Timestamp
+import java.sql.Types
+import javax.sql.DataSource
+
+@Requires(env = ["component"])
+@Singleton
+class {DB}TestTableOperationsClient(
+    private val dataSource: DataSource,
+) : TestTableOperationsClient {
+
+    override suspend fun ping() {
+        dataSource.connection.use { connection ->
+            connection.createStatement().use { statement ->
+                statement.executeQuery("SELECT 1")
+            }
+        }
+    }
+
+    override suspend fun dropNamespace(namespace: String) {
+        dataSource.connection.use { connection ->
+            connection.createStatement().use { statement ->
+                // Postgres/MySQL:
+                statement.execute("DROP SCHEMA IF EXISTS \"${namespace}\" CASCADE")
+
+                // Or for databases with DROP DATABASE:
+                // statement.execute("DROP DATABASE IF EXISTS `${namespace}`")
+            }
+        }
+    }
+
+    override suspend fun insertRecords(
+        table: TableName,
+        records: List<Map<String, AirbyteValue>>
+    ) {
+        if (records.isEmpty()) return
+
+        dataSource.connection.use { connection ->
+            records.forEach { record ->
+                val columns = record.keys.joinToString(", ") { "\"$it\"" }
+                val placeholders = record.keys.joinToString(", ") { "?" }
+                val sql = """
+                    INSERT INTO "${table.namespace}"."${table.name}" ($columns)
+                    VALUES ($placeholders)
+                """
+
+                connection.prepareStatement(sql).use { statement ->
+                    record.values.forEachIndexed { index, value ->
+                        setParameter(statement, index + 1, value)
+                    }
+                    statement.executeUpdate()
+                }
+            }
+        }
+    }
+
+    override suspend fun readTable(table: TableName): List<Map<String, Any>> {
+        val results = mutableListOf<Map<String, Any>>()
+
+        dataSource.connection.use { connection ->
+            val sql = "SELECT * FROM \"${table.namespace}\".\"${table.name}\""
+            connection.createStatement().use { statement ->
+                val rs = statement.executeQuery(sql)
+                val metadata = rs.metaData
+
+                while (rs.next()) {
+                    val row = mutableMapOf<String, Any>()
+                    for (i in 1..metadata.columnCount) {
+                        val columnName = metadata.getColumnName(i)
+                        val value = rs.getObject(i)
+                        if (value != null) {
+                            row[columnName] = value
+                        }
+                    }
+                    results.add(row)
+                }
+            }
+        }
+
+        return results
+    }
+
+    private fun setParameter(statement: PreparedStatement, index: Int, value: AirbyteValue) {
+        when (value) {
+            is StringValue -> statement.setString(index, value.value)
+            is IntegerValue -> statement.setLong(index, value.value)
+            is NumberValue -> statement.setBigDecimal(index, value.value)
+            is BooleanValue -> statement.setBoolean(index, value.value)
+            is TimestampValue -> statement.setTimestamp(index, Timestamp.from(value.value))
+            is DateValue -> statement.setDate(index, Date.valueOf(value.value))
+            is ObjectValue -> statement.setString(index, value.toJson())  // JSON as string
+            is ArrayValue -> statement.setString(index, value.toJson())   // JSON as string
+            is NullValue -> statement.setNull(index, Types.VARCHAR)
+            else -> statement.setString(index, value.toString())
+        }
     }
 }
 ```
 
-**Note:** For non-JDBC databases, use native client APIs for insert/read
+**What this does:**
+- **ping():** Validates connection works
+- **dropNamespace():** Cleanup after tests
+- **insertRecords():** Insert test data for verification
+- **readTable():** Read back data to verify writes worked
+- **setParameter():** Convert AirbyteValue types to JDBC types
 
-### Step 3.5: Enable Table Tests
+**For non-JDBC databases:** Replace JDBC code with native client API calls.
 
-**File:** Update `{DB}TableOperationsTest.kt`
+---
+
+### Database Step 6: Create Full Test Suite
+
+**File:** `src/test-integration/kotlin/.../component/{DB}TableOperationsTest.kt`
+
+**Create test file with ALL tests enabled from the start:**
 
 ```kotlin
-@Test
-override fun `create and drop tables`() {
-    super.`create and drop tables`()
-}
+package io.airbyte.integrations.destination.{db}.component
 
-@Test
-override fun `insert records`() {
-    super.`insert records`()
-}
+import io.airbyte.cdk.load.component.TableOperationsClient
+import io.airbyte.cdk.load.component.TableOperationsSuite
+import io.airbyte.cdk.load.component.TestTableOperationsClient
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import org.junit.jupiter.api.Test
 
-@Test
-override fun `count table rows`() {
-    super.`count table rows`()
+@MicronautTest(environments = ["component"])
+class {DB}TableOperationsTest(
+    override val client: TableOperationsClient,
+    override val testClient: TestTableOperationsClient,
+) : TableOperationsSuite {
+
+    @Test
+    override fun `connect to database`() {
+        super.`connect to database`()
+    }
+
+    @Test
+    override fun `create and drop namespaces`() {
+        super.`create and drop namespaces`()
+    }
+
+    @Test
+    override fun `create and drop tables`() {
+        super.`create and drop tables`()
+    }
+
+    @Test
+    override fun `insert records`() {
+        super.`insert records`()
+    }
+
+    @Test
+    override fun `count table rows`() {
+        super.`count table rows`()
+    }
 }
 ```
 
-### Step 3.6: Validate
+**What each test validates:**
+1. **connect to database:** DataSource works, can execute SELECT 1
+2. **create and drop namespaces:** Namespace operations (CREATE/DROP SCHEMA)
+3. **create and drop tables:** Table operations (CREATE/DROP TABLE)
+4. **insert records:** Test client can insert data, client can create tables
+5. **count table rows:** COUNT query works, handles empty and non-empty tables
 
-**Validate:**
+---
+
+### Database Step 7: Validate Full Implementation
+
+**Run all component tests:**
+
 ```bash
-$ ./gradlew :destination-{db}:testComponentCreateAndDropTables \
-             :destination-{db}:testComponentInsertRecords \
-             :destination-{db}:testComponentCountTableRows  # 3 tests should pass
-$ ./gradlew :destination-{db}:componentTest  # 5 tests should pass
+$ ./gradlew :destination-{db}:componentTest
 ```
 
-✅ **Checkpoint:** Can manage tables and data + all previous phases still work
+**Expected output:**
+```
+{DB}TableOperationsTest > connect to database PASSED
+{DB}TableOperationsTest > create and drop namespaces PASSED
+{DB}TableOperationsTest > create and drop tables PASSED
+{DB}TableOperationsTest > insert records PASSED
+{DB}TableOperationsTest > count table rows PASSED
+
+SpecTest > spec matches expected PASSED
+
+BUILD SUCCESSFUL in 15s
+6 tests, 6 passed
+```
+
+**Success criteria (ALL must be true):**
+- [ ] All 5 TableOperationsSuite tests show "PASSED"
+- [ ] No SQL syntax errors in logs
+- [ ] No connection errors
+- [ ] Test log shows SQL statements (from .andLog())
+- [ ] BUILD SUCCESSFUL
 
 ---
 
+**If tests FAIL, debug systematically:**
+
+#### Test 1 fails: "connect to database"
+**Symptom:** Connection refused, authentication failed, or timeout
+
+**Check:**
+1. Testcontainer started? Look for "Container is started" in logs
+2. Connection string correct? Check hostname, port in test config
+3. Database initialized? Some databases need init time
+
+**Fix:**
+```bash
+# Verify container is running
+$ docker ps | grep {db}
+
+# Check container logs
+$ docker logs <container-id>
+
+# Try manual connection
+$ {db-cli} -h localhost -p <port> -U test -d test
+```
+
+#### Test 2 fails: "create and drop namespaces"
+**Symptom:** SQL syntax error on CREATE SCHEMA or namespace query
+
+**Check:**
+1. SQL syntax correct for your database? (SCHEMA vs DATABASE)
+2. Quoting correct? (double quotes vs backticks)
+3. Information schema query correct?
+
+**Fix:**
+- Copy SQL from logs
+- Run in database console manually
+- Adjust SqlGenerator methods
+
+#### Test 3 fails: "create and drop tables"
+**Symptom:** SQL syntax error on CREATE TABLE
+
+**Check:**
+1. Column type mapping correct? (toDialectType)
+2. Metadata columns use correct types?
+3. Quoting in fullyQualifiedName correct?
+
+**Fix:**
+- Copy CREATE TABLE SQL from logs
+- Verify each column type is valid
+- Test in database console
+
+#### Test 4 fails: "insert records"
+**Symptom:** SQL syntax error on INSERT or type conversion error
+
+**Check:**
+1. setParameter() handles all AirbyteValue types?
+2. JSON serialization works for ObjectValue/ArrayValue?
+3. Timestamp/Date conversions correct?
+
+**Fix:**
+- Add logging to setParameter()
+- Verify each type converts correctly
+- Test with single record first
+
+#### Test 5 fails: "count table rows"
+**Symptom:** COUNT query fails or returns wrong value
+
+**Check:**
+1. COUNT SQL syntax correct?
+2. Handles empty table (returns 0)?
+3. Handles non-existent table (returns null)?
+
+**Fix:**
+- Test COUNT with empty table manually
+- Verify countTable catches SQLException for missing table
+
 ---
 
-## Phase 5: Check Operation
+**Common issues across all tests:**
 
-**Goal:** Implement --check operation (validates database connection)
+**Issue: "No bean of type [TableOperationsClient]"**
+```
+Fix: Check BeanFactory has @Singleton fun client(...): TableOperationsClient
+Verify: ./gradlew :destination-{db}:compileKotlin succeeds
+```
 
-**Checkpoint:** Check operation works
+**Issue: "TODO not yet implemented"**
+```
+Symptom: Test calls TODO() stub method
+Fix: Verify you implemented all methods (not just namespace or table, but BOTH)
+Check: Client has no TODO() in methods called by tests
+```
 
-### Step 5.1: Create Checker
+**Issue: SQL logged but not executed**
+```
+Symptom: .andLog() works but SQL doesn't run
+Fix: Verify execute() method actually calls statement.execute(sql)
+Check: Add logging after execute to confirm it ran
+```
+
+---
+
+✅ **Checkpoint:** Complete TableOperationsClient implementation
+
+**What you've achieved:**
+- ✅ DataSource connection working
+- ✅ Namespace operations (CREATE/DROP/EXISTS)
+- ✅ Table operations (CREATE/DROP/COUNT/getGenerationId)
+- ✅ All 5 TableOperationsSuite tests passing
+- ✅ Ready for Phase 3 (Write Infrastructure)
+
+**What's NOT done yet (later phases):**
+- ❌ Schema evolution (Advanced Phase 1)
+- ❌ Upsert/dedupe (Advanced Phase 2)
+- ❌ Overwrite/truncate (Write Phase 2)
+- ❌ Copy operations (Write Phase 3)
+- ❌ Write operations (Write Phase 1+)
+
+---
+
+## Database Phase 2: Check Operation
+
+**Goal:** Implement `--check` operation to validate database connection and permissions
+
+**Why separate phase?** Check is a different component (Checker) with integration test validation. Natural checkpoint after basic operations work.
+
+**Checkpoint:** --check operation works
+
+---
+
+### Database Step 1: Create Checker
 
 **File:** `check/{DB}Checker.kt`
 
@@ -764,17 +1011,21 @@ class {DB}Checker(
 
         runBlocking {
             try {
+                // 1. Verify namespace exists or can be created
                 client.createNamespace(testNamespace)
 
+                // 2. Create test table with Airbyte metadata columns
                 val testStream = createTestStream()
                 val columnMapping = ColumnNameMapping(mapOf("test_col" to "test_col"))
 
                 client.createTable(testStream, tableName, columnMapping, replace = false)
 
+                // 3. Verify table was created (count should be 0)
                 val count = client.countTable(tableName)
                 require(count == 0L) { "Expected empty table, got $count rows" }
 
             } finally {
+                // Always cleanup test table
                 client.dropTable(tableName)
             }
         }
@@ -782,9 +1033,16 @@ class {DB}Checker(
 
     private fun createTestStream(): DestinationStream {
         return DestinationStream(
-            descriptor = DestinationStream.Descriptor(namespace = config.database, name = "test"),
+            descriptor = DestinationStream.Descriptor(
+                namespace = config.database,
+                name = "test"
+            ),
             importType = DestinationStream.ImportType.APPEND,
-            schema = ObjectType(linkedMapOf("test_col" to FieldType(StringType, true))),
+            schema = ObjectType(
+                properties = linkedMapOf(
+                    "test_col" to FieldType(StringType, nullable = true)
+                )
+            ),
             generationId = 0,
             minimumGenerationId = 0,
             syncId = 0,
@@ -793,7 +1051,21 @@ class {DB}Checker(
 }
 ```
 
-### Step 5.2: Create Check Integration Test
+**What check() does:**
+1. Creates (or verifies exists) namespace
+2. Creates test table with metadata columns
+3. Verifies table creation succeeded (count = 0)
+4. Cleans up test table
+
+**Why this validates the connection:**
+- Tests database connectivity
+- Tests CREATE/DROP permissions
+- Tests metadata column types work
+- Provides clear error messages if permissions missing
+
+---
+
+### Database Step 2: Create Check Integration Test
 
 **File:** `src/test-integration/kotlin/.../check/{DB}CheckTest.kt`
 
@@ -814,21 +1086,90 @@ class {DB}CheckTest :
     )
 ```
 
-### Step 5.3: Validate Check Operation
+**What this test does:**
+- Spawns real connector process (not mocked)
+- Runs `--check` operation with real config
+- Verifies CONNECTION_STATUS message returned
 
-**Validate:**
-```bash
-$ ./gradlew :destination-{db}:integrationTestCheckSuccessConfigs  # 1 test should pass
-$ ./gradlew :destination-{db}:componentTest  # 5 tests should pass
-$ ./gradlew :destination-{db}:integrationTest  # testSpecOss, testSuccessConfigs should pass
-```
-
-✅ **Checkpoint:** --check operation works + all previous phases still work
+**Config file location:** `secrets/config.json` (same as manual testing)
 
 ---
+
+### Database Step 3: Validate Check Operation
+
+**Run check integration test:**
+
+```bash
+$ ./gradlew :destination-{db}:integrationTestCheckSuccessConfigs
+```
+
+**Expected output:**
+```
+{DB}CheckTest > testSuccessConfigs[0] PASSED
+
+BUILD SUCCESSFUL in 5s
+```
+
+**Run full test suite (regression check):**
+
+```bash
+$ ./gradlew :destination-{db}:integrationTest
+```
+
+**Expected tests passing:**
+- `SpecTest > spec matches expected` ✅ (from Phase 1)
+- `{DB}CheckTest > testSuccessConfigs[0]` ✅ (new in Phase 3)
+
+**Success criteria:**
+- [ ] Check test shows "PASSED"
+- [ ] Connector log shows "CONNECTION_STATUS" with "status": "SUCCEEDED"
+- [ ] No SQL errors in logs
+- [ ] Test table cleaned up (check database - should not exist)
+
+**If check test FAILS:**
+
+**Symptom: "Permission denied" or "Access denied"**
+```
+Fix: Verify database user has CREATE/DROP privileges
+Test: Run CREATE SCHEMA manually with test credentials
+```
+
+**Symptom: "Table not created" (count != 0)**
+```
+Fix: Check CREATE TABLE SQL in logs
+Verify: Metadata column types are correct for your database
+```
+
+**Symptom: Test table not cleaned up**
+```
+Fix: Check finally block executes even if test fails
+Verify: dropTable() doesn't throw exception
+```
+
+---
+
+✅ **Checkpoint:** Database Phase 2 complete - Check operation working
+
+**What you've achieved:**
+- ✅ Database Phase 1: Complete TableOperationsClient (5 tests passing)
+- ✅ Database Phase 2: Check operation validates connection (1 test passing)
+- ✅ Total: 6 integration tests passing
+- ✅ Ready for Infrastructure Phase 1: Name Generators
 
 ---
 
 ## Next Steps
 
-**Next:** Continue to [3-write-infrastructure.md](./3-write-infrastructure.md) to set up the write operation infrastructure.
+**Continue to:** [3-write-infrastructure.md](./3-write-infrastructure.md)
+
+**What's next:**
+- Infrastructure Phase 1: Name generators (TableCatalog dependencies)
+- Infrastructure Phase 2: Write operation infrastructure (DI setup)
+- Write Phase 1+: Business logic (Writer, Aggregate, InsertBuffer)
+
+**Current progress:**
+- ✅ Setup Phase 1: Scaffolding
+- ✅ Setup Phase 2: Spec operation
+- ✅ Database Phase 1: TableOperationsClient (complete)
+- ✅ Database Phase 2: Check operation (complete)
+- ⏭️ Infrastructure Phase 1-2: Write operations setup (next guide)

--- a/connector-writer/destination/step-by-step/3-write-infrastructure.md
+++ b/connector-writer/destination/step-by-step/3-write-infrastructure.md
@@ -12,7 +12,7 @@ After completing this guide, you'll have:
 
 ---
 
-## Phase 6: Name Generators & TableCatalog DI
+## Infrastructure Phase 1: Name Generators & TableCatalog DI
 
 **Goal:** Create name generator beans required for TableCatalog instantiation
 
@@ -25,7 +25,7 @@ After completing this guide, you'll have:
 
 Without these beans, you'll get **"Error instantiating TableCatalog"** or **"No bean of type [FinalTableNameGenerator]"** errors in Phase 7 write tests.
 
-### Step 6.1: Create RawTableNameGenerator
+### Infrastructure Step 1: Create RawTableNameGenerator
 
 **File:** `config/{DB}NameGenerators.kt`
 
@@ -58,7 +58,7 @@ class {DB}RawTableNameGenerator(
 - Modern connectors typically use final tables only, but interface must be implemented
 - Keep implementation simple (identity mapping is fine)
 
-### Step 6.2: Create FinalTableNameGenerator
+### Infrastructure Step 2: Create FinalTableNameGenerator
 
 **Add to same file:** `config/{DB}NameGenerators.kt`
 
@@ -90,7 +90,7 @@ class {DB}FinalTableNameGenerator(
 // Output: TableName("my_database", "customers")  // Uses config.database as fallback
 ```
 
-### Step 6.3: Create ColumnNameGenerator
+### Infrastructure Step 3: Create ColumnNameGenerator
 
 **Add to same file:** `config/{DB}NameGenerators.kt`
 
@@ -123,7 +123,7 @@ class {DB}ColumnNameGenerator : ColumnNameGenerator {
 "userId" → "userId"
 ```
 
-### Step 6.4: Add Name Transformation Helper
+### Infrastructure Step 4: Add Name Transformation Helper
 
 **Add to same file:** `config/{DB}NameGenerators.kt`
 
@@ -177,7 +177,7 @@ private fun String.toDbCompatible(): String {
 private val POSTGRES_RESERVED_WORDS = setOf("user", "table", "select", ...)
 ```
 
-### Step 6.5: Register TempTableNameGenerator in BeanFactory
+### Infrastructure Step 5: Register TempTableNameGenerator in BeanFactory
 
 **File:** Update `{DB}BeanFactory.kt`
 
@@ -200,7 +200,7 @@ fun tempTableNameGenerator(config: {DB}Configuration): TempTableNameGenerator {
 - CDK provides implementation, but YOU must register it
 - Used by Writer to create staging tables
 
-### Step 6.6: Verify Compilation
+### Infrastructure Step 6: Verify Compilation
 
 **Validate:**
 ```bash
@@ -227,7 +227,7 @@ $ ./gradlew :destination-{db}:integrationTest  # testSpecOss, testSuccessConfigs
 
 ---
 
-## Phase 7: Write Operation Infrastructure
+## Infrastructure Phase 2: Write Operation Infrastructure
 
 **Goal:** Create write operation infrastructure beans (no business logic yet)
 
@@ -242,7 +242,7 @@ $ ./gradlew :destination-{db}:integrationTest  # testSpecOss, testSuccessConfigs
 
 **Key insight:** Separate infrastructure DI from business logic DI to catch errors incrementally.
 
-### Step 7.1: Create WriteOperationV2
+### Infrastructure Step 1: Create WriteOperationV2
 
 **File:** `cdk/WriteOperationV2.kt`
 
@@ -293,7 +293,7 @@ IllegalStateException: A legal sync requires a declared @Singleton of a type tha
 - Many connectors keep this file identical across databases
 - Signals "this is infrastructure, not business logic"
 
-### Step 7.2: Create DatabaseInitialStatusGatherer
+### Infrastructure Step 2: Create DatabaseInitialStatusGatherer
 
 **File:** `config/{DB}DirectLoadDatabaseInitialStatusGatherer.kt`
 
@@ -337,7 +337,7 @@ DirectLoadInitialStatus(
 
 ⚠️ **MISSING IN V1 GUIDE:** This step existed as code but bean registration was missing!
 
-### Step 7.3: Register DatabaseInitialStatusGatherer in BeanFactory
+### Infrastructure Step 3: Register DatabaseInitialStatusGatherer in BeanFactory
 
 **File:** Update `{DB}BeanFactory.kt`
 
@@ -363,7 +363,7 @@ fun initialStatusGatherer(
 - Micronaut needs explicit return type for generic beans
 - Factory method provides type safety
 
-### Step 7.4: Create ColumnNameMapper
+### Infrastructure Step 4: Create ColumnNameMapper
 
 **File:** `write/transform/{DB}ColumnNameMapper.kt`
 
@@ -407,7 +407,7 @@ class {DB}ColumnNameMapper(
 - ColumnNameMapper: Uses mappings during transform (Phase 7)
 - Separation of concerns: generation vs. application
 
-### Step 7.5: Register AggregatePublishingConfig in BeanFactory
+### Infrastructure Step 5: Register AggregatePublishingConfig in BeanFactory
 
 **File:** Update `{DB}BeanFactory.kt`
 
@@ -449,7 +449,7 @@ fun aggregatePublishingConfig(dataChannelMedium: DataChannelMedium): AggregatePu
 - Tune later based on performance requirements
 - Start with defaults - they work for most databases
 
-### Step 7.6: Create WriteInitializationTest
+### Infrastructure Step 6: Create WriteInitializationTest
 
 **File:** `src/test-integration/kotlin/.../write/{DB}WriteInitTest.kt`
 
@@ -498,7 +498,7 @@ Phase 7: WriteInitTest validates they work with real catalog
 Phase 8: ConnectorWiringSuite validates full write path with mock catalog
 ```
 
-### Step 7.6: Create Test Config File
+### Infrastructure Step 7: Create Test Config File
 
 **File:** `secrets/config.json`
 
@@ -525,7 +525,7 @@ $ mkdir -p destination-{db}/secrets
 
 **Note:** Add `secrets/` to `.gitignore` to avoid committing credentials
 
-### Step 7.7: Validate WriteInitializationTest
+### Infrastructure Step 8: Validate WriteInitializationTest
 
 **Validate:**
 ```bash

--- a/connector-writer/destination/step-by-step/5-advanced-features.md
+++ b/connector-writer/destination/step-by-step/5-advanced-features.md
@@ -22,6 +22,7 @@ After completing this guide, you'll have a production-ready connector with:
 
 ---
 
+## Advanced Phase 1: Schema Evolution
 
 **Goal:** Automatically adapt to schema changes
 
@@ -33,7 +34,7 @@ After completing this guide, you'll have a production-ready connector with:
 3. **Change type**: Source changes field type → alter column (with casting)
 4. **Change nullability**: Source changes nullable → alter column constraints
 
-### Step 12.1: Implement discoverSchema()
+### Advanced Step 1: Implement discoverSchema()
 
 **File:** Update `client/{DB}AirbyteClient.kt`
 
@@ -90,7 +91,7 @@ private val AIRBYTE_META_COLUMNS = setOf(
 - **ClickHouse**: `system.columns` or client API `getTableSchema()`
 - **BigQuery**: `INFORMATION_SCHEMA.COLUMNS`
 
-### Step 12.2: Implement computeSchema()
+### Advanced Step 2: Implement computeSchema()
 
 **File:** Update `client/{DB}AirbyteClient.kt`
 
@@ -117,7 +118,7 @@ override fun computeSchema(
 - Applies column name mapping (Phase 6 generators)
 - Uses ColumnUtils.toDialectType() from Phase 4
 
-### Step 12.3: Implement alterTable() - ADD COLUMN
+### Advanced Step 3: Implement alterTable() - ADD COLUMN
 
 **File:** Update `client/{DB}SqlGenerator.kt`
 
@@ -154,7 +155,7 @@ fun alterTable(
 }
 ```
 
-### Step 12.4: Implement alterTable() - MODIFY COLUMN
+### Advanced Step 4: Implement alterTable() - MODIFY COLUMN
 
 **Add to alterTable():**
 
@@ -245,7 +246,7 @@ fun recreateTable(
 }
 ```
 
-### Step 12.5: Implement applyChangeset()
+### Advanced Step 5: Implement applyChangeset()
 
 **File:** Update `client/{DB}AirbyteClient.kt`
 
@@ -275,7 +276,7 @@ override suspend fun applyChangeset(
 }
 ```
 
-### Step 12.6: Implement ensureSchemaMatches()
+### Advanced Step 6: Implement ensureSchemaMatches()
 
 **File:** Update `client/{DB}AirbyteClient.kt`
 
@@ -303,7 +304,7 @@ override suspend fun ensureSchemaMatches(
 - If source schema changed since last sync, applies schema changes
 - Automatic - no user intervention needed
 
-### Step 12.7: Validate Schema Evolution
+### Advanced Step 7: Validate Schema Evolution
 
 **Validate:**
 ```bash
@@ -317,7 +318,7 @@ $ ./gradlew :destination-{db}:integrationTest  # 3 tests should pass
 
 ---
 
-## Phase 13: Dedupe Mode
+## Advanced Phase 2: Dedupe Mode
 
 **Goal:** Support primary key deduplication
 
@@ -336,7 +337,7 @@ $ ./gradlew :destination-{db}:integrationTest  # 3 tests should pass
 - **Overwrite** (Phase 10): Swap tables
 - **Dedupe** (Phase 13): Upsert with primary key
 
-### Step 13.1: Implement upsertTable() in SQL Generator
+### Advanced Step 1: Implement upsertTable() in SQL Generator
 
 **Option A: MERGE Statement (Snowflake, SQL Server, BigQuery)**
 
@@ -500,7 +501,7 @@ fun upsertTable(...): List<String> {
 }
 ```
 
-### Step 13.2: Implement upsertTable() in Client
+### Advanced Step 2: Implement upsertTable() in Client
 
 **File:** Update `client/{DB}AirbyteClient.kt`
 
@@ -523,7 +524,7 @@ override suspend fun upsertTable(
 }
 ```
 
-### Step 13.3: Update Writer for Dedupe Mode
+### Advanced Step 3: Update Writer for Dedupe Mode
 
 **File:** Update `write/{DB}Writer.kt`
 
@@ -585,7 +586,7 @@ override fun createStreamLoader(stream: DestinationStream): StreamLoader {
   - DirectLoadTableDedupStreamLoader (incremental dedupe)
   - DirectLoadTableDedupTruncateStreamLoader (full refresh dedupe)
 
-### Step 13.4: Enable Tests
+### Advanced Step 4: Enable Tests
 
 **File:** Update `src/test-integration/kotlin/.../component/{DB}TableOperationsTest.kt`
 
@@ -596,7 +597,7 @@ override fun `upsert tables`() {
 }
 ```
 
-### Step 13.5: Validate
+### Advanced Step 5: Validate
 
 **Validate:**
 ```bash
@@ -611,7 +612,7 @@ $ ./gradlew :destination-{db}:integrationTest  # 3 tests should pass
 
 ---
 
-## Phase 14: CDC Support (Optional)
+## Advanced Phase 3: CDC Support (Optional)
 
 **Goal:** Handle source deletions
 
@@ -624,7 +625,7 @@ $ ./gradlew :destination-{db}:integrationTest  # 3 tests should pass
   - **Hard delete**: Remove record from destination
   - **Soft delete**: Keep record with deletion timestamp
 
-### Step 14.1: Add CDC Configuration
+### Advanced Step 1: Add CDC Configuration
 
 **File:** Update `spec/{DB}Specification.kt`
 
@@ -659,7 +660,7 @@ override fun makeWithoutExceptionHandling(pojo: {DB}Specification): {DB}Configur
 }
 ```
 
-### Step 14.2: Add CDC Logic to upsertTable()
+### Advanced Step 2: Add CDC Logic to upsertTable()
 
 **File:** Update `client/{DB}SqlGenerator.kt`
 
@@ -726,11 +727,11 @@ private val CDC_DELETED_AT_COLUMN = "_ab_cdc_deleted_at"
 - Skip INSERT for deleted records (don't re-insert deleted rows)
 - Soft delete: No special clauses (just upsert the deletion record with timestamp)
 
-### Step 14.3: Test CDC
+### Advanced Step 3: Test CDC
 
 CDC tests are typically included in integration tests automatically if you have CDC streams configured. No separate test enablement needed - the framework tests CDC if the stream has `_ab_cdc_deleted_at` column.
 
-### Step 14.4: Validate
+### Advanced Step 4: Validate
 
 **Validate:**
 ```bash
@@ -744,7 +745,7 @@ $ ./gradlew :destination-{db}:integrationTest  # 3 tests should pass (CDC tested
 
 ---
 
-## Phase 15: Optimization & Polish
+## Advanced Phase 4: Optimization & Polish
 
 **Goal:** Production-ready performance
 

--- a/connector-writer/destination/step-by-step/6-testing.md
+++ b/connector-writer/destination/step-by-step/6-testing.md
@@ -57,7 +57,9 @@ Before starting, you must have:
 
 ---
 
-## Step 1: Implement Test Helper Classes
+## Testing Phase 1: BasicFunctionalityIntegrationTest
+
+### Testing Step 1: Implement Test Helper Classes
 
 ### Step 1.1: Create DestinationDataDumper
 
@@ -210,7 +212,7 @@ class {DB}Cleaner(
 
 ---
 
-## Step 2: Create BasicFunctionalityIntegrationTest Class
+### Testing Step 2: Create BasicFunctionalityIntegrationTest Class
 
 ### Step 2.1: Understand Required Parameters
 
@@ -346,7 +348,7 @@ class {DB}BasicFunctionalityTest : BasicFunctionalityIntegrationTest(
 
 ---
 
-## Step 3: Configure Test Parameters
+### Testing Step 3: Configure Test Parameters
 
 ### Quick Reference Table
 
@@ -531,7 +533,7 @@ AllTypesBehavior.StronglyTyped(
 
 ---
 
-## Step 4: Run Tests
+### Testing Step 4: Run Tests
 
 ### Test Individually
 
@@ -558,7 +560,7 @@ $ ./gradlew :destination-{db}:integrationTest --tests "*BasicFunctionalityTest"
 
 ---
 
-## Step 5: Debug Common Failures
+### Testing Step 5: Debug Common Failures
 
 ### Test: testAppend fails with "Record mismatch"
 
@@ -598,7 +600,7 @@ $ ./gradlew :destination-{db}:integrationTest --tests "*BasicFunctionalityTest"
 
 ---
 
-## Step 6: Optional Test Customization
+### Testing Step 6: Optional Test Customization
 
 ### Skip Tests Not Applicable
 


### PR DESCRIPTION
## What

Reworks the docs:
* come up with a numbering scheme that remains local to a file: easier to maintain and limits cross files impact when updating
* rework 2 database setup, the ordering wasn't clear enough and agents would often continue without building or testing. This should clarify the flow.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
