### PR TITLE
fix(ci): use per-connector versioned registry URLs in prerelease comment

### DIFF
--- a/.github/workflows/publish-connectors-prerelease-command.yml
+++ b/.github/workflows/publish-connectors-prerelease-command.yml
@@ -189,8 +189,8 @@ jobs:
           echo "docker_image=airbyte/$CONNECTOR_NAME" >> $GITHUB_OUTPUT
           echo "docker_tag=$DOCKER_TAG" >> $GITHUB_OUTPUT
           echo "dockerhub_url=https://hub.docker.com/layers/airbyte/$CONNECTOR_NAME/$DOCKER_TAG" >> $GITHUB_OUTPUT
-          echo "oss_registry_url=https://connectors.airbyte.com/files/registries/v0/oss_registry.json" >> $GITHUB_OUTPUT
-          echo "cloud_registry_url=https://connectors.airbyte.com/files/registries/v0/cloud_registry.json" >> $GITHUB_OUTPUT
+          echo "oss_registry_url=https://connectors.airbyte.com/files/metadata/airbyte/$CONNECTOR_NAME/$DOCKER_TAG/oss.json" >> $GITHUB_OUTPUT
+          echo "cloud_registry_url=https://connectors.airbyte.com/files/metadata/airbyte/$CONNECTOR_NAME/$DOCKER_TAG/cloud.json" >> $GITHUB_OUTPUT
 
       - name: Append completion comment
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0


### PR DESCRIPTION
## What

Updates the Registry JSON URLs in the prerelease workflow completion comment to link to the per-connector versioned endpoints instead of the global registry files.

Previously, the comment linked to the global registry files which contain all connectors. Now it links directly to the specific connector's registry entry for the published version.

## How

Changed the URL pattern from:
- `https://connectors.airbyte.com/files/registries/v0/{oss,cloud}_registry.json`

To:
- `https://connectors.airbyte.com/files/metadata/airbyte/{connector}/{version}/{oss,cloud}.json`

This pattern was discovered in `airbyte-ci/connectors/metadata_service/lib/tests/test_registry_entry.py`.

## Review guide

1. `.github/workflows/publish-connectors-prerelease-command.yml` - verify the URL pattern matches what the metadata service publishes for pre-release versions

## User Impact

PR comments after prerelease publishing will now link directly to the specific connector's registry entry JSON for that version, making it easier to verify the registry entry was created correctly.

## Human Review Checklist

- [ ] Verify the URL pattern `metadata/airbyte/{connector}/{version}/{registry_type}.json` is correct for pre-release versions
- [ ] Confirm pre-release versions actually get registry entries at this path (the pattern was found in tests, but worth confirming for dev tags)

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Link to Devin run: https://app.devin.ai/sessions/268ce25d70154de195af58bae8e658e5
Requested by: AJ Steers (@aaronsteers)