### PR TITLE
Map the namespace before creating the final table names.

### DIFF
--- a/airbyte-cdk/bulk/changelog.md
+++ b/airbyte-cdk/bulk/changelog.md
@@ -1,3 +1,9 @@
+## Version 0.1.87
+
+**Load CDK**
+
+* Properly call NamespaceMapper before calculating final table names.
+
 ## Version 0.1.86
 
 **Load CDK**

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/command/DestinationCatalog.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/command/DestinationCatalog.kt
@@ -108,9 +108,7 @@ class DefaultDestinationCatalogFactory {
     ): DestinationCatalog {
         // we resolve the table names with the properly mapped descriptors
         val mappedDescriptors =
-            catalog.streams
-                .map { namespaceMapper.map(it.stream.namespace, it.stream.name) }
-                .toSet()
+            catalog.streams.map { namespaceMapper.map(it.stream.namespace, it.stream.name) }.toSet()
         val names = tableNameResolver.getTableNameMapping(mappedDescriptors)
 
         return DestinationCatalog(

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/command/DestinationCatalog.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/command/DestinationCatalog.kt
@@ -111,6 +111,11 @@ class DefaultDestinationCatalogFactory {
             catalog.streams.map { namespaceMapper.map(it.stream.namespace, it.stream.name) }.toSet()
         val names = tableNameResolver.getTableNameMapping(mappedDescriptors)
 
+        require(
+            names.size == catalog.streams.size,
+            { "Invariant violation: An incomplete table name mapping was generated." }
+        )
+
         return DestinationCatalog(
             streams =
                 catalog.streams.map {

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/command/DestinationCatalog.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/command/DestinationCatalog.kt
@@ -104,17 +104,19 @@ class DefaultDestinationCatalogFactory {
         catalog: ConfiguredAirbyteCatalog,
         streamFactory: DestinationStreamFactory,
         tableNameResolver: TableNameResolver,
+        namespaceMapper: NamespaceMapper,
     ): DestinationCatalog {
-        val descriptors =
+        // we resolve the table names with the properly mapped descriptors
+        val mappedDescriptors =
             catalog.streams
-                .map { DestinationStream.Descriptor(it.stream.namespace, it.stream.name) }
+                .map { namespaceMapper.map(it.stream.namespace, it.stream.name) }
                 .toSet()
-        val names = tableNameResolver.getTableNameMapping(descriptors)
+        val names = tableNameResolver.getTableNameMapping(mappedDescriptors)
 
         return DestinationCatalog(
             streams =
                 catalog.streams.map {
-                    val key = DestinationStream.Descriptor(it.stream.namespace, it.stream.name)
+                    val key = namespaceMapper.map(it.stream.namespace, it.stream.name)
                     streamFactory.make(it, names[key]!!)
                 }
         )

--- a/airbyte-cdk/bulk/version.properties
+++ b/airbyte-cdk/bulk/version.properties
@@ -1,1 +1,1 @@
-version=0.1.86
+version=0.1.87


### PR DESCRIPTION
## What
Properly calls the `NamespaceMapper` before passing to the final table name generators.