### PR TITLE
Destination Snowflake: Write VARIANT columns correctly

### DIFF
--- a/airbyte-integrations/connectors/destination-snowflake/src/test-integration/kotlin/io/airbyte/integrations/destination/snowflake/component/SnowflakeTableSchemaEvolutionTest.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test-integration/kotlin/io/airbyte/integrations/destination/snowflake/component/SnowflakeTableSchemaEvolutionTest.kt
@@ -7,8 +7,10 @@ package io.airbyte.integrations.destination.snowflake.component
 import io.airbyte.cdk.load.command.ImportType
 import io.airbyte.cdk.load.component.TableSchemaEvolutionFixtures
 import io.airbyte.cdk.load.component.TableSchemaEvolutionSuite
+import io.airbyte.cdk.load.data.StringValue
 import io.airbyte.cdk.load.message.Meta
 import io.airbyte.cdk.load.table.ColumnNameMapping
+import io.airbyte.cdk.load.util.serializeToString
 import io.airbyte.integrations.destination.snowflake.client.SnowflakeAirbyteClient
 import io.airbyte.integrations.destination.snowflake.component.SnowflakeComponentTestFixtures.allTypesColumnNameMapping
 import io.airbyte.integrations.destination.snowflake.component.SnowflakeComponentTestFixtures.allTypesTableSchema
@@ -124,8 +126,20 @@ class SnowflakeTableSchemaEvolutionTest(
         super.`change from unknown type to string type`(
             idAndTestMapping,
             idAndTestMapping,
-            TableSchemaEvolutionFixtures.UNKNOWN_TO_STRING_TYPE_INPUT_RECORDS,
+            UNKNOWN_TO_STRING_TYPE_INPUT_RECORDS,
             TableSchemaEvolutionFixtures.UNKNOWN_TO_STRING_TYPE_EXPECTED_RECORDS,
         )
     }
+
+    /**
+     * [io.airbyte.integrations.destination.snowflake.write.transform.SnowflakeValueCoercer.map]
+     * serializes union/unknownType values into strings, so that Snowflake understands how to parse
+     * them from the CSV file. Emulate that behavior here.
+     */
+    private val UNKNOWN_TO_STRING_TYPE_INPUT_RECORDS =
+        TableSchemaEvolutionFixtures.UNKNOWN_TO_STRING_TYPE_INPUT_RECORDS.map { record ->
+            val mutableRecord = record.toMutableMap()
+            mutableRecord["test"] = StringValue(record["test"].serializeToString())
+            mutableRecord
+        }
 }

--- a/airbyte-integrations/connectors/destination-snowflake/src/test-integration/kotlin/io/airbyte/integrations/destination/snowflake/write/SnowflakeAcceptanceTest.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test-integration/kotlin/io/airbyte/integrations/destination/snowflake/write/SnowflakeAcceptanceTest.kt
@@ -189,8 +189,6 @@ abstract class SnowflakeAcceptanceTest(
         useDataFlowPipeline = true,
     ) {
     @Disabled override fun testAppendJsonSchemaEvolution() {}
-
-    @Disabled override fun testContainerTypes() {}
 }
 
 fun stringToMeta(metaAsString: String?): OutputRecord.Meta? {

--- a/airbyte-integrations/connectors/destination-snowflake/src/test-integration/kotlin/io/airbyte/integrations/destination/snowflake/write/SnowflakeAcceptanceTest.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test-integration/kotlin/io/airbyte/integrations/destination/snowflake/write/SnowflakeAcceptanceTest.kt
@@ -30,7 +30,6 @@ import io.airbyte.integrations.destination.snowflake.spec.SnowflakeSpecification
 import io.airbyte.protocol.models.v0.AirbyteRecordMessageMetaChange
 import java.nio.file.Files
 import java.nio.file.Path
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 
 internal val CONFIG_PATH = getConfigPath(CONFIG_WITH_AUTH_STAGING)
@@ -187,9 +186,7 @@ abstract class SnowflakeAcceptanceTest(
         nameMapper = nameMapper,
         coercesLegacyUnions = coercesLegacyUnions,
         useDataFlowPipeline = true,
-    ) {
-    @Disabled override fun testAppendJsonSchemaEvolution() {}
-}
+    )
 
 fun stringToMeta(metaAsString: String?): OutputRecord.Meta? {
     if (metaAsString.isNullOrEmpty()) {

--- a/airbyte-integrations/connectors/destination-snowflake/src/test-integration/kotlin/io/airbyte/integrations/destination/snowflake/write/SnowflakeAcceptanceTest.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test-integration/kotlin/io/airbyte/integrations/destination/snowflake/write/SnowflakeAcceptanceTest.kt
@@ -46,7 +46,7 @@ class SnowflakeInsertAcceptanceTest :
             },
         recordMapper = SnowflakeExpectedRecordMapper,
         nameMapper = SnowflakeNameMapper(),
-        unknownTypesBehavior = UnknownTypesBehavior.SERIALIZE,
+        unknownTypesBehavior = UnknownTypesBehavior.PASS_THROUGH,
     ) {
     @Test
     override fun testAppendSchemaEvolution() {
@@ -63,7 +63,7 @@ class SnowflakeInsertIgnoreCasingAcceptanceTest :
             },
         recordMapper = SnowflakeExpectedRecordMapper,
         nameMapper = SnowflakeNameMapper(),
-        unknownTypesBehavior = UnknownTypesBehavior.SERIALIZE,
+        unknownTypesBehavior = UnknownTypesBehavior.PASS_THROUGH,
     ) {
     @Test
     override fun testBasicWrite() {
@@ -159,7 +159,7 @@ abstract class SnowflakeAcceptanceTest(
         isStreamSchemaRetroactiveForUnknownTypeToString =
             isStreamSchemaRetroactiveForUnknownTypeToString,
         dedupBehavior = dedupBehavior,
-        stringifySchemalessObjects = true,
+        stringifySchemalessObjects = false,
         schematizedObjectBehavior = SchematizedNestedValueBehavior.PASS_THROUGH,
         schematizedArrayBehavior = SchematizedNestedValueBehavior.PASS_THROUGH,
         unionBehavior = UnionBehavior.PASS_THROUGH,
@@ -188,9 +188,6 @@ abstract class SnowflakeAcceptanceTest(
         coercesLegacyUnions = coercesLegacyUnions,
         useDataFlowPipeline = true,
     ) {
-
-    @Disabled override fun testUnions() {}
-
     @Disabled override fun testAppendJsonSchemaEvolution() {}
 
     @Disabled override fun testContainerTypes() {}

--- a/airbyte-integrations/connectors/destination-snowflake/src/test-integration/kotlin/io/airbyte/integrations/destination/snowflake/write/SnowflakeAcceptanceTest.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test-integration/kotlin/io/airbyte/integrations/destination/snowflake/write/SnowflakeAcceptanceTest.kt
@@ -30,6 +30,7 @@ import io.airbyte.integrations.destination.snowflake.spec.SnowflakeSpecification
 import io.airbyte.protocol.models.v0.AirbyteRecordMessageMetaChange
 import java.nio.file.Files
 import java.nio.file.Path
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 
 internal val CONFIG_PATH = getConfigPath(CONFIG_WITH_AUTH_STAGING)
@@ -132,6 +133,12 @@ class SnowflakeRawInsertProtoAcceptanceTest :
     @Test
     override fun testBasicWrite() {
         super.testBasicWrite()
+    }
+
+    @Disabled("https://github.com/airbytehq/airbyte-internal-issues/issues/15495")
+    @Test
+    override fun testContainerTypes() {
+        super.testContainerTypes()
     }
 }
 

--- a/airbyte-integrations/connectors/destination-snowflake/src/test-integration/kotlin/io/airbyte/integrations/destination/snowflake/write/SnowflakeDataDumper.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test-integration/kotlin/io/airbyte/integrations/destination/snowflake/write/SnowflakeDataDumper.kt
@@ -9,11 +9,12 @@ import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.data.AirbyteValue
 import io.airbyte.cdk.load.data.NullValue
 import io.airbyte.cdk.load.data.ObjectValue
+import io.airbyte.cdk.load.data.json.toAirbyteValue
 import io.airbyte.cdk.load.message.Meta
 import io.airbyte.cdk.load.table.CDC_DELETED_AT_COLUMN
 import io.airbyte.cdk.load.test.util.DestinationDataDumper
 import io.airbyte.cdk.load.test.util.OutputRecord
-import io.airbyte.commons.json.Jsons.deserializeExact
+import io.airbyte.cdk.load.util.deserializeToNode
 import io.airbyte.integrations.destination.snowflake.SnowflakeBeanFactory
 import io.airbyte.integrations.destination.snowflake.db.SnowflakeFinalTableNameGenerator
 import io.airbyte.integrations.destination.snowflake.db.toSnowflakeCompatibleName
@@ -127,28 +128,14 @@ class SnowflakeDataDumper(
         throw UnsupportedOperationException("Snowflake does not support file transfer.")
     }
 
-    private fun unformatJsonValue(columnType: String, value: Any): Any? {
-        /*
-         * Snowflake automatically pretty-prints JSON results for variant, object and array
-         * when selecting them via a SQL query.  You can get around this by using the `TO_JSON`
-         * function on the column when running the query.  However, we do not have access to the
-         * catalog in the dumper to know which columns need to be un-prettied/modified to match
-         * the toPrettyString() method of the Jackson JsonNode.  To compensate for this, we will
-         * read the JSON string into a JsonNode and then re-pretty-ify it into a string so that
-         * it can match what the expected record mapper is doing.
-         */
+    private fun unformatJsonValue(columnType: String, value: Any): Any {
         return when (columnType.lowercase()) {
             "variant",
             "array",
-            "object" -> {
-                val jsonNode = deserializeExact(value.toString())
-                if (jsonNode.isNull) {
-                    // Don't convert null into a string "null"
-                    null
-                } else {
-                    jsonNode.toPrettyString()
-                }
-            }
+            "object" ->
+                // blind cast to string is safe - snowflake JDBC driver getObject returns String
+                // for variant/array/object
+                (value as String).deserializeToNode().toAirbyteValue()
             else -> value
         }
     }

--- a/airbyte-integrations/connectors/destination-snowflake/src/test-integration/kotlin/io/airbyte/integrations/destination/snowflake/write/SnowflakeExpectedRecordMapper.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test-integration/kotlin/io/airbyte/integrations/destination/snowflake/write/SnowflakeExpectedRecordMapper.kt
@@ -21,6 +21,8 @@ import io.airbyte.integrations.destination.snowflake.db.toSnowflakeCompatibleNam
 import io.airbyte.integrations.destination.snowflake.write.transform.SnowflakeValueCoercer
 import io.airbyte.protocol.models.v0.AirbyteRecordMessageMetaChange
 import io.airbyte.protocol.models.v0.AirbyteRecordMessageMetaChange.Change
+import io.mockk.every
+import io.mockk.mockk
 
 object SnowflakeExpectedRecordMapper : ExpectedRecordMapper {
 
@@ -43,7 +45,7 @@ object SnowflakeExpectedRecordMapper : ExpectedRecordMapper {
 
     private fun mapAirbyteValue(value: AirbyteValue): AirbyteValue {
         val validationResult =
-            SnowflakeValueCoercer()
+            SnowflakeValueCoercer(mockk { every { legacyRawTablesOnly } returns false })
                 .validate(
                     EnrichedAirbyteValue(
                         value,

--- a/airbyte-integrations/connectors/destination-snowflake/src/test-integration/kotlin/io/airbyte/integrations/destination/snowflake/write/SnowflakeExpectedRecordMapper.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test-integration/kotlin/io/airbyte/integrations/destination/snowflake/write/SnowflakeExpectedRecordMapper.kt
@@ -6,13 +6,11 @@ package io.airbyte.integrations.destination.snowflake.write
 
 import io.airbyte.cdk.load.data.AirbyteType
 import io.airbyte.cdk.load.data.AirbyteValue
-import io.airbyte.cdk.load.data.ArrayValue
 import io.airbyte.cdk.load.data.EnrichedAirbyteValue
 import io.airbyte.cdk.load.data.NullValue
 import io.airbyte.cdk.load.data.ObjectValue
 import io.airbyte.cdk.load.data.StringValue
 import io.airbyte.cdk.load.data.TimeWithTimezoneValue
-import io.airbyte.cdk.load.data.json.toJson
 import io.airbyte.cdk.load.dataflow.transform.ValidationResult
 import io.airbyte.cdk.load.message.Meta
 import io.airbyte.cdk.load.test.util.ExpectedRecordMapper
@@ -60,8 +58,6 @@ object SnowflakeExpectedRecordMapper : ExpectedRecordMapper {
             ValidationResult.Valid ->
                 when (value) {
                     is TimeWithTimezoneValue -> StringValue(value.value.toString())
-                    is ArrayValue,
-                    is ObjectValue -> StringValue(value.toJson().toPrettyString())
                     else -> value
                 }
         }

--- a/airbyte-integrations/connectors/destination-snowflake/src/test/kotlin/io/airbyte/integrations/destination/snowflake/write/load/SnowflakeSchemaRecordFormatterTest.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test/kotlin/io/airbyte/integrations/destination/snowflake/write/load/SnowflakeSchemaRecordFormatterTest.kt
@@ -64,7 +64,6 @@ internal class SnowflakeSchemaRecordFormatterTest {
             createExpected(
                 record = record,
                 columns = columns,
-                airbyteColumns = AIRBYTE_COLUMN_TYPES_MAP.keys.toList(),
             )
         assertEquals(expectedValue, formattedValue)
     }
@@ -88,7 +87,6 @@ internal class SnowflakeSchemaRecordFormatterTest {
             createExpected(
                 record = record,
                 columns = columns,
-                airbyteColumns = AIRBYTE_COLUMN_TYPES_MAP.keys.toList(),
             )
         assertEquals(expectedValue, formattedValue)
     }
@@ -114,7 +112,6 @@ internal class SnowflakeSchemaRecordFormatterTest {
             createExpected(
                 record = record,
                 columns = columns,
-                airbyteColumns = AIRBYTE_COLUMN_TYPES_MAP.keys.toList(),
                 filterMissing = false,
             )
         assertEquals(expectedValue, formattedValue)
@@ -132,7 +129,6 @@ internal class SnowflakeSchemaRecordFormatterTest {
     private fun createExpected(
         record: Map<String, AirbyteValue>,
         columns: Map<String, String>,
-        airbyteColumns: List<String>,
         filterMissing: Boolean = true,
     ) =
         record.entries

--- a/airbyte-integrations/connectors/destination-snowflake/src/test/kotlin/io/airbyte/integrations/destination/snowflake/write/load/SnowflakeSchemaRecordFormatterTest.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test/kotlin/io/airbyte/integrations/destination/snowflake/write/load/SnowflakeSchemaRecordFormatterTest.kt
@@ -13,7 +13,6 @@ import io.airbyte.cdk.load.message.Meta.Companion.COLUMN_NAME_AB_EXTRACTED_AT
 import io.airbyte.cdk.load.message.Meta.Companion.COLUMN_NAME_AB_GENERATION_ID
 import io.airbyte.cdk.load.message.Meta.Companion.COLUMN_NAME_AB_META
 import io.airbyte.cdk.load.message.Meta.Companion.COLUMN_NAME_AB_RAW_ID
-import io.airbyte.cdk.load.util.serializeToString
 import io.airbyte.integrations.destination.snowflake.db.toSnowflakeCompatibleName
 import io.airbyte.integrations.destination.snowflake.sql.SnowflakeColumnUtils
 import io.mockk.every
@@ -138,14 +137,7 @@ internal class SnowflakeSchemaRecordFormatterTest {
     ) =
         record.entries
             .associate { entry -> entry.key.toSnowflakeCompatibleName() to entry.value }
-            .map { entry ->
-                val columnName = entry.key.toSnowflakeCompatibleName()
-                if (!airbyteColumns.contains(columnName) && columns[columnName] == "VARIANT") {
-                    AbstractMap.SimpleEntry(entry.key, entry.value.serializeToString())
-                } else {
-                    AbstractMap.SimpleEntry(entry.key, entry.value.toCsvValue())
-                }
-            }
+            .map { entry -> AbstractMap.SimpleEntry(entry.key, entry.value.toCsvValue()) }
             .sortedBy { entry ->
                 if (columns.keys.indexOf(entry.key) > -1) columns.keys.indexOf(entry.key)
                 else Int.MAX_VALUE

--- a/airbyte-integrations/connectors/destination-snowflake/src/test/kotlin/io/airbyte/integrations/destination/snowflake/write/transform/SnowflakeValueCoercerTest.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test/kotlin/io/airbyte/integrations/destination/snowflake/write/transform/SnowflakeValueCoercerTest.kt
@@ -21,6 +21,8 @@ import io.airbyte.cdk.load.data.StringValue
 import io.airbyte.cdk.load.data.UnionType
 import io.airbyte.cdk.load.dataflow.transform.ValidationResult
 import io.airbyte.protocol.models.v0.AirbyteRecordMessageMetaChange
+import io.mockk.every
+import io.mockk.mockk
 import java.math.BigDecimal
 import java.math.BigInteger
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -33,7 +35,7 @@ internal class SnowflakeValueCoercerTest {
 
     @BeforeEach
     fun setUp() {
-        coercer = SnowflakeValueCoercer()
+        coercer = SnowflakeValueCoercer(mockk { every { legacyRawTablesOnly } returns false })
     }
 
     @Test


### PR DESCRIPTION
## What
for https://github.com/airbytehq/oncall/issues/10269

Don't double-serialize values when writing to variant (i.e. write `{"foo": "bar"}` instead of `"{\"foo\": \"bar\"}"`. Did some manual testing locally to verify behavior. 
* Old behavior: `select * from test20251204gFBd.test_stream` -> `"\"potato\""`
* New behavior: `select * from test20251204prDu.test_stream` -> `"potato"`

## How
* stop serializing in the RecordMapper
* serialize UnknownType in the ValueCoercer, where we're supposed (?) to do it
* update the valuecoercer to only do `map` in non-raw tables mode (... I could be convinced to also add this check in `validate`, tbh)
* update tests as needed:
    * SnowflakeTableSchemaEvolutionTest - input records need to match the output of `ValueCoercer.map`
    * data dumper - :shrug:
    * SnowflakeExpectedRecordMapper - fix compiler error
* enable a disabled test that was intended to catch this (`testUnions`); fix test config / related stuff
    * those test config fixes also mean we can reenable the other disabled tests :shrug:

## Review guide
review the files in lexicographical order :shrug:

## User Impact
Future records will be written correctly. Users should refresh affected tables to fix existing records (they could probably also manually `update <table> set <column> = parse_json(<column>)`, but that's a bit wonkier)

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
