### PR TITLE
Add CDC_CURSOR_COLUMN to load cdk for reference.

### DIFF
--- a/airbyte-cdk/bulk/changelog.md
+++ b/airbyte-cdk/bulk/changelog.md
@@ -1,3 +1,9 @@
+## Version 0.1.88
+
+**Load CDK**
+
+* Add CDC_CURSOR_COLUMN_NAME constant.
+
 ## Version 0.1.87
 
 **Load CDK**

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/table/ColumnsConstants.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/table/ColumnsConstants.kt
@@ -4,4 +4,13 @@
 
 package io.airbyte.cdk.load.table
 
+/**
+ * CDC meta column names.
+ *
+ * Note: These CDC column names are brittle as they are separate yet coupled to the logic sources
+ * use to generate these column names. See
+ * [io.airbyte.integrations.source.mssql.MsSqlSourceOperations.MsSqlServerCdcMetaFields] for an
+ * example.
+ */
 const val CDC_DELETED_AT_COLUMN = "_ab_cdc_deleted_at"
+const val CDC_CURSOR_COLUMN = "_ab_cdc_cursor"

--- a/airbyte-cdk/bulk/version.properties
+++ b/airbyte-cdk/bulk/version.properties
@@ -1,1 +1,1 @@
-version=0.1.87
+version=0.1.88


### PR DESCRIPTION
## What
Adds the cdc cursor name constant so we can identify it and ignore it in ClickHouse
