### PR TITLE
Enhance abctl upgrade instructions for platforms

### DIFF
--- a/docusaurus/platform_versioned_docs/version-2.0/operator-guides/upgrading-airbyte.md
+++ b/docusaurus/platform_versioned_docs/version-2.0/operator-guides/upgrading-airbyte.md
@@ -66,7 +66,7 @@ Run `abctl local install` to upgrade to the latest version of Airbyte. If you'd 
 
 Occasionally, you need to update `abctl` to the latest version. This is separate from upgrading Airbyte. It only upgrades the command line tool.
 
-## Mac OS
+#### macOS
 
 Run `brew upgrade abctl`. 
 

--- a/docusaurus/platform_versioned_docs/version-2.0/operator-guides/upgrading-airbyte.md
+++ b/docusaurus/platform_versioned_docs/version-2.0/operator-guides/upgrading-airbyte.md
@@ -70,7 +70,7 @@ Occasionally, you need to update `abctl` to the latest version. This is separate
 
 Run `brew upgrade abctl`. 
 
-## Linux 
+#### Linux 
 
 Run `curl -LsfS https://get.airbyte.com | bash -`.
 

--- a/docusaurus/platform_versioned_docs/version-2.0/operator-guides/upgrading-airbyte.md
+++ b/docusaurus/platform_versioned_docs/version-2.0/operator-guides/upgrading-airbyte.md
@@ -64,4 +64,14 @@ Run `abctl local install` to upgrade to the latest version of Airbyte. If you'd 
 
 ### Upgrade abctl
 
-Occasionally, you need to update `abctl` to the latest version. Do that by running `brew upgrade abctl`. This is separate from upgrading Airbyte. It only upgrades the command line tool.
+Occasionally, you need to update `abctl` to the latest version. This is separate from upgrading Airbyte. It only upgrades the command line tool.
+
+## Mac OS
+
+Run `brew upgrade abctl`. 
+
+## Linux 
+
+Run `curl -LsfS https://get.airbyte.com | bash -`.
+
+


### PR DESCRIPTION
Added instructions for upgrading abctl on Linux environments. 

## What
Expanded documentation on how to update abctl not installed via brew.

## How
Provides cmd to run shell script used for initial abctl installation.

## Review guide

## User Impact
Clearer documentation .

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
- [ ] NO ❌
