### PR TITLE
chore(ci): Refactor live and regression tests to use airbyte-ops-mcp (do not merge)

### DIFF
--- a/.github/workflows/approve-regression-tests-command.yml
+++ b/.github/workflows/approve-regression-tests-command.yml
@@ -75,7 +75,7 @@ jobs:
             --data '{
               "state": "success",
               "context": "Regression Tests on ${{ github.event.inputs.connector-name }}",
-              "target_url": "https://github.com/airbytehq/airbyte/tree/master/airbyte-ci/connectors/live-tests"
+              "target_url": "https://github.com/airbytehq/airbyte-ops-mcp"
             }')
           if [ $response -ne 201 ]; then
             echo "Failed to approve regression tests for ${{ github.event.inputs.connector-name }}. HTTP status code: $response"
@@ -97,7 +97,7 @@ jobs:
             --data '{
               "state": "success",
               "context": "Regression Test Results Reviewed and Approved",
-              "target_url": "https://github.com/airbytehq/airbyte/tree/master/airbyte-ci/connectors/live-tests"
+              "target_url": "https://github.com/airbytehq/airbyte-ops-mcp"
             }')
           if [ $response -ne 201 ]; then
             echo "Failed to update regression test approval status check. HTTP status code: $response"

--- a/.github/workflows/run-live-tests-command.yml
+++ b/.github/workflows/run-live-tests-command.yml
@@ -140,6 +140,24 @@ jobs:
       - name: Output workflow result
         if: always()
         run: |
+          conclusion="${{ steps.trigger-workflow.outputs.workflow-conclusion }}"
+          conclusion="${conclusion:-unknown}"
+          workflow_url="${{ steps.trigger-workflow.outputs.workflow-url }}"
+          workflow_url="${workflow_url:-https://github.com/airbytehq/airbyte-ops-mcp/actions/workflows/connector-live-test.yml}"
+          connector="${{ inputs.connector_image }}"
+          command="${{ inputs.command }}"
+          command="${command:-check}"
+
           echo "Live test workflow completed."
-          echo "Conclusion: ${{ steps.trigger-workflow.outputs.workflow-conclusion }}"
-          echo "Workflow URL: ${{ steps.trigger-workflow.outputs.workflow-url }}"
+          echo "Conclusion: $conclusion"
+          echo "Workflow URL: $workflow_url"
+
+          {
+            echo "## Live Test Results"
+            echo ""
+            echo "**Connector:** \`$connector\`"
+            echo "**Command:** \`$command\`"
+            echo "**Conclusion:** \`$conclusion\`"
+            echo ""
+            echo "[View full test logs in airbyte-ops-mcp]($workflow_url)"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/run-live-tests-command.yml
+++ b/.github/workflows/run-live-tests-command.yml
@@ -79,8 +79,8 @@ jobs:
       - name: Build inputs JSON
         id: build-inputs
         run: |
-          # Build the inputs JSON, only including non-empty values
-          INPUTS_JSON=$(jq -n \
+          # Build the inputs JSON as compact single-line output for GITHUB_OUTPUT
+          INPUTS_JSON=$(jq -c -n \
             --arg connector_image "${{ inputs.connector_image }}" \
             --arg command "${{ inputs.command || 'check' }}" \
             --arg connection_id "${{ inputs.connection_id }}" \

--- a/.github/workflows/run-live-tests-command.yml
+++ b/.github/workflows/run-live-tests-command.yml
@@ -1,9 +1,7 @@
 name: On-Demand Live Connector Validation Tests
-# This workflow uses the airbyte-ops-mcp implementation for live tests.
+# This workflow triggers the live test workflow in airbyte-ops-mcp.
+# Logs and artifacts are kept in the private airbyte-ops-mcp repo.
 # See: https://github.com/airbytehq/airbyte-ops-mcp
-
-permissions:
-  contents: read
 
 concurrency:
   # This is the name of the concurrency group. It is used to prevent concurrent runs of the same workflow.
@@ -63,46 +61,47 @@ on:
         type: string
 
 jobs:
-  live_tests:
-    name: Live Tests
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
+  trigger_live_tests:
+    name: Trigger Live Tests in airbyte-ops-mcp
+    runs-on: ubuntu-24.04
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
+      - name: Authenticate as GitHub App
+        uses: actions/create-github-app-token@v2
+        id: get-app-token
         with:
-          version: "latest"
+          owner: airbytehq
+          repositories: |
+            airbyte
+            airbyte-ops-mcp
+          app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
+          private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
-      - name: Run Live Test
-        id: live-test
+      - name: Trigger live test workflow in airbyte-ops-mcp
         env:
-          AIRBYTE_CLOUD_CLIENT_ID: ${{ secrets.AIRBYTE_CLOUD_CLIENT_ID }}
-          AIRBYTE_CLOUD_CLIENT_SECRET: ${{ secrets.AIRBYTE_CLOUD_CLIENT_SECRET }}
+          GH_TOKEN: ${{ steps.get-app-token.outputs.token }}
         run: |
-          ARGS=(--connector-image "${{ inputs.connector_image }}" --command "${{ inputs.command }}")
+          # Build the inputs JSON, only including non-empty values
+          INPUTS_JSON=$(jq -n \
+            --arg connector_image "${{ inputs.connector_image }}" \
+            --arg command "${{ inputs.command || 'check' }}" \
+            --arg connection_id "${{ inputs.connection_id }}" \
+            --arg state_path "${{ inputs.state_path }}" \
+            '{
+              connector_image: $connector_image,
+              command: $command
+            } + (if $connection_id != "" then {connection_id: $connection_id} else {} end)
+              + (if $state_path != "" then {state_path: $state_path} else {} end)')
 
-          if [ -n "${{ inputs.connection_id }}" ]; then
-            ARGS+=(--connection-id "${{ inputs.connection_id }}")
-          fi
+          echo "Triggering live test workflow with inputs:"
+          echo "$INPUTS_JSON" | jq .
 
-          if [ -n "${{ inputs.state_path }}" ]; then
-            ARGS+=(--state-path "${{ inputs.state_path }}")
-          fi
+          curl -X POST \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/airbytehq/airbyte-ops-mcp/actions/workflows/connector-live-test.yml/dispatches \
+            -d "$(jq -n --argjson inputs "$INPUTS_JSON" '{ref: "main", inputs: $inputs}')"
 
-          uvx --from=airbyte-internal-ops airbyte-ops cloud connector live-test "${ARGS[@]}"
-
-      - name: Upload Test Artifacts
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: live-test-artifacts-${{ github.run_id }}
-          path: /tmp/live_test_artifacts/
-          retention-days: 7
+          echo ""
+          echo "Live test workflow triggered in airbyte-ops-mcp."
+          echo "View the workflow runs at: https://github.com/airbytehq/airbyte-ops-mcp/actions/workflows/connector-live-test.yml"

--- a/.github/workflows/run-live-tests-command.yml
+++ b/.github/workflows/run-live-tests-command.yml
@@ -96,15 +96,50 @@ jobs:
           echo "inputs_json=$INPUTS_JSON" >> "$GITHUB_OUTPUT"
 
       - name: Trigger live test workflow in airbyte-ops-mcp
-        uses: benc-uk/workflow-dispatch@v1
+        id: trigger-workflow
+        uses: the-actions-org/workflow-dispatch@v4
         with:
           workflow: connector-live-test.yml
           repo: airbytehq/airbyte-ops-mcp
           ref: main
           token: ${{ steps.get-app-token.outputs.token }}
           inputs: ${{ steps.build-inputs.outputs.inputs_json }}
+          wait-for-completion: true
+          wait-for-completion-timeout: 30m
+          wait-for-completion-interval: 30s
+          display-workflow-run-url: true
 
-      - name: Output workflow link
+      - name: Post result to PR comment
+        if: always() && inputs.pr
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.get-app-token.outputs.token }}
+          script: |
+            const conclusion = '${{ steps.trigger-workflow.outputs.workflow-conclusion }}' || 'unknown';
+            const workflowUrl = '${{ steps.trigger-workflow.outputs.workflow-url }}' || 'https://github.com/airbytehq/airbyte-ops-mcp/actions/workflows/connector-live-test.yml';
+            const connector = '${{ inputs.connector_image }}';
+            const command = '${{ inputs.command || 'check' }}';
+            
+            const statusEmoji = conclusion === 'success' ? ':white_check_mark:' : conclusion === 'failure' ? ':x:' : ':warning:';
+            
+            const body = `## Live Test Results ${statusEmoji}
+            
+            **Connector:** \`${connector}\`
+            **Command:** \`${command}\`
+            **Result:** \`${conclusion}\`
+            
+            [View full test logs](${workflowUrl}) (requires access to airbyte-ops-mcp)`;
+            
+            await github.rest.issues.createComment({
+              owner: 'airbytehq',
+              repo: 'airbyte',
+              issue_number: ${{ inputs.pr || 0 }},
+              body: body
+            });
+
+      - name: Output workflow result
+        if: always()
         run: |
-          echo "Live test workflow triggered in airbyte-ops-mcp."
-          echo "View the workflow runs at: https://github.com/airbytehq/airbyte-ops-mcp/actions/workflows/connector-live-test.yml"
+          echo "Live test workflow completed."
+          echo "Conclusion: ${{ steps.trigger-workflow.outputs.workflow-conclusion }}"
+          echo "Workflow URL: ${{ steps.trigger-workflow.outputs.workflow-url }}"

--- a/.github/workflows/run-live-tests-command.yml
+++ b/.github/workflows/run-live-tests-command.yml
@@ -1,4 +1,9 @@
 name: On-Demand Live Connector Validation Tests
+# This workflow uses the airbyte-ops-mcp implementation for live tests.
+# See: https://github.com/airbytehq/airbyte-ops-mcp
+
+permissions:
+  contents: read
 
 concurrency:
   # This is the name of the concurrency group. It is used to prevent concurrent runs of the same workflow.
@@ -34,144 +39,70 @@ on:
         type: number
 
       # Workflow-specific inputs
-      connector_filter:
-        description: >
-          Connector filter. Will be passed to the `airbyte-ci connectors` command.
-          To select all modified connectors, use '--modified'. To select specific connectors,
-          pass one or or more `--name` args, e.g. '--name=source-faker --name=source-hardcoded-records'.
-        default: "--modified"
-      connection_id:
-        description: >
-          Connection ID. ID of the connection to test; use "auto" to let the
-          connection retriever choose a connection.
-        default: "auto"
-      streams:
-        description: >
-          (Optional) Streams. Which streams to include in tests.
-          If not set, these will be chosen automatically.
-        required: false
-        default: ""
+      connector_image:
+        description: "Full connector image name with tag (e.g., airbyte/source-github:1.0.0)"
+        required: true
         type: string
-      should_read_with_state:
-        description: Whether to run tests against the read command with state
-        default: "true"
-        type: boolean
-      use_local_cdk:
-        description: Use the local CDK when building the target connector
-        default: "false"
-        type: boolean
-      disable_proxy:
-        description: Disable proxy for requests
-        default: "false"
-        type: boolean
-
-      # Workaround: GitHub currently supports a max of 10 inputs for workflow_dispatch events.
-      # We need to consolidate some inputs to stay within this limit.
-      # connection_subset:
-      #   description: The subset of connections to select from.
-      #   default: "sandboxes"
-      #   type: choice
-      #   options:
-      #     - sandboxes
-      #     - all
+      command:
+        description: "Airbyte command to run"
+        required: false
+        type: choice
+        options:
+          - spec
+          - check
+          - discover
+          - read
+        default: check
+      connection_id:
+        description: "Airbyte Cloud connection ID to fetch config/catalog from"
+        required: false
+        type: string
+      state_path:
+        description: "Path to state JSON file (optional for read)"
+        required: false
+        type: string
 
 jobs:
   live_tests:
     name: Live Tests
-    runs-on: linux-24.04-large # Custom runner, defined in GitHub org settings
-    timeout-minutes: 360 # 6 hours
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
-      - name: Checkout Airbyte
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
-      - name: Extract branch name [WORKFLOW DISPATCH]
-        shell: bash
-        if: github.event_name == 'workflow_dispatch'
-        run: echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
-        id: extract_branch
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-      - name: Install Poetry
-        id: install_poetry
-        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1.4.1
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
         with:
-          version: 1.8.5
+          version: "latest"
 
-      - name: Make poetry venv in project
-        id: poetry_venv
-        run: poetry config virtualenvs.in-project true
-
-      - name: Install Python packages
-        id: install_python_packages
-        working-directory: airbyte-ci/connectors/pipelines
-        run: poetry install
-
-      - name: Fetch last commit id from remote branch [WORKFLOW DISPATCH]
-        if: github.event_name == 'workflow_dispatch'
-        id: fetch_last_commit_id_wd
-        run: echo "commit_id=$(git rev-parse origin/${{ steps.extract_branch.outputs.branch }})" >> $GITHUB_OUTPUT
-
-      - name: Setup Stream Parameters
-        if: github.event_name == 'workflow_dispatch'
-        run: |
-          if [ -z "${{ github.event.inputs.streams }}" ]; then
-            echo "STREAM_PARAMS=" >> $GITHUB_ENV
-          else
-            STREAMS=$(echo "${{ github.event.inputs.streams }}" | sed 's/,/ --connector_live_tests.selected-streams=/g')
-            echo "STREAM_PARAMS=--connector_live_tests.selected-streams=$STREAMS" >> $GITHUB_ENV
-          fi
-
-      - name: Setup Local CDK Flag
-        if: github.event_name == 'workflow_dispatch'
-        run: |
-          if ${{ github.event.inputs.use_local_cdk }}; then
-            echo "USE_LOCAL_CDK_FLAG=--use-local-cdk" >> $GITHUB_ENV
-          else
-            echo "USE_LOCAL_CDK_FLAG=" >> $GITHUB_ENV
-          fi
-
-      - name: Setup State Flag
-        if: github.event_name == 'workflow_dispatch'
-        run: |
-          if ${{ github.event.inputs.should_read_with_state }}; then
-            echo "READ_WITH_STATE_FLAG=--connector_live_tests.should-read-with-state" >> $GITHUB_ENV
-          else
-            echo "READ_WITH_STATE_FLAG=" >> $GITHUB_ENV
-          fi
-
-      - name: Setup Proxy Flag
-        if: github.event_name == 'workflow_dispatch'
-        run: |
-          if ${{ github.event.inputs.disable_proxy }}; then
-            echo "DISABLE_PROXY_FLAG=--connector_live_tests.disable-proxy" >> $GITHUB_ENV
-          else
-            echo "DISABLE_PROXY_FLAG=" >> $GITHUB_ENV
-          fi
-
-      - name: Setup Connection Subset Option
-        if: github.event_name == 'workflow_dispatch'
-        run: |
-          echo "CONNECTION_SUBSET=--connector_live_tests.connection-subset=sandboxes" >> $GITHUB_ENV
-        # TODO: re-enable when we have resolved the more-than-10-inputs issue in workflow_dispatch.
-        # run: |
-        #   echo "CONNECTION_SUBSET=--connector_live_tests.connection-subset=${{ github.event.inputs.connection_subset }}" >> $GITHUB_ENV
-
-      # NOTE: We still use a PAT here (rather than a GitHub App) because the workflow needs
-      # permissions to add commits to our main repo as well as forks. This will only work on
-      # forks if the user installs the app into their fork. Until we document this as a clear
-      # path, we will have to keep using the PAT.
-      - name: Run Live Tests [WORKFLOW DISPATCH]
-        if: github.event_name == 'workflow_dispatch' # TODO: consider using the matrix strategy (https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs). See https://github.com/airbytehq/airbyte/pull/37659#discussion_r1583380234 for details.
-        uses: ./.github/actions/run-airbyte-ci
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          context: "manual"
-          dagger_cloud_token: ${{ secrets.DAGGER_CLOUD_TOKEN_CACHE_3 }}
-          docker_hub_password: ${{ secrets.DOCKER_HUB_PASSWORD }}
-          docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          gcp_gsm_credentials: ${{ secrets.GCP_GSM_CREDENTIALS }}
-          gcp_integration_tester_credentials: ${{ secrets.GCLOUD_INTEGRATION_TESTER }}
-          sentry_dsn: ${{ secrets.SENTRY_AIRBYTE_CI_DSN }}
-          git_branch: ${{ steps.extract_branch.outputs.branch }}
-          git_revision: ${{ steps.fetch_last_commit_id_pr.outputs.commit_id }}
-          github_token: ${{ secrets.GH_PAT_MAINTENANCE_OSS }}
-          s3_build_cache_access_key_id: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
-          s3_build_cache_secret_key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
-          subcommand: connectors ${{ env.USE_LOCAL_CDK_FLAG }} ${{ inputs.connector_filter }} test --only-step connector_live_tests --connector_live_tests.test-suite=live --connector_live_tests.connection-id=${{ github.event.inputs.connection_id }} --connector_live_tests.pr-url="https://github.com/airbytehq/airbyte/pull/${{ github.event.inputs.pr }}" ${{ env.READ_WITH_STATE_FLAG }} ${{ env.DISABLE_PROXY_FLAG }} ${{ env.STREAM_PARAMS }} ${{ env.CONNECTION_SUBSET }}
+          python-version: "3.11"
+
+      - name: Run Live Test
+        id: live-test
+        env:
+          AIRBYTE_CLOUD_CLIENT_ID: ${{ secrets.AIRBYTE_CLOUD_CLIENT_ID }}
+          AIRBYTE_CLOUD_CLIENT_SECRET: ${{ secrets.AIRBYTE_CLOUD_CLIENT_SECRET }}
+        run: |
+          ARGS=(--connector-image "${{ inputs.connector_image }}" --command "${{ inputs.command }}")
+
+          if [ -n "${{ inputs.connection_id }}" ]; then
+            ARGS+=(--connection-id "${{ inputs.connection_id }}")
+          fi
+
+          if [ -n "${{ inputs.state_path }}" ]; then
+            ARGS+=(--state-path "${{ inputs.state_path }}")
+          fi
+
+          uvx --from=airbyte-internal-ops airbyte-ops cloud connector live-test "${ARGS[@]}"
+
+      - name: Upload Test Artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: live-test-artifacts-${{ github.run_id }}
+          path: /tmp/live_test_artifacts/
+          retention-days: 7

--- a/.github/workflows/run-live-tests-command.yml
+++ b/.github/workflows/run-live-tests-command.yml
@@ -76,9 +76,8 @@ jobs:
           app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
           private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
 
-      - name: Trigger live test workflow in airbyte-ops-mcp
-        env:
-          GH_TOKEN: ${{ steps.get-app-token.outputs.token }}
+      - name: Build inputs JSON
+        id: build-inputs
         run: |
           # Build the inputs JSON, only including non-empty values
           INPUTS_JSON=$(jq -n \
@@ -94,14 +93,18 @@ jobs:
 
           echo "Triggering live test workflow with inputs:"
           echo "$INPUTS_JSON" | jq .
+          echo "inputs_json=$INPUTS_JSON" >> "$GITHUB_OUTPUT"
 
-          curl -X POST \
-            -H "Authorization: Bearer $GH_TOKEN" \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/repos/airbytehq/airbyte-ops-mcp/actions/workflows/connector-live-test.yml/dispatches \
-            -d "$(jq -n --argjson inputs "$INPUTS_JSON" '{ref: "main", inputs: $inputs}')"
+      - name: Trigger live test workflow in airbyte-ops-mcp
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          workflow: connector-live-test.yml
+          repo: airbytehq/airbyte-ops-mcp
+          ref: main
+          token: ${{ steps.get-app-token.outputs.token }}
+          inputs: ${{ steps.build-inputs.outputs.inputs_json }}
 
-          echo ""
+      - name: Output workflow link
+        run: |
           echo "Live test workflow triggered in airbyte-ops-mcp."
           echo "View the workflow runs at: https://github.com/airbytehq/airbyte-ops-mcp/actions/workflows/connector-live-test.yml"

--- a/.github/workflows/run-live-tests-command.yml
+++ b/.github/workflows/run-live-tests-command.yml
@@ -119,17 +119,17 @@ jobs:
             const workflowUrl = '${{ steps.trigger-workflow.outputs.workflow-url }}' || 'https://github.com/airbytehq/airbyte-ops-mcp/actions/workflows/connector-live-test.yml';
             const connector = '${{ inputs.connector_image }}';
             const command = '${{ inputs.command || 'check' }}';
-            
+
             const statusEmoji = conclusion === 'success' ? ':white_check_mark:' : conclusion === 'failure' ? ':x:' : ':warning:';
-            
+
             const body = `## Live Test Results ${statusEmoji}
-            
+
             **Connector:** \`${connector}\`
             **Command:** \`${command}\`
             **Result:** \`${conclusion}\`
-            
+
             [View full test logs](${workflowUrl}) (requires access to airbyte-ops-mcp)`;
-            
+
             await github.rest.issues.createComment({
               owner: 'airbytehq',
               repo: 'airbyte',

--- a/.github/workflows/run-regression-tests-command.yml
+++ b/.github/workflows/run-regression-tests-command.yml
@@ -148,6 +148,26 @@ jobs:
       - name: Output workflow result
         if: always()
         run: |
+          conclusion="${{ steps.trigger-workflow.outputs.workflow-conclusion }}"
+          conclusion="${conclusion:-unknown}"
+          workflow_url="${{ steps.trigger-workflow.outputs.workflow-url }}"
+          workflow_url="${workflow_url:-https://github.com/airbytehq/airbyte-ops-mcp/actions/workflows/connector-regression-test.yml}"
+          target_image="${{ inputs.target_image }}"
+          control_image="${{ inputs.control_image }}"
+          command="${{ inputs.command }}"
+          command="${command:-check}"
+
           echo "Regression test workflow completed."
-          echo "Conclusion: ${{ steps.trigger-workflow.outputs.workflow-conclusion }}"
-          echo "Workflow URL: ${{ steps.trigger-workflow.outputs.workflow-url }}"
+          echo "Conclusion: $conclusion"
+          echo "Workflow URL: $workflow_url"
+
+          {
+            echo "## Regression Test Results"
+            echo ""
+            echo "**Target:** \`$target_image\`"
+            echo "**Control:** \`$control_image\`"
+            echo "**Command:** \`$command\`"
+            echo "**Conclusion:** \`$conclusion\`"
+            echo ""
+            echo "[View full test logs in airbyte-ops-mcp]($workflow_url)"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/run-regression-tests-command.yml
+++ b/.github/workflows/run-regression-tests-command.yml
@@ -83,8 +83,8 @@ jobs:
       - name: Build inputs JSON
         id: build-inputs
         run: |
-          # Build the inputs JSON, only including non-empty values
-          INPUTS_JSON=$(jq -n \
+          # Build the inputs JSON as compact single-line output for GITHUB_OUTPUT
+          INPUTS_JSON=$(jq -c -n \
             --arg target_image "${{ inputs.target_image }}" \
             --arg control_image "${{ inputs.control_image }}" \
             --arg command "${{ inputs.command || 'check' }}" \

--- a/.github/workflows/run-regression-tests-command.yml
+++ b/.github/workflows/run-regression-tests-command.yml
@@ -126,18 +126,18 @@ jobs:
             const targetImage = '${{ inputs.target_image }}';
             const controlImage = '${{ inputs.control_image }}';
             const command = '${{ inputs.command || 'check' }}';
-            
+
             const statusEmoji = conclusion === 'success' ? ':white_check_mark:' : conclusion === 'failure' ? ':x:' : ':warning:';
-            
+
             const body = `## Regression Test Results ${statusEmoji}
-            
+
             **Target:** \`${targetImage}\`
             **Control:** \`${controlImage}\`
             **Command:** \`${command}\`
             **Result:** \`${conclusion}\`
-            
+
             [View full test logs](${workflowUrl}) (requires access to airbyte-ops-mcp)`;
-            
+
             await github.rest.issues.createComment({
               owner: 'airbytehq',
               repo: 'airbyte',

--- a/.github/workflows/run-regression-tests-command.yml
+++ b/.github/workflows/run-regression-tests-command.yml
@@ -80,9 +80,8 @@ jobs:
           app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
           private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
 
-      - name: Trigger regression test workflow in airbyte-ops-mcp
-        env:
-          GH_TOKEN: ${{ steps.get-app-token.outputs.token }}
+      - name: Build inputs JSON
+        id: build-inputs
         run: |
           # Build the inputs JSON, only including non-empty values
           INPUTS_JSON=$(jq -n \
@@ -100,14 +99,18 @@ jobs:
 
           echo "Triggering regression test workflow with inputs:"
           echo "$INPUTS_JSON" | jq .
+          echo "inputs_json=$INPUTS_JSON" >> "$GITHUB_OUTPUT"
 
-          curl -X POST \
-            -H "Authorization: Bearer $GH_TOKEN" \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/repos/airbytehq/airbyte-ops-mcp/actions/workflows/connector-regression-test.yml/dispatches \
-            -d "$(jq -n --argjson inputs "$INPUTS_JSON" '{ref: "main", inputs: $inputs}')"
+      - name: Trigger regression test workflow in airbyte-ops-mcp
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          workflow: connector-regression-test.yml
+          repo: airbytehq/airbyte-ops-mcp
+          ref: main
+          token: ${{ steps.get-app-token.outputs.token }}
+          inputs: ${{ steps.build-inputs.outputs.inputs_json }}
 
-          echo ""
+      - name: Output workflow link
+        run: |
           echo "Regression test workflow triggered in airbyte-ops-mcp."
           echo "View the workflow runs at: https://github.com/airbytehq/airbyte-ops-mcp/actions/workflows/connector-regression-test.yml"

--- a/.github/workflows/run-regression-tests-command.yml
+++ b/.github/workflows/run-regression-tests-command.yml
@@ -102,15 +102,52 @@ jobs:
           echo "inputs_json=$INPUTS_JSON" >> "$GITHUB_OUTPUT"
 
       - name: Trigger regression test workflow in airbyte-ops-mcp
-        uses: benc-uk/workflow-dispatch@v1
+        id: trigger-workflow
+        uses: the-actions-org/workflow-dispatch@v4
         with:
           workflow: connector-regression-test.yml
           repo: airbytehq/airbyte-ops-mcp
           ref: main
           token: ${{ steps.get-app-token.outputs.token }}
           inputs: ${{ steps.build-inputs.outputs.inputs_json }}
+          wait-for-completion: true
+          wait-for-completion-timeout: 30m
+          wait-for-completion-interval: 30s
+          display-workflow-run-url: true
 
-      - name: Output workflow link
+      - name: Post result to PR comment
+        if: always() && inputs.pr
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.get-app-token.outputs.token }}
+          script: |
+            const conclusion = '${{ steps.trigger-workflow.outputs.workflow-conclusion }}' || 'unknown';
+            const workflowUrl = '${{ steps.trigger-workflow.outputs.workflow-url }}' || 'https://github.com/airbytehq/airbyte-ops-mcp/actions/workflows/connector-regression-test.yml';
+            const targetImage = '${{ inputs.target_image }}';
+            const controlImage = '${{ inputs.control_image }}';
+            const command = '${{ inputs.command || 'check' }}';
+            
+            const statusEmoji = conclusion === 'success' ? ':white_check_mark:' : conclusion === 'failure' ? ':x:' : ':warning:';
+            
+            const body = `## Regression Test Results ${statusEmoji}
+            
+            **Target:** \`${targetImage}\`
+            **Control:** \`${controlImage}\`
+            **Command:** \`${command}\`
+            **Result:** \`${conclusion}\`
+            
+            [View full test logs](${workflowUrl}) (requires access to airbyte-ops-mcp)`;
+            
+            await github.rest.issues.createComment({
+              owner: 'airbytehq',
+              repo: 'airbyte',
+              issue_number: ${{ inputs.pr || 0 }},
+              body: body
+            });
+
+      - name: Output workflow result
+        if: always()
         run: |
-          echo "Regression test workflow triggered in airbyte-ops-mcp."
-          echo "View the workflow runs at: https://github.com/airbytehq/airbyte-ops-mcp/actions/workflows/connector-regression-test.yml"
+          echo "Regression test workflow completed."
+          echo "Conclusion: ${{ steps.trigger-workflow.outputs.workflow-conclusion }}"
+          echo "Workflow URL: ${{ steps.trigger-workflow.outputs.workflow-url }}"

--- a/.github/workflows/run-regression-tests-command.yml
+++ b/.github/workflows/run-regression-tests-command.yml
@@ -1,4 +1,10 @@
 name: On-Demand Connector Regression Tests
+# This workflow uses the airbyte-ops-mcp implementation for regression tests.
+# See: https://github.com/airbytehq/airbyte-ops-mcp
+
+permissions:
+  contents: read
+  checks: write
 
 concurrency:
   # This is the name of the concurrency group. It is used to prevent concurrent runs of the same workflow.
@@ -34,282 +40,118 @@ on:
         type: number
 
       # Workflow-specific inputs
-      connector_filter:
-        description: >
-          Connector filter. Will be passed to the `airbyte-ci connectors` command.
-          To select all modified connectors, use '--modified'. To select specific connectors,
-          pass one or or more `--name` args, e.g. '--name=source-faker --name=source-hardcoded-records'.
-        default: "--modified"
-      connection_id:
-        description: >
-          Connection ID. ID of the connection to test; use "auto" to let the
-          connection retriever choose a connection.
-        default: "auto"
-      streams:
-        description: >
-          (Optional) Streams. Which streams to include in tests.
-          If not set, these will be chosen automatically.
-        required: false
-        default: ""
+      target_image:
+        description: "Target connector image (new version) with tag (e.g., airbyte/source-github:2.0.0)"
+        required: true
         type: string
-      should_read_with_state:
-        description: Whether to run tests against the read command with state
-        default: "true"
-        type: boolean
-      use_local_cdk:
-        description: Use the local CDK when building the target connector
-        default: "false"
-        type: boolean
-      disable_proxy:
-        description: Disable proxy for requests
-        default: "false"
-        type: boolean
-
-      # Workaround: GitHub currently supports a max of 10 inputs for workflow_dispatch events.
-      # We need to consolidate some inputs to stay within this limit.
-      # connection_subset:
-      #   description: The subset of connections to select from.
-      #   default: "sandboxes"
-      #   type: choice
-      #   options:
-      #     - sandboxes
-      #     - all
-      # control_version:
-      #   description: The version to use as a control version. This is useful when the version defined in the cloud registry does not have a lot of usage (either because a progressive rollout is underway or because a new version has just been released).
-      #   required: false
-      #   type: string
+      control_image:
+        description: "Control connector image (baseline version) with tag (e.g., airbyte/source-github:1.0.0)"
+        required: true
+        type: string
+      command:
+        description: "Airbyte command to run"
+        required: false
+        type: choice
+        options:
+          - spec
+          - check
+          - discover
+          - read
+        default: check
+      connection_id:
+        description: "Airbyte Cloud connection ID to fetch config/catalog from"
+        required: false
+        type: string
+      state_path:
+        description: "Path to state JSON file (optional for read)"
+        required: false
+        type: string
 
 jobs:
   regression_tests:
     name: Regression Tests
-    runs-on: linux-24.04-large # Custom runner, defined in GitHub org settings
-    timeout-minutes: 360 # 6 hours
-    permissions:
-      contents: read
-      pull-requests: write
-      issues: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
     steps:
-      - name: Append start with run link
-        id: pr-comment-id
-        if: github.event_name == 'workflow_dispatch' && github.event.inputs.pr != ''
-        uses: peter-evans/create-or-update-comment@v4
-        with:
-          token: ${{ github.token }}
-          issue-number: ${{ github.event.inputs.pr }}
-          comment-id: ${{ github.event.inputs.comment-id }}
-          edit-mode: append
-          body: |
-            > Starting regression tests (filter: `${{ github.event.inputs.connector_filter || '--modified' }}`)
-            > Workflow run: [${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-      - name: Install Python
-        id: install_python
-        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-          check-latest: true
-          update-environment: true
 
-      - name: Checkout Airbyte
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
-      - name: Extract branch name [WORKFLOW DISPATCH]
-        shell: bash
-        if: github.event_name == 'workflow_dispatch'
-        run: echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
-        id: extract_branch
+      - name: Run Regression Test
+        id: regression-test
+        env:
+          AIRBYTE_CLOUD_CLIENT_ID: ${{ secrets.AIRBYTE_CLOUD_CLIENT_ID }}
+          AIRBYTE_CLOUD_CLIENT_SECRET: ${{ secrets.AIRBYTE_CLOUD_CLIENT_SECRET }}
+        run: |
+          ARGS=(--target-image "${{ inputs.target_image }}" --control-image "${{ inputs.control_image }}" --command "${{ inputs.command }}")
 
-      - name: Install Poetry
-        id: install_poetry
-        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1.4.1
+          if [ -n "${{ inputs.connection_id }}" ]; then
+            ARGS+=(--connection-id "${{ inputs.connection_id }}")
+          fi
+
+          if [ -n "${{ inputs.state_path }}" ]; then
+            ARGS+=(--state-path "${{ inputs.state_path }}")
+          fi
+
+          uvx --from=airbyte-internal-ops airbyte-ops cloud connector regression-test "${ARGS[@]}"
+
+      - name: Create Regression Test Report Check
+        id: create-report-check
+        if: always()
+        uses: actions/github-script@v7
         with:
-          version: 1.8.5
+          script: |
+            const fs = require('fs');
+            const reportPath = '/tmp/regression_test_artifacts/report.md';
 
-      - name: Make poetry venv in project
-        id: poetry_venv
-        run: poetry config virtualenvs.in-project true
+            let reportContent = 'Report not generated';
+            if (fs.existsSync(reportPath)) {
+              reportContent = fs.readFileSync(reportPath, 'utf8');
+            }
 
-      - name: Install Python packages
-        id: install_python_packages
-        working-directory: airbyte-ci/connectors/pipelines
-        run: poetry install
+            const conclusion = '${{ steps.regression-test.outcome }}' === 'success' ? 'success' : 'failure';
 
-      - name: Fetch last commit id from remote branch [WORKFLOW DISPATCH]
-        if: github.event_name == 'workflow_dispatch'
-        id: fetch_last_commit_id_wd
-        run: echo "commit_id=$(git rev-parse origin/${{ steps.extract_branch.outputs.branch }})" >> $GITHUB_OUTPUT
+            const check = await github.rest.checks.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: 'Regression Test Report',
+              head_sha: context.sha,
+              status: 'completed',
+              conclusion: conclusion,
+              output: {
+                title: 'Regression Test Report',
+                summary: `Regression test comparing \`${{ inputs.target_image }}\` vs \`${{ inputs.control_image }}\` using \`${{ inputs.command }}\` command.`,
+                text: reportContent
+              }
+            });
 
-      - name: Setup Stream Parameters
-        if: github.event_name == 'workflow_dispatch'
+            core.setOutput('report_url', check.data.html_url);
+
+      - name: Add Report Link to Summary
+        if: always()
         run: |
-          if [ -z "${{ github.event.inputs.streams }}" ]; then
-            echo "STREAM_PARAMS=" >> $GITHUB_ENV
-          else
-            STREAMS=$(echo "${{ github.event.inputs.streams }}" | sed 's/,/ --connector_live_tests.selected-streams=/g')
-            echo "STREAM_PARAMS=--connector_live_tests.selected-streams=$STREAMS" >> $GITHUB_ENV
-          fi
+          {
+            echo ""
+            echo "---"
+            echo ""
+            echo "### View Full Report"
+            echo ""
+            echo "[Open Regression Test Report](${{ steps.create-report-check.outputs.report_url }})"
+          } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Setup Local CDK Flag
-        if: github.event_name == 'workflow_dispatch'
-        run: |
-          if ${{ github.event.inputs.use_local_cdk }}; then
-            echo "USE_LOCAL_CDK_FLAG=--use-local-cdk" >> $GITHUB_ENV
-          else
-            echo "USE_LOCAL_CDK_FLAG=" >> $GITHUB_ENV
-          fi
-
-      - name: Setup State Flag
-        if: github.event_name == 'workflow_dispatch'
-        run: |
-          if ${{ github.event.inputs.should_read_with_state }}; then
-            echo "READ_WITH_STATE_FLAG=--connector_live_tests.should-read-with-state" >> $GITHUB_ENV
-          else
-            echo "READ_WITH_STATE_FLAG=" >> $GITHUB_ENV
-          fi
-
-      - name: Setup Proxy Flag
-        if: github.event_name == 'workflow_dispatch'
-        run: |
-          if ${{ github.event.inputs.disable_proxy }}; then
-            echo "DISABLE_PROXY_FLAG=--connector_live_tests.disable-proxy" >> $GITHUB_ENV
-          else
-            echo "DISABLE_PROXY_FLAG=" >> $GITHUB_ENV
-          fi
-
-      - name: Setup Connection Subset Option
-        if: github.event_name == 'workflow_dispatch'
-        run: |
-          echo "CONNECTION_SUBSET=--connector_live_tests.connection-subset=sandboxes" >> $GITHUB_ENV
-        # TODO: re-enable when we have resolved the more-than-10-inputs issue in workflow_dispatch.
-        # run: |
-        #   echo "CONNECTION_SUBSET=--connector_live_tests.connection-subset=${{ github.event.inputs.connection_subset }}" >> $GITHUB_ENV
-
-      - name: Setup Control Version
-        if: github.event_name == 'workflow_dispatch'
-        run: |
-          echo "CONTROL_VERSION=" >> $GITHUB_ENV
-        # TODO: re-enable when we have resolved the more-than-10-inputs issue in workflow_dispatch.
-        # run: |
-        #   if [ -n "${{ github.event.inputs.control_version }}" ]; then
-        #     echo "CONTROL_VERSION=--connector_live_tests.control-version=${{ github.event.inputs.control_version }}" >> $GITHUB_ENV
-        #   else
-        #     echo "CONTROL_VERSION=" >> $GITHUB_ENV
-        #   fi
-
-      # NOTE: We still use a PAT here (rather than a GitHub App) because the workflow needs
-      # permissions to add commits to our main repo as well as forks. This will only work on
-      # forks if the user installs the app into their fork. Until we document this as a clear
-      # path, we will have to keep using the PAT.
-      - name: Run Regression Tests [WORKFLOW DISPATCH]
-        id: run-regression-tests
-        if: github.event_name == 'workflow_dispatch' # TODO: consider using the matrix strategy (https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs). See https://github.com/airbytehq/airbyte/pull/37659#discussion_r1583380234 for details.
-        uses: ./.github/actions/run-airbyte-ci
-        with:
-          context: "manual"
-          dagger_cloud_token: ${{ secrets.DAGGER_CLOUD_TOKEN_CACHE_3 }}
-          docker_hub_password: ${{ secrets.DOCKER_HUB_PASSWORD }}
-          docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          gcp_gsm_credentials: ${{ secrets.GCP_GSM_CREDENTIALS }}
-          gcp_integration_tester_credentials: ${{ secrets.GCLOUD_INTEGRATION_TESTER }}
-          sentry_dsn: ${{ secrets.SENTRY_AIRBYTE_CI_DSN }}
-          git_branch: ${{ steps.extract_branch.outputs.branch }}
-          git_revision: ${{ steps.fetch_last_commit_id_pr.outputs.commit_id }}
-          github_token: ${{ secrets.GH_PAT_MAINTENANCE_OSS }}
-          s3_build_cache_access_key_id: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
-          s3_build_cache_secret_key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
-          subcommand: connectors ${{ env.USE_LOCAL_CDK_FLAG }} ${{ inputs.connector_filter }} test --only-step connector_live_tests --connector_live_tests.test-suite=regression --connector_live_tests.connection-id=${{ github.event.inputs.connection_id }} --connector_live_tests.pr-url="https://github.com/airbytehq/airbyte/pull/${{ github.event.inputs.pr }}" ${{ env.READ_WITH_STATE_FLAG }} ${{ env.DISABLE_PROXY_FLAG }} ${{ env.STREAM_PARAMS }} ${{ env.CONNECTION_SUBSET }} ${{ env.CONTROL_VERSION }} --global-status-check-context="Regression Tests" --global-status-check-description='Running regression tests'
-
-      - name: Locate regression test report
-        if: always() && github.event_name == 'workflow_dispatch'
-        id: locate-report
-        run: |
-          # Find the most recent report.html file in /tmp/live_tests_artifacts/
-          REPORT_PATH=$(find /tmp/live_tests_artifacts -name "report.html" -type f -printf '%T@ %p\n' 2>/dev/null | sort -n | tail -1 | cut -f2- -d" ")
-          if [ -n "$REPORT_PATH" ]; then
-            echo "report_path=$REPORT_PATH" >> "$GITHUB_OUTPUT"
-            echo "Found report at: $REPORT_PATH"
-          else
-            echo "report_path=" >> "$GITHUB_OUTPUT"
-            echo "No report.html found in /tmp/live_tests_artifacts/"
-          fi
-
-      - name: Upload regression test report
-        if: always() && github.event_name == 'workflow_dispatch' && steps.locate-report.outputs.report_path != ''
+      - name: Upload Test Artifacts
+        if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: regression-test-report
-          path: ${{ steps.locate-report.outputs.report_path }}
-          if-no-files-found: ignore
-
-      - name: Append regression outcome
-        if: always() && github.event_name == 'workflow_dispatch' && github.event.inputs.pr != ''
-        uses: peter-evans/create-or-update-comment@v4
-        with:
-          token: ${{ github.token }}
-          comment-id: ${{ steps.pr-comment-id.outputs.comment-id }}
-          edit-mode: append
-          body: |
-            > Regression tests: ${{ steps.run-regression-tests.outcome == 'success' && '✅ PASSED' || steps.run-regression-tests.outcome == 'failure' && '❌ FAILED' || steps.run-regression-tests.outcome == 'cancelled' && '⚠️ CANCELLED' || steps.run-regression-tests.outcome == 'skipped' && '⏭️ SKIPPED' || '❓ UNKNOWN' }}
-            > Report: ${{ steps.locate-report.outputs.report_path != '' && 'artifact `regression-test-report` available in the run' || 'not generated' }}
-
-      - name: Install live-tests dependencies for LLM evaluation
-        if: always() && github.event_name == 'workflow_dispatch'
-        working-directory: airbyte-ci/connectors/live-tests
-        run: poetry install
-
-      - name: Install and Start Ollama
-        if: always() && github.event_name == 'workflow_dispatch'
-        run: |
-          curl -fsSL https://ollama.com/install.sh | sh
-          ollama serve &
-          sleep 5
-          ollama pull llama3.2:3b
-          echo "Ollama server started and model pulled"
-
-      - name: Evaluate Regression Test Report with LLM
-        if: always() && github.event_name == 'workflow_dispatch' && steps.locate-report.outputs.report_path != ''
-        id: llm-eval
-        continue-on-error: true
-        working-directory: airbyte-ci/connectors/live-tests
-        env:
-          OPENAI_API_KEY: ollama
-          OPENAI_BASE_URL: http://127.0.0.1:11434/v1
-          EVAL_MODEL: llama3.2:3b
-        run: |
-          set -u
-          echo "ran=false" >> "$GITHUB_OUTPUT"
-          echo "result=error" >> "$GITHUB_OUTPUT"
-
-          REPORT_PATH="${{ steps.locate-report.outputs.report_path }}"
-
-          if [ -z "$REPORT_PATH" ]; then
-            echo "Error: No report path provided from locate-report step" >&2
-            echo "## ⚠️ LLM Evaluation Skipped" >> "$GITHUB_STEP_SUMMARY"
-            echo "No regression test report found. The tests may have failed to generate a report." >> "$GITHUB_STEP_SUMMARY"
-            exit 1
-          fi
-
-          echo "Evaluating report at: $REPORT_PATH"
-
-          # Run the evaluation script
-          OUT_JSON="$RUNNER_TEMP/llm_eval.json"
-          poetry run python src/live_tests/regression_tests/llm_evaluation/evaluate_report.py \
-            --report-path "$REPORT_PATH" \
-            --output-json "$OUT_JSON"
-
-          # If we got here, script exit 0 and produced a judgment
-          PASS=$(jq -r '.evaluation.pass' "$OUT_JSON")
-          if [ "$PASS" = "true" ]; then RES="pass"; else RES="fail"; fi
-          echo "ran=true" >> "$GITHUB_OUTPUT"
-          echo "result=$RES" >> "$GITHUB_OUTPUT"
-
-      - name: Append LLM outcome
-        if: always() && github.event_name == 'workflow_dispatch' && github.event.inputs.pr != ''
-        env:
-          EVAL_MODEL: llama3.2:3b
-        uses: peter-evans/create-or-update-comment@v4
-        with:
-          token: ${{ github.token }}
-          comment-id: ${{ steps.pr-comment-id.outputs.comment-id }}
-          edit-mode: append
-          body: |
-            > LLM Evaluation: ${{ steps.llm-eval.outputs.ran == 'true' && (steps.llm-eval.outputs.result == 'pass' && '✅ PASS' || steps.llm-eval.outputs.result == 'fail' && '❌ FAIL' || '⚠️ ERROR') || '⚠️ Did not run' }}${{ steps.llm-eval.outputs.ran == 'true' && format(' (model: {0})', env.EVAL_MODEL) || '' }}
+          name: regression-test-artifacts-${{ github.run_id }}
+          path: /tmp/regression_test_artifacts/
+          retention-days: 7

--- a/.github/workflows/run-regression-tests-command.yml
+++ b/.github/workflows/run-regression-tests-command.yml
@@ -1,10 +1,7 @@
 name: On-Demand Connector Regression Tests
-# This workflow uses the airbyte-ops-mcp implementation for regression tests.
+# This workflow triggers the regression test workflow in airbyte-ops-mcp.
+# Logs and artifacts are kept in the private airbyte-ops-mcp repo.
 # See: https://github.com/airbytehq/airbyte-ops-mcp
-
-permissions:
-  contents: read
-  checks: write
 
 concurrency:
   # This is the name of the concurrency group. It is used to prevent concurrent runs of the same workflow.
@@ -68,90 +65,49 @@ on:
         type: string
 
 jobs:
-  regression_tests:
-    name: Regression Tests
-    runs-on: ubuntu-latest
-    timeout-minutes: 120
+  trigger_regression_tests:
+    name: Trigger Regression Tests in airbyte-ops-mcp
+    runs-on: ubuntu-24.04
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
+      - name: Authenticate as GitHub App
+        uses: actions/create-github-app-token@v2
+        id: get-app-token
         with:
-          version: "latest"
+          owner: airbytehq
+          repositories: |
+            airbyte
+            airbyte-ops-mcp
+          app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
+          private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
-      - name: Run Regression Test
-        id: regression-test
+      - name: Trigger regression test workflow in airbyte-ops-mcp
         env:
-          AIRBYTE_CLOUD_CLIENT_ID: ${{ secrets.AIRBYTE_CLOUD_CLIENT_ID }}
-          AIRBYTE_CLOUD_CLIENT_SECRET: ${{ secrets.AIRBYTE_CLOUD_CLIENT_SECRET }}
+          GH_TOKEN: ${{ steps.get-app-token.outputs.token }}
         run: |
-          ARGS=(--target-image "${{ inputs.target_image }}" --control-image "${{ inputs.control_image }}" --command "${{ inputs.command }}")
+          # Build the inputs JSON, only including non-empty values
+          INPUTS_JSON=$(jq -n \
+            --arg target_image "${{ inputs.target_image }}" \
+            --arg control_image "${{ inputs.control_image }}" \
+            --arg command "${{ inputs.command || 'check' }}" \
+            --arg connection_id "${{ inputs.connection_id }}" \
+            --arg state_path "${{ inputs.state_path }}" \
+            '{
+              target_image: $target_image,
+              control_image: $control_image,
+              command: $command
+            } + (if $connection_id != "" then {connection_id: $connection_id} else {} end)
+              + (if $state_path != "" then {state_path: $state_path} else {} end)')
 
-          if [ -n "${{ inputs.connection_id }}" ]; then
-            ARGS+=(--connection-id "${{ inputs.connection_id }}")
-          fi
+          echo "Triggering regression test workflow with inputs:"
+          echo "$INPUTS_JSON" | jq .
 
-          if [ -n "${{ inputs.state_path }}" ]; then
-            ARGS+=(--state-path "${{ inputs.state_path }}")
-          fi
+          curl -X POST \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/airbytehq/airbyte-ops-mcp/actions/workflows/connector-regression-test.yml/dispatches \
+            -d "$(jq -n --argjson inputs "$INPUTS_JSON" '{ref: "main", inputs: $inputs}')"
 
-          uvx --from=airbyte-internal-ops airbyte-ops cloud connector regression-test "${ARGS[@]}"
-
-      - name: Create Regression Test Report Check
-        id: create-report-check
-        if: always()
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            const reportPath = '/tmp/regression_test_artifacts/report.md';
-
-            let reportContent = 'Report not generated';
-            if (fs.existsSync(reportPath)) {
-              reportContent = fs.readFileSync(reportPath, 'utf8');
-            }
-
-            const conclusion = '${{ steps.regression-test.outcome }}' === 'success' ? 'success' : 'failure';
-
-            const check = await github.rest.checks.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              name: 'Regression Test Report',
-              head_sha: context.sha,
-              status: 'completed',
-              conclusion: conclusion,
-              output: {
-                title: 'Regression Test Report',
-                summary: `Regression test comparing \`${{ inputs.target_image }}\` vs \`${{ inputs.control_image }}\` using \`${{ inputs.command }}\` command.`,
-                text: reportContent
-              }
-            });
-
-            core.setOutput('report_url', check.data.html_url);
-
-      - name: Add Report Link to Summary
-        if: always()
-        run: |
-          {
-            echo ""
-            echo "---"
-            echo ""
-            echo "### View Full Report"
-            echo ""
-            echo "[Open Regression Test Report](${{ steps.create-report-check.outputs.report_url }})"
-          } >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Upload Test Artifacts
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: regression-test-artifacts-${{ github.run_id }}
-          path: /tmp/regression_test_artifacts/
-          retention-days: 7
+          echo ""
+          echo "Regression test workflow triggered in airbyte-ops-mcp."
+          echo "View the workflow runs at: https://github.com/airbytehq/airbyte-ops-mcp/actions/workflows/connector-regression-test.yml"


### PR DESCRIPTION
## What

Refactors the GitHub CI workflows for live and regression tests to use the new implementations in [airbyte-ops-mcp](https://github.com/airbytehq/airbyte-ops-mcp) instead of the legacy Dagger-based airbyte-ci implementations.

Requested by @aaronsteers via [Slack](https://airbytehq-team.slack.com/archives/C0A28T1TQ5T/p1765250940526789).

Link to Devin run: https://app.devin.ai/sessions/837e5fb971bc4d40b57780f7a225efb0

## How

The workflows now act as thin wrappers that trigger the actual test workflows in the private `airbyte-ops-mcp` repository using the `the-actions-org/workflow-dispatch@v4` GitHub Action. This keeps all test logs and artifacts in the private repo.

- **run-live-tests-command.yml**: Triggers `connector-live-test.yml` workflow in airbyte-ops-mcp
- **run-regression-tests-command.yml**: Triggers `connector-regression-test.yml` workflow in airbyte-ops-mcp
- **approve-regression-tests-command.yml**: Updated target URLs from `airbyte-ci/connectors/live-tests` to `airbyte-ops-mcp`

Authentication uses the Octavia Bot GitHub App token with access to both `airbyte` and `airbyte-ops-mcp` repositories.

### Updates since last revision

- Replaced `benc-uk/workflow-dispatch@v1` with `the-actions-org/workflow-dispatch@v4` for better features
- Added **wait-for-completion** functionality: workflows now wait up to 30 minutes for the ops-mcp workflow to complete before finishing
- Added **PR comment posting**: when triggered from a PR, results are automatically posted as a comment with status emoji, connector info, and link to full logs
- Added **GitHub Actions job summary**: the workflow Summary tab now displays test results with a direct link to the ops-mcp workflow run

## Review guide

**Critical items to verify:**

1. **GitHub App access**: Confirm Octavia Bot has `actions:write` permission on `airbyte-ops-mcp` repo
2. **Workflow file names**: Verify `connector-live-test.yml` and `connector-regression-test.yml` exist in airbyte-ops-mcp
3. **Input parameter names**: Verify the input names (`connector_image`, `command`, `connection_id`, `state_path`, `target_image`, `control_image`) match what the ops-mcp workflows expect
4. **Secrets availability**: Workflows now require `OCTAVIA_BOT_APP_ID` and `OCTAVIA_BOT_PRIVATE_KEY` (instead of previous GCP/Docker/S3 secrets)
5. **Input parameter changes** (breaking): 
   - Live tests: `connector_filter` → `connector_image` (now requires full image name with tag)
   - Regression tests: `connector_filter` → `target_image` + `control_image`
6. **Removed features**:
   - LLM evaluation step (Ollama-based)
   - Stream selection, local CDK support, proxy disable options
7. **Third-party action**: Verify `the-actions-org/workflow-dispatch@v4` is acceptable for production use
8. **Timeout**: 30-minute wait timeout may need adjustment for long-running tests

## Verified end-to-end test runs

With wait-for-completion enabled:
- Airbyte workflow: https://github.com/airbytehq/airbyte/actions/runs/20053611754
- Ops-mcp workflow: https://github.com/airbytehq/airbyte-ops-mcp/actions/runs/20053614506

## User Impact

- Users must now specify full connector image names (e.g., `airbyte/source-github:1.0.0`) instead of using `--modified` or `--name` filters
- Slash commands `/run-live-tests` and `/run-regression-tests` will require updated parameters
- Test results and detailed logs are only visible in the [airbyte-ops-mcp Actions](https://github.com/airbytehq/airbyte-ops-mcp/actions) (private repo)
- When triggered from a PR, a summary comment is automatically posted with the test result and link to full logs
- The workflow Summary tab now shows test results with a clickable link to the ops-mcp workflow

## Can this PR be safely reverted and rolled back?

- [x] YES 💚