### PR TITLE
fix(ci): Pass GitHub App token to comment action in AI slash commands

### DIFF
--- a/.github/workflows/ai-canary-prerelease-command.yml
+++ b/.github/workflows/ai-canary-prerelease-command.yml
@@ -50,6 +50,7 @@ jobs:
         if: inputs.comment-id != ''
         uses: peter-evans/create-or-update-comment@v4
         with:
+          token: ${{ steps.get-app-token.outputs.token }}
           comment-id: ${{ inputs.comment-id }}
           issue-number: ${{ inputs.pr }}
           body: |

--- a/.github/workflows/ai-prove-fix-command.yml
+++ b/.github/workflows/ai-prove-fix-command.yml
@@ -50,6 +50,7 @@ jobs:
         if: inputs.comment-id != ''
         uses: peter-evans/create-or-update-comment@v4
         with:
+          token: ${{ steps.get-app-token.outputs.token }}
           comment-id: ${{ inputs.comment-id }}
           issue-number: ${{ inputs.pr }}
           body: |

--- a/.github/workflows/ai-release-watch-command.yml
+++ b/.github/workflows/ai-release-watch-command.yml
@@ -50,6 +50,7 @@ jobs:
         if: inputs.comment-id != ''
         uses: peter-evans/create-or-update-comment@v4
         with:
+          token: ${{ steps.get-app-token.outputs.token }}
           comment-id: ${{ inputs.comment-id }}
           issue-number: ${{ inputs.pr }}
           body: |


### PR DESCRIPTION
## What

Fixes 403 "Resource not accessible by integration" errors when AI slash commands (`/ai-prove-fix`, `/ai-canary-prerelease`, `/ai-release-watch`) try to update PR comments.

Related failure: https://github.com/airbytehq/airbyte/actions/runs/20141998033/job/57811891830

## How

The `peter-evans/create-or-update-comment@v4` action was not receiving a `token` parameter, so it defaulted to using `GITHUB_TOKEN`. However, the workflows already create a GitHub App token (Octavia Bot) earlier in the job - this fix simply passes that token to the comment action.

## Review guide

1. `.github/workflows/ai-prove-fix-command.yml` - adds token parameter
2. `.github/workflows/ai-canary-prerelease-command.yml` - same change
3. `.github/workflows/ai-release-watch-command.yml` - same change

All three changes are identical - adding `token: ${{ steps.get-app-token.outputs.token }}` to the comment action.

## User Impact

AI slash commands will be able to post status updates to PR comments when invoked.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Requested by: @aaronsteers

[Link to Devin run](https://app.devin.ai/sessions/a9367a5c411d438e83a7a08c54ecc7f5)