### PR TITLE
Destination deepset: Fix trace messages, preserve file extensions, and add logging

### DIFF
--- a/airbyte-integrations/connectors/destination-deepset/destination_deepset/api.py
+++ b/airbyte-integrations/connectors/destination-deepset/destination_deepset/api.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from uuid import UUID
 
 import httpx
@@ -10,6 +11,8 @@ from tenacity import Retrying, retry_if_exception_type, stop_after_attempt, wait
 
 from destination_deepset import util
 from destination_deepset.models import DeepsetCloudConfig, DeepsetCloudFile
+
+logger = logging.getLogger("airbyte")
 
 
 class APIError(RuntimeError):
@@ -73,6 +76,7 @@ class DeepsetCloudApi:
         Raises:
             APIError: Raised when an error is encountered.
         """
+        logger.info(f"[DEEPSET] Health check: {self.config.base_url}/api/v1/me")
         try:
             for attempt in self.retry():
                 with attempt:
@@ -81,13 +85,17 @@ class DeepsetCloudApi:
 
             workspaces = util.get(response.json(), "organization.workspaces", [])
             access = next((True for workspace in workspaces if workspace["name"] == self.config.workspace), False)
+            logger.debug(f"[DEEPSET] Available workspaces: {[w['name'] for w in workspaces]}")
         except Exception as ex:
+            logger.error(f"[DEEPSET] Health check failed: {ex}")
             raise APIError from ex
         else:
             if access:
+                logger.info(f"[DEEPSET] Access confirmed for workspace: {self.config.workspace}")
                 return
 
         error = "User does not have access to the selected workspace!"
+        logger.error(f"[DEEPSET] {error}")
         raise ConfigurationError(error)
 
     def upload(self, file: DeepsetCloudFile, write_mode: str = "KEEP") -> UUID:
@@ -103,12 +111,14 @@ class DeepsetCloudApi:
         Returns:
             UUID: The unique identifier of the uploaded file
         """
+        endpoint = f"/api/v1/workspaces/{self.config.workspace}/files"
+        logger.debug(f"[DEEPSET] POST {endpoint} (write_mode={write_mode})")
 
         try:
             for attempt in self.retry():
                 with attempt:
                     response = self.client.post(
-                        f"/api/v1/workspaces/{self.config.workspace}/files",
+                        endpoint,
                         files={"file": (file.name, file.content)},
                         data={"meta": file.meta_as_string},
                         params={"write_mode": write_mode},
@@ -120,9 +130,12 @@ class DeepsetCloudApi:
 
         except HTTPStatusError as ex:
             status_code, response_text = ex.response.status_code, ex.response.text
+            logger.error(f"[DEEPSET] HTTP error: status_code={status_code}, response={response_text}")
             message = f"File upload failed: {status_code = }, {response_text = }."
             raise FileUploadError(message) from ex
         except Exception as ex:
+            logger.error(f"[DEEPSET] Unexpected error during upload: {type(ex).__name__}: {ex}")
             raise FileUploadError from ex
 
+        logger.error("[DEEPSET] No file_id in response")
         raise FileUploadError

--- a/airbyte-integrations/connectors/destination-deepset/destination_deepset/api.py
+++ b/airbyte-integrations/connectors/destination-deepset/destination_deepset/api.py
@@ -12,6 +12,7 @@ from tenacity import Retrying, retry_if_exception_type, stop_after_attempt, wait
 from destination_deepset import util
 from destination_deepset.models import DeepsetCloudConfig, DeepsetCloudFile
 
+
 logger = logging.getLogger("airbyte")
 
 

--- a/airbyte-integrations/connectors/destination-deepset/destination_deepset/util.py
+++ b/airbyte-integrations/connectors/destination-deepset/destination_deepset/util.py
@@ -61,12 +61,12 @@ def get_trace_message(message: str, exception: Exception | None = None) -> Airby
         type=Type.TRACE,
         trace=AirbyteTraceMessage(
             type=TraceType.ERROR,
-            emitted_at=time(),
+            emitted_at=time() * 1000,
             error=AirbyteErrorTraceMessage(
                 message=message,
                 internal_message=str(exception) if exception else None,
                 stack_trace=format_exc(),
-                failure_type=FailureType.transient_error.value,
+                failure_type=FailureType.transient_error,
             ),
         ),
     )

--- a/airbyte-integrations/connectors/destination-deepset/destination_deepset/writer.py
+++ b/airbyte-integrations/connectors/destination-deepset/destination_deepset/writer.py
@@ -10,6 +10,7 @@ from destination_deepset import util
 from destination_deepset.api import APIError, DeepsetCloudApi
 from destination_deepset.models import DeepsetCloudConfig, DeepsetCloudFile
 
+
 logger = logging.getLogger("airbyte")
 
 

--- a/airbyte-integrations/connectors/destination-deepset/destination_deepset/writer.py
+++ b/airbyte-integrations/connectors/destination-deepset/destination_deepset/writer.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any, Mapping
 
 from airbyte_cdk.models import AirbyteMessage, DestinationSyncMode
 from destination_deepset import util
 from destination_deepset.api import APIError, DeepsetCloudApi
 from destination_deepset.models import DeepsetCloudConfig, DeepsetCloudFile
+
+logger = logging.getLogger("airbyte")
 
 
 class WriterError:
@@ -52,9 +55,12 @@ class DeepsetCloudFileWriter:
             AirbyteMessage: Returns an Airbyte message with a suitable status.
         """
         write_mode = util.get_file_write_mode(destination_sync_mode)
+        logger.info(f"[DEEPSET] Uploading file: {file.name}, write_mode={write_mode}")
         try:
             file_id = self.client.upload(file, write_mode=write_mode)
+            logger.info(f"[DEEPSET] Upload successful: file_id={file_id}")
         except APIError as ex:
+            logger.error(f"[DEEPSET] Upload failed: {ex}")
             return util.get_trace_message(
                 f"Failed to upload a record to deepset cloud workspace, workspace = {self.client.config.workspace}.",
                 exception=ex,

--- a/airbyte-integrations/connectors/destination-deepset/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-deepset/metadata.yaml
@@ -14,7 +14,7 @@ data:
     - suite: acceptanceTests
   connectorType: destination
   dockerRepository: airbyte/destination-deepset
-  dockerImageTag: 0.1.8
+  dockerImageTag: 0.1.9
   license: ELv2
   documentationUrl: https://docs.airbyte.com/integrations/destinations/deepset
   githubIssueLabel: destination-deepset

--- a/airbyte-integrations/connectors/destination-deepset/pyproject.toml
+++ b/airbyte-integrations/connectors/destination-deepset/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "0.1.8"
+version = "0.1.9"
 name = "destination-deepset"
 description = "Destination implementation for deepset."
 authors = ["Airbyte <contact@airbyte.io>"]

--- a/airbyte-integrations/connectors/destination-deepset/pyproject.toml
+++ b/airbyte-integrations/connectors/destination-deepset/pyproject.toml
@@ -12,7 +12,8 @@ readme = "README.md"
 documentation = "https://docs.airbyte.com/integrations/destinations/deepset"
 homepage = "https://airbyte.com"
 repository = "https://github.com/airbytehq/airbyte"
-packages = [{ include = "destination_deepset" }, { include = "main.py" }]
+[[tool.poetry.packages]]
+include = "destination_deepset"
 
 [tool.poetry.dependencies]
 python = "^3.10,<3.12"
@@ -26,3 +27,10 @@ destination-deepset = "destination_deepset.run:run"
 [tool.poetry.group.dev.dependencies]
 pytest = "^8"
 pytest-httpx = "*"
+
+[tool.poe]
+include = [
+    # Shared tasks definition file(s) can be imported here.
+    # Run `poe` or `poe --help` to see the list of available tasks.
+    "${POE_GIT_DIR}/poe-tasks/poetry-connector-tasks.toml",
+]

--- a/docs/integrations/destinations/deepset.md
+++ b/docs/integrations/destinations/deepset.md
@@ -17,6 +17,18 @@ The deepset destination connector supports the following sync modes:
 * [Incremental sync - append](https://docs.airbyte.com/understanding-airbyte/connections/incremental-append/)
 * [Incremental sync - append + deduped ](https://docs.airbyte.com/understanding-airbyte/connections/incremental-append-deduped)
 
+### Expected Input Schema
+
+The deepset destination connector expects records with a specific schema designed for document/file data. This connector is intended for use with file-based sources that extract text content from documents (PDFs, Word documents, etc.).
+
+#### Required Fields
+
+| Field          | Type   | Description                                                                                      |
+| :------------- | :----- | :----------------------------------------------------------------------------------------------- |
+| `content`      | string | The text content of the document, typically extracted from the source file. |
+| `document_key` | string | A unique identifier for the document. Used to generate the filename in deepset.                  |
+
+
 ## Syncing Data to deepset AI Platform
 
 To use the deepset destination in Airbyte:

--- a/docs/integrations/destinations/deepset.md
+++ b/docs/integrations/destinations/deepset.md
@@ -56,6 +56,7 @@ After you connect a source and the first stream synchronization succeeds, your r
 
 | Version | Date       | Pull Request                                             | Subject                                |
 | :------ | :--------- | :------------------------------------------------------- | :------------------------------------- |
+| 0.1.9 | 2025-12-09 | [70815](https://github.com/airbytehq/airbyte/pull/70815) | Fix trace messages, preserve file extensions, add logging |
 | 0.1.8 | 2025-05-17 | [60635](https://github.com/airbytehq/airbyte/pull/60635) | Update dependencies |
 | 0.1.7 | 2025-05-10 | [59834](https://github.com/airbytehq/airbyte/pull/59834) | Update dependencies |
 | 0.1.6 | 2025-05-03 | [58717](https://github.com/airbytehq/airbyte/pull/58717) | Update dependencies |


### PR DESCRIPTION
## What
Fix multiple issues in the deepset cloud destination connector:
- Fix trace message timestamp format (should be in milliseconds)
- Fix failure_type enum usage in error traces
- Preserve original file extensions instead of forcing .md
- Add comprehensive logging throughout the connector for better debugging
- Update documentation with expected input schema 

## User Impact

- Users will see more detailed logs when debugging issues with the deepset destination
- Files will preserve their original extension (e.g., .pdf, .docx) instead of being renamed to .md
- Error messages in trace logs will now have correct timestamps
- Documentation now clearly explains the expected input schema (required content and document_key fields)

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
