### PR TITLE
fix(ci): allow prerelease workflow to comment when only pr number is provided

### DIFF
--- a/.github/workflows/publish-connectors-prerelease-command.yml
+++ b/.github/workflows/publish-connectors-prerelease-command.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Append start comment
         id: append-start-comment
-        if: inputs.comment-id != ''
+        if: inputs.comment-id != '' || inputs.pr != ''
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
           comment-id: ${{ inputs.comment-id }}
@@ -97,7 +97,7 @@ jobs:
     name: Post Completion Status
     needs: [init, publish]
     runs-on: ubuntu-24.04
-    if: always() && inputs.comment-id != ''
+    if: always() && (inputs.comment-id != '' || inputs.pr != '')
     steps:
       - name: Determine publish status
         id: status


### PR DESCRIPTION
## What

Fixes the prerelease connector publish workflow to post PR comments when triggered via workflow_dispatch with only a PR number (without a comment-id).

Previously, the workflow only posted start/completion comments when `comment-id` was provided (i.e., when triggered via slash command). This meant MCP-triggered or manual workflow_dispatch runs that only pass `pr` would not get any feedback comments on the PR.

## How

Changed the `if` conditions on two steps to check for either `comment-id` OR `pr` being non-empty:

1. **Line 70** (Append start comment step): `inputs.comment-id != ''` → `inputs.comment-id != '' || inputs.pr != ''`
2. **Line 100** (post-completion job): `always() && inputs.comment-id != ''` → `always() && (inputs.comment-id != '' || inputs.pr != '')`

The `peter-evans/create-or-update-comment` action handles both cases:
- When `comment-id` is provided: updates that existing comment
- When only `issue-number` is provided: creates a new comment on the PR

## Review guide

1. `.github/workflows/publish-connectors-prerelease-command.yml` - verify the condition logic and parentheses placement

## User Impact

MCP-triggered and manual workflow_dispatch runs will now post start and completion comments on the PR, providing visibility into the prerelease publish status.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Link to Devin run: https://app.devin.ai/sessions/268ce25d70154de195af58bae8e658e5
Requested by: AJ Steers (@aaronsteers)