### PR TITLE
chore(source-github): Fix stale external documentation URL

### DIFF
--- a/airbyte-integrations/connectors/source-github/metadata.yaml
+++ b/airbyte-integrations/connectors/source-github/metadata.yaml
@@ -92,7 +92,7 @@ data:
       url: https://docs.github.com/en/rest/about-the-rest-api/api-versions
       type: api_release_history
     - title: GitHub API changelog
-      url: https://github.blog/changelog/label/api/
+      url: https://github.blog/changelog/
       type: api_release_history
     - title: GitHub authentication
       url: https://docs.github.com/en/rest/overview/authenticating-to-the-rest-api


### PR DESCRIPTION
## What

Fixes a stale external documentation URL in the source-github connector's metadata.yaml file.

The URL `https://github.blog/changelog/label/api/` returns a 404 error. This was discovered during API deprecation monitoring research.

Related oncall issue: https://github.com/airbytehq/oncall/issues/10406

## How

Updated the GitHub API changelog URL from the broken label-filtered URL to the main changelog page:
- **Before**: `https://github.blog/changelog/label/api/` (404 error)
- **After**: `https://github.blog/changelog/` (working URL)

## Review guide

1. `airbyte-integrations/connectors/source-github/metadata.yaml` - Single line URL change in `externalDocumentationUrls` section

**Reviewer verification**: You may want to confirm the old URL returns 404 and the new URL is accessible.

## User Impact

No direct user impact. This change ensures that external documentation URL references in connector metadata are valid and accessible for tooling that uses these URLs (e.g., API deprecation monitoring systems).

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

**Requested by**: AJ Steers (@aaronsteers)

**Link to Devin run**: https://app.devin.ai/sessions/b059a911d470440ca670450c9b2c1e31