### PR TITLE
refactor(ci): replace connector listing shell scripts with airbyte-ops CLI

### DIFF
--- a/.github/workflows/build-connector-images-command.yml
+++ b/.github/workflows/build-connector-images-command.yml
@@ -65,11 +65,23 @@ jobs:
           # Use fetch-depth: 0 to ensure we can access the full commit history
           fetch-depth: 0
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+
       - name: Generate Connector Matrix from Changes
         id: generate-matrix
         run: |
-          # Get the list of modified connectors
-          echo "connectors_matrix=$(./poe-tasks/get-modified-connectors.sh --json)" | tee -a $GITHUB_OUTPUT
+          # Get the list of modified connectors using airbyte-ops CLI
+          MATRIX_JSON=$(uvx --from airbyte-internal-ops airbyte-ops repo connector list . \
+            --modified-only \
+            --output-format json-gh-matrix)
+
+          # Transform from {"include": [...]} to {"connector": [...]} format for compatibility
+          if [ "$(echo "$MATRIX_JSON" | jq '.include | length')" -eq 0 ]; then
+            echo "connectors_matrix={\"connector\": [\"\"]}" | tee -a $GITHUB_OUTPUT
+          else
+            echo "connectors_matrix=$(echo "$MATRIX_JSON" | jq '{connector: [.include[].connector]}')" | tee -a $GITHUB_OUTPUT
+          fi
 
     outputs:
       connectors-matrix: ${{ steps.generate-matrix.outputs.connectors_matrix }}

--- a/.github/workflows/build-connector-images-command.yml
+++ b/.github/workflows/build-connector-images-command.yml
@@ -72,16 +72,10 @@ jobs:
         id: generate-matrix
         run: |
           # Get the list of modified connectors using airbyte-ops CLI
-          MATRIX_JSON=$(uvx --from airbyte-internal-ops airbyte-ops repo connector list . \
+          # Output is already in GitHub Actions matrix format: {"include": [...]}
+          echo "connectors_matrix=$(uvx --from airbyte-internal-ops airbyte-ops repo connector list . \
             --modified-only \
-            --output-format json-gh-matrix)
-
-          # Transform from {"include": [...]} to {"connector": [...]} format for compatibility
-          if [ "$(echo "$MATRIX_JSON" | jq '.include | length')" -eq 0 ]; then
-            echo "connectors_matrix={\"connector\": [\"\"]}" | tee -a $GITHUB_OUTPUT
-          else
-            echo "connectors_matrix=$(echo "$MATRIX_JSON" | jq '{connector: [.include[].connector]}')" | tee -a $GITHUB_OUTPUT
-          fi
+            --output-format json-gh-matrix)" | tee -a $GITHUB_OUTPUT
 
     outputs:
       connectors-matrix: ${{ steps.generate-matrix.outputs.connectors_matrix }}

--- a/.github/workflows/build-connector-images-command.yml
+++ b/.github/workflows/build-connector-images-command.yml
@@ -73,9 +73,11 @@ jobs:
         run: |
           # Get the list of modified connectors using airbyte-ops CLI
           # Output is already in GitHub Actions matrix format: {"include": [...]}
-          echo "connectors_matrix=$(uvx --from airbyte-internal-ops airbyte-ops repo connector list . \
+          echo -n "connectors_matrix=" >> $GITHUB_OUTPUT
+          uvx --from=airbyte-internal-ops airbyte-ops repo connector list \
             --modified-only \
-            --output-format json-gh-matrix)" | tee -a $GITHUB_OUTPUT
+            --output-format=json-gh-matrix \
+            | tee -a $GITHUB_OUTPUT
 
     outputs:
       connectors-matrix: ${{ steps.generate-matrix.outputs.connectors_matrix }}

--- a/.github/workflows/bump-version-command.yml
+++ b/.github/workflows/bump-version-command.yml
@@ -147,7 +147,6 @@ jobs:
 
           uvx --from=airbyte-internal-ops airbyte-ops repo connector bump-version \
             --name="${{ matrix.connector }}" \
-            --repo-path=. \
             --bump-type="${{ github.event.inputs.type }}" \
             --changelog-message="$CHANGELOG_MSG" \
             --pr-number=${{ github.event.inputs.pr }}

--- a/.github/workflows/bump-version-command.yml
+++ b/.github/workflows/bump-version-command.yml
@@ -39,9 +39,16 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  bump-version:
-    name: "Bump version of connectors in this PR"
+  generate-matrix:
+    name: "Generate connector matrix"
     runs-on: ubuntu-24.04
+    outputs:
+      connectors-matrix: ${{ steps.generate-matrix.outputs.connectors_matrix }}
+      repo: ${{ steps.job-vars.outputs.repo }}
+      branch: ${{ steps.job-vars.outputs.branch }}
+      pr_title: ${{ steps.job-vars.outputs.pr_title }}
+      run-url: ${{ steps.job-vars.outputs.run-url }}
+      comment-id: ${{ steps.first-comment-action.outputs.comment-id }}
     steps:
       - name: Get job variables
         id: job-vars
@@ -64,7 +71,7 @@ jobs:
         with:
           repository: ${{ steps.job-vars.outputs.repo }}
           ref: ${{ steps.job-vars.outputs.branch }}
-          fetch-depth: 1
+          fetch-depth: 0
           # Important that token is a PAT so that CI checks are triggered again.
           # Without this we would be forever waiting on required checks to pass.
           token: ${{ secrets.GH_PAT_APPROVINGTON_OCTAVIA }}
@@ -83,35 +90,76 @@ jobs:
 
             [1]: ${{ steps.job-vars.outputs.run-url }}
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+
+      - name: Generate connector matrix
+        id: generate-matrix
+        run: |
+          # Get modified connectors using airbyte-ops CLI
+          MATRIX_JSON=$(uvx --from airbyte-internal-ops airbyte-ops repo connector list . \
+            --modified-only \
+            --pr ${{ github.event.inputs.pr }} \
+            --output-format json-gh-matrix)
+
+          # Handle empty matrix case - add empty connector for no-op run
+          if [ "$(echo "$MATRIX_JSON" | jq '.include | length')" -eq 0 ]; then
+            MATRIX_JSON='{"include": [{"connector": ""}]}'
+          fi
+
+          echo "connectors_matrix=$MATRIX_JSON" >> $GITHUB_OUTPUT
+          echo "Matrix: $MATRIX_JSON"
+
+  bump-version:
+    name: "Bump ${{ matrix.connector }}${{ matrix.connector == '' && ' (no connectors modified)' || '' }}"
+    needs: [generate-matrix]
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix: ${{ fromJson(needs.generate-matrix.outputs.connectors-matrix) }}
+      fail-fast: false
+    steps:
+      - name: Checkout Airbyte
+        if: matrix.connector != ''
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          repository: ${{ needs.generate-matrix.outputs.repo }}
+          ref: ${{ needs.generate-matrix.outputs.branch }}
+          fetch-depth: 1
+          token: ${{ secrets.GH_PAT_APPROVINGTON_OCTAVIA }}
+
+      - name: Install uv
+        if: matrix.connector != ''
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+
       - name: Log changelog source
+        if: matrix.connector != ''
         run: |
           if [ -n "${{ github.event.inputs.changelog }}" ]; then
             echo "Using user-provided changelog: ${{ github.event.inputs.changelog }}"
           else
-            echo "Using PR title as changelog: ${{ steps.job-vars.outputs.pr_title }}"
+            echo "Using PR title as changelog: ${{ needs.generate-matrix.outputs.pr_title }}"
           fi
 
-      - name: Run airbyte-ci connectors --modified bump-version
-        uses: ./.github/actions/run-airbyte-ci
-        continue-on-error: true
-        with:
-          context: "manual"
-          gcs_credentials: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
-          sentry_dsn: ${{ secrets.SENTRY_AIRBYTE_CI_DSN }}
-          github_token: ${{ steps.get-app-token.outputs.token }}
-          git_repo_url: https://github.com/${{ steps.job-vars.outputs.repo }}.git
-          subcommand: |
-            connectors --modified bump-version \
-              ${{ github.event.inputs.type }} \
-              "${{ github.event.inputs.changelog != '' && github.event.inputs.changelog || steps.job-vars.outputs.pr_title }}" \
-              --pr-number ${{ github.event.inputs.pr }}
+      - name: Bump version for ${{ matrix.connector }}
+        if: matrix.connector != ''
+        run: |
+          CHANGELOG_MSG="${{ github.event.inputs.changelog != '' && github.event.inputs.changelog || needs.generate-matrix.outputs.pr_title }}"
+
+          uvx --from airbyte-internal-ops airbyte-ops repo connector bump-version \
+            --name "${{ matrix.connector }}" \
+            --repo-path . \
+            --bump-type "${{ github.event.inputs.type }}" \
+            --changelog-message "$CHANGELOG_MSG" \
+            --pr-number ${{ github.event.inputs.pr }}
 
       # This is helpful in the case that we change a previously committed generated file to be ignored by git.
       - name: Remove any files that have been gitignored
+        if: matrix.connector != ''
         run: git ls-files -i -c --exclude-from=.gitignore | xargs -r git rm --cached
 
       # Check for changes in git
       - name: Check for changes
+        if: matrix.connector != ''
         id: git-diff
         run: |
           git diff --quiet && echo "No changes to commit" || echo "changes=true" >> $GITHUB_OUTPUT
@@ -120,43 +168,49 @@ jobs:
       # Commit changes (if any)
       - name: Commit changes
         id: commit-step
-        if: steps.git-diff.outputs.changes == 'true'
+        if: matrix.connector != '' && steps.git-diff.outputs.changes == 'true'
         run: |
           git config --global user.name "Octavia Squidington III"
           git config --global user.email "octavia-squidington-iii@users.noreply.github.com"
           git add .
-          git commit -m "chore: bump-version ${{ github.event.inputs.bump-type }}"
+          git commit -m "chore: bump-version ${{ matrix.connector }} ${{ github.event.inputs.type }}"
           echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
-      - name: Push changes to '(${{ steps.job-vars.outputs.repo }})'
-        if: steps.git-diff.outputs.changes == 'true'
+      - name: Push changes
+        if: matrix.connector != '' && steps.git-diff.outputs.changes == 'true'
         run: |
-          git remote add contributor https://github.com/${{ steps.job-vars.outputs.repo }}.git
-          git push contributor HEAD:'${{ steps.job-vars.outputs.branch }}'
+          git remote add contributor https://github.com/${{ needs.generate-matrix.outputs.repo }}.git || true
+          git push contributor HEAD:'${{ needs.generate-matrix.outputs.branch }}'
 
+  report-status:
+    name: "Report status"
+    needs: [generate-matrix, bump-version]
+    runs-on: ubuntu-24.04
+    if: always()
+    steps:
       - name: Append success comment
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
-        if: steps.git-diff.outputs.changes == 'true'
+        if: needs.bump-version.result == 'success'
         with:
-          comment-id: ${{ steps.first-comment-action.outputs.comment-id }}
+          comment-id: ${{ needs.generate-matrix.outputs.comment-id }}
           reactions: hooray
           body: |
-            > ✅ Changes applied successfully. (${{ steps.commit-step.outputs.sha }})
-
-      - name: Append success comment (no-op)
-        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
-        if: steps.git-diff.outputs.changes != 'true'
-        with:
-          comment-id: ${{ steps.first-comment-action.outputs.comment-id }}
-          reactions: "-1"
-          body: |
-            > 🔴 Job completed successfully (no changes, this is sus).
+            > ✅ Bump version completed successfully.
 
       - name: Append failure comment
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
-        if: failure()
+        if: needs.bump-version.result == 'failure'
         with:
-          comment-id: ${{ steps.first-comment-action.outputs.comment-id }}
+          comment-id: ${{ needs.generate-matrix.outputs.comment-id }}
           reactions: confused
           body: |
-            > 🔴 Job failed.
+            > 🔴 Bump version job failed.
+
+      - name: Append skipped comment
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        if: needs.bump-version.result == 'skipped'
+        with:
+          comment-id: ${{ needs.generate-matrix.outputs.comment-id }}
+          reactions: "-1"
+          body: |
+            > 🔴 No connectors found to bump.

--- a/.github/workflows/bump-version-command.yml
+++ b/.github/workflows/bump-version-command.yml
@@ -97,10 +97,10 @@ jobs:
         id: generate-matrix
         run: |
           # Get modified connectors using airbyte-ops CLI
-          MATRIX_JSON=$(uvx --from airbyte-internal-ops airbyte-ops repo connector list . \
+          MATRIX_JSON=$(uvx --from=airbyte-internal-ops airbyte-ops repo connector list \
             --modified-only \
-            --pr ${{ github.event.inputs.pr }} \
-            --output-format json-gh-matrix)
+            --pr=${{ github.event.inputs.pr }} \
+            --output-format=json-gh-matrix)
 
           # Handle empty matrix case - add empty connector for no-op run
           if [ "$(echo "$MATRIX_JSON" | jq '.include | length')" -eq 0 ]; then
@@ -145,12 +145,12 @@ jobs:
         run: |
           CHANGELOG_MSG="${{ github.event.inputs.changelog != '' && github.event.inputs.changelog || needs.generate-matrix.outputs.pr_title }}"
 
-          uvx --from airbyte-internal-ops airbyte-ops repo connector bump-version \
-            --name "${{ matrix.connector }}" \
-            --repo-path . \
-            --bump-type "${{ github.event.inputs.type }}" \
-            --changelog-message "$CHANGELOG_MSG" \
-            --pr-number ${{ github.event.inputs.pr }}
+          uvx --from=airbyte-internal-ops airbyte-ops repo connector bump-version \
+            --name="${{ matrix.connector }}" \
+            --repo-path=. \
+            --bump-type="${{ github.event.inputs.type }}" \
+            --changelog-message="$CHANGELOG_MSG" \
+            --pr-number=${{ github.event.inputs.pr }}
 
       # This is helpful in the case that we change a previously committed generated file to be ignored by git.
       - name: Remove any files that have been gitignored

--- a/.github/workflows/connector-ci-checks.yml
+++ b/.github/workflows/connector-ci-checks.yml
@@ -86,21 +86,44 @@ jobs:
               - 'airbyte-cdk/java/**/**/src/main/**/*'
               - 'airbyte-cdk/bulk/**/**/src/main/**/*'
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+
       - name: Generate Connector Matrix from Changes
         id: generate-matrix
         run: |
-          # Get the list of modified connectors
-          echo "connectors_matrix=$(./poe-tasks/get-modified-connectors.sh --json)" | tee -a $GITHUB_OUTPUT
+          # Helper function to get connectors and format for matrix
+          get_connectors() {
+            local extra_args="$1"
+            local result
+            result=$(uvx --from airbyte-internal-ops airbyte-ops repo connector list . \
+              --modified-only \
+              --output-format json-gh-matrix \
+              $extra_args)
+
+            # Transform from {"include": [...]} to {"connector": [...]} format for compatibility
+            # Handle empty matrix case
+            if [ "$(echo "$result" | jq '.include | length')" -eq 0 ]; then
+              echo '{"connector": [""]}'
+            else
+              echo "$result" | jq '{connector: [.include[].connector]}'
+            fi
+          }
+
+          # Get the list of all modified connectors
+          echo "connectors_matrix=$(get_connectors "")" | tee -a $GITHUB_OUTPUT
 
           # If local-cdk-changed is true, get Java connectors with useLocalCdk = true
           # Otherwise, get modified Java connectors
+          # NOTE: --local-cdk is not yet supported in airbyte-ops CLI, falling back to --language java
           if [[ "${{ steps.cdk-changes.outputs.java-cdk == 'true' }}" == "true" ]]; then
-            echo "jvm_connectors_matrix=$(./poe-tasks/get-modified-connectors.sh --json --local-cdk)" | tee -a $GITHUB_OUTPUT
+            # TODO: Replace with --local-cdk once supported in airbyte-ops CLI
+            echo "jvm_connectors_matrix=$(get_connectors "--language java")" | tee -a $GITHUB_OUTPUT
           else
-            echo "jvm_connectors_matrix=$(./poe-tasks/get-modified-connectors.sh --json --java)" | tee -a $GITHUB_OUTPUT
+            echo "jvm_connectors_matrix=$(get_connectors "--language java")" | tee -a $GITHUB_OUTPUT
           fi
 
-          echo "non_jvm_connectors_matrix=$(./poe-tasks/get-modified-connectors.sh --json --no-java)" | tee -a $GITHUB_OUTPUT
+          echo "non_jvm_connectors_matrix=$(get_connectors "--exclude-language java")" | tee -a $GITHUB_OUTPUT
 
       - name: Set JVM Runner Type
         id: set-jvm-runner-type

--- a/.github/workflows/connector-ci-checks.yml
+++ b/.github/workflows/connector-ci-checks.yml
@@ -106,17 +106,17 @@ jobs:
 
           # If local-cdk-changed is true, get Java connectors with useLocalCdk = true
           # Otherwise, get modified Java connectors
-          # NOTE: --local-cdk is not yet supported in airbyte-ops CLI, falling back to --language java
+          # NOTE: --local-cdk is not yet supported in airbyte-ops CLI, falling back to --language=java
           echo -n "jvm_connectors_matrix=" >> $GITHUB_OUTPUT
           if [[ "${{ steps.cdk-changes.outputs.java-cdk == 'true' }}" == "true" ]]; then
             # TODO: Replace with --local-cdk once supported in airbyte-ops CLI
-            get_connectors --language java | tee -a $GITHUB_OUTPUT
+            get_connectors --language=java | tee -a $GITHUB_OUTPUT
           else
-            get_connectors --language java | tee -a $GITHUB_OUTPUT
+            get_connectors --language=java | tee -a $GITHUB_OUTPUT
           fi
 
           echo -n "non_jvm_connectors_matrix=" >> $GITHUB_OUTPUT
-          get_connectors --exclude-language java | tee -a $GITHUB_OUTPUT
+          get_connectors --exclude-language=java | tee -a $GITHUB_OUTPUT
 
       - name: Set JVM Runner Type
         id: set-jvm-runner-type

--- a/.github/workflows/connector-ci-checks.yml
+++ b/.github/workflows/connector-ci-checks.yml
@@ -94,26 +94,29 @@ jobs:
         run: |
           # Helper function to get connectors - output is already in GitHub Actions matrix format
           get_connectors() {
-            uvx --from airbyte-internal-ops airbyte-ops repo connector list . \
+            uvx --from=airbyte-internal-ops airbyte-ops repo connector list \
               --modified-only \
-              --output-format json-gh-matrix \
-              $@
+              --output-format=json-gh-matrix \
+              "$@"
           }
 
           # Get the list of all modified connectors
-          echo "connectors_matrix=$(get_connectors)" | tee -a $GITHUB_OUTPUT
+          echo -n "connectors_matrix=" >> $GITHUB_OUTPUT
+          get_connectors | tee -a $GITHUB_OUTPUT
 
           # If local-cdk-changed is true, get Java connectors with useLocalCdk = true
           # Otherwise, get modified Java connectors
           # NOTE: --local-cdk is not yet supported in airbyte-ops CLI, falling back to --language java
+          echo -n "jvm_connectors_matrix=" >> $GITHUB_OUTPUT
           if [[ "${{ steps.cdk-changes.outputs.java-cdk == 'true' }}" == "true" ]]; then
             # TODO: Replace with --local-cdk once supported in airbyte-ops CLI
-            echo "jvm_connectors_matrix=$(get_connectors --language java)" | tee -a $GITHUB_OUTPUT
+            get_connectors --language java | tee -a $GITHUB_OUTPUT
           else
-            echo "jvm_connectors_matrix=$(get_connectors --language java)" | tee -a $GITHUB_OUTPUT
+            get_connectors --language java | tee -a $GITHUB_OUTPUT
           fi
 
-          echo "non_jvm_connectors_matrix=$(get_connectors --exclude-language java)" | tee -a $GITHUB_OUTPUT
+          echo -n "non_jvm_connectors_matrix=" >> $GITHUB_OUTPUT
+          get_connectors --exclude-language java | tee -a $GITHUB_OUTPUT
 
       - name: Set JVM Runner Type
         id: set-jvm-runner-type

--- a/.github/workflows/connector-ci-checks.yml
+++ b/.github/workflows/connector-ci-checks.yml
@@ -92,38 +92,28 @@ jobs:
       - name: Generate Connector Matrix from Changes
         id: generate-matrix
         run: |
-          # Helper function to get connectors and format for matrix
+          # Helper function to get connectors - output is already in GitHub Actions matrix format
           get_connectors() {
-            local extra_args="$1"
-            local result
-            result=$(uvx --from airbyte-internal-ops airbyte-ops repo connector list . \
+            uvx --from airbyte-internal-ops airbyte-ops repo connector list . \
               --modified-only \
               --output-format json-gh-matrix \
-              $extra_args)
-
-            # Transform from {"include": [...]} to {"connector": [...]} format for compatibility
-            # Handle empty matrix case
-            if [ "$(echo "$result" | jq '.include | length')" -eq 0 ]; then
-              echo '{"connector": [""]}'
-            else
-              echo "$result" | jq '{connector: [.include[].connector]}'
-            fi
+              $@
           }
 
           # Get the list of all modified connectors
-          echo "connectors_matrix=$(get_connectors "")" | tee -a $GITHUB_OUTPUT
+          echo "connectors_matrix=$(get_connectors)" | tee -a $GITHUB_OUTPUT
 
           # If local-cdk-changed is true, get Java connectors with useLocalCdk = true
           # Otherwise, get modified Java connectors
           # NOTE: --local-cdk is not yet supported in airbyte-ops CLI, falling back to --language java
           if [[ "${{ steps.cdk-changes.outputs.java-cdk == 'true' }}" == "true" ]]; then
             # TODO: Replace with --local-cdk once supported in airbyte-ops CLI
-            echo "jvm_connectors_matrix=$(get_connectors "--language java")" | tee -a $GITHUB_OUTPUT
+            echo "jvm_connectors_matrix=$(get_connectors --language java)" | tee -a $GITHUB_OUTPUT
           else
-            echo "jvm_connectors_matrix=$(get_connectors "--language java")" | tee -a $GITHUB_OUTPUT
+            echo "jvm_connectors_matrix=$(get_connectors --language java)" | tee -a $GITHUB_OUTPUT
           fi
 
-          echo "non_jvm_connectors_matrix=$(get_connectors "--exclude-language java")" | tee -a $GITHUB_OUTPUT
+          echo "non_jvm_connectors_matrix=$(get_connectors --exclude-language java)" | tee -a $GITHUB_OUTPUT
 
       - name: Set JVM Runner Type
         id: set-jvm-runner-type

--- a/.github/workflows/publish-connectors-prerelease-command.yml
+++ b/.github/workflows/publish-connectors-prerelease-command.yml
@@ -90,9 +90,9 @@ jobs:
 
           echo "No connector provided, detecting modified connectors..."
           # Use airbyte-ops CLI to get modified connectors
-          MODIFIED_JSON=$(uvx --from airbyte-internal-ops airbyte-ops repo connector list . \
+          MODIFIED_JSON=$(uvx --from=airbyte-internal-ops airbyte-ops repo connector list \
             --modified-only \
-            --output-format json-gh-matrix)
+            --output-format=json-gh-matrix)
           echo "Modified connectors JSON: $MODIFIED_JSON"
 
           # Extract connector names from the include array

--- a/.github/workflows/publish-connectors-prerelease-command.yml
+++ b/.github/workflows/publish-connectors-prerelease-command.yml
@@ -75,6 +75,9 @@ jobs:
           echo "run-url=https://github.com/${{ github.repository }}/actions/runs/$GITHUB_RUN_ID" >> $GITHUB_OUTPUT
           echo "pr-number=${{ inputs.pr }}" >> $GITHUB_OUTPUT
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+
       - name: Resolve connector name
         id: resolve-connector
         run: |
@@ -86,11 +89,15 @@ jobs:
           fi
 
           echo "No connector provided, detecting modified connectors..."
-          MODIFIED_JSON=$(./poe-tasks/get-modified-connectors.sh --json)
+          # Use airbyte-ops CLI to get modified connectors
+          MODIFIED_JSON=$(uvx --from airbyte-internal-ops airbyte-ops repo connector list . \
+            --modified-only \
+            --output-format json-gh-matrix)
           echo "Modified connectors JSON: $MODIFIED_JSON"
 
-          CONNECTORS=$(echo "$MODIFIED_JSON" | jq -r '.connector | map(select(. != "")) | .[]')
-          CONNECTOR_COUNT=$(echo "$MODIFIED_JSON" | jq -r '.connector | map(select(. != "")) | length')
+          # Extract connector names from the include array
+          CONNECTORS=$(echo "$MODIFIED_JSON" | jq -r '.include | map(select(.connector != "")) | .[].connector')
+          CONNECTOR_COUNT=$(echo "$MODIFIED_JSON" | jq -r '.include | map(select(.connector != "")) | length')
 
           echo "Found $CONNECTOR_COUNT modified connector(s)"
 


### PR DESCRIPTION
## What

Replaces `./poe-tasks/get-modified-connectors.sh` shell script calls with the new `airbyte-ops` CLI (`uvx --from=airbyte-internal-ops airbyte-ops repo connector list`) in GitHub Actions workflows.

Related to the airbyte-ops-mcp migration tracked in [airbyte-ops-mcp#61](https://github.com/airbytehq/airbyte-ops-mcp/issues/61).

**Note:** `publish_connectors.yml` was NOT updated because it uses `--prev-commit` mode which is not yet supported in the CLI.

## How

Updated 4 workflows to use the new CLI:

1. **bump-version-command.yml** - Restructured from 1 job to 3 jobs:
   - `generate-matrix`: Lists modified connectors using CLI
   - `bump-version`: Matrix job that bumps one connector per job
   - `report-status`: Reports success/failure via PR comments

2. **connector-ci-checks.yml** - Added helper function to call CLI with language filters (`--language=java`, `--exclude-language=java`)

3. **build-connector-images-command.yml** - Direct replacement with CLI call

4. **publish-connectors-prerelease-command.yml** - Direct replacement with CLI call (extracts single connector from `.include` array)

The CLI's `json-gh-matrix` output format is already compatible with GitHub Actions matrix input, so no transformation is needed for most workflows.

## Review guide

1. `.github/workflows/bump-version-command.yml` - **Most significant change**. Review the job restructure and matrix approach carefully.
2. `.github/workflows/connector-ci-checks.yml` - Review the `get_connectors()` helper function and the `--local-cdk` TODO comment (falls back to `--language=java`).
3. `.github/workflows/build-connector-images-command.yml` - Straightforward replacement.
4. `.github/workflows/publish-connectors-prerelease-command.yml` - Straightforward replacement with jq extraction for single connector name.

**Key items to verify:**
- [ ] Matrix-based bump-version handles concurrent pushes to the same branch correctly
- [ ] The `--local-cdk` fallback to `--language=java` is acceptable behavior (noted with TODO)
- [ ] Empty matrix handling in bump-version (adds dummy entry `{"connector": ""}`)
- [ ] CLI is available via `uvx --from=airbyte-internal-ops` in CI environment
- [ ] The `echo -n "name=" >> $GITHUB_OUTPUT` + `tee -a` pattern produces valid output (no newline issues)

## Updates since last revision

- Updated all CLI calls to use `--arg=val` syntax consistently (including `--language=java` and `--exclude-language=java`)
- Removed explicit `--repo-path` argument (now auto-detected by CLI)
- Updated `tee` syntax for better auditability in logs

## User Impact

No user-facing changes. CI workflows will use the new `airbyte-ops` CLI instead of shell scripts for listing modified connectors.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Link to Devin run: https://app.devin.ai/sessions/712e931077ad44728fb86a73e86f782b
Requested by: AJ Steers (@aaronsteers)