### PR TITLE
chore: Add workflow to auto-label community PRs from forks

### DIFF
--- a/.github/workflows/label-community-prs.yml
+++ b/.github/workflows/label-community-prs.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   label-community-pr:
-    name: Add Community Label
+    name: Add "Community" Label to PR
     # Only run for PRs from forks
     if: github.event.pull_request.head.repo.fork == true
     runs-on: ubuntu-24.04
@@ -19,29 +19,6 @@ jobs:
       pull-requests: write
     steps:
       - name: Add community label
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        uses: actions-ecosystem/action-add-labels@bd52874380e3909a1ac983768df6976535ece7f8 # v1.1.3
         with:
-          script: |
-            const { owner, repo } = context.repo;
-            const issue_number = context.payload.pull_request.number;
-            
-            // Check if the PR already has the "community" label
-            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
-              owner,
-              repo,
-              issue_number,
-            });
-            
-            const hasCommunityLabel = labels.some(label => label.name === 'community');
-            
-            if (!hasCommunityLabel) {
-              await github.rest.issues.addLabels({
-                owner,
-                repo,
-                issue_number,
-                labels: ['community'],
-              });
-              console.log('Added "community" label to PR #' + issue_number);
-            } else {
-              console.log('PR #' + issue_number + ' already has the "community" label');
-            }
+          labels: community

--- a/.github/workflows/label-community-prs.yml
+++ b/.github/workflows/label-community-prs.yml
@@ -1,0 +1,47 @@
+name: Label Community PRs
+
+# This workflow automatically adds the "community" label to PRs from forks.
+# This enables automatic tracking on the Community PRs project board.
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+
+jobs:
+  label-community-pr:
+    name: Add Community Label
+    # Only run for PRs from forks
+    if: github.event.pull_request.head.repo.fork == true
+    runs-on: ubuntu-24.04
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Add community label
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+            
+            // Check if the PR already has the "community" label
+            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+              owner,
+              repo,
+              issue_number,
+            });
+            
+            const hasCommunityLabel = labels.some(label => label.name === 'community');
+            
+            if (!hasCommunityLabel) {
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number,
+                labels: ['community'],
+              });
+              console.log('Added "community" label to PR #' + issue_number);
+            } else {
+              console.log('PR #' + issue_number + ' already has the "community" label');
+            }

--- a/.github/workflows/label-community-prs.yml
+++ b/.github/workflows/label-community-prs.yml
@@ -16,9 +16,12 @@ jobs:
     if: github.event.pull_request.head.repo.fork == true
     runs-on: ubuntu-24.04
     permissions:
+      issues: write
       pull-requests: write
     steps:
       - name: Add community label
+        # This action uses GitHub's addLabels API, which is idempotent.
+        # If the label already exists, the API call succeeds without error.
         uses: actions-ecosystem/action-add-labels@bd52874380e3909a1ac983768df6976535ece7f8 # v1.1.3
         with:
           labels: community


### PR DESCRIPTION
## What

Adds a GitHub Actions workflow that automatically applies the `community` label to PRs opened from forks. This enables automatic tracking on the [Community PRs project board](https://github.com/orgs/airbytehq/projects/148).

Related test PR: #70845

## How

The new workflow (`label-community-prs.yml`) triggers on `pull_request_target` events (`opened` and `reopened`) and:
1. Checks if the PR is from a fork using `github.event.pull_request.head.repo.fork == true`
2. Adds the `community` label using the [`actions-ecosystem/action-add-labels`](https://github.com/actions-ecosystem/action-add-labels) marketplace action (v1.1.3)

Uses `pull_request_target` (rather than `pull_request`) to safely handle PRs from forks with write permissions, while only performing label operations (no code checkout/execution from the fork).

The action uses GitHub's `addLabels` API, which is idempotent—if the label already exists, the API call succeeds without error.

## Review guide

1. `.github/workflows/label-community-prs.yml` - the entire change

**Human review checklist:**
- [ ] Verify the workflow does NOT checkout or execute any code from the fork
- [ ] Confirm permissions are appropriately scoped (`issues: write` + `pull-requests: write`)
- [ ] Verify the pinned action SHA (`bd52874380e3909a1ac983768df6976535ece7f8`) matches [v1.1.3](https://github.com/actions-ecosystem/action-add-labels/releases/tag/v1.1.3)

**Note:** This workflow cannot be tested via CI. To verify, merge this PR and then close/reopen the test PR #70845 to trigger the workflow.

## User Impact

PRs from external contributors (forks) will automatically receive the `community` label, enabling:
- Automatic addition to the Community PRs project board
- Easier filtering and tracking of community contributions

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

**Requested by:** @aaronsteers (AJ Steers)
**Devin session:** https://app.devin.ai/sessions/b0784474061f4084a04ce5251ce1e9f2