### PR TITLE
chore(source-github): Fix stale external documentation URL

### DIFF
--- a/airbyte-integrations/connectors/source-github/metadata.yaml
+++ b/airbyte-integrations/connectors/source-github/metadata.yaml
@@ -92,7 +92,7 @@ data:
       url: https://docs.github.com/en/rest/about-the-rest-api/api-versions
       type: api_release_history
     - title: GitHub API changelog
-      url: https://github.blog/changelog/label/api/
+      url: https://github.blog/changelog/
       type: api_release_history
     - title: GitHub authentication
       url: https://docs.github.com/en/rest/overview/authenticating-to-the-rest-api


### PR DESCRIPTION
## What

Fixes a stale external documentation URL in the source-github connector metadata. The URL `https://github.blog/changelog/label/api/` returns a 404 error.

This was discovered during an API deprecation monitoring investigation for the GitHub connector.

## How

Updated the GitHub API changelog URL from `https://github.blog/changelog/label/api/` (404) to `https://github.blog/changelog/` (200) in the connector's `metadata.yaml` file.

## Review guide

1. `airbyte-integrations/connectors/source-github/metadata.yaml` - Single line URL change

## User Impact

No user-facing impact. This only affects the external documentation URLs stored in connector metadata, which are used for API deprecation monitoring and documentation purposes.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Requested by AJ Steers (@aaronsteers)

Link to Devin run: https://app.devin.ai/sessions/da77a0a5d31e4ee58304581a3d74711b