### PR TITLE
feat(destination-postgres): Add component tests for schema evolution and table operations

### DIFF
--- a/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/client/PostgresAirbyteClient.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/client/PostgresAirbyteClient.kt
@@ -4,13 +4,17 @@
 
 package io.airbyte.integrations.destination.postgres.client
 
+import io.airbyte.cdk.ConfigErrorException
+import io.airbyte.cdk.load.command.Dedupe
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.component.ColumnChangeset
+import io.airbyte.cdk.load.component.ColumnType
 import io.airbyte.cdk.load.component.TableColumns
 import io.airbyte.cdk.load.component.TableOperationsClient
 import io.airbyte.cdk.load.component.TableSchema
 import io.airbyte.cdk.load.component.TableSchemaEvolutionClient
 import io.airbyte.cdk.load.message.Meta.Companion.COLUMN_NAME_AB_GENERATION_ID
+import io.airbyte.cdk.load.message.Meta.Companion.COLUMN_NAMES
 import io.airbyte.cdk.load.schema.model.TableName
 import io.airbyte.cdk.load.table.ColumnNameMapping
 import io.airbyte.integrations.destination.postgres.sql.COUNT_TOTAL_ALIAS
@@ -164,14 +168,69 @@ class PostgresAirbyteClient(
     }
 
     override suspend fun discoverSchema(tableName: TableName): TableSchema {
-        TODO("Not yet implemented")
+        val columns = mutableMapOf<String, ColumnType>()
+        executeQuery(sqlGenerator.getTableSchema(tableName)) { rs ->
+            while (rs.next()) {
+                val columnName = rs.getString(COLUMN_NAME_COLUMN)
+                val dataType = rs.getString("data_type")
+                val isNullable = rs.getString("is_nullable") == "YES"
+
+                columns[columnName] = ColumnType(normalizePostgresType(dataType), isNullable)
+            }
+        }
+
+        log.info { "Discovered PostgreSQL table schema: $columns" }
+
+        val hasAllAirbyteColumns = columns.keys.containsAll(COLUMN_NAMES)
+        if (!hasAllAirbyteColumns) {
+            val message =
+                "The target table ($tableName) already exists in the destination, but does not contain Airbyte's internal columns. Airbyte can only sync to Airbyte-controlled tables. To fix this error, you must either delete the target table or add a prefix in the connection configuration in order to sync to a separate table in the destination."
+            log.error { message }
+            throw ConfigErrorException(message)
+        }
+
+        // Filter out Airbyte internal columns
+        val schemaWithoutAirbyteColumns = columns.filterNot { it.key in COLUMN_NAMES }
+
+        log.info { "Found PostgreSQL columns (excluding Airbyte columns): $schemaWithoutAirbyteColumns" }
+
+        return TableSchema(schemaWithoutAirbyteColumns)
     }
 
     override fun computeSchema(
         stream: DestinationStream,
         columnNameMapping: ColumnNameMapping
     ): TableSchema {
-        TODO("Not yet implemented")
+        val importType = stream.importType
+        val primaryKeys =
+            if (importType is Dedupe) {
+                postgresColumnUtils
+                    .getPrimaryKeysColumnNames(importType, columnNameMapping)
+                    .toSet()
+            } else {
+                emptySet()
+            }
+        val cursor =
+            if (importType is Dedupe) {
+                postgresColumnUtils.getCursorColumnName(importType.cursor, columnNameMapping)
+            } else {
+                null
+            }
+
+        return TableSchema(
+            stream.schema
+                .asColumns()
+                .map { (fieldName, fieldType) ->
+                    val targetColumnName =
+                        postgresColumnUtils.getTargetColumnName(fieldName, columnNameMapping)
+                    // Primary keys and cursor columns should not be nullable
+                    val nullable =
+                        !primaryKeys.contains(targetColumnName) && cursor != targetColumnName
+                    val type = postgresColumnUtils.toDialectType(fieldType.type)
+                    targetColumnName to ColumnType(type = type, nullable = nullable)
+                }
+                .toMap()
+        )
     }
 
     override suspend fun applyChangeset(
@@ -181,7 +240,72 @@ class PostgresAirbyteClient(
         expectedColumns: TableColumns,
         columnChangeset: ColumnChangeset
     ) {
-        TODO("Not yet implemented")
+        if (columnChangeset.isNoop()) {
+            log.info { "No schema changes needed for table $tableName" }
+            return
+        }
+
+        log.info { "Applying schema changes to table $tableName:" }
+        log.info { "  Columns to add: ${columnChangeset.columnsToAdd.keys}" }
+        log.info { "  Columns to drop: ${columnChangeset.columnsToDrop.keys}" }
+        log.info { "  Columns to change: ${columnChangeset.columnsToChange.keys}" }
+
+        // Convert ColumnChangeset to the Column format used by matchSchemas
+        val columnsToAdd =
+            columnChangeset.columnsToAdd.map { (name, type) ->
+                Column(name, type.type, type.nullable)
+            }.toSet()
+
+        val columnsToRemove =
+            columnChangeset.columnsToDrop.map { (name, type) ->
+                Column(name, type.type, type.nullable)
+            }.toSet()
+
+        val columnsToModify =
+            columnChangeset.columnsToChange.map { (name, change) ->
+                Column(name, change.newType.type, change.newType.nullable)
+            }.toSet()
+
+        // Track nullability changes separately for ALTER COLUMN SET/DROP NOT NULL
+        val nullabilityChanges =
+            columnChangeset.columnsToChange.filter { (_, change) ->
+                change.originalType.nullable != change.newType.nullable
+            }
+
+        // Get current columns in DB for the ALTER statement context
+        val columnsInDb = getColumnsFromDb(tableName)
+
+        execute(
+            sqlGenerator.matchSchemas(
+                tableName = tableName,
+                columnsToAdd = columnsToAdd,
+                columnsToRemove = columnsToRemove,
+                columnsToModify = columnsToModify,
+                columnsInDb = columnsInDb,
+                recreatePrimaryKeyIndex =
+                    shouldRecreatePrimaryKeyIndex(stream, tableName, columnNameMapping),
+                primaryKeyColumnNames =
+                    postgresColumnUtils.getPrimaryKeysColumnNames(stream, columnNameMapping),
+                recreateCursorIndex =
+                    shouldRecreateCursorIndex(stream, tableName, columnNameMapping),
+                cursorColumnName =
+                    postgresColumnUtils.getCursorColumnName(stream, columnNameMapping),
+            )
+        )
+
+        // Apply nullability changes (SET/DROP NOT NULL)
+        if (nullabilityChanges.isNotEmpty()) {
+            log.info { "Applying nullability changes: $nullabilityChanges" }
+            val fullyQualifiedTableName =
+                "\"${tableName.namespace}\".\"${tableName.name}\""
+            nullabilityChanges.forEach { (columnName, change) ->
+                val nullabilityClause =
+                    if (change.newType.nullable) "DROP NOT NULL" else "SET NOT NULL"
+                execute(
+                    "ALTER TABLE $fullyQualifiedTableName ALTER COLUMN \"$columnName\" $nullabilityClause;"
+                )
+            }
+        }
     }
 
     /**
@@ -339,6 +463,43 @@ class PostgresAirbyteClient(
         } catch (e: Exception) {
             log.error(e) { "Failed to retrieve the generation ID for table $tableName" }
             0L
+        }
+
+    override suspend fun namespaceExists(namespace: String): Boolean =
+        try {
+            executeQuery(
+                """
+                SELECT EXISTS(
+                    SELECT 1 FROM information_schema.schemata
+                    WHERE schema_name = '$namespace'
+                )
+                """
+                    .trimIndent()
+            ) { rs ->
+                rs.next() && rs.getBoolean(1)
+            }
+        } catch (e: Exception) {
+            log.error(e) { "Failed to check if namespace $namespace exists" }
+            false
+        }
+
+    override suspend fun tableExists(table: TableName): Boolean =
+        try {
+            executeQuery(
+                """
+                SELECT EXISTS(
+                    SELECT 1 FROM information_schema.tables
+                    WHERE table_schema = '${table.namespace}'
+                    AND table_name = '${table.name}'
+                )
+                """
+                    .trimIndent()
+            ) { rs ->
+                rs.next() && rs.getBoolean(1)
+            }
+        } catch (e: Exception) {
+            log.error(e) { "Failed to check if table $table exists" }
+            false
         }
 
     fun describeTable(tableName: TableName): List<String> =

--- a/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresDirectLoadSqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresDirectLoadSqlGenerator.kt
@@ -518,7 +518,7 @@ class PostgresDirectLoadSqlGenerator(
 
     fun getTableSchema(tableName: TableName): String =
         """
-        SELECT column_name, data_type
+        SELECT column_name, data_type, is_nullable
         FROM information_schema.columns
         WHERE table_schema = '${tableName.namespace}'
         AND table_name = '${tableName.name}';

--- a/airbyte-integrations/connectors/destination-postgres/src/test-integration/kotlin/io/airbyte/integrations/destination/postgres/component/PostgresTableOperationsTest.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/test-integration/kotlin/io/airbyte/integrations/destination/postgres/component/PostgresTableOperationsTest.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.postgres.component
+
+import io.airbyte.cdk.load.component.TableOperationsSuite
+import io.airbyte.cdk.load.component.TestTableOperationsClient
+import io.airbyte.integrations.destination.postgres.client.PostgresAirbyteClient
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import jakarta.inject.Inject
+import org.junit.jupiter.api.Test
+
+@MicronautTest(environments = ["component"])
+class PostgresTableOperationsTest : TableOperationsSuite {
+    @Inject override lateinit var client: PostgresAirbyteClient
+    @Inject override lateinit var testClient: TestTableOperationsClient
+
+    @Test
+    override fun `connect to database`() {
+        super.`connect to database`()
+    }
+
+    @Test
+    override fun `create and drop namespaces`() {
+        super.`create and drop namespaces`()
+    }
+
+    @Test
+    override fun `create and drop tables`() {
+        super.`create and drop tables`()
+    }
+
+    @Test
+    override fun `insert records`() {
+        super.`insert records`()
+    }
+
+    @Test
+    override fun `count table rows`() {
+        super.`count table rows`()
+    }
+
+    @Test
+    override fun `overwrite tables`() {
+        super.`overwrite tables`()
+    }
+
+    @Test
+    override fun `copy tables`() {
+        super.`copy tables`()
+    }
+
+    @Test
+    override fun `get generation id`() {
+        super.`get generation id`()
+    }
+
+    @Test
+    override fun `upsert tables`() {
+        super.`upsert tables`()
+    }
+}

--- a/airbyte-integrations/connectors/destination-postgres/src/test-integration/kotlin/io/airbyte/integrations/destination/postgres/component/PostgresTableSchemaEvolutionTest.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/test-integration/kotlin/io/airbyte/integrations/destination/postgres/component/PostgresTableSchemaEvolutionTest.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.postgres.component
+
+import io.airbyte.cdk.load.command.ImportType
+import io.airbyte.cdk.load.component.ColumnType
+import io.airbyte.cdk.load.component.TableOperationsClient
+import io.airbyte.cdk.load.component.TableSchema
+import io.airbyte.cdk.load.component.TableSchemaEvolutionClient
+import io.airbyte.cdk.load.component.TableSchemaEvolutionFixtures
+import io.airbyte.cdk.load.component.TableSchemaEvolutionSuite
+import io.airbyte.cdk.load.component.TestTableOperationsClient
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import org.junit.jupiter.api.Test
+
+@MicronautTest(environments = ["component"], resolveParameters = false)
+class PostgresTableSchemaEvolutionTest(
+    override val client: TableSchemaEvolutionClient,
+    override val opsClient: TableOperationsClient,
+    override val testClient: TestTableOperationsClient
+) : TableSchemaEvolutionSuite {
+
+    // PostgreSQL type mappings based on PostgresColumnUtils.toDialectType()
+    private val allTypesTableSchema =
+        TableSchema(
+            mapOf(
+                "string" to ColumnType("varchar", true),
+                "boolean" to ColumnType("boolean", true),
+                "integer" to ColumnType("bigint", true),
+                "number" to ColumnType("decimal", true),
+                "date" to ColumnType("date", true),
+                "timestamp_tz" to ColumnType("timestamp with time zone", true),
+                "timestamp_ntz" to ColumnType("timestamp", true),
+                "time_tz" to ColumnType("time with time zone", true),
+                "time_ntz" to ColumnType("time", true),
+                "array" to ColumnType("jsonb", true),
+                "object" to ColumnType("jsonb", true),
+                "unknown" to ColumnType("jsonb", true),
+            )
+        )
+
+    @Test
+    fun `discover recognizes all data types`() {
+        super.`discover recognizes all data types`(allTypesTableSchema)
+    }
+
+    @Test
+    fun `computeSchema handles all data types`() {
+        super.`computeSchema handles all data types`(allTypesTableSchema)
+    }
+
+    @Test
+    override fun `noop diff`() {
+        super.`noop diff`()
+    }
+
+    @Test
+    override fun `changeset is correct when adding a column`() {
+        super.`changeset is correct when adding a column`()
+    }
+
+    @Test
+    override fun `changeset is correct when dropping a column`() {
+        super.`changeset is correct when dropping a column`()
+    }
+
+    @Test
+    override fun `changeset is correct when changing a column's type`() {
+        super.`changeset is correct when changing a column's type`()
+    }
+
+    @Test
+    override fun `apply changeset - handle sync mode append`() {
+        super.`apply changeset - handle sync mode append`()
+    }
+
+    @Test
+    override fun `apply changeset - handle changing sync mode from append to dedup`() {
+        super.`apply changeset - handle changing sync mode from append to dedup`()
+    }
+
+    @Test
+    override fun `apply changeset - handle changing sync mode from dedup to append`() {
+        super.`apply changeset - handle changing sync mode from dedup to append`()
+    }
+
+    @Test
+    override fun `apply changeset - handle sync mode dedup`() {
+        super.`apply changeset - handle sync mode dedup`()
+    }
+
+    override fun `apply changeset`(
+        initialStreamImportType: ImportType,
+        modifiedStreamImportType: ImportType,
+    ) {
+        `apply changeset`(
+            TableSchemaEvolutionFixtures.APPLY_CHANGESET_INITIAL_COLUMN_MAPPING,
+            TableSchemaEvolutionFixtures.APPLY_CHANGESET_MODIFIED_COLUMN_MAPPING,
+            expectedExtractedAt = "2025-01-22T00:00:00Z",
+            initialStreamImportType,
+            modifiedStreamImportType,
+        )
+    }
+
+    @Test
+    override fun `change from string type to unknown type`() {
+        super.`change from string type to unknown type`()
+    }
+
+    @Test
+    override fun `change from unknown type to string type`() {
+        super.`change from unknown type to string type`()
+    }
+}

--- a/airbyte-integrations/connectors/destination-postgres/src/test-integration/kotlin/io/airbyte/integrations/destination/postgres/component/PostgresTestTableOperationsClient.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/test-integration/kotlin/io/airbyte/integrations/destination/postgres/component/PostgresTestTableOperationsClient.kt
@@ -44,8 +44,7 @@ class PostgresTestTableOperationsClient(
                     null::"${table.namespace}"."${table.name}",
                     ?::json
                 )
-                """
-                    .trimIndent()
+                """.trimIndent()
 
             connection.prepareStatement(sql).use { stmt ->
                 stmt.setString(1, records.serializeToString())

--- a/airbyte-integrations/connectors/destination-postgres/src/test-integration/kotlin/io/airbyte/integrations/destination/postgres/component/PostgresTestTableOperationsClient.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/test-integration/kotlin/io/airbyte/integrations/destination/postgres/component/PostgresTestTableOperationsClient.kt
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.postgres.component
+
+import io.airbyte.cdk.load.component.TestTableOperationsClient
+import io.airbyte.cdk.load.data.AirbyteValue
+import io.airbyte.cdk.load.schema.model.TableName
+import io.airbyte.cdk.load.util.serializeToString
+import io.micronaut.context.annotation.Requires
+import jakarta.inject.Singleton
+import javax.sql.DataSource
+
+@Requires(env = ["component"])
+@Singleton
+class PostgresTestTableOperationsClient(
+    private val dataSource: DataSource,
+) : TestTableOperationsClient {
+
+    override suspend fun ping() {
+        dataSource.connection.use { connection ->
+            connection.createStatement().use { stmt -> stmt.execute("SELECT 1") }
+        }
+    }
+
+    override suspend fun dropNamespace(namespace: String) {
+        dataSource.connection.use { connection ->
+            connection.createStatement().use { stmt ->
+                stmt.execute("DROP SCHEMA IF EXISTS \"$namespace\" CASCADE")
+            }
+        }
+    }
+
+    override suspend fun insertRecords(table: TableName, records: List<Map<String, AirbyteValue>>) {
+        if (records.isEmpty()) return
+
+        dataSource.connection.use { connection ->
+            // Use PostgreSQL's ability to insert JSON directly
+            val sql =
+                """
+                INSERT INTO "${table.namespace}"."${table.name}"
+                SELECT * FROM json_populate_recordset(
+                    null::"${table.namespace}"."${table.name}",
+                    ?::json
+                )
+                """
+                    .trimIndent()
+
+            connection.prepareStatement(sql).use { stmt ->
+                stmt.setString(1, records.serializeToString())
+                stmt.executeUpdate()
+            }
+        }
+    }
+
+    override suspend fun readTable(table: TableName): List<Map<String, Any>> {
+        val records = mutableListOf<Map<String, Any>>()
+
+        dataSource.connection.use { connection ->
+            val sql = "SELECT * FROM \"${table.namespace}\".\"${table.name}\""
+            connection.createStatement().use { stmt ->
+                stmt.executeQuery(sql).use { rs ->
+                    val metaData = rs.metaData
+                    val columnCount = metaData.columnCount
+
+                    while (rs.next()) {
+                        val record = mutableMapOf<String, Any>()
+                        for (i in 1..columnCount) {
+                            val columnName = metaData.getColumnName(i)
+                            val value = rs.getObject(i)
+                            if (value != null) {
+                                record[columnName] = normalizeValue(value)
+                            }
+                        }
+                        records.add(record)
+                    }
+                }
+            }
+        }
+
+        return records
+    }
+
+    private fun normalizeValue(value: Any): Any {
+        return when (value) {
+            is java.sql.Timestamp -> value.toInstant().toString()
+            is java.time.OffsetDateTime -> value.toInstant().toString()
+            is org.postgresql.util.PGobject -> {
+                // Handle JSONB and other PostgreSQL-specific types
+                when (value.type) {
+                    "jsonb",
+                    "json" -> {
+                        // Parse JSON and return appropriate type
+                        val jsonStr = value.value ?: "{}"
+                        try {
+                            io.airbyte.cdk.load.util.Jsons.readTree(jsonStr).let { node ->
+                                when {
+                                    node.isObject -> {
+                                        val map = linkedMapOf<String, Any?>()
+                                        node.fields().forEach { (k, v) ->
+                                            map[k] =
+                                                when {
+                                                    v.isNull -> null
+                                                    v.isTextual -> v.textValue()
+                                                    v.isNumber -> v.numberValue()
+                                                    v.isBoolean -> v.booleanValue()
+                                                    else -> v.toString()
+                                                }
+                                        }
+                                        map
+                                    }
+                                    node.isTextual -> node.textValue()
+                                    node.isNumber -> node.numberValue()
+                                    node.isBoolean -> node.booleanValue()
+                                    node.isArray -> jsonStr // Keep array as string for comparison
+                                    else -> jsonStr
+                                }
+                            }
+                        } catch (e: Exception) {
+                            jsonStr
+                        }
+                    }
+                    else -> value.value ?: ""
+                }
+            }
+            is java.math.BigDecimal -> value.toLong()
+            is java.math.BigInteger -> value.toLong()
+            is Short -> value.toLong()
+            is Int -> value.toLong()
+            else -> value
+        }
+    }
+}

--- a/airbyte-integrations/connectors/destination-postgres/src/test-integration/kotlin/io/airbyte/integrations/destination/postgres/component/config/ComponentTestConfigFactory.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/test-integration/kotlin/io/airbyte/integrations/destination/postgres/component/config/ComponentTestConfigFactory.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.postgres.component.config
+
+import io.airbyte.cdk.util.Jsons
+import io.airbyte.integrations.destination.postgres.PostgresContainerHelper
+import io.airbyte.integrations.destination.postgres.spec.PostgresConfiguration
+import io.airbyte.integrations.destination.postgres.spec.PostgresConfigurationFactory
+import io.airbyte.integrations.destination.postgres.spec.PostgresSpecificationOss
+import io.micronaut.context.annotation.Factory
+import io.micronaut.context.annotation.Primary
+import io.micronaut.context.annotation.Requires
+import jakarta.inject.Singleton
+
+@Requires(env = ["component"])
+@Factory
+class ComponentTestConfigFactory {
+    @Singleton
+    @Primary
+    fun config(): PostgresConfiguration {
+        // Start the container
+        PostgresContainerHelper.start()
+
+        // Build config JSON with container connection details
+        val configJson =
+            """
+            {
+                "host": "${PostgresContainerHelper.getHost()}",
+                "port": ${PostgresContainerHelper.getPort()},
+                "database": "${PostgresContainerHelper.getDatabaseName()}",
+                "schema": "public",
+                "username": "${PostgresContainerHelper.getUsername()}",
+                "password": "${PostgresContainerHelper.getPassword()}"
+            }
+            """
+                .trimIndent()
+
+        val spec = Jsons.readValue(configJson, PostgresSpecificationOss::class.java)
+        return PostgresConfigurationFactory().makeWithoutExceptionHandling(spec)
+    }
+}

--- a/airbyte-integrations/connectors/destination-postgres/src/test-integration/kotlin/io/airbyte/integrations/destination/postgres/component/config/ComponentTestConfigFactory.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/test-integration/kotlin/io/airbyte/integrations/destination/postgres/component/config/ComponentTestConfigFactory.kt
@@ -34,8 +34,7 @@ class ComponentTestConfigFactory {
                 "username": "${PostgresContainerHelper.getUsername()}",
                 "password": "${PostgresContainerHelper.getPassword()}"
             }
-            """
-                .trimIndent()
+            """.trimIndent()
 
         val spec = Jsons.readValue(configJson, PostgresSpecificationOss::class.java)
         return PostgresConfigurationFactory().makeWithoutExceptionHandling(spec)

--- a/airbyte-integrations/connectors/destination-postgres/src/test-integration/kotlin/io/airbyte/integrations/destination/postgres/write/PostgresRawDataDumper.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/test-integration/kotlin/io/airbyte/integrations/destination/postgres/write/PostgresRawDataDumper.kt
@@ -31,7 +31,7 @@ import io.airbyte.cdk.load.data.TimestampWithoutTimezoneValue
 import io.airbyte.cdk.load.data.UnknownType
 import io.airbyte.cdk.load.data.json.toAirbyteValue
 import io.airbyte.cdk.load.message.Meta
-import io.airbyte.cdk.load.orchestration.db.legacy_typing_deduping.TypingDedupingUtil
+import io.airbyte.cdk.load.table.TypingDedupingUtil
 import io.airbyte.cdk.load.test.util.DestinationDataDumper
 import io.airbyte.cdk.load.test.util.OutputRecord
 import io.airbyte.cdk.load.util.deserializeToNode

--- a/airbyte-integrations/connectors/destination-postgres/src/test/kotlin/io/airbyte/integrations/destination/postgres/check/PostgresOssCheckerTest.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/test/kotlin/io/airbyte/integrations/destination/postgres/check/PostgresOssCheckerTest.kt
@@ -5,8 +5,8 @@
 package io.airbyte.integrations.destination.postgres.check
 
 import io.airbyte.cdk.load.command.DestinationStream
-import io.airbyte.cdk.load.table.ColumnNameMapping
 import io.airbyte.cdk.load.schema.model.TableName
+import io.airbyte.cdk.load.table.ColumnNameMapping
 import io.airbyte.integrations.destination.postgres.client.PostgresAirbyteClient
 import io.airbyte.integrations.destination.postgres.spec.PostgresConfiguration
 import io.mockk.coEvery

--- a/airbyte-integrations/connectors/destination-postgres/src/test/kotlin/io/airbyte/integrations/destination/postgres/check/PostgresOssCheckerTest.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/test/kotlin/io/airbyte/integrations/destination/postgres/check/PostgresOssCheckerTest.kt
@@ -6,7 +6,7 @@ package io.airbyte.integrations.destination.postgres.check
 
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.table.ColumnNameMapping
-import io.airbyte.cdk.load.table.TableName
+import io.airbyte.cdk.load.schema.model.TableName
 import io.airbyte.integrations.destination.postgres.client.PostgresAirbyteClient
 import io.airbyte.integrations.destination.postgres.spec.PostgresConfiguration
 import io.mockk.coEvery

--- a/airbyte-integrations/connectors/destination-postgres/src/test/kotlin/io/airbyte/integrations/destination/postgres/client/PostgresAirbyteClientTest.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/test/kotlin/io/airbyte/integrations/destination/postgres/client/PostgresAirbyteClientTest.kt
@@ -7,7 +7,7 @@ package io.airbyte.integrations.destination.postgres.client
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.message.Meta.Companion.COLUMN_NAME_AB_GENERATION_ID
 import io.airbyte.cdk.load.table.ColumnNameMapping
-import io.airbyte.cdk.load.table.TableName
+import io.airbyte.cdk.load.schema.model.TableName
 import io.airbyte.integrations.destination.postgres.spec.PostgresConfiguration
 import io.airbyte.integrations.destination.postgres.sql.COUNT_TOTAL_ALIAS
 import io.airbyte.integrations.destination.postgres.sql.Column

--- a/airbyte-integrations/connectors/destination-postgres/src/test/kotlin/io/airbyte/integrations/destination/postgres/client/PostgresAirbyteClientTest.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/test/kotlin/io/airbyte/integrations/destination/postgres/client/PostgresAirbyteClientTest.kt
@@ -6,8 +6,8 @@ package io.airbyte.integrations.destination.postgres.client
 
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.message.Meta.Companion.COLUMN_NAME_AB_GENERATION_ID
-import io.airbyte.cdk.load.table.ColumnNameMapping
 import io.airbyte.cdk.load.schema.model.TableName
+import io.airbyte.cdk.load.table.ColumnNameMapping
 import io.airbyte.integrations.destination.postgres.spec.PostgresConfiguration
 import io.airbyte.integrations.destination.postgres.sql.COUNT_TOTAL_ALIAS
 import io.airbyte.integrations.destination.postgres.sql.Column

--- a/airbyte-integrations/connectors/destination-postgres/src/test/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresDirectLoadSqlGeneratorTest.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/test/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresDirectLoadSqlGeneratorTest.kt
@@ -12,9 +12,9 @@ import io.airbyte.cdk.load.data.IntegerType
 import io.airbyte.cdk.load.data.ObjectType
 import io.airbyte.cdk.load.data.StringType
 import io.airbyte.cdk.load.data.TimestampTypeWithTimezone
+import io.airbyte.cdk.load.schema.model.TableName
 import io.airbyte.cdk.load.table.CDC_DELETED_AT_COLUMN
 import io.airbyte.cdk.load.table.ColumnNameMapping
-import io.airbyte.cdk.load.schema.model.TableName
 import io.airbyte.integrations.destination.postgres.spec.CdcDeletionMode
 import io.airbyte.integrations.destination.postgres.spec.PostgresConfiguration
 import io.mockk.every

--- a/airbyte-integrations/connectors/destination-postgres/src/test/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresDirectLoadSqlGeneratorTest.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/test/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresDirectLoadSqlGeneratorTest.kt
@@ -14,7 +14,7 @@ import io.airbyte.cdk.load.data.StringType
 import io.airbyte.cdk.load.data.TimestampTypeWithTimezone
 import io.airbyte.cdk.load.table.CDC_DELETED_AT_COLUMN
 import io.airbyte.cdk.load.table.ColumnNameMapping
-import io.airbyte.cdk.load.table.TableName
+import io.airbyte.cdk.load.schema.model.TableName
 import io.airbyte.integrations.destination.postgres.spec.CdcDeletionMode
 import io.airbyte.integrations.destination.postgres.spec.PostgresConfiguration
 import io.mockk.every


### PR DESCRIPTION
## Summary
- Add comprehensive component tests for the PostgreSQL destination connector
- Implement `PostgresTableSchemaEvolutionTest` covering all schema evolution scenarios
- Implement `PostgresTableOperationsTest` covering table CRUD operations
- Add `PostgresTestTableOperationsClient` and `ComponentTestConfigFactory` test infrastructure

## Changes
- **New test files:**
  - `PostgresTableSchemaEvolutionTest.kt` - Tests for schema discovery, computation, and evolution
  - `PostgresTableOperationsTest.kt` - Tests for namespace/table operations
  - `PostgresTestTableOperationsClient.kt` - Test database operations client
  - `ComponentTestConfigFactory.kt` - Configuration factory using test containers

- **Bug fixes:**
  - Implement `namespaceExists()` and `tableExists()` in PostgresAirbyteClient
  - Fix `applyChangeset()` to handle nullability changes when transitioning between Append and Dedupe modes
  - Fix import paths for CDK API changes

## Test plan
- [x] All 21 component tests pass
- [x] `./gradlew :airbyte-integrations:connectors:destination-postgres:integrationTestNonDocker --tests "io.airbyte.integrations.destination.postgres.component.*"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)