### PR TITLE
chore(ci): add auto-approval for up-to-date pipeline PRs

### DIFF
--- a/.github/workflows/connectors_up_to_date.yml
+++ b/.github/workflows/connectors_up_to_date.yml
@@ -81,3 +81,65 @@ jobs:
           s3_build_cache_access_key_id: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
           s3_build_cache_secret_key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
           subcommand: "connectors --concurrency=10 ${{ matrix.connector_names}} up-to-date  --create-prs --auto-merge"
+
+  approve_prs:
+    name: Auto-approve up-to-date PRs
+    needs: run_connectors_up_to_date
+    runs-on: ubuntu-24.04
+    if: always()
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Authenticate as 'octavia-bot-hoard' GitHub App
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        id: get-app-token
+        with:
+          owner: "airbytehq"
+          repositories: ${{ github.event.repository.name }}
+          app-id: ${{ secrets.OCTAVIA_BOT_HOARD_APP_ID }}
+          private-key: ${{ secrets.OCTAVIA_BOT_HOARD_PRIVATE_KEY }}
+      - name: Find and approve up-to-date PRs
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          github-token: ${{ steps.get-app-token.outputs.token }}
+          script: |
+            const { data: pullRequests } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100
+            });
+
+            const upToDatePRs = pullRequests.filter(pr =>
+              pr.labels.some(label => label.name === 'up-to-date')
+            );
+
+            console.log(`Found ${upToDatePRs.length} open PRs with 'up-to-date' label`);
+
+            for (const pr of upToDatePRs) {
+              try {
+                // Check if PR already has an approval
+                const { data: reviews } = await github.rest.pulls.listReviews({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: pr.number
+                });
+
+                const hasApproval = reviews.some(review => review.state === 'APPROVED');
+
+                if (!hasApproval) {
+                  await github.rest.pulls.createReview({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    pull_number: pr.number,
+                    event: 'APPROVE',
+                    body: 'Auto-approved by up-to-date pipeline.'
+                  });
+                  console.log(`Approved PR #${pr.number}: ${pr.title}`);
+                } else {
+                  console.log(`PR #${pr.number} already has an approval, skipping`);
+                }
+              } catch (error) {
+                console.error(`Failed to approve PR #${pr.number}: ${error.message}`);
+              }
+            }


### PR DESCRIPTION
## What

Adds automatic approval for PRs created by the up-to-date pipeline. The pipeline already enables GitHub's native auto-merge, but auto-merge requires at least one approval before it can merge (due to branch protection rules). This change completes the automation by adding the missing approval step.

Requested by @aaronsteers.

## How

Adds a new `approve_prs` job to the `connectors_up_to_date.yml` workflow that:
1. Runs after all `run_connectors_up_to_date` matrix jobs complete
2. Authenticates using the existing `octavia-bot-hoard` GitHub App
3. Uses `actions/github-script` to find all open PRs with the `up-to-date` label
4. Approves each PR that doesn't already have an approval

The job uses `if: always()` to run regardless of whether the PR creation jobs succeeded, ensuring any successfully created PRs get approved even if some matrix jobs failed.

## Review guide

1. `.github/workflows/connectors_up_to_date.yml` - Review the new `approve_prs` job

Key items to verify:
- [ ] The `if: always()` behavior is desired (runs even if PR creation jobs fail)
- [ ] The pagination limit of 100 PRs is sufficient for this use case
- [ ] Using `actions/github-script` is acceptable (chosen because we need to approve multiple PRs; dedicated auto-approve actions only handle one PR at a time)

## User Impact

PRs created by the up-to-date pipeline will now be automatically approved, allowing GitHub's auto-merge to proceed without manual intervention.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin run: https://app.devin.ai/sessions/a1ee801373cd4c0bb748ebfb8debff66