### PR TITLE
docs(connector-development): Enhance breaking changes policy with additional requirements

### DIFF
--- a/airbyte-ci/connectors/connectors_qa/src/connectors_qa/checks/documentation/documentation.py
+++ b/airbyte-ci/connectors/connectors_qa/src/connectors_qa/checks/documentation/documentation.py
@@ -30,7 +30,7 @@ class DocumentationCheck(Check):
 
 class CheckMigrationGuide(DocumentationCheck):
     name = "Breaking changes must be accompanied by a migration guide"
-    description = "When a breaking change is introduced, we check that a migration guide is available. It should be stored under `./docs/integrations/<connector-type>s/<connector-name>-migrations.md`.\nThis document should contain a section for each breaking change, in order of the version descending. It must explain users which action to take to migrate to the new version.\nSee the [Breaking Changes Policy](https://docs.airbyte.com/platform/connector-development/connector-breaking-changes) for full requirements."
+    description = "When a breaking change is introduced, we check that a migration guide is available. It should be stored under `./docs/integrations/<connector-type>s/<connector-name>-migrations.md`.\nThis document should contain a section for each breaking change, in order of the version descending. It must explain users which action to take to migrate to the new version.\nSee the Breaking Changes Policy for full requirements: https://docs.airbyte.com/platform/connector-development/connector-breaking-changes"
 
     def _run(self, connector: Connector) -> CheckResult:
         breaking_changes = get(connector.metadata, "releases.breakingChanges")

--- a/airbyte-ci/connectors/connectors_qa/src/connectors_qa/checks/documentation/documentation.py
+++ b/airbyte-ci/connectors/connectors_qa/src/connectors_qa/checks/documentation/documentation.py
@@ -30,7 +30,7 @@ class DocumentationCheck(Check):
 
 class CheckMigrationGuide(DocumentationCheck):
     name = "Breaking changes must be accompanied by a migration guide"
-    description = "When a breaking change is introduced, we check that a migration guide is available. It should be stored under `./docs/integrations/<connector-type>s/<connector-name>-migrations.md`.\nThis document should contain a section for each breaking change, in order of the version descending. It must explain users which action to take to migrate to the new version."
+    description = "When a breaking change is introduced, we check that a migration guide is available. It should be stored under `./docs/integrations/<connector-type>s/<connector-name>-migrations.md`.\nThis document should contain a section for each breaking change, in order of the version descending. It must explain users which action to take to migrate to the new version.\nSee the [Breaking Changes Policy](https://docs.airbyte.com/platform/connector-development/connector-breaking-changes) for full requirements."
 
     def _run(self, connector: Connector) -> CheckResult:
         breaking_changes = get(connector.metadata, "releases.breakingChanges")

--- a/airbyte-ci/connectors/connectors_qa/src/connectors_qa/checks/metadata.py
+++ b/airbyte-ci/connectors/connectors_qa/src/connectors_qa/checks/metadata.py
@@ -145,7 +145,7 @@ class ValidateBreakingChangesDeadlines(MetadataCheck):
     """
 
     name = "Breaking change deadline should be a week in the future"
-    description = "If the connector version has a breaking change, the deadline field must be set to at least a week in the future."
+    description = "If the connector version has a breaking change, the deadline field must be set to at least a week in the future. See the [Breaking Changes Policy](https://docs.airbyte.com/platform/connector-development/connector-breaking-changes) for full requirements."
     runs_on_released_connectors = False
     minimum_days_until_deadline = 7
 

--- a/airbyte-ci/connectors/connectors_qa/src/connectors_qa/checks/metadata.py
+++ b/airbyte-ci/connectors/connectors_qa/src/connectors_qa/checks/metadata.py
@@ -145,7 +145,7 @@ class ValidateBreakingChangesDeadlines(MetadataCheck):
     """
 
     name = "Breaking change deadline should be a week in the future"
-    description = "If the connector version has a breaking change, the deadline field must be set to at least a week in the future. See the [Breaking Changes Policy](https://docs.airbyte.com/platform/connector-development/connector-breaking-changes) for full requirements."
+    description = "If the connector version has a breaking change, the deadline field must be set to at least a week in the future. See the Breaking Changes Policy for full requirements: https://docs.airbyte.com/platform/connector-development/connector-breaking-changes"
     runs_on_released_connectors = False
     minimum_days_until_deadline = 7
 

--- a/docs/community/contributing-to-airbyte/resources/qa-checks.md
+++ b/docs/community/contributing-to-airbyte/resources/qa-checks.md
@@ -24,7 +24,7 @@ _Applies to connector with any Airbyte usage level_
 
 When a breaking change is introduced, we check that a migration guide is available. It should be stored under `./docs/integrations/<connector-type>s/<connector-name>-migrations.md`.
 This document should contain a section for each breaking change, in order of the version descending. It must explain users which action to take to migrate to the new version.
-See the [Breaking Changes Policy](https://docs.airbyte.com/platform/connector-development/connector-breaking-changes) for full requirements.
+See the Breaking Changes Policy for full requirements: https://docs.airbyte.com/platform/connector-development/connector-breaking-changes
 
 ### Connectors must have user facing documentation
 
@@ -303,7 +303,7 @@ _Applies to connector with any support level_
 _Applies to connector with any internal support level_
 _Applies to connector with any Airbyte usage level_
 
-If the connector version has a breaking change, the deadline field must be set to at least a week in the future. See the [Breaking Changes Policy](https://docs.airbyte.com/platform/connector-development/connector-breaking-changes) for full requirements.
+If the connector version has a breaking change, the deadline field must be set to at least a week in the future. See the Breaking Changes Policy for full requirements: https://docs.airbyte.com/platform/connector-development/connector-breaking-changes
 
 ### Certified source connector must have a value filled out for maxSecondsBetweenMessages in metadata
 

--- a/docs/community/contributing-to-airbyte/resources/qa-checks.md
+++ b/docs/community/contributing-to-airbyte/resources/qa-checks.md
@@ -24,6 +24,7 @@ _Applies to connector with any Airbyte usage level_
 
 When a breaking change is introduced, we check that a migration guide is available. It should be stored under `./docs/integrations/<connector-type>s/<connector-name>-migrations.md`.
 This document should contain a section for each breaking change, in order of the version descending. It must explain users which action to take to migrate to the new version.
+See the [Breaking Changes Policy](https://docs.airbyte.com/platform/connector-development/connector-breaking-changes) for full requirements.
 
 ### Connectors must have user facing documentation
 
@@ -302,7 +303,7 @@ _Applies to connector with any support level_
 _Applies to connector with any internal support level_
 _Applies to connector with any Airbyte usage level_
 
-If the connector version has a breaking change, the deadline field must be set to at least a week in the future.
+If the connector version has a breaking change, the deadline field must be set to at least a week in the future. See the [Breaking Changes Policy](https://docs.airbyte.com/platform/connector-development/connector-breaking-changes) for full requirements.
 
 ### Certified source connector must have a value filled out for maxSecondsBetweenMessages in metadata
 

--- a/docs/platform/connector-development/connector-breaking-changes.md
+++ b/docs/platform/connector-development/connector-breaking-changes.md
@@ -1,13 +1,16 @@
 # Managing Breaking Changes in Connectors
 
-Whenever possible, changes to connectors should be implemented in a non-breaking way. This allows users to upgrade to the latest version of a connector without additional action required on their part. Assume that _every_ breaking changes creates friction for users and should be avoided except when absolutely necessary.
+Whenever possible, changes to connectors should be implemented in a non-breaking way. This allows users to upgrade to the latest version of a connector without additional action required on their part. Assume that _every_ breaking change creates friction for users and should be avoided except when absolutely necessary.
 
 When it is not possible to make changes in a non-breaking manner, additional **breaking change requirements** include:
 
-1. A **Major Version** increase. (Or minor in the case of a pre-1.0.0 connector in accordance with Semantic Versioning rules)
+1. A **Major Version** increase (or minor in the case of a pre-1.0.0 connector in accordance with Semantic Versioning rules)
 2. A [`breakingChanges` entry](https://docs.airbyte.com/connector-development/connector-metadata-file/) in the `releases` section of the `metadata.yaml` file
 3. A migration guide which details steps that users should take to resolve the change
-4. An Airbyte Engineer to complete the [Connector Breaking Change Release Playbook](https://docs.google.com/document/u/0/d/1VYQggHbL_PN0dDDu7rCyzBLGRtX-R3cpwXaY8QxEgzw/edit) (internal link) before merging the PR.
+4. CI will enforce that breaking changes have an entry in the associated `{connector-name}-migrations.md` file.
+5. Breaking changes require approval from the `@airbytehq/breaking-change-reviewers` GitHub team, which is automatically requested for review on migration guide changes (see [CODEOWNERS](https://github.com/airbytehq/airbyte/blob/master/CODEOWNERS)). PRs with breaking changes must also be labeled with `breaking-change`.
+6. PR titles for breaking changes must include a "!" to signify the PR contains breaking changes (e.g., `Source Example: fix!: schema change`).
+7. An Airbyte Engineer to complete the [Connector Breaking Change Release Playbook](https://docs.google.com/document/u/0/d/1VYQggHbL_PN0dDDu7rCyzBLGRtX-R3cpwXaY8QxEgzw/edit) (internal link) before merging the PR.
 
 ## Types of Breaking Changes
 
@@ -17,9 +20,19 @@ A breaking change is any change that requires users to take action before they c
 - **Schema Change** - The type of property previously present within a record has changed
 - **Stream or Property Removal** - Data that was previously being synced is no longer going to be synced.
 - **Destination Format / Normalization Change** - The way the destination writes the final data or how normalization cleans that data is changing in a way that requires a full-refresh.
-- **State Changes** - The format of the source’s state has changed, and the full dataset will need to be re-synced
-- **Full Downstream Rewrite** - Very rarely, a change is so sigificant that it requires a full rewrite of downstream SQL transformations or BI dashboards. In these cases, consider forking the connector as a "Gen 2" version instead of making a breaking change that would fully break users' downstream pipelines.
-  - Example: Migration from legacy JSON-only "raw" tables to normalized typed columns in a destination tables. These historic changes were so significant that they would break all downstream SQL transformations and BI dashboards. A "gen-2" approach in these cases gives users the ability to run both "Gen 1" and "Gen 2" in parallel, migrating only after they have had a chance to adapt their code to the new data models.
+- **State Changes** - The format of the source's state has changed, and the full dataset will need to be re-synced
+- **Non-Reversible Upgrades** - Connector upgrades which cannot be safely rolled back should be considered a subset of breaking changes and must be similarly flagged and approved.
+- **Full Downstream Rewrite** - Very rarely, a change is so significant that it requires a full rewrite of downstream SQL transformations or BI dashboards. In these cases, consider forking the connector as a "Gen 2" version instead of making a breaking change that would fully break users' downstream pipelines. See [Major Rewrites and Gen 2 Connectors](#major-rewrites-and-gen-2-connectors) below.
+
+### What is NOT a Breaking Change
+
+The addition of new config options, new streams, or new stream properties should generally not be considered a breaking change. However, there is one important edge case to consider:
+
+**High-Volume Streams**: Adding a new high-volume stream (one that produces 2x or more the volume of other streams) can break existing pipelines by overwhelming destination capacity or significantly increasing sync times. When adding high-volume streams to existing connectors:
+
+1. Default the new stream to _not_ be included in the `suggestedStreams` metadata.
+2. If the connector does not yet have a `suggestedStreams` set, add one that excludes the new high-volume stream.
+3. Document the stream's volume characteristics in the connector documentation.
 
 ### Avoiding Breaking Changes with Migrations
 
@@ -135,10 +148,35 @@ The `upgradeDeadline` field specifies the date by which users should upgrade (fo
 
 - **Automated notifications:** The platform automatically emails users when a breaking change is released and sends reminders as the deadline approaches.
 
+## Major Rewrites and Gen 2 Connectors
+
+Significant breaking changes such as those required by a lift-and-shift or full connector rewrite should use a "-gen2" suffix and establish a new canonical connector ID. This approach provides several benefits:
+
+1. **Incremental Adoption**: Users can adopt the new connector without it requiring full parity with the original.
+2. **Side-by-Side Testing**: Users can run both the original and Gen 2 connectors in parallel.
+3. **Extended Migration Window**: Users have the option to use one or both connectors for an extended period of time.
+4. **Self-Service Migration**: Users can safely test the old and new versions without direct support from the Airbyte team.
+
+This pattern is particularly appropriate when:
+
+- The connector is being completely rewritten with a new architecture.
+- Schema changes are so significant they would break all downstream SQL transformations and BI dashboards.
+- The migration path is complex enough that users need extended time to adapt their pipelines.
+
+Example: Migration from legacy JSON-only "raw" tables to normalized typed columns in destination tables. These historic changes were so significant that they would break all downstream SQL transformations and BI dashboards. A "gen-2" approach in these cases gives users the ability to run both "Gen 1" and "Gen 2" in parallel, migrating only after they have had a chance to adapt their code to the new data models.
+
+## Future Considerations
+
+The following improvements to breaking change management are under consideration for future implementation:
+
+- **AI-Assisted Review**: A new AI review process for any connectors which are marked as breaking, to help identify potential issues and ensure proper documentation.
+- **Static Analysis**: A new CI workflow which performs static analysis to confirm that connector changes are marked as breaking if they include any breaking changes.
+- **Regression Testing**: Automated regression testing to detect unintended breaking changes before they are merged.
+
 ## Related Topics
 
 - [Semantic Versioning for Connectors](/community/contributing-to-airbyte/resources/pull-requests-handbook#semantic-versioning-for-connectors) - Guidelines for determining Major/Minor/Patch version changes
 - [Connector Metadata File](https://docs.airbyte.com/connector-development/connector-metadata-file/) - Technical reference for `breakingChanges` metadata format
-- [Pull Request Title Convention](/community/contributing-to-airbyte/resources/pull-requests-handbook#pull-request-title-convention) - How to format PR titles (use 🚨 emoji for breaking changes)
+- [Pull Request Title Convention](/community/contributing-to-airbyte/resources/pull-requests-handbook#pull-request-title-convention) - How to format PR titles (use "!" for breaking changes)
 - [QA Checks](/community/contributing-to-airbyte/resources/qa-checks) - Automated quality checks including breaking change requirements
 - [Connector Breaking Change Release Playbook](https://docs.google.com/document/u/0/d/1VYQggHbL_PN0dDDu7rCyzBLGRtX-R3cpwXaY8QxEgzw/edit) - Internal process for Airbyte Engineers (requires access)

--- a/docusaurus/platform_versioned_docs/version-2.0/connector-development/connector-breaking-changes.md
+++ b/docusaurus/platform_versioned_docs/version-2.0/connector-development/connector-breaking-changes.md
@@ -1,13 +1,16 @@
 # Managing Breaking Changes in Connectors
 
-Whenever possible, changes to connectors should be implemented in a non-breaking way. This allows users to upgrade to the latest version of a connector without additional action required on their part. Assume that _every_ breaking changes creates friction for users and should be avoided except when absolutely necessary.
+Whenever possible, changes to connectors should be implemented in a non-breaking way. This allows users to upgrade to the latest version of a connector without additional action required on their part. Assume that _every_ breaking change creates friction for users and should be avoided except when absolutely necessary.
 
 When it is not possible to make changes in a non-breaking manner, additional **breaking change requirements** include:
 
-1. A **Major Version** increase. (Or minor in the case of a pre-1.0.0 connector in accordance with Semantic Versioning rules)
+1. A **Major Version** increase (or minor in the case of a pre-1.0.0 connector in accordance with Semantic Versioning rules)
 2. A [`breakingChanges` entry](https://docs.airbyte.com/connector-development/connector-metadata-file/) in the `releases` section of the `metadata.yaml` file
 3. A migration guide which details steps that users should take to resolve the change
-4. An Airbyte Engineer to complete the [Connector Breaking Change Release Playbook](https://docs.google.com/document/u/0/d/1VYQggHbL_PN0dDDu7rCyzBLGRtX-R3cpwXaY8QxEgzw/edit) (internal link) before merging the PR.
+4. CI will enforce that breaking changes have an entry in the associated `{connector-name}-migrations.md` file
+5. Breaking changes require approval from designated reviewers and the appropriate GitHub team must be added to PRs with breaking changes
+6. PR titles for breaking changes must include a "!" to signify the PR contains breaking changes (e.g., `🚨 Source Example: fix!: schema change`)
+7. An Airbyte Engineer to complete the [Connector Breaking Change Release Playbook](https://docs.google.com/document/u/0/d/1VYQggHbL_PN0dDDu7rCyzBLGRtX-R3cpwXaY8QxEgzw/edit) (internal link) before merging the PR
 
 ## Types of Breaking Changes
 
@@ -18,8 +21,18 @@ A breaking change is any change that requires users to take action before they c
 - **Stream or Property Removal** - Data that was previously being synced is no longer going to be synced.
 - **Destination Format / Normalization Change** - The way the destination writes the final data or how normalization cleans that data is changing in a way that requires a full-refresh.
 - **State Changes** - The format of the source’s state has changed, and the full dataset will need to be re-synced
-- **Full Downstream Rewrite** - Very rarely, a change is so sigificant that it requires a full rewrite of downstream SQL transformations or BI dashboards. In these cases, consider forking the connector as a "Gen 2" version instead of making a breaking change that would fully break users' downstream pipelines.
-  - Example: Migration from legacy JSON-only "raw" tables to normalized typed columns in a destination tables. These historic changes were so significant that they would break all downstream SQL transformations and BI dashboards. A "gen-2" approach in these cases gives users the ability to run both "Gen 1" and "Gen 2" in parallel, migrating only after they have had a chance to adapt their code to the new data models.
+- **Non-Reversible Upgrades** - Connector upgrades which cannot be safely rolled back should be considered a subset of breaking changes and must be similarly flagged.
+- **Full Downstream Rewrite** - Very rarely, a change is so significant that it requires a full rewrite of downstream SQL transformations or BI dashboards. In these cases, consider forking the connector as a "Gen 2" version instead of making a breaking change that would fully break users' downstream pipelines. See [Major Rewrites and Gen 2 Connectors](#major-rewrites-and-gen-2-connectors) below.
+
+### What is NOT a Breaking Change
+
+The addition of new config options, new streams, or new stream properties should generally not be considered a breaking change. However, there is one important edge case to consider:
+
+**High-Volume Streams**: Adding a new high-volume stream (one that produces 2x or more the volume of other streams) can break existing pipelines by overwhelming destination capacity or significantly increasing sync times. When adding high-volume streams to existing connectors:
+
+1. Default the new stream to _not_ be included in the `suggestedStreams` metadata
+2. If the connector does not yet have a `suggestedStreams` set, add one that excludes the new high-volume stream
+3. Document the stream's volume characteristics in the connector documentation
 
 ### Avoiding Breaking Changes with Migrations
 
@@ -135,10 +148,35 @@ The `upgradeDeadline` field specifies the date by which users should upgrade (fo
 
 - **Automated notifications:** The platform automatically emails users when a breaking change is released and sends reminders as the deadline approaches.
 
+## Major Rewrites and Gen 2 Connectors
+
+Significant breaking changes such as those required by a lift-and-shift or full connector rewrite should use a "-gen2" suffix and establish a new canonical connector ID. This approach provides several benefits:
+
+1. **Incremental Adoption**: Users can adopt the new connector without it requiring full parity with the original
+2. **Side-by-Side Testing**: Users can run both the original and Gen 2 connectors in parallel
+3. **Extended Migration Window**: Users have the option to use one or both connectors for an extended period of time
+4. **Self-Service Migration**: Users can safely test the old and new versions without direct support from the Airbyte team
+
+This pattern is particularly appropriate when:
+
+- The connector is being completely rewritten with a new architecture
+- Schema changes are so significant they would break all downstream SQL transformations and BI dashboards
+- The migration path is complex enough that users need extended time to adapt their pipelines
+
+Example: Migration from legacy JSON-only "raw" tables to normalized typed columns in destination tables. These historic changes were so significant that they would break all downstream SQL transformations and BI dashboards. A "gen-2" approach in these cases gives users the ability to run both "Gen 1" and "Gen 2" in parallel, migrating only after they have had a chance to adapt their code to the new data models.
+
+## Future Considerations
+
+The following improvements to breaking change management are under consideration for future implementation:
+
+- **AI-Assisted Review**: A new AI review process for any connectors which are marked as breaking, to help identify potential issues and ensure proper documentation
+- **Static Analysis**: A new CI workflow which performs static analysis to confirm that connector changes are marked as breaking if they include any breaking changes
+- **Regression Testing**: Automated regression testing to detect unintended breaking changes before they are merged
+
 ## Related Topics
 
 - [Semantic Versioning for Connectors](../contributing-to-airbyte/resources/pull-requests-handbook.md#semantic-versioning-for-connectors) - Guidelines for determining Major/Minor/Patch version changes
 - [Connector Metadata File](https://docs.airbyte.com/connector-development/connector-metadata-file/) - Technical reference for `breakingChanges` metadata format
 - [Pull Request Title Convention](../contributing-to-airbyte/resources/pull-requests-handbook.md#pull-request-title-convention) - How to format PR titles (use 🚨 emoji for breaking changes)
-- [QA Checks](/community/contributing-to-airbyte/resources/qa-checks) - Automated quality checks including breaking change requirements
+- [QA Checks](../contributing-to-airbyte/resources/qa-checks.md) - Automated quality checks including breaking change requirements
 - [Connector Breaking Change Release Playbook](https://docs.google.com/document/u/0/d/1VYQggHbL_PN0dDDu7rCyzBLGRtX-R3cpwXaY8QxEgzw/edit) - Internal process for Airbyte Engineers (requires access)

--- a/docusaurus/platform_versioned_docs/version-2.0/connector-development/connector-breaking-changes.md
+++ b/docusaurus/platform_versioned_docs/version-2.0/connector-development/connector-breaking-changes.md
@@ -21,7 +21,7 @@ A breaking change is any change that requires users to take action before they c
 - **Stream or Property Removal** - Data that was previously being synced is no longer going to be synced.
 - **Destination Format / Normalization Change** - The way the destination writes the final data or how normalization cleans that data is changing in a way that requires a full-refresh.
 - **State Changes** - The format of the source’s state has changed, and the full dataset will need to be re-synced
-- **Non-Reversible Upgrades** - Connector upgrades which cannot be safely rolled back should be considered a subset of breaking changes and must be similarly flagged.
+- **Non-Reversible Upgrades** - Connector upgrades which cannot be safely rolled back should be considered a subset of breaking changes and must be similarly flagged and approved.
 - **Full Downstream Rewrite** - Very rarely, a change is so significant that it requires a full rewrite of downstream SQL transformations or BI dashboards. In these cases, consider forking the connector as a "Gen 2" version instead of making a breaking change that would fully break users' downstream pipelines. See [Major Rewrites and Gen 2 Connectors](#major-rewrites-and-gen-2-connectors) below.
 
 ### What is NOT a Breaking Change

--- a/docusaurus/platform_versioned_docs/version-2.0/connector-development/connector-breaking-changes.md
+++ b/docusaurus/platform_versioned_docs/version-2.0/connector-development/connector-breaking-changes.md
@@ -7,10 +7,10 @@ When it is not possible to make changes in a non-breaking manner, additional **b
 1. A **Major Version** increase (or minor in the case of a pre-1.0.0 connector in accordance with Semantic Versioning rules)
 2. A [`breakingChanges` entry](https://docs.airbyte.com/connector-development/connector-metadata-file/) in the `releases` section of the `metadata.yaml` file
 3. A migration guide which details steps that users should take to resolve the change
-4. CI will enforce that breaking changes have an entry in the associated `{connector-name}-migrations.md` file
-5. Breaking changes require approval from the `@airbytehq/breaking-change-reviewers` GitHub team, which is automatically requested for review on migration guide changes (see [CODEOWNERS](https://github.com/airbytehq/airbyte/blob/master/CODEOWNERS)). PRs with breaking changes must also be labeled with `breaking-change`
-6. PR titles for breaking changes must include a "!" to signify the PR contains breaking changes (e.g., `🚨 Source Example: fix!: schema change`)
-7. An Airbyte Engineer to complete the [Connector Breaking Change Release Playbook](https://docs.google.com/document/u/0/d/1VYQggHbL_PN0dDDu7rCyzBLGRtX-R3cpwXaY8QxEgzw/edit) (internal link) before merging the PR
+4. CI will enforce that breaking changes have an entry in the associated `{connector-name}-migrations.md` file.
+5. Breaking changes require approval from the `@airbytehq/breaking-change-reviewers` GitHub team, which is automatically requested for review on migration guide changes (see [CODEOWNERS](https://github.com/airbytehq/airbyte/blob/master/CODEOWNERS)). PRs with breaking changes must also be labeled with `breaking-change`.
+6. PR titles for breaking changes must include a "!" to signify the PR contains breaking changes (e.g., `🚨 Source Example: fix!: schema change`).
+7. An Airbyte Engineer to complete the [Connector Breaking Change Release Playbook](https://docs.google.com/document/u/0/d/1VYQggHbL_PN0dDDu7rCyzBLGRtX-R3cpwXaY8QxEgzw/edit) (internal link) before merging the PR.
 
 ## Types of Breaking Changes
 
@@ -30,9 +30,9 @@ The addition of new config options, new streams, or new stream properties should
 
 **High-Volume Streams**: Adding a new high-volume stream (one that produces 2x or more the volume of other streams) can break existing pipelines by overwhelming destination capacity or significantly increasing sync times. When adding high-volume streams to existing connectors:
 
-1. Default the new stream to _not_ be included in the `suggestedStreams` metadata
-2. If the connector does not yet have a `suggestedStreams` set, add one that excludes the new high-volume stream
-3. Document the stream's volume characteristics in the connector documentation
+1. Default the new stream to _not_ be included in the `suggestedStreams` metadata.
+2. If the connector does not yet have a `suggestedStreams` set, add one that excludes the new high-volume stream.
+3. Document the stream's volume characteristics in the connector documentation.
 
 ### Avoiding Breaking Changes with Migrations
 
@@ -152,16 +152,16 @@ The `upgradeDeadline` field specifies the date by which users should upgrade (fo
 
 Significant breaking changes such as those required by a lift-and-shift or full connector rewrite should use a "-gen2" suffix and establish a new canonical connector ID. This approach provides several benefits:
 
-1. **Incremental Adoption**: Users can adopt the new connector without it requiring full parity with the original
-2. **Side-by-Side Testing**: Users can run both the original and Gen 2 connectors in parallel
-3. **Extended Migration Window**: Users have the option to use one or both connectors for an extended period of time
-4. **Self-Service Migration**: Users can safely test the old and new versions without direct support from the Airbyte team
+1. **Incremental Adoption**: Users can adopt the new connector without it requiring full parity with the original.
+2. **Side-by-Side Testing**: Users can run both the original and Gen 2 connectors in parallel.
+3. **Extended Migration Window**: Users have the option to use one or both connectors for an extended period of time.
+4. **Self-Service Migration**: Users can safely test the old and new versions without direct support from the Airbyte team.
 
 This pattern is particularly appropriate when:
 
-- The connector is being completely rewritten with a new architecture
-- Schema changes are so significant they would break all downstream SQL transformations and BI dashboards
-- The migration path is complex enough that users need extended time to adapt their pipelines
+- The connector is being completely rewritten with a new architecture.
+- Schema changes are so significant they would break all downstream SQL transformations and BI dashboards.
+- The migration path is complex enough that users need extended time to adapt their pipelines.
 
 Example: Migration from legacy JSON-only "raw" tables to normalized typed columns in destination tables. These historic changes were so significant that they would break all downstream SQL transformations and BI dashboards. A "gen-2" approach in these cases gives users the ability to run both "Gen 1" and "Gen 2" in parallel, migrating only after they have had a chance to adapt their code to the new data models.
 
@@ -169,9 +169,9 @@ Example: Migration from legacy JSON-only "raw" tables to normalized typed column
 
 The following improvements to breaking change management are under consideration for future implementation:
 
-- **AI-Assisted Review**: A new AI review process for any connectors which are marked as breaking, to help identify potential issues and ensure proper documentation
-- **Static Analysis**: A new CI workflow which performs static analysis to confirm that connector changes are marked as breaking if they include any breaking changes
-- **Regression Testing**: Automated regression testing to detect unintended breaking changes before they are merged
+- **AI-Assisted Review**: A new AI review process for any connectors which are marked as breaking, to help identify potential issues and ensure proper documentation.
+- **Static Analysis**: A new CI workflow which performs static analysis to confirm that connector changes are marked as breaking if they include any breaking changes.
+- **Regression Testing**: Automated regression testing to detect unintended breaking changes before they are merged.
 
 ## Related Topics
 

--- a/docusaurus/platform_versioned_docs/version-2.0/connector-development/connector-breaking-changes.md
+++ b/docusaurus/platform_versioned_docs/version-2.0/connector-development/connector-breaking-changes.md
@@ -8,7 +8,7 @@ When it is not possible to make changes in a non-breaking manner, additional **b
 2. A [`breakingChanges` entry](https://docs.airbyte.com/connector-development/connector-metadata-file/) in the `releases` section of the `metadata.yaml` file
 3. A migration guide which details steps that users should take to resolve the change
 4. CI will enforce that breaking changes have an entry in the associated `{connector-name}-migrations.md` file
-5. Breaking changes require approval from the `@airbytehq/breaking-change-reviewers` GitHub team, which is automatically requested for review on migration guide changes. PRs with breaking changes must also be labeled with `breaking-change`
+5. Breaking changes require approval from the `@airbytehq/breaking-change-reviewers` GitHub team, which is automatically requested for review on migration guide changes (see [CODEOWNERS](https://github.com/airbytehq/airbyte/blob/master/CODEOWNERS)). PRs with breaking changes must also be labeled with `breaking-change`
 6. PR titles for breaking changes must include a "!" to signify the PR contains breaking changes (e.g., `🚨 Source Example: fix!: schema change`)
 7. An Airbyte Engineer to complete the [Connector Breaking Change Release Playbook](https://docs.google.com/document/u/0/d/1VYQggHbL_PN0dDDu7rCyzBLGRtX-R3cpwXaY8QxEgzw/edit) (internal link) before merging the PR
 

--- a/docusaurus/platform_versioned_docs/version-2.0/connector-development/connector-breaking-changes.md
+++ b/docusaurus/platform_versioned_docs/version-2.0/connector-development/connector-breaking-changes.md
@@ -8,7 +8,7 @@ When it is not possible to make changes in a non-breaking manner, additional **b
 2. A [`breakingChanges` entry](https://docs.airbyte.com/connector-development/connector-metadata-file/) in the `releases` section of the `metadata.yaml` file
 3. A migration guide which details steps that users should take to resolve the change
 4. CI will enforce that breaking changes have an entry in the associated `{connector-name}-migrations.md` file
-5. Breaking changes require approval from designated reviewers and the appropriate GitHub team must be added to PRs with breaking changes
+5. Breaking changes require approval from the `@airbytehq/breaking-change-reviewers` GitHub team, which is automatically requested for review on migration guide changes. PRs with breaking changes must also be labeled with `breaking-change`
 6. PR titles for breaking changes must include a "!" to signify the PR contains breaking changes (e.g., `🚨 Source Example: fix!: schema change`)
 7. An Airbyte Engineer to complete the [Connector Breaking Change Release Playbook](https://docs.google.com/document/u/0/d/1VYQggHbL_PN0dDDu7rCyzBLGRtX-R3cpwXaY8QxEgzw/edit) (internal link) before merging the PR
 


### PR DESCRIPTION
## What

Enhances the connector breaking changes policy documentation with additional requirements and links the policy from CI check descriptions. This is part of a broader effort to consolidate and publicize breaking change requirements across the codebase.

Requested by @aaronsteers.

Link to Devin run: https://app.devin.ai/sessions/e1666a6c77464ed0967bb55c7b2f518e

## How

**Documentation updates** (`connector-breaking-changes.md`):
- Added new requirements: CI enforcement of migration guides, reviewer approval requirements, PR title convention with "!"
- Added requirement for `@airbytehq/breaking-change-reviewers` team approval with link to [CODEOWNERS](https://github.com/airbytehq/airbyte/blob/master/CODEOWNERS)
- Added requirement for `breaking-change` label on PRs with breaking changes
- Added "Non-Reversible Upgrades" as a type of breaking change (must be flagged and approved)
- Added "What is NOT a Breaking Change" section with guidance on high-volume streams edge case
- Added "Major Rewrites and Gen 2 Connectors" section with detailed guidance on the `-gen2` suffix pattern
- Added "Future Considerations" section outlining planned improvements (AI review, static analysis, regression testing)
- Fixed typo ("sigificant" → "significant") and updated QA Checks link path

**CI check updates**:
- Added links to the Breaking Changes Policy in `CheckMigrationGuide` and `ValidateBreakingChangesDeadlines` check descriptions
- Regenerated `qa-checks.md` to reflect the updated check descriptions

## Review guide

1. `docs/platform/connector-development/connector-breaking-changes.md` - Main policy content (canonical source for future versions)
2. `docusaurus/platform_versioned_docs/version-2.0/connector-development/connector-breaking-changes.md` - Version 2.0 policy content
3. `airbyte-ci/connectors/connectors_qa/src/connectors_qa/checks/documentation/documentation.py` - CI check description update
4. `airbyte-ci/connectors/connectors_qa/src/connectors_qa/checks/metadata.py` - CI check description update
5. `docs/community/contributing-to-airbyte/resources/qa-checks.md` - Auto-generated file reflecting CI check description changes

**Human review checklist:**
- [ ] New policy points align with organizational requirements
- [ ] Policy content is consistent between main docs and version-2.0 docs
- [ ] QA Checks link path resolves correctly
- [ ] Breaking changes policy URL will work once deployed
- [ ] CODEOWNERS link resolves correctly

## Updates since last revision

- Replicated all enhanced policy content from `docusaurus/platform_versioned_docs/version-2.0/` to `docs/platform/` (the canonical source for future versions) per Ian's review feedback
- Regenerated `qa-checks.md` using `connectors-qa generate-documentation` to fix CI test failure
- Note: Historical versions 1.6, 1.7, 1.8 don't have this file, so no historical updates were needed

## User Impact

Contributors will see clearer guidance on breaking change requirements in documentation and CI error messages will now link to the full policy for reference.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚