### PR TITLE
fix: Add missing github_token to community label workflow

### DIFF
--- a/.github/workflows/label-community-prs.yml
+++ b/.github/workflows/label-community-prs.yml
@@ -24,4 +24,5 @@ jobs:
         # If the label already exists, the API call succeeds without error.
         uses: actions-ecosystem/action-add-labels@bd52874380e3909a1ac983768df6976535ece7f8 # v1.1.3
         with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           labels: community


### PR DESCRIPTION
## What

Fixes the community label workflow (added in #70848) which was failing with:
```
Error: Input required and not supplied: github_token
```

## How

Adds the required `github_token` input to the `actions-ecosystem/action-add-labels` action. The action needs this token to authenticate with the GitHub API when adding labels.

## Review guide

1. `.github/workflows/label-community-prs.yml` - single line addition

## User Impact

The workflow will now successfully add the `community` label to PRs from forks, enabling automatic tracking on the Community PRs project board.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

**Requested by:** @aaronsteers (AJ Steers)
**Devin session:** https://app.devin.ai/sessions/b0784474061f4084a04ce5251ce1e9f2