### PR TITLE
fix(source-gitlab): Skip group enumeration when only projects_list is specified

### DIFF
--- a/airbyte-integrations/connectors/source-gitlab/unit_tests/test_streams.py
+++ b/airbyte-integrations/connectors/source-gitlab/unit_tests/test_streams.py
@@ -27,7 +27,11 @@ CONFIG = BASE_CONFIG | {"projects_list": ["p_1"]}
     ),
 )
 def test_should_retry(requests_mock, stream_name, extra_mocks):
-    requests_mock.get(url=GROUPS_LIST_URL, status_code=200)
+    """Test that 403 responses are handled gracefully and don't produce records.
+    
+    Note: The groups API is not called when only projects_list is set (no groups_list),
+    so we only expect calls for the extra_mocks.
+    """
     source = get_source(config=CONFIG)
     migrated_config = source.configure(config=CONFIG, temp_dir="/not/a/real/path")
     stream = get_stream_by_name(source=source, stream_name=stream_name, config=migrated_config)
@@ -38,7 +42,7 @@ def test_should_retry(requests_mock, stream_name, extra_mocks):
     for partition in stream.generate_partitions():
         records.extend(list(partition.read()))
     assert records == []
-    assert requests_mock.call_count == len(extra_mocks) + 1
+    assert requests_mock.call_count == len(extra_mocks)
 
 
 test_cases = (

--- a/airbyte-integrations/connectors/source-gitlab/unit_tests/test_streams.py
+++ b/airbyte-integrations/connectors/source-gitlab/unit_tests/test_streams.py
@@ -28,7 +28,7 @@ CONFIG = BASE_CONFIG | {"projects_list": ["p_1"]}
 )
 def test_should_retry(requests_mock, stream_name, extra_mocks):
     """Test that 403 responses are handled gracefully and don't produce records.
-    
+
     Note: The groups API is not called when only projects_list is set (no groups_list),
     so we only expect calls for the extra_mocks.
     """
@@ -170,7 +170,7 @@ def test_stream_slices_child_stream(requests_mock):
         url="https://gitlab.com/api/v4/projects/p_1?per_page=50&statistics=1",
         json=[{"id": 13082000, "description": "", "name": "New CI Test Project"}],
     )
-    stream_state = {"13082000": {"" "created_at": "2021-03-10T23:58:1213"}}
+    stream_state = {"13082000": {"created_at": "2021-03-10T23:58:1213"}}
 
     slices = list(map(lambda partition: partition.to_slice(), commits.generate_partitions()))
     assert slices


### PR DESCRIPTION
## What
Fixes connection check timeout (HTTP 504) when users specify only projects without groups. The connector was enumerating all accessible groups on GitLab before checking the specified projects, causing multi-minute delays and eventual timeouts for users with access to large GitLab instances.

## How
Added a short-circuit in `ProjectStreamsPartitionRouter.stream_slices()` that directly yields project slices when `projects_list` is specified but `groups_list` is empty. This bypasses the expensive group enumeration that was previously always performed.

Also includes a minor logic cleanup: simplified `if not projects_list or projects_list and project_id in projects_list:` to `if not projects_list or project_id in projects_list:`.

## Review guide
1. `components.py` - Main fix: short-circuit logic at lines 57-65
2. `test_partition_routers.py` - Updated tests to verify new behavior
3. `test_streams.py` - Updated `test_should_retry` to reflect that groups API is no longer called

Key review points:
- Verify the condition `if projects_list and not groups_list` correctly identifies the "only projects specified" case
- The test `test_projects_stream_slices_with_only_projects_list_skips_groups_api` intentionally does NOT mock the groups API to verify it's not called
- The test `test_projects_stream_slices_with_group_project_ids_filtered_by_projects_list_config` now requires `groups_list` to be set to test the filtering behavior
- `test_should_retry` assertion changed from `len(extra_mocks) + 1` to `len(extra_mocks)` since groups API is no longer called

### Recommended reviewer checklist
- [ ] Confirm the short-circuit condition `if projects_list and not groups_list` handles edge cases correctly (e.g., empty lists)
- [ ] Verify the behavioral change is acceptable: users specifying only projects will no longer get implicit group discovery

## User Impact
Users who specify only projects (without groups) will now experience significantly faster connection checks. The connector will directly validate the specified projects instead of first enumerating all accessible groups.

**Behavioral change**: Users who previously relied on implicit group discovery when specifying only projects will now get only the explicitly specified projects. This is the expected behavior based on the configuration.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚

---
Link to Devin run: https://app.devin.ai/sessions/2b8cb9486b8346469cb18f3c73049c3a
Requested by: Vikram Srigada (vikram.srigada@airbyte.io) / @vikram661