### PR TITLE
switch Comparable to PartiallyOrdered

### DIFF
--- a/airbyte-cdk/bulk/changelog.md
+++ b/airbyte-cdk/bulk/changelog.md
@@ -1,3 +1,8 @@
+## WIP changes for Postgres (version number TBD)
+
+* Field replaced by EmittedField
+* CDC Position objects now implement PartiallyOrdered rather than Comparable
+
 ## Version 0.1.79
 
 **Extract CDK**

--- a/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/CdcPartitionReader.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/CdcPartitionReader.kt
@@ -45,7 +45,7 @@ import org.apache.kafka.connect.source.SourceRecord
 
 /** [PartitionReader] implementation for CDC with Debezium. */
 @SuppressFBWarnings(value = ["NP_NONNULL_RETURN_VIOLATION"], justification = "Micronaut DI")
-class CdcPartitionReader<T : Comparable<T>>(
+class CdcPartitionReader<T : PartiallyOrdered<T>>(
     val resourceAcquirer: ResourceAcquirer,
     val readerOps: CdcPartitionReaderDebeziumOperations<T>,
     val upperBound: T,
@@ -398,7 +398,7 @@ class CdcPartitionReader<T : Comparable<T>>(
                 if (currentPosition == null) {
                     return null
                 }
-                val isProgressing = lastHeartbeatPosition?.let { currentPosition > it } ?: true
+                val isProgressing = currentPosition.isGreater(lastHeartbeatPosition)
                 if (isProgressing) {
                     lastHeartbeatPosition = currentPosition
                     lastHeartbeatTime = now
@@ -418,7 +418,7 @@ class CdcPartitionReader<T : Comparable<T>>(
                 }
             }
 
-            if (currentPosition == null || currentPosition < upperBound) {
+            if (upperBound.isGreater(currentPosition)) {
                 return null
             }
             // Close because the current event is past the sync upper bound.

--- a/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/CdcPartitionReaderDebeziumOperations.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/CdcPartitionReaderDebeziumOperations.kt
@@ -8,13 +8,7 @@ import io.airbyte.cdk.command.OpaqueStateValue
 import io.airbyte.cdk.read.Stream
 import org.apache.kafka.connect.source.SourceRecord
 
-// TODO: The T: Comparable<T> type here is used to determine when the target offset has been
-//  reached. This doesn't actually require a well defined ordering on all offsets. In Postgres,
-//  the criteria for stopping a sync do not result in a well-ordering of all offsets. As a result,
-//  its implementation of compareTo(other: T) breaks the contract of compareTo(). To fix this,
-//  we should define and use a weaker interface than Comparable with a method like:
-//  fun hasReached(target: T): Boolean.
-interface CdcPartitionReaderDebeziumOperations<T : Comparable<T>> {
+interface CdcPartitionReaderDebeziumOperations<T : PartiallyOrdered<T>> {
 
     /**
      * Transforms a [DebeziumRecordKey] and a [DebeziumRecordValue] into a [DeserializedRecord].

--- a/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/CdcPartitionsCreatorDebeziumOperations.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/CdcPartitionsCreatorDebeziumOperations.kt
@@ -7,13 +7,7 @@ package io.airbyte.cdk.read.cdc
 import io.airbyte.cdk.command.OpaqueStateValue
 import io.airbyte.cdk.read.Stream
 
-// TODO: The T: Comparable<T> type here is used to determine when the target offset has been
-//  reached. This doesn't actually require a well defined ordering on all offsets. In Postgres,
-//  the criteria for stopping a sync do not result in a well-ordering of all offsets. As a result,
-//  the implementation of compareTo(other: T) breaks the contract of compareTo(). To fix this,
-//  we should define and use a weaker interface than Comparable with a method like:
-//  fun hasReached(target: T): Boolean.
-interface CdcPartitionsCreatorDebeziumOperations<T : Comparable<T>> {
+interface CdcPartitionsCreatorDebeziumOperations<T : PartiallyOrdered<T>> {
 
     /** Extracts the WAL position from a [DebeziumOffset]. */
     fun position(offset: DebeziumOffset): T

--- a/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/CdcPartitionsCreatorFactory.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/CdcPartitionsCreatorFactory.kt
@@ -18,7 +18,7 @@ import java.util.concurrent.atomic.AtomicReference
 @Singleton
 @Order(10)
 /** [PartitionsCreatorFactory] implementation for CDC with Debezium. */
-class CdcPartitionsCreatorFactory<T : Comparable<T>>(
+class CdcPartitionsCreatorFactory<T : PartiallyOrdered<T>>(
     val concurrencyResource: ConcurrencyResource,
     val resourceAcquirer: ResourceAcquirer,
     val cdcPartitionsCreatorDbzOps: CdcPartitionsCreatorDebeziumOperations<T>,
@@ -60,8 +60,8 @@ class CdcPartitionsCreatorFactory<T : Comparable<T>>(
 }
 
 @Singleton
-class CdcPartitionsCreatorFactorySupplier<T : CdcPartitionsCreatorFactory<C>, C : Comparable<C>>(
-    val factory: T
-) : PartitionsCreatorFactorySupplier<T> {
-    override fun get(): T = factory
+class CdcPartitionsCreatorFactorySupplier<
+    F : CdcPartitionsCreatorFactory<P>, P : PartiallyOrdered<P>>(val factory: F) :
+    PartitionsCreatorFactorySupplier<F> {
+    override fun get(): F = factory
 }

--- a/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/DebeziumOperations.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/DebeziumOperations.kt
@@ -6,5 +6,5 @@ package io.airbyte.cdk.read.cdc
 
 /** Stateless connector-specific Debezium operations. */
 @Deprecated("Implement the two interfaces separately")
-interface DebeziumOperations<T : Comparable<T>> :
+interface DebeziumOperations<T : PartiallyOrdered<T>> :
     CdcPartitionsCreatorDebeziumOperations<T>, CdcPartitionReaderDebeziumOperations<T>

--- a/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/PartiallyOrdered.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/PartiallyOrdered.kt
@@ -1,5 +1,22 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
 package io.airbyte.cdk.read.cdc
 
+/**
+ * Represents the mathematical concept of partial ordering. Unlike Comparable, the compareTo method
+ * can return null when the two elements don't have a natural ordering.
+ *
+ * We use this interface to compare CDC positions to see when we have reached the target offset or
+ * to determine whether we are making still progress. We need partial ordering rather than a full
+ * ordering like Comparable because sometimes we are missing some fields in the offset and can't
+ * determine whether one offset is beyond another. In these cases, we typically continue until we
+ * encounter a fully populated offset.
+ *
+ * The supplied convenience methods handle the null checking and allow us to make these kinds of
+ * comparisons ergonomically.
+ */
 fun interface PartiallyOrdered<T> {
     fun compareTo(other: T): Int?
 }

--- a/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/PartiallyOrdered.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/PartiallyOrdered.kt
@@ -1,0 +1,18 @@
+package io.airbyte.cdk.read.cdc
+
+fun interface PartiallyOrdered<T> {
+    fun compareTo(other: T): Int?
+}
+
+// Convenience methods
+fun <T : PartiallyOrdered<T>> T?.isGreater(other: T?): Boolean {
+    if (this == null || other == null) return false
+    val comparison = this.compareTo(other)
+    return comparison != null && comparison > 0
+}
+
+fun <T : PartiallyOrdered<T>> T?.isGreaterOrEqual(other: T?): Boolean {
+    if (this == null || other == null) return false
+    val comparison = this.compareTo(other)
+    return comparison != null && comparison >= 0
+}

--- a/airbyte-cdk/bulk/toolkits/extract-cdc/src/testFixtures/kotlin/io/airbyte/cdk/read/cdc/AbstractCdcPartitionReaderTest.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-cdc/src/testFixtures/kotlin/io/airbyte/cdk/read/cdc/AbstractCdcPartitionReaderTest.kt
@@ -61,7 +61,7 @@ import org.junit.jupiter.api.extension.ExtendWith
  */
 @SuppressFBWarnings(value = ["NP_NONNULL_RETURN_VIOLATION"], justification = "Micronaut DI")
 @ExtendWith(MockKExtension::class)
-abstract class AbstractCdcPartitionReaderTest<T : Comparable<T>, C : AutoCloseable>(
+abstract class AbstractCdcPartitionReaderTest<T : PartiallyOrdered<T>, C : AutoCloseable>(
     namespace: String?,
     val heartbeat: Duration = Duration.ofMillis(100),
     val timeout: Duration = Duration.ofSeconds(10),
@@ -291,7 +291,7 @@ abstract class AbstractCdcPartitionReaderTest<T : Comparable<T>, C : AutoCloseab
     data class Update(override val id: Int, val v: Int) : Record
     data class Delete(override val id: Int, val ignore: Boolean = false) : Record
 
-    abstract inner class AbstractCdcPartitionsCreatorDbzOps<T : Comparable<T>> :
+    abstract inner class AbstractCdcPartitionsCreatorDbzOps<T : PartiallyOrdered<T>> :
         CdcPartitionsCreatorDebeziumOperations<T> {
 
         override fun deserializeState(opaqueStateValue: OpaqueStateValue): DebeziumWarmStartState {
@@ -319,7 +319,7 @@ abstract class AbstractCdcPartitionReaderTest<T : Comparable<T>, C : AutoCloseab
         }
     }
 
-    abstract inner class AbstractCdcPartitionReaderDbzOps<T : Comparable<T>> :
+    abstract inner class AbstractCdcPartitionReaderDbzOps<T : PartiallyOrdered<T>> :
         CdcPartitionReaderDebeziumOperations<T> {
 
         override fun deserializeRecord(

--- a/airbyte-integrations/connectors/source-postgres/src/main/kotlin/io/airbyte/integrations/source/postgres/cdc/PostgresSourceCdcPosition.kt
+++ b/airbyte-integrations/connectors/source-postgres/src/main/kotlin/io/airbyte/integrations/source/postgres/cdc/PostgresSourceCdcPosition.kt
@@ -4,21 +4,17 @@
 
 package io.airbyte.integrations.source.postgres.cdc
 
+import io.airbyte.cdk.read.cdc.PartiallyOrdered
 import io.debezium.connector.postgresql.connection.Lsn
 
 data class PostgresSourceCdcPosition(
     val lsn: Lsn?, // For decorating records with _ab_cdc_lsn.
     val lsnCommit: Lsn?, // For determining when target LSN is reached.
-) : Comparable<PostgresSourceCdcPosition> {
-    override fun compareTo(other: PostgresSourceCdcPosition): Int {
+) : PartiallyOrdered<PostgresSourceCdcPosition> {
+    // See https://github.com/airbytehq/airbyte/pull/35939.
+    override fun compareTo(other: PostgresSourceCdcPosition): Int? {
         if (this == other) return 0
-        // This breaks the contract of compareTo because it does not provide a consistent ordering:
-        // For a and b such that a.lsnCommit == null, b.lsnCommit == null, and a.lsn != b.lsn,
-        // a.compareTo(b) = 1 and b.compareTo(a) = 1.
-        // The intent here is to duplicate the logic in the previous version of the connector, where
-        // we do not terminate a sync based on a comparison of offsets without a lsn_commit.
-        // See https://github.com/airbytehq/airbyte/pull/35939.
-        if (lsnCommit == null || other.lsnCommit == null) return 1
+        if (lsnCommit == null || other.lsnCommit == null) return null
         return lsnCommit.compareTo(other.lsnCommit)
     }
 }


### PR DESCRIPTION
## What
Loosen the contract around CDC Position objects to be partially ordered rather than totally ordered.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌
