### PR TITLE
chore(source-klaviyo): Pin cloud version to 2.15.0

### DIFF
--- a/airbyte-integrations/connectors/source-klaviyo/metadata.yaml
+++ b/airbyte-integrations/connectors/source-klaviyo/metadata.yaml
@@ -21,6 +21,7 @@ data:
       packageName: airbyte-source-klaviyo
   registryOverrides:
     cloud:
+      dockerImageTag: 2.15.0
       enabled: true
     oss:
       enabled: true


### PR DESCRIPTION
## What
Pins the source-klaviyo connector version on Airbyte Cloud to 2.15.0, while OSS continues to use the latest version (2.16.8).

## How
Added `dockerImageTag: 2.15.0` to the `registryOverrides.cloud` section in metadata.yaml. This follows the established pattern used by other connectors (e.g., source-faker, source-oracle) for version pinning.

## Review guide
1. `airbyte-integrations/connectors/source-klaviyo/metadata.yaml` - Single line addition to pin cloud version

## User Impact
Cloud users will use source-klaviyo version 2.15.0 instead of the latest version. OSS users are unaffected and will continue to use the latest version.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚

---
Requested by: @brianjlai
Link to Devin run: https://app.devin.ai/sessions/9351a3f4d6e343dc93d0942e144eaa0e