### PR TITLE
fix(source-gong): Update CDK import path for DatetimeBasedCursor

### DIFF
--- a/airbyte-integrations/connectors/source-gong/components.py
+++ b/airbyte-integrations/connectors/source-gong/components.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Mapping, MutableMapping, Optional
 
-from airbyte_cdk.sources.declarative.incremental.datetime_based_cursor import DatetimeBasedCursor
+from airbyte_cdk import DatetimeBasedCursor
 from airbyte_cdk.sources.declarative.requesters.request_option import RequestOptionType
 from airbyte_cdk.sources.declarative.types import StreamSlice, StreamState
 

--- a/airbyte-integrations/connectors/source-gong/metadata.yaml
+++ b/airbyte-integrations/connectors/source-gong/metadata.yaml
@@ -3,7 +3,7 @@ data:
     ql: 100
     sl: 100
   connectorBuildOptions:
-    baseImage: docker.io/airbyte/source-declarative-manifest:6.60.12@sha256:b236b4ff8351a7d7f0ff7f938bbf0ab7b455c4c9e6e7cc93933f4aa9201d66cb
+    baseImage: docker.io/airbyte/source-declarative-manifest:7.5.1@sha256:8da9d362c184e2e46532ab94f6f9968a74835c0882d6a4a2f9f9c9e5b972f2a1
   connectorSubtype: api
   connectorType: source
   definitionId: 32382e40-3b49-4b99-9c5c-4076501914e7

--- a/airbyte-integrations/connectors/source-gong/metadata.yaml
+++ b/airbyte-integrations/connectors/source-gong/metadata.yaml
@@ -3,7 +3,7 @@ data:
     ql: 100
     sl: 100
   connectorBuildOptions:
-    baseImage: docker.io/airbyte/source-declarative-manifest:7.5.1@sha256:8da9d362c184e2e46532ab94f6f9968a74835c0882d6a4a2f9f9c9e5b972f2a1
+    baseImage: docker.io/airbyte/source-declarative-manifest:6.60.12@sha256:b236b4ff8351a7d7f0ff7f938bbf0ab7b455c4c9e6e7cc93933f4aa9201d66cb
   connectorSubtype: api
   connectorType: source
   definitionId: 32382e40-3b49-4b99-9c5c-4076501914e7


### PR DESCRIPTION
## What
Fixes a CDK breaking change in the source-gong connector. The `DatetimeBasedCursor` import path changed in newer CDK versions - the old path `airbyte_cdk.sources.declarative.incremental.datetime_based_cursor` no longer exists and must be imported from the top-level `airbyte_cdk` module.

## How
Updated the `DatetimeBasedCursor` import in `components.py` to use the top-level `airbyte_cdk` module export.

**Note:** The base image remains at `source-declarative-manifest:6.60.12` because the newer version (7.5.1) has a stricter schema that doesn't support the `CustomIncrementalSync` type used in this connector's manifest.yaml. Upgrading the base image would require additional manifest changes.

## Review guide
1. `airbyte-integrations/connectors/source-gong/components.py` - Import path fix (single line change)

## User Impact
The connector will continue to work correctly. No functional changes to the connector's behavior.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚

---
Requested by: AJ Steers (@aaronsteers)
Link to Devin run: https://app.devin.ai/sessions/25236232dcb84beca142b97c4de5d17a