### PR TITLE
docs: add inline scopedImpact example to breaking changes guide

### DIFF
--- a/docs/platform/connector-development/connector-breaking-changes.md
+++ b/docs/platform/connector-development/connector-breaking-changes.md
@@ -60,7 +60,24 @@ When in doubt, treat type changes as breaking unless you can verify that all dow
 
 Some legitimate breaking changes may not impact all users of the connector. For example, a change to the schema of a specific stream only impacts users who are syncing that stream.
 
-The breaking change metadata allows you to specify narrowed scopes, and specifically _which streams_ are specifically affected by a breaking change. See the [`breakingChanges` entry](https://docs.airbyte.com/connector-development/connector-metadata-file/) documentation for supported scopes. If a user is not using the affected streams and therefor are not affected by a breaking change, they will not see any in-app messaging or emails about the change.
+The breaking change metadata allows you to specify narrowed scopes, and specifically _which streams_ are specifically affected by a breaking change. If a user is not using the affected streams and therefore are not affected by a breaking change, they will not see any in-app messaging or emails about the change.
+
+To scope a breaking change to specific streams, add the `scopedImpact` property to your `metadata.yaml` entry:
+
+```yaml
+releases:
+  breakingChanges:
+    2.0.0:
+      message: "This version changes the cursor for the `users` stream. After upgrading, please reset the stream."
+      upgradeDeadline: "2024-03-01"
+      scopedImpact:
+        - scopeType: stream
+          impactedScopes: ["users"]
+```
+
+In this example, only users syncing the `users` stream are affected. Users syncing other streams can safely ignore this breaking change.
+
+For the full schema and additional scope types, see the [`scopedImpact` documentation](/platform/connector-development/connector-metadata-file#scopedimpact).
 
 ## Migration Guide Documentation Requirements
 

--- a/docs/platform/connector-development/connector-breaking-changes.md
+++ b/docs/platform/connector-development/connector-breaking-changes.md
@@ -60,7 +60,7 @@ When in doubt, treat type changes as breaking unless you can verify that all dow
 
 Some legitimate breaking changes may not impact all users of the connector. For example, a change to the schema of a specific stream only impacts users who are syncing that stream.
 
-The breaking change metadata allows you to specify narrowed scopes, and specifically _which streams_ are specifically affected by a breaking change. If a user is not using the affected streams and therefore are not affected by a breaking change, they will not see any in-app messaging or emails about the change.
+The breaking change metadata allows you to specify narrowed scopes, and specifically _which streams_ are affected by a breaking change. If a user is not using the affected streams and therefore are not affected by a breaking change, they will not see any in-app messaging or emails about the change.
 
 To scope a breaking change to specific streams, add the `scopedImpact` property to your `metadata.yaml` entry:
 


### PR DESCRIPTION
## What

Adds an inline code example showing how to use the `scopedImpact` property when declaring stream-scoped breaking changes in connector `metadata.yaml` files.

Requested by @aaronsteers.

## How

- Added a YAML code snippet demonstrating the `scopedImpact` property syntax
- Added explanatory text describing what the example does
- Added a link to the full `scopedImpact` documentation in the connector metadata file reference
- Fixed typo: "therefor" → "therefore"

## Review guide

1. `docs/platform/connector-development/connector-breaking-changes.md` - Review the new example in the "Defining the Scope of Breaking Changes" section

## User Impact

Connector developers will have a clearer, actionable example of how to declare stream-scoped breaking changes directly in the breaking changes guide, rather than needing to navigate to a separate page to find the syntax.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Link to Devin run: https://app.devin.ai/sessions/999719f26b044cf6b24bc7db7e856a78

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._