### PR TITLE
chore(ci): Use airbyte-ops CLI for connector matrix generation (do not merge)

### DIFF
--- a/.github/workflows/connector-ci-checks.yml
+++ b/.github/workflows/connector-ci-checks.yml
@@ -86,21 +86,31 @@ jobs:
               - 'airbyte-cdk/java/**/**/src/main/**/*'
               - 'airbyte-cdk/bulk/**/**/src/main/**/*'
 
+      - name: Install airbyte-ops CLI
+        run: |
+          # Install uv if not available
+          if ! command -v uv &> /dev/null; then
+            curl -LsSf https://astral.sh/uv/install.sh | sh
+            export PATH="$HOME/.local/bin:$PATH"
+          fi
+          # Install airbyte-ops CLI tool
+          uv tool install airbyte-internal-ops
+
       - name: Generate Connector Matrix from Changes
         id: generate-matrix
         run: |
-          # Get the list of modified connectors
-          echo "connectors_matrix=$(./poe-tasks/get-modified-connectors.sh --json)" | tee -a $GITHUB_OUTPUT
+          # Get the list of modified connectors using airbyte-ops CLI
+          echo "connectors_matrix=$(airbyte-ops repo connector list --repo-path . --modified-only --output-format json-gh-matrix)" | tee -a $GITHUB_OUTPUT
 
           # If local-cdk-changed is true, get Java connectors with useLocalCdk = true
           # Otherwise, get modified Java connectors
           if [[ "${{ steps.cdk-changes.outputs.java-cdk == 'true' }}" == "true" ]]; then
-            echo "jvm_connectors_matrix=$(./poe-tasks/get-modified-connectors.sh --json --local-cdk)" | tee -a $GITHUB_OUTPUT
+            echo "jvm_connectors_matrix=$(airbyte-ops repo connector list --repo-path . --modified-only --local-cdk --language java --output-format json-gh-matrix)" | tee -a $GITHUB_OUTPUT
           else
-            echo "jvm_connectors_matrix=$(./poe-tasks/get-modified-connectors.sh --json --java)" | tee -a $GITHUB_OUTPUT
+            echo "jvm_connectors_matrix=$(airbyte-ops repo connector list --repo-path . --modified-only --language java --output-format json-gh-matrix)" | tee -a $GITHUB_OUTPUT
           fi
 
-          echo "non_jvm_connectors_matrix=$(./poe-tasks/get-modified-connectors.sh --json --no-java)" | tee -a $GITHUB_OUTPUT
+          echo "non_jvm_connectors_matrix=$(airbyte-ops repo connector list --repo-path . --modified-only --exclude-language java --output-format json-gh-matrix)" | tee -a $GITHUB_OUTPUT
 
       - name: Set JVM Runner Type
         id: set-jvm-runner-type

--- a/.github/workflows/connector-ci-checks.yml
+++ b/.github/workflows/connector-ci-checks.yml
@@ -96,17 +96,17 @@ jobs:
         id: generate-matrix
         run: |
           # Get the list of modified connectors using airbyte-ops CLI
-          echo "connectors_matrix=$(airbyte-ops repo connector list --repo-path . --modified-only --output-format json-gh-matrix)" | tee -a $GITHUB_OUTPUT
+          echo "connectors_matrix=$(airbyte-ops repo connector list . --modified-only --output-format json-gh-matrix)" | tee -a $GITHUB_OUTPUT
 
           # If local-cdk-changed is true, get Java connectors with useLocalCdk = true
           # Otherwise, get modified Java connectors
           if [[ "${{ steps.cdk-changes.outputs.java-cdk == 'true' }}" == "true" ]]; then
-            echo "jvm_connectors_matrix=$(airbyte-ops repo connector list --repo-path . --modified-only --local-cdk --language java --output-format json-gh-matrix)" | tee -a $GITHUB_OUTPUT
+            echo "jvm_connectors_matrix=$(airbyte-ops repo connector list . --modified-only --local-cdk --language java --output-format json-gh-matrix)" | tee -a $GITHUB_OUTPUT
           else
-            echo "jvm_connectors_matrix=$(airbyte-ops repo connector list --repo-path . --modified-only --language java --output-format json-gh-matrix)" | tee -a $GITHUB_OUTPUT
+            echo "jvm_connectors_matrix=$(airbyte-ops repo connector list . --modified-only --language java --output-format json-gh-matrix)" | tee -a $GITHUB_OUTPUT
           fi
 
-          echo "non_jvm_connectors_matrix=$(airbyte-ops repo connector list --repo-path . --modified-only --exclude-language java --output-format json-gh-matrix)" | tee -a $GITHUB_OUTPUT
+          echo "non_jvm_connectors_matrix=$(airbyte-ops repo connector list . --modified-only --exclude-language java --output-format json-gh-matrix)" | tee -a $GITHUB_OUTPUT
 
       - name: Set JVM Runner Type
         id: set-jvm-runner-type

--- a/.github/workflows/connector-ci-checks.yml
+++ b/.github/workflows/connector-ci-checks.yml
@@ -86,15 +86,11 @@ jobs:
               - 'airbyte-cdk/java/**/**/src/main/**/*'
               - 'airbyte-cdk/bulk/**/**/src/main/**/*'
 
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+
       - name: Install airbyte-ops CLI
-        run: |
-          # Install uv if not available
-          if ! command -v uv &> /dev/null; then
-            curl -LsSf https://astral.sh/uv/install.sh | sh
-            export PATH="$HOME/.local/bin:$PATH"
-          fi
-          # Install airbyte-ops CLI tool
-          uv tool install airbyte-internal-ops
+        run: uv tool install airbyte-internal-ops
 
       - name: Generate Connector Matrix from Changes
         id: generate-matrix

--- a/.github/workflows/connector-ci-checks.yml
+++ b/.github/workflows/connector-ci-checks.yml
@@ -96,17 +96,17 @@ jobs:
         id: generate-matrix
         run: |
           # Get the list of modified connectors using airbyte-ops CLI
-          echo "connectors_matrix=$(airbyte-ops repo connector list . --modified-only --output-format json-gh-matrix)" | tee -a $GITHUB_OUTPUT
+          echo "connectors_matrix=$(airbyte-ops repo connector list . --modified-only --output-format=json-gh-matrix)" | tee -a $GITHUB_OUTPUT
 
           # If local-cdk-changed is true, get Java connectors with useLocalCdk = true
           # Otherwise, get modified Java connectors
           if [[ "${{ steps.cdk-changes.outputs.java-cdk == 'true' }}" == "true" ]]; then
-            echo "jvm_connectors_matrix=$(airbyte-ops repo connector list . --modified-only --local-cdk --language java --output-format json-gh-matrix)" | tee -a $GITHUB_OUTPUT
+            echo "jvm_connectors_matrix=$(airbyte-ops repo connector list . --modified-only --local-cdk --language=java --output-format=json-gh-matrix)" | tee -a $GITHUB_OUTPUT
           else
-            echo "jvm_connectors_matrix=$(airbyte-ops repo connector list . --modified-only --language java --output-format json-gh-matrix)" | tee -a $GITHUB_OUTPUT
+            echo "jvm_connectors_matrix=$(airbyte-ops repo connector list . --modified-only --language=java --output-format=json-gh-matrix)" | tee -a $GITHUB_OUTPUT
           fi
 
-          echo "non_jvm_connectors_matrix=$(airbyte-ops repo connector list . --modified-only --exclude-language java --output-format json-gh-matrix)" | tee -a $GITHUB_OUTPUT
+          echo "non_jvm_connectors_matrix=$(airbyte-ops repo connector list . --modified-only --exclude-language=java --output-format=json-gh-matrix)" | tee -a $GITHUB_OUTPUT
 
       - name: Set JVM Runner Type
         id: set-jvm-runner-type


### PR DESCRIPTION
## What

Replace the bash script `./poe-tasks/get-modified-connectors.sh` with the `airbyte-ops` CLI for generating connector matrices in CI workflows.

This PR depends on:
- airbytehq/airbyte-ops-mcp#104

---

## How

1. Use `astral-sh/setup-uv` action to install uv
2. Install the `airbyte-ops` CLI via `uv tool install airbyte-internal-ops`
3. Replace bash script invocations with `airbyte-ops repo connector list .` commands using equivalent flags:
   - `--json` → `--output-format json-gh-matrix`
   - `--java` → `--language java`
   - `--no-java` → `--exclude-language java`
   - `--local-cdk` → `--local-cdk`
   - `--modified-only` (new explicit flag)

## Review guide

1. `.github/workflows/connector-ci-checks.yml` - The only file changed. Review the CLI command syntax and flag mappings.

**Key things to verify:**
- [ ] The `json-gh-matrix` output format matches what downstream matrix jobs expect
- [ ] The `--local-cdk` flag behavior matches the bash script (adds local-CDK connectors to the modified set)
- [ ] Empty result handling is compatible with existing matrix job behavior
- [ ] The `airbyte-internal-ops` package is published before merging (requires ops-mcp PR to be merged first)

## User Impact

No user-facing impact. This is an internal CI tooling change that should produce identical connector matrices.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Requested by AJ Steers (@aaronsteers)

Link to Devin run: https://app.devin.ai/sessions/bdb005b0d7124d659d9ca41d7e6a5134