### PR TITLE
Fix CDC race condition when Debezium engine thread closes before record emitted

### DIFF
--- a/airbyte-cdk/bulk/changelog.md
+++ b/airbyte-cdk/bulk/changelog.md
@@ -1,3 +1,9 @@
+## Version 0.1.85
+
+**Extract CDK**
+
+* Fix CDC partition reader race condition when draining records after debezium shutdown.
+
 ## Version 0.1.84
 
 load cdk: Move most DB packages into core. Refactor table schema interface into TableSchemaMapper.

--- a/airbyte-cdk/bulk/version.properties
+++ b/airbyte-cdk/bulk/version.properties
@@ -1,1 +1,1 @@
-version=0.1.84
+version=0.1.85


### PR DESCRIPTION
## Summary
- Fix race condition in CDC partition reader when Debezium engine thread closes before all records are emitted
- Update counters only after successful record emission during engine shutdown
- Bump CDK version to 0.1.85

## Details
This PR addresses a race condition that can occur in the CDC partition reader when the Debezium engine thread begins shutdown while records are still being processed. The issue was that `updateCounters()` was being called before confirming the record was successfully emitted, which could lead to incorrect state tracking.

The fix ensures that:
1. During normal operation, counters are updated after record emission (existing behavior)
2. During engine shutdown (draining phase), counters will updated together in same detached coroutine as record emitting, and make sure we don't do double update 

Changes made:
- Modified `CdcPartitionReader.kt` to check `engineShuttingDown` flag before updating counters in the normal flow
- Moved counter update after `recordAcceptor.invoke()` in the shutdown/draining flow
- Updated changelog and version to 0.1.85

## Test plan
- Existing CDC tests pass
- Manual testing confirms race condition no longer occurs during shutdown

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._