### PR TITLE
test(source-jira): Add mock server tests (do not merge)

### DIFF
--- a/airbyte-integrations/connectors/source-jira/unit_tests/integration/config.py
+++ b/airbyte-integrations/connectors/source-jira/unit_tests/integration/config.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 
 from datetime import datetime
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 
 class ConfigBuilder:
@@ -22,12 +22,29 @@ class ConfigBuilder:
         self._config["domain"] = domain
         return self
 
+    def with_email(self, email: str) -> "ConfigBuilder":
+        self._config["email"] = email
+        return self
+
     def with_start_date(self, start_datetime: datetime) -> "ConfigBuilder":
         self._config["start_date"] = start_datetime.strftime("%Y-%m-%dT%H:%M:%SZ")
         return self
 
+    def with_start_date_str(self, start_date: str) -> "ConfigBuilder":
+        self._config["start_date"] = start_date
+        return self
+
     def with_projects(self, projects: List[str]) -> "ConfigBuilder":
         self._config["projects"] = projects
+        return self
+
+    def with_enable_experimental_streams(self, enabled: bool = True) -> "ConfigBuilder":
+        self._config["enable_experimental_streams"] = enabled
+        return self
+
+    def with_lookback_window_minutes(self, minutes: Optional[int]) -> "ConfigBuilder":
+        if minutes is not None:
+            self._config["lookback_window_minutes"] = minutes
         return self
 
     def build(self) -> Dict[str, Any]:

--- a/airbyte-integrations/connectors/source-jira/unit_tests/integration/request_builder.py
+++ b/airbyte-integrations/connectors/source-jira/unit_tests/integration/request_builder.py
@@ -4,6 +4,7 @@ import base64
 from typing import Optional
 
 from airbyte_cdk.test.mock_http import HttpRequest
+from airbyte_cdk.test.mock_http.request import ANY_QUERY_PARAMS
 
 
 class JiraRequestBuilder:
@@ -386,6 +387,7 @@ class JiraRequestBuilder:
         if self._any_query_params:
             return HttpRequest(
                 url=f"{self._get_base_url()}/{self._resource}",
+                query_params=ANY_QUERY_PARAMS,
                 headers={"Authorization": self._get_auth_header()},
             )
 

--- a/airbyte-integrations/connectors/source-jira/unit_tests/integration/request_builder.py
+++ b/airbyte-integrations/connectors/source-jira/unit_tests/integration/request_builder.py
@@ -1,0 +1,403 @@
+# Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+
+import base64
+from typing import Optional
+
+from airbyte_cdk.test.mock_http import HttpRequest
+
+
+class JiraRequestBuilder:
+    """
+    Builder for creating HTTP requests for Jira API endpoints.
+
+    This builder helps create clean, reusable request definitions for tests
+    instead of manually constructing HttpRequest objects each time.
+
+    Example usage:
+        request = (
+            JiraRequestBuilder.projects_endpoint("domain.atlassian.net", "email@test.com", "api_token")
+            .with_max_results(50)
+            .build()
+        )
+    """
+
+    BASE_URL_V3 = "https://{domain}/rest/api/3"
+    BASE_URL_V1 = "https://{domain}/rest/agile/1.0"
+
+    @classmethod
+    def projects_endpoint(cls, domain: str, email: str, api_token: str) -> "JiraRequestBuilder":
+        """Create a request builder for the /project/search endpoint."""
+        return cls("project/search", domain, email, api_token, api_version="v3")
+
+    @classmethod
+    def users_endpoint(cls, domain: str, email: str, api_token: str) -> "JiraRequestBuilder":
+        """Create a request builder for the /users/search endpoint."""
+        return cls("users/search", domain, email, api_token, api_version="v3")
+
+    @classmethod
+    def boards_endpoint(cls, domain: str, email: str, api_token: str) -> "JiraRequestBuilder":
+        """Create a request builder for the /board endpoint (agile API v1)."""
+        return cls("board", domain, email, api_token, api_version="v1")
+
+    @classmethod
+    def filters_endpoint(cls, domain: str, email: str, api_token: str) -> "JiraRequestBuilder":
+        """Create a request builder for the /filter/search endpoint."""
+        return cls("filter/search", domain, email, api_token, api_version="v3")
+
+    @classmethod
+    def issues_endpoint(cls, domain: str, email: str, api_token: str) -> "JiraRequestBuilder":
+        """Create a request builder for the /search/jql endpoint."""
+        return cls("search/jql", domain, email, api_token, api_version="v3")
+
+    @classmethod
+    def application_roles_endpoint(cls, domain: str, email: str, api_token: str) -> "JiraRequestBuilder":
+        """Create a request builder for the /applicationrole endpoint."""
+        return cls("applicationrole", domain, email, api_token, api_version="v3")
+
+    @classmethod
+    def dashboards_endpoint(cls, domain: str, email: str, api_token: str) -> "JiraRequestBuilder":
+        """Create a request builder for the /dashboard endpoint."""
+        return cls("dashboard", domain, email, api_token, api_version="v3")
+
+    @classmethod
+    def groups_endpoint(cls, domain: str, email: str, api_token: str) -> "JiraRequestBuilder":
+        """Create a request builder for the /group/bulk endpoint."""
+        return cls("group/bulk", domain, email, api_token, api_version="v3")
+
+    @classmethod
+    def issue_fields_endpoint(cls, domain: str, email: str, api_token: str) -> "JiraRequestBuilder":
+        """Create a request builder for the /field endpoint."""
+        return cls("field", domain, email, api_token, api_version="v3")
+
+    @classmethod
+    def issue_field_configurations_endpoint(cls, domain: str, email: str, api_token: str) -> "JiraRequestBuilder":
+        """Create a request builder for the /fieldconfiguration endpoint."""
+        return cls("fieldconfiguration", domain, email, api_token, api_version="v3")
+
+    @classmethod
+    def issue_link_types_endpoint(cls, domain: str, email: str, api_token: str) -> "JiraRequestBuilder":
+        """Create a request builder for the /issueLinkType endpoint."""
+        return cls("issueLinkType", domain, email, api_token, api_version="v3")
+
+    @classmethod
+    def issue_navigator_settings_endpoint(cls, domain: str, email: str, api_token: str) -> "JiraRequestBuilder":
+        """Create a request builder for the /settings/columns endpoint."""
+        return cls("settings/columns", domain, email, api_token, api_version="v3")
+
+    @classmethod
+    def issue_notification_schemes_endpoint(cls, domain: str, email: str, api_token: str) -> "JiraRequestBuilder":
+        """Create a request builder for the /notificationscheme endpoint."""
+        return cls("notificationscheme", domain, email, api_token, api_version="v3")
+
+    @classmethod
+    def issue_priorities_endpoint(cls, domain: str, email: str, api_token: str) -> "JiraRequestBuilder":
+        """Create a request builder for the /priority/search endpoint."""
+        return cls("priority/search", domain, email, api_token, api_version="v3")
+
+    @classmethod
+    def issue_resolutions_endpoint(cls, domain: str, email: str, api_token: str) -> "JiraRequestBuilder":
+        """Create a request builder for the /resolution/search endpoint."""
+        return cls("resolution/search", domain, email, api_token, api_version="v3")
+
+    @classmethod
+    def issue_security_schemes_endpoint(cls, domain: str, email: str, api_token: str) -> "JiraRequestBuilder":
+        """Create a request builder for the /issuesecurityschemes endpoint."""
+        return cls("issuesecurityschemes", domain, email, api_token, api_version="v3")
+
+    @classmethod
+    def issue_types_endpoint(cls, domain: str, email: str, api_token: str) -> "JiraRequestBuilder":
+        """Create a request builder for the /issuetype endpoint."""
+        return cls("issuetype", domain, email, api_token, api_version="v3")
+
+    @classmethod
+    def issue_type_schemes_endpoint(cls, domain: str, email: str, api_token: str) -> "JiraRequestBuilder":
+        """Create a request builder for the /issuetypescheme endpoint."""
+        return cls("issuetypescheme", domain, email, api_token, api_version="v3")
+
+    @classmethod
+    def issue_type_screen_schemes_endpoint(cls, domain: str, email: str, api_token: str) -> "JiraRequestBuilder":
+        """Create a request builder for the /issuetypescreenscheme endpoint."""
+        return cls("issuetypescreenscheme", domain, email, api_token, api_version="v3")
+
+    @classmethod
+    def jira_settings_endpoint(cls, domain: str, email: str, api_token: str) -> "JiraRequestBuilder":
+        """Create a request builder for the /application-properties endpoint."""
+        return cls("application-properties", domain, email, api_token, api_version="v3")
+
+    @classmethod
+    def labels_endpoint(cls, domain: str, email: str, api_token: str) -> "JiraRequestBuilder":
+        """Create a request builder for the /label endpoint."""
+        return cls("label", domain, email, api_token, api_version="v3")
+
+    @classmethod
+    def permissions_endpoint(cls, domain: str, email: str, api_token: str) -> "JiraRequestBuilder":
+        """Create a request builder for the /permissions endpoint."""
+        return cls("permissions", domain, email, api_token, api_version="v3")
+
+    @classmethod
+    def permission_schemes_endpoint(cls, domain: str, email: str, api_token: str) -> "JiraRequestBuilder":
+        """Create a request builder for the /permissionscheme endpoint."""
+        return cls("permissionscheme", domain, email, api_token, api_version="v3")
+
+    @classmethod
+    def project_categories_endpoint(cls, domain: str, email: str, api_token: str) -> "JiraRequestBuilder":
+        """Create a request builder for the /projectCategory endpoint."""
+        return cls("projectCategory", domain, email, api_token, api_version="v3")
+
+    @classmethod
+    def project_roles_endpoint(cls, domain: str, email: str, api_token: str) -> "JiraRequestBuilder":
+        """Create a request builder for the /role endpoint."""
+        return cls("role", domain, email, api_token, api_version="v3")
+
+    @classmethod
+    def project_types_endpoint(cls, domain: str, email: str, api_token: str) -> "JiraRequestBuilder":
+        """Create a request builder for the /project/type endpoint."""
+        return cls("project/type", domain, email, api_token, api_version="v3")
+
+    @classmethod
+    def screens_endpoint(cls, domain: str, email: str, api_token: str) -> "JiraRequestBuilder":
+        """Create a request builder for the /screens endpoint."""
+        return cls("screens", domain, email, api_token, api_version="v3")
+
+    @classmethod
+    def screen_schemes_endpoint(cls, domain: str, email: str, api_token: str) -> "JiraRequestBuilder":
+        """Create a request builder for the /screenscheme endpoint."""
+        return cls("screenscheme", domain, email, api_token, api_version="v3")
+
+    @classmethod
+    def time_tracking_endpoint(cls, domain: str, email: str, api_token: str) -> "JiraRequestBuilder":
+        """Create a request builder for the /configuration/timetracking/list endpoint."""
+        return cls("configuration/timetracking/list", domain, email, api_token, api_version="v3")
+
+    @classmethod
+    def workflows_endpoint(cls, domain: str, email: str, api_token: str) -> "JiraRequestBuilder":
+        """Create a request builder for the /workflow/search endpoint."""
+        return cls("workflow/search", domain, email, api_token, api_version="v3")
+
+    @classmethod
+    def workflow_schemes_endpoint(cls, domain: str, email: str, api_token: str) -> "JiraRequestBuilder":
+        """Create a request builder for the /workflowscheme endpoint."""
+        return cls("workflowscheme", domain, email, api_token, api_version="v3")
+
+    @classmethod
+    def workflow_statuses_endpoint(cls, domain: str, email: str, api_token: str) -> "JiraRequestBuilder":
+        """Create a request builder for the /status endpoint."""
+        return cls("status", domain, email, api_token, api_version="v3")
+
+    @classmethod
+    def workflow_status_categories_endpoint(cls, domain: str, email: str, api_token: str) -> "JiraRequestBuilder":
+        """Create a request builder for the /statuscategory endpoint."""
+        return cls("statuscategory", domain, email, api_token, api_version="v3")
+
+    @classmethod
+    def avatars_endpoint(cls, domain: str, email: str, api_token: str, avatar_type: str) -> "JiraRequestBuilder":
+        """Create a request builder for the /avatar/{type}/system endpoint."""
+        return cls(f"avatar/{avatar_type}/system", domain, email, api_token, api_version="v3")
+
+    @classmethod
+    def sprints_endpoint(cls, domain: str, email: str, api_token: str, board_id: int) -> "JiraRequestBuilder":
+        """Create a request builder for the /board/{boardId}/sprint endpoint (agile API v1)."""
+        return cls(f"board/{board_id}/sprint", domain, email, api_token, api_version="v1")
+
+    @classmethod
+    def board_issues_endpoint(cls, domain: str, email: str, api_token: str, board_id: int) -> "JiraRequestBuilder":
+        """Create a request builder for the /board/{boardId}/issue endpoint (agile API v1)."""
+        return cls(f"board/{board_id}/issue", domain, email, api_token, api_version="v1")
+
+    @classmethod
+    def sprint_issues_endpoint(cls, domain: str, email: str, api_token: str, sprint_id: int) -> "JiraRequestBuilder":
+        """Create a request builder for the /sprint/{sprintId}/issue endpoint (agile API v1)."""
+        return cls(f"sprint/{sprint_id}/issue", domain, email, api_token, api_version="v1")
+
+    @classmethod
+    def filter_sharing_endpoint(cls, domain: str, email: str, api_token: str, filter_id: int) -> "JiraRequestBuilder":
+        """Create a request builder for the /filter/{id}/permission endpoint."""
+        return cls(f"filter/{filter_id}/permission", domain, email, api_token, api_version="v3")
+
+    @classmethod
+    def issue_comments_endpoint(cls, domain: str, email: str, api_token: str, issue_id_or_key: str) -> "JiraRequestBuilder":
+        """Create a request builder for the /issue/{issueIdOrKey}/comment endpoint."""
+        return cls(f"issue/{issue_id_or_key}/comment", domain, email, api_token, api_version="v3")
+
+    @classmethod
+    def issue_worklogs_endpoint(cls, domain: str, email: str, api_token: str, issue_id_or_key: str) -> "JiraRequestBuilder":
+        """Create a request builder for the /issue/{issueIdOrKey}/worklog endpoint."""
+        return cls(f"issue/{issue_id_or_key}/worklog", domain, email, api_token, api_version="v3")
+
+    @classmethod
+    def issue_watchers_endpoint(cls, domain: str, email: str, api_token: str, issue_id_or_key: str) -> "JiraRequestBuilder":
+        """Create a request builder for the /issue/{issueIdOrKey}/watchers endpoint."""
+        return cls(f"issue/{issue_id_or_key}/watchers", domain, email, api_token, api_version="v3")
+
+    @classmethod
+    def issue_votes_endpoint(cls, domain: str, email: str, api_token: str, issue_id_or_key: str) -> "JiraRequestBuilder":
+        """Create a request builder for the /issue/{issueIdOrKey}/votes endpoint."""
+        return cls(f"issue/{issue_id_or_key}/votes", domain, email, api_token, api_version="v3")
+
+    @classmethod
+    def issue_remote_links_endpoint(cls, domain: str, email: str, api_token: str, issue_id_or_key: str) -> "JiraRequestBuilder":
+        """Create a request builder for the /issue/{issueIdOrKey}/remotelink endpoint."""
+        return cls(f"issue/{issue_id_or_key}/remotelink", domain, email, api_token, api_version="v3")
+
+    @classmethod
+    def issue_transitions_endpoint(cls, domain: str, email: str, api_token: str, issue_id_or_key: str) -> "JiraRequestBuilder":
+        """Create a request builder for the /issue/{issueIdOrKey}/transitions endpoint."""
+        return cls(f"issue/{issue_id_or_key}/transitions", domain, email, api_token, api_version="v3")
+
+    @classmethod
+    def issue_properties_endpoint(cls, domain: str, email: str, api_token: str, issue_id_or_key: str) -> "JiraRequestBuilder":
+        """Create a request builder for the /issue/{issueIdOrKey}/properties endpoint."""
+        return cls(f"issue/{issue_id_or_key}/properties", domain, email, api_token, api_version="v3")
+
+    @classmethod
+    def issue_changelogs_endpoint(cls, domain: str, email: str, api_token: str, issue_id_or_key: str) -> "JiraRequestBuilder":
+        """Create a request builder for the /issue/{issueIdOrKey}/changelog endpoint."""
+        return cls(f"issue/{issue_id_or_key}/changelog", domain, email, api_token, api_version="v3")
+
+    @classmethod
+    def project_components_endpoint(cls, domain: str, email: str, api_token: str, project_id_or_key: str) -> "JiraRequestBuilder":
+        """Create a request builder for the /project/{projectIdOrKey}/component endpoint."""
+        return cls(f"project/{project_id_or_key}/component", domain, email, api_token, api_version="v3")
+
+    @classmethod
+    def project_email_endpoint(cls, domain: str, email: str, api_token: str, project_id: str) -> "JiraRequestBuilder":
+        """Create a request builder for the /project/{projectId}/email endpoint."""
+        return cls(f"project/{project_id}/email", domain, email, api_token, api_version="v3")
+
+    @classmethod
+    def project_permission_schemes_endpoint(cls, domain: str, email: str, api_token: str, project_id_or_key: str) -> "JiraRequestBuilder":
+        """Create a request builder for the /project/{projectKeyOrId}/securitylevel endpoint."""
+        return cls(f"project/{project_id_or_key}/securitylevel", domain, email, api_token, api_version="v3")
+
+    @classmethod
+    def project_versions_endpoint(cls, domain: str, email: str, api_token: str, project_id_or_key: str) -> "JiraRequestBuilder":
+        """Create a request builder for the /project/{projectIdOrKey}/version endpoint."""
+        return cls(f"project/{project_id_or_key}/version", domain, email, api_token, api_version="v3")
+
+    @classmethod
+    def project_avatars_endpoint(cls, domain: str, email: str, api_token: str, project_id_or_key: str) -> "JiraRequestBuilder":
+        """Create a request builder for the /project/{projectIdOrKey}/avatars endpoint."""
+        return cls(f"project/{project_id_or_key}/avatars", domain, email, api_token, api_version="v3")
+
+    @classmethod
+    def screen_tabs_endpoint(cls, domain: str, email: str, api_token: str, screen_id: int) -> "JiraRequestBuilder":
+        """Create a request builder for the /screens/{screenId}/tabs endpoint."""
+        return cls(f"screens/{screen_id}/tabs", domain, email, api_token, api_version="v3")
+
+    @classmethod
+    def screen_tab_fields_endpoint(cls, domain: str, email: str, api_token: str, screen_id: int, tab_id: int) -> "JiraRequestBuilder":
+        """Create a request builder for the /screens/{screenId}/tabs/{tabId}/fields endpoint."""
+        return cls(f"screens/{screen_id}/tabs/{tab_id}/fields", domain, email, api_token, api_version="v3")
+
+    @classmethod
+    def issue_custom_field_contexts_endpoint(cls, domain: str, email: str, api_token: str, field_id: str) -> "JiraRequestBuilder":
+        """Create a request builder for the /field/{fieldId}/context endpoint."""
+        return cls(f"field/{field_id}/context", domain, email, api_token, api_version="v3")
+
+    @classmethod
+    def issue_custom_field_options_endpoint(
+        cls, domain: str, email: str, api_token: str, field_id: str, context_id: int
+    ) -> "JiraRequestBuilder":
+        """Create a request builder for the /field/{fieldId}/context/{contextId}/option endpoint."""
+        return cls(f"field/{field_id}/context/{context_id}/option", domain, email, api_token, api_version="v3")
+
+    @classmethod
+    def users_groups_detailed_endpoint(cls, domain: str, email: str, api_token: str, account_id: str) -> "JiraRequestBuilder":
+        """Create a request builder for the /user/groups endpoint."""
+        builder = cls("user/groups", domain, email, api_token, api_version="v3")
+        builder._query_params["accountId"] = account_id
+        return builder
+
+    def __init__(self, resource: str, domain: str, email: str, api_token: str, api_version: str = "v3"):
+        """
+        Initialize the request builder.
+
+        Args:
+            resource: The API resource path (e.g., 'project/search', 'board')
+            domain: The Jira domain (e.g., 'domain.atlassian.net')
+            email: The email for authentication
+            api_token: The API token for authentication
+            api_version: API version ('v3' for REST API, 'v1' for Agile API)
+        """
+        self._resource = resource
+        self._domain = domain
+        self._email = email
+        self._api_token = api_token
+        self._api_version = api_version
+        self._max_results: Optional[int] = None
+        self._start_at: Optional[int] = None
+        self._query_params: dict = {}
+        self._any_query_params = False
+
+    def with_max_results(self, max_results: int) -> "JiraRequestBuilder":
+        """Set the maxResults query parameter for pagination."""
+        self._max_results = max_results
+        return self
+
+    def with_start_at(self, start_at: int) -> "JiraRequestBuilder":
+        """Set the startAt query parameter for pagination."""
+        self._start_at = start_at
+        return self
+
+    def with_query_param(self, key: str, value: str) -> "JiraRequestBuilder":
+        """Add a custom query parameter."""
+        self._query_params[key] = value
+        return self
+
+    def with_any_query_params(self) -> "JiraRequestBuilder":
+        """Allow any query parameters (useful for dynamic/unpredictable params)."""
+        self._any_query_params = True
+        return self
+
+    def with_expand(self, expand: str) -> "JiraRequestBuilder":
+        """Set the expand query parameter."""
+        self._query_params["expand"] = expand
+        return self
+
+    def with_jql(self, jql: str) -> "JiraRequestBuilder":
+        """Set the jql query parameter for issue searches."""
+        self._query_params["jql"] = jql
+        return self
+
+    def with_fields(self, fields: str) -> "JiraRequestBuilder":
+        """Set the fields query parameter for issue searches."""
+        self._query_params["fields"] = fields
+        return self
+
+    def _get_base_url(self) -> str:
+        """Get the base URL based on API version."""
+        if self._api_version == "v1":
+            return self.BASE_URL_V1.format(domain=self._domain)
+        return self.BASE_URL_V3.format(domain=self._domain)
+
+    def _get_auth_header(self) -> str:
+        """Generate the Basic auth header value."""
+        credentials = f"{self._email}:{self._api_token}"
+        encoded = base64.b64encode(credentials.encode()).decode()
+        return f"Basic {encoded}"
+
+    def build(self) -> HttpRequest:
+        """
+        Build and return the HttpRequest object.
+
+        Returns:
+            HttpRequest configured with the URL, query params, and headers
+        """
+        if self._any_query_params:
+            return HttpRequest(
+                url=f"{self._get_base_url()}/{self._resource}",
+                headers={"Authorization": self._get_auth_header()},
+            )
+
+        query_params = dict(self._query_params)
+
+        if self._max_results is not None:
+            query_params["maxResults"] = str(self._max_results)
+        if self._start_at is not None:
+            query_params["startAt"] = str(self._start_at)
+
+        return HttpRequest(
+            url=f"{self._get_base_url()}/{self._resource}",
+            query_params=query_params if query_params else None,
+            headers={"Authorization": self._get_auth_header()},
+        )

--- a/airbyte-integrations/connectors/source-jira/unit_tests/integration/response_builder.py
+++ b/airbyte-integrations/connectors/source-jira/unit_tests/integration/response_builder.py
@@ -1,0 +1,404 @@
+# Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+
+import json
+from typing import Any, Dict, List, Optional
+
+from airbyte_cdk.test.mock_http import HttpResponse
+
+
+class JiraPaginatedResponseBuilder:
+    """
+    Builder for creating paginated Jira API responses.
+
+    This builder simplifies creating mock responses for pagination tests by handling
+    the boilerplate JSON structure that Jira API returns.
+
+    Jira uses offset-based pagination with:
+    - startAt: The starting index of the returned items
+    - maxResults: The maximum number of items per page
+    - total: Total number of items available
+    - isLast: Boolean indicating if this is the last page
+
+    Example usage:
+        response = (
+            JiraPaginatedResponseBuilder("values")
+            .with_records([project1, project2])
+            .with_pagination(start_at=0, max_results=50, total=100)
+            .build()
+        )
+    """
+
+    def __init__(self, record_field: str = "values"):
+        """
+        Initialize the response builder.
+
+        Args:
+            record_field: The field name containing the records (e.g., "values", "issues")
+        """
+        self.record_field = record_field
+        self.records: List[Dict[str, Any]] = []
+        self.start_at = 0
+        self.max_results = 50
+        self.total: Optional[int] = None
+        self.is_last: Optional[bool] = None
+        self._extra_fields: Dict[str, Any] = {}
+
+    def with_records(self, records: List[Dict[str, Any]]) -> "JiraPaginatedResponseBuilder":
+        """
+        Add records to the response.
+
+        Args:
+            records: List of record dictionaries to include in the response
+
+        Returns:
+            Self for method chaining
+        """
+        self.records = records
+        return self
+
+    def with_pagination(
+        self,
+        start_at: int = 0,
+        max_results: int = 50,
+        total: Optional[int] = None,
+        is_last: Optional[bool] = None,
+    ) -> "JiraPaginatedResponseBuilder":
+        """
+        Set pagination metadata.
+
+        Args:
+            start_at: Starting index of returned items
+            max_results: Maximum items per page
+            total: Total number of items available (defaults to len(records) if not set)
+            is_last: Whether this is the last page (calculated if not set)
+
+        Returns:
+            Self for method chaining
+        """
+        self.start_at = start_at
+        self.max_results = max_results
+        self.total = total
+        self.is_last = is_last
+        return self
+
+    def with_extra_field(self, key: str, value: Any) -> "JiraPaginatedResponseBuilder":
+        """
+        Add an extra field to the response body.
+
+        Args:
+            key: Field name
+            value: Field value
+
+        Returns:
+            Self for method chaining
+        """
+        self._extra_fields[key] = value
+        return self
+
+    def build(self) -> HttpResponse:
+        """
+        Build the HTTP response with paginated data.
+
+        Returns:
+            HttpResponse object with the paginated response body
+        """
+        total = self.total if self.total is not None else len(self.records)
+
+        if self.is_last is not None:
+            is_last = self.is_last
+        else:
+            is_last = (self.start_at + self.max_results) >= total
+
+        response_body = {
+            self.record_field: self.records,
+            "startAt": self.start_at,
+            "maxResults": self.max_results,
+            "total": total,
+            "isLast": is_last,
+        }
+
+        response_body.update(self._extra_fields)
+
+        return HttpResponse(body=json.dumps(response_body), status_code=200)
+
+    @classmethod
+    def single_page(
+        cls,
+        record_field: str,
+        records: List[Dict[str, Any]],
+        max_results: int = 50,
+    ) -> HttpResponse:
+        """
+        Convenience method to create a single-page response.
+
+        Args:
+            record_field: The field name containing the records
+            records: List of records to include
+            max_results: Maximum items per page
+
+        Returns:
+            HttpResponse for a single page with isLast=True
+        """
+        return (
+            cls(record_field)
+            .with_records(records)
+            .with_pagination(start_at=0, max_results=max_results, total=len(records), is_last=True)
+            .build()
+        )
+
+    @classmethod
+    def empty_page(cls, record_field: str = "values", max_results: int = 50) -> HttpResponse:
+        """
+        Convenience method to create an empty response.
+
+        Args:
+            record_field: The field name containing the records
+            max_results: Maximum items per page
+
+        Returns:
+            HttpResponse for an empty result set
+        """
+        return (
+            cls(record_field)
+            .with_records([])
+            .with_pagination(start_at=0, max_results=max_results, total=0, is_last=True)
+            .build()
+        )
+
+
+class JiraJqlPaginatedResponseBuilder:
+    """
+    Builder for creating paginated Jira JQL search responses.
+
+    JQL search uses token-based pagination with:
+    - nextPageToken: Token for the next page (null if last page)
+    - isLast: Boolean indicating if this is the last page
+
+    Example usage:
+        response = (
+            JiraJqlPaginatedResponseBuilder()
+            .with_records([issue1, issue2])
+            .with_next_page_token("next_token_123")
+            .build()
+        )
+    """
+
+    def __init__(self, record_field: str = "issues"):
+        """
+        Initialize the response builder.
+
+        Args:
+            record_field: The field name containing the records (default: "issues")
+        """
+        self.record_field = record_field
+        self.records: List[Dict[str, Any]] = []
+        self.next_page_token: Optional[str] = None
+        self.is_last: Optional[bool] = None
+        self._extra_fields: Dict[str, Any] = {}
+
+    def with_records(self, records: List[Dict[str, Any]]) -> "JiraJqlPaginatedResponseBuilder":
+        """
+        Add records to the response.
+
+        Args:
+            records: List of record dictionaries to include in the response
+
+        Returns:
+            Self for method chaining
+        """
+        self.records = records
+        return self
+
+    def with_next_page_token(self, token: Optional[str]) -> "JiraJqlPaginatedResponseBuilder":
+        """
+        Set the next page token.
+
+        Args:
+            token: Token for the next page, or None if this is the last page
+
+        Returns:
+            Self for method chaining
+        """
+        self.next_page_token = token
+        return self
+
+    def with_is_last(self, is_last: bool) -> "JiraJqlPaginatedResponseBuilder":
+        """
+        Set whether this is the last page.
+
+        Args:
+            is_last: True if this is the last page
+
+        Returns:
+            Self for method chaining
+        """
+        self.is_last = is_last
+        return self
+
+    def with_extra_field(self, key: str, value: Any) -> "JiraJqlPaginatedResponseBuilder":
+        """
+        Add an extra field to the response body.
+
+        Args:
+            key: Field name
+            value: Field value
+
+        Returns:
+            Self for method chaining
+        """
+        self._extra_fields[key] = value
+        return self
+
+    def build(self) -> HttpResponse:
+        """
+        Build the HTTP response with paginated data.
+
+        Returns:
+            HttpResponse object with the paginated response body
+        """
+        is_last = self.is_last if self.is_last is not None else (self.next_page_token is None)
+
+        response_body = {
+            self.record_field: self.records,
+            "isLast": is_last,
+        }
+
+        if self.next_page_token is not None:
+            response_body["nextPageToken"] = self.next_page_token
+
+        response_body.update(self._extra_fields)
+
+        return HttpResponse(body=json.dumps(response_body), status_code=200)
+
+    @classmethod
+    def single_page(cls, records: List[Dict[str, Any]], record_field: str = "issues") -> HttpResponse:
+        """
+        Convenience method to create a single-page response.
+
+        Args:
+            records: List of records to include
+            record_field: The field name containing the records
+
+        Returns:
+            HttpResponse for a single page with no next token
+        """
+        return cls(record_field).with_records(records).with_is_last(True).build()
+
+    @classmethod
+    def empty_page(cls, record_field: str = "issues") -> HttpResponse:
+        """
+        Convenience method to create an empty response.
+
+        Args:
+            record_field: The field name containing the records
+
+        Returns:
+            HttpResponse for an empty result set
+        """
+        return cls(record_field).with_records([]).with_is_last(True).build()
+
+
+class JiraListResponseBuilder:
+    """
+    Builder for creating non-paginated Jira API list responses.
+
+    Some Jira endpoints return a simple list without pagination metadata.
+
+    Example usage:
+        response = JiraListResponseBuilder.build([role1, role2])
+    """
+
+    @classmethod
+    def build(cls, records: List[Dict[str, Any]], status_code: int = 200) -> HttpResponse:
+        """
+        Build a simple list response.
+
+        Args:
+            records: List of records to include
+            status_code: HTTP status code
+
+        Returns:
+            HttpResponse with the list as the body
+        """
+        return HttpResponse(body=json.dumps(records), status_code=status_code)
+
+    @classmethod
+    def empty(cls) -> HttpResponse:
+        """
+        Build an empty list response.
+
+        Returns:
+            HttpResponse with an empty list
+        """
+        return HttpResponse(body=json.dumps([]), status_code=200)
+
+
+class JiraObjectResponseBuilder:
+    """
+    Builder for creating single object Jira API responses.
+
+    Some Jira endpoints return a single object (e.g., permissions, settings).
+
+    Example usage:
+        response = JiraObjectResponseBuilder.build({"permissions": {...}})
+    """
+
+    @classmethod
+    def build(cls, obj: Dict[str, Any], status_code: int = 200) -> HttpResponse:
+        """
+        Build a single object response.
+
+        Args:
+            obj: The object to return
+            status_code: HTTP status code
+
+        Returns:
+            HttpResponse with the object as the body
+        """
+        return HttpResponse(body=json.dumps(obj), status_code=status_code)
+
+
+class JiraErrorResponseBuilder:
+    """
+    Builder for creating Jira API error responses.
+
+    Example usage:
+        response = JiraErrorResponseBuilder.build(404, ["Issue not found"])
+    """
+
+    @classmethod
+    def build(cls, status_code: int, error_messages: List[str]) -> HttpResponse:
+        """
+        Build an error response.
+
+        Args:
+            status_code: HTTP status code
+            error_messages: List of error messages
+
+        Returns:
+            HttpResponse with error body
+        """
+        return HttpResponse(
+            body=json.dumps({"errorMessages": error_messages}),
+            status_code=status_code,
+        )
+
+    @classmethod
+    def not_found(cls, message: str = "Not found") -> HttpResponse:
+        """Build a 404 Not Found response."""
+        return cls.build(404, [message])
+
+    @classmethod
+    def forbidden(cls, message: str = "Forbidden") -> HttpResponse:
+        """Build a 403 Forbidden response."""
+        return cls.build(403, [message])
+
+    @classmethod
+    def unauthorized(cls, message: str = "Unauthorized") -> HttpResponse:
+        """Build a 401 Unauthorized response."""
+        return cls.build(401, [message])
+
+    @classmethod
+    def bad_request(cls, message: str = "Bad request") -> HttpResponse:
+        """Build a 400 Bad Request response."""
+        return cls.build(400, [message])

--- a/airbyte-integrations/connectors/source-jira/unit_tests/integration/test_boards.py
+++ b/airbyte-integrations/connectors/source-jira/unit_tests/integration/test_boards.py
@@ -1,0 +1,201 @@
+# Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+
+from datetime import datetime, timezone
+from unittest import TestCase
+
+import freezegun
+from conftest import get_source
+
+from airbyte_cdk.models import SyncMode
+from airbyte_cdk.test.catalog_builder import CatalogBuilder
+from airbyte_cdk.test.entrypoint_wrapper import read
+from airbyte_cdk.test.mock_http import HttpMocker
+from integration.config import ConfigBuilder
+from integration.request_builder import JiraRequestBuilder
+from integration.response_builder import JiraPaginatedResponseBuilder
+
+
+_NOW = datetime.now(timezone.utc)
+_STREAM_NAME = "boards"
+_DOMAIN = "test.atlassian.net"
+_EMAIL = "test@example.com"
+_API_TOKEN = "test_api_token"
+
+
+@freezegun.freeze_time(_NOW.isoformat())
+class TestBoardsStream(TestCase):
+    """
+    Tests for the Jira 'boards' stream.
+
+    The boards stream uses the Agile API (v1) and returns boards with pagination.
+    It also applies a record_filter based on the projects config.
+    """
+
+    @HttpMocker()
+    def test_full_refresh_single_page(self, http_mocker: HttpMocker):
+        """
+        Test that connector correctly fetches one page of boards.
+
+        Given: A configured Jira connector
+        When: Running a full refresh sync for the boards stream
+        Then: The connector should make the correct API request and return all records
+        """
+        config = ConfigBuilder().with_domain(_DOMAIN).with_email(_EMAIL).with_api_token(_API_TOKEN).build()
+
+        http_mocker.get(
+            JiraRequestBuilder.boards_endpoint(_DOMAIN, _EMAIL, _API_TOKEN)
+            .with_any_query_params()
+            .build(),
+            JiraPaginatedResponseBuilder("values")
+            .with_records(
+                [
+                    {
+                        "id": 1,
+                        "name": "Scrum Board",
+                        "type": "scrum",
+                        "location": {
+                            "projectId": 10001,
+                            "projectKey": "PROJ1",
+                            "displayName": "Project One",
+                        },
+                    },
+                    {
+                        "id": 2,
+                        "name": "Kanban Board",
+                        "type": "kanban",
+                        "location": {
+                            "projectId": 10002,
+                            "projectKey": "PROJ2",
+                            "displayName": "Project Two",
+                        },
+                    },
+                ]
+            )
+            .with_pagination(start_at=0, max_results=50, total=2, is_last=True)
+            .build(),
+        )
+
+        source = get_source(config=config)
+        catalog = CatalogBuilder().with_stream(_STREAM_NAME, SyncMode.full_refresh).build()
+        output = read(source, config=config, catalog=catalog)
+
+        assert len(output.records) == 2
+        assert output.records[0].record.data["id"] == 1
+        assert output.records[0].record.data["name"] == "Scrum Board"
+        # Verify transformation adds projectId and projectKey fields
+        assert output.records[0].record.data["projectId"] == "10001"
+        assert output.records[0].record.data["projectKey"] == "PROJ1"
+        assert output.records[1].record.data["id"] == 2
+        assert output.records[1].record.data["name"] == "Kanban Board"
+
+    @HttpMocker()
+    def test_pagination_multiple_pages(self, http_mocker: HttpMocker):
+        """
+        Test that connector fetches all pages when pagination is present.
+
+        Given: An API that returns multiple pages of boards
+        When: Running a full refresh sync
+        Then: The connector should follow pagination and return all records
+        """
+        config = ConfigBuilder().with_domain(_DOMAIN).with_email(_EMAIL).with_api_token(_API_TOKEN).build()
+
+        # Use a list of responses to simulate pagination - responses are returned in order
+        http_mocker.get(
+            JiraRequestBuilder.boards_endpoint(_DOMAIN, _EMAIL, _API_TOKEN)
+            .with_any_query_params()
+            .build(),
+            [
+                JiraPaginatedResponseBuilder("values")
+                .with_records(
+                    [
+                        {"id": 1, "name": "Board 1", "type": "scrum", "location": {"projectId": 10001, "projectKey": "PROJ1"}},
+                        {"id": 2, "name": "Board 2", "type": "kanban", "location": {"projectId": 10002, "projectKey": "PROJ2"}},
+                    ]
+                )
+                .with_pagination(start_at=0, max_results=2, total=3, is_last=False)
+                .build(),
+                JiraPaginatedResponseBuilder("values")
+                .with_records([{"id": 3, "name": "Board 3", "type": "scrum", "location": {"projectId": 10003, "projectKey": "PROJ3"}}])
+                .with_pagination(start_at=2, max_results=2, total=3, is_last=True)
+                .build(),
+            ],
+        )
+
+        source = get_source(config=config)
+        catalog = CatalogBuilder().with_stream(_STREAM_NAME, SyncMode.full_refresh).build()
+        output = read(source, config=config, catalog=catalog)
+
+        assert len(output.records) == 3
+        assert output.records[0].record.data["id"] == 1
+        assert output.records[1].record.data["id"] == 2
+        assert output.records[2].record.data["id"] == 3
+
+    @HttpMocker()
+    def test_empty_results(self, http_mocker: HttpMocker):
+        """
+        Test that connector handles empty results gracefully.
+
+        Given: An API that returns no boards
+        When: Running a full refresh sync
+        Then: The connector should return zero records without errors
+        """
+        config = ConfigBuilder().with_domain(_DOMAIN).with_email(_EMAIL).with_api_token(_API_TOKEN).build()
+
+        http_mocker.get(
+            JiraRequestBuilder.boards_endpoint(_DOMAIN, _EMAIL, _API_TOKEN)
+            .with_any_query_params()
+            .build(),
+            JiraPaginatedResponseBuilder.empty_page("values"),
+        )
+
+        source = get_source(config=config)
+        catalog = CatalogBuilder().with_stream(_STREAM_NAME, SyncMode.full_refresh).build()
+        output = read(source, config=config, catalog=catalog)
+
+        assert len(output.records) == 0
+        assert not any(log.log.level == "ERROR" for log in output.logs)
+
+    @HttpMocker()
+    def test_project_filter(self, http_mocker: HttpMocker):
+        """
+        Test that connector filters boards based on projects config.
+
+        The boards stream has a record_filter that only includes boards
+        whose projectKey is in the config['projects'] list.
+
+        Given: A connector configured with specific projects
+        When: Running a full refresh sync
+        Then: Only boards matching the project filter should be returned
+        """
+        config = (
+            ConfigBuilder()
+            .with_domain(_DOMAIN)
+            .with_email(_EMAIL)
+            .with_api_token(_API_TOKEN)
+            .with_projects(["PROJ1"])  # Only include PROJ1
+            .build()
+        )
+
+        http_mocker.get(
+            JiraRequestBuilder.boards_endpoint(_DOMAIN, _EMAIL, _API_TOKEN)
+            .with_any_query_params()
+            .build(),
+            JiraPaginatedResponseBuilder("values")
+            .with_records(
+                [
+                    {"id": 1, "name": "Board 1", "type": "scrum", "location": {"projectId": 10001, "projectKey": "PROJ1"}},
+                    {"id": 2, "name": "Board 2", "type": "kanban", "location": {"projectId": 10002, "projectKey": "PROJ2"}},
+                    {"id": 3, "name": "Board 3", "type": "scrum", "location": {"projectId": 10001, "projectKey": "PROJ1"}},
+                ]
+            )
+            .with_pagination(start_at=0, max_results=50, total=3, is_last=True)
+            .build(),
+        )
+
+        source = get_source(config=config)
+        catalog = CatalogBuilder().with_stream(_STREAM_NAME, SyncMode.full_refresh).build()
+        output = read(source, config=config, catalog=catalog)
+
+        # Only boards with projectKey "PROJ1" should be returned
+        assert len(output.records) == 2
+        assert all(record.record.data["projectKey"] == "PROJ1" for record in output.records)

--- a/airbyte-integrations/connectors/source-jira/unit_tests/integration/test_filters.py
+++ b/airbyte-integrations/connectors/source-jira/unit_tests/integration/test_filters.py
@@ -1,0 +1,149 @@
+# Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+
+from datetime import datetime, timezone
+from unittest import TestCase
+
+import freezegun
+from conftest import get_source
+
+from airbyte_cdk.models import SyncMode
+from airbyte_cdk.test.catalog_builder import CatalogBuilder
+from airbyte_cdk.test.entrypoint_wrapper import read
+from airbyte_cdk.test.mock_http import HttpMocker
+from integration.config import ConfigBuilder
+from integration.request_builder import JiraRequestBuilder
+from integration.response_builder import JiraPaginatedResponseBuilder
+
+
+_NOW = datetime.now(timezone.utc)
+_STREAM_NAME = "filters"
+_DOMAIN = "test.atlassian.net"
+_EMAIL = "test@example.com"
+_API_TOKEN = "test_api_token"
+
+
+@freezegun.freeze_time(_NOW.isoformat())
+class TestFiltersStream(TestCase):
+    """
+    Tests for the Jira 'filters' stream.
+
+    The filters stream returns saved filters with pagination.
+    It uses the expand parameter to include additional filter details.
+    """
+
+    @HttpMocker()
+    def test_full_refresh_single_page(self, http_mocker: HttpMocker):
+        """
+        Test that connector correctly fetches one page of filters.
+
+        Given: A configured Jira connector
+        When: Running a full refresh sync for the filters stream
+        Then: The connector should make the correct API request and return all records
+        """
+        config = ConfigBuilder().with_domain(_DOMAIN).with_email(_EMAIL).with_api_token(_API_TOKEN).build()
+
+        http_mocker.get(
+            JiraRequestBuilder.filters_endpoint(_DOMAIN, _EMAIL, _API_TOKEN)
+            .with_any_query_params()
+            .build(),
+            JiraPaginatedResponseBuilder("values")
+            .with_records(
+                [
+                    {
+                        "id": "10001",
+                        "name": "My Open Issues",
+                        "description": "All open issues assigned to me",
+                        "jql": "assignee = currentUser() AND resolution = Unresolved",
+                        "favourite": True,
+                        "favouritedCount": 5,
+                    },
+                    {
+                        "id": "10002",
+                        "name": "Sprint Backlog",
+                        "description": "Issues in the current sprint",
+                        "jql": "sprint in openSprints()",
+                        "favourite": False,
+                        "favouritedCount": 10,
+                    },
+                ]
+            )
+            .with_pagination(start_at=0, max_results=50, total=2, is_last=True)
+            .build(),
+        )
+
+        source = get_source(config=config)
+        catalog = CatalogBuilder().with_stream(_STREAM_NAME, SyncMode.full_refresh).build()
+        output = read(source, config=config, catalog=catalog)
+
+        assert len(output.records) == 2
+        assert output.records[0].record.data["id"] == "10001"
+        assert output.records[0].record.data["name"] == "My Open Issues"
+        assert output.records[1].record.data["id"] == "10002"
+        assert output.records[1].record.data["name"] == "Sprint Backlog"
+
+    @HttpMocker()
+    def test_pagination_multiple_pages(self, http_mocker: HttpMocker):
+        """
+        Test that connector fetches all pages when pagination is present.
+
+        Given: An API that returns multiple pages of filters
+        When: Running a full refresh sync
+        Then: The connector should follow pagination and return all records
+        """
+        config = ConfigBuilder().with_domain(_DOMAIN).with_email(_EMAIL).with_api_token(_API_TOKEN).build()
+
+        # Use a list of responses to simulate pagination - responses are returned in order
+        http_mocker.get(
+            JiraRequestBuilder.filters_endpoint(_DOMAIN, _EMAIL, _API_TOKEN)
+            .with_any_query_params()
+            .build(),
+            [
+                JiraPaginatedResponseBuilder("values")
+                .with_records(
+                    [
+                        {"id": "10001", "name": "Filter 1", "jql": "project = PROJ1"},
+                        {"id": "10002", "name": "Filter 2", "jql": "project = PROJ2"},
+                    ]
+                )
+                .with_pagination(start_at=0, max_results=2, total=3, is_last=False)
+                .build(),
+                JiraPaginatedResponseBuilder("values")
+                .with_records([{"id": "10003", "name": "Filter 3", "jql": "project = PROJ3"}])
+                .with_pagination(start_at=2, max_results=2, total=3, is_last=True)
+                .build(),
+            ],
+        )
+
+        source = get_source(config=config)
+        catalog = CatalogBuilder().with_stream(_STREAM_NAME, SyncMode.full_refresh).build()
+        output = read(source, config=config, catalog=catalog)
+
+        assert len(output.records) == 3
+        assert output.records[0].record.data["id"] == "10001"
+        assert output.records[1].record.data["id"] == "10002"
+        assert output.records[2].record.data["id"] == "10003"
+
+    @HttpMocker()
+    def test_empty_results(self, http_mocker: HttpMocker):
+        """
+        Test that connector handles empty results gracefully.
+
+        Given: An API that returns no filters
+        When: Running a full refresh sync
+        Then: The connector should return zero records without errors
+        """
+        config = ConfigBuilder().with_domain(_DOMAIN).with_email(_EMAIL).with_api_token(_API_TOKEN).build()
+
+        http_mocker.get(
+            JiraRequestBuilder.filters_endpoint(_DOMAIN, _EMAIL, _API_TOKEN)
+            .with_any_query_params()
+            .build(),
+            JiraPaginatedResponseBuilder.empty_page("values"),
+        )
+
+        source = get_source(config=config)
+        catalog = CatalogBuilder().with_stream(_STREAM_NAME, SyncMode.full_refresh).build()
+        output = read(source, config=config, catalog=catalog)
+
+        assert len(output.records) == 0
+        assert not any(log.log.level == "ERROR" for log in output.logs)

--- a/airbyte-integrations/connectors/source-jira/unit_tests/integration/test_projects.py
+++ b/airbyte-integrations/connectors/source-jira/unit_tests/integration/test_projects.py
@@ -1,0 +1,192 @@
+# Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+
+import json
+from datetime import datetime, timezone
+from unittest import TestCase
+
+import freezegun
+from conftest import get_source
+
+from airbyte_cdk.models import SyncMode
+from airbyte_cdk.test.catalog_builder import CatalogBuilder
+from airbyte_cdk.test.entrypoint_wrapper import read
+from airbyte_cdk.test.mock_http import HttpMocker, HttpResponse
+from integration.config import ConfigBuilder
+from integration.request_builder import JiraRequestBuilder
+from integration.response_builder import JiraErrorResponseBuilder, JiraPaginatedResponseBuilder
+
+
+_NOW = datetime.now(timezone.utc)
+_STREAM_NAME = "projects"
+_DOMAIN = "test.atlassian.net"
+_EMAIL = "test@example.com"
+_API_TOKEN = "test_api_token"
+
+
+@freezegun.freeze_time(_NOW.isoformat())
+class TestProjectsStream(TestCase):
+    """
+    Tests for the Jira 'projects' stream.
+
+    These tests verify:
+    - Full refresh sync works correctly
+    - Pagination is handled properly (offset-based with startAt/maxResults)
+    - Error handling for various HTTP status codes
+    """
+
+    @HttpMocker()
+    def test_full_refresh_single_page(self, http_mocker: HttpMocker):
+        """
+        Test that connector correctly fetches one page of projects.
+
+        Given: A configured Jira connector
+        When: Running a full refresh sync for the projects stream
+        Then: The connector should make the correct API request and return all records
+        """
+        config = ConfigBuilder().with_domain(_DOMAIN).with_email(_EMAIL).with_api_token(_API_TOKEN).build()
+
+        http_mocker.get(
+            JiraRequestBuilder.projects_endpoint(_DOMAIN, _EMAIL, _API_TOKEN)
+            .with_any_query_params()
+            .build(),
+            JiraPaginatedResponseBuilder("values")
+            .with_records(
+                [
+                    {
+                        "id": "10001",
+                        "key": "PROJ1",
+                        "name": "Project One",
+                        "projectTypeKey": "software",
+                        "simplified": False,
+                        "style": "classic",
+                        "isPrivate": False,
+                    },
+                    {
+                        "id": "10002",
+                        "key": "PROJ2",
+                        "name": "Project Two",
+                        "projectTypeKey": "business",
+                        "simplified": True,
+                        "style": "next-gen",
+                        "isPrivate": True,
+                    },
+                ]
+            )
+            .with_pagination(start_at=0, max_results=50, total=2, is_last=True)
+            .build(),
+        )
+
+        source = get_source(config=config)
+        catalog = CatalogBuilder().with_stream(_STREAM_NAME, SyncMode.full_refresh).build()
+        output = read(source, config=config, catalog=catalog)
+
+        assert len(output.records) == 2
+        assert output.records[0].record.data["id"] == "10001"
+        assert output.records[0].record.data["key"] == "PROJ1"
+        assert output.records[1].record.data["id"] == "10002"
+        assert output.records[1].record.data["key"] == "PROJ2"
+
+    @HttpMocker()
+    def test_pagination_multiple_pages(self, http_mocker: HttpMocker):
+        """
+        Test that connector fetches all pages when pagination is present.
+
+        NOTE: This test validates pagination for the 'projects' stream. Many Jira streams
+        use the same DefaultPaginator configuration with startAt/maxResults, so this provides
+        pagination coverage for multiple streams.
+
+        Given: An API that returns multiple pages of projects
+        When: Running a full refresh sync
+        Then: The connector should follow pagination and return all records
+
+        The Jira paginator stop_condition is:
+        {{ response.get('isLast') or response.get('startAt') + response.get('maxResults') >= response.get('total') }}
+
+        So we need to ensure startAt + maxResults < total for the first page to trigger pagination.
+        """
+        config = ConfigBuilder().with_domain(_DOMAIN).with_email(_EMAIL).with_api_token(_API_TOKEN).build()
+
+        # Use a list of responses to simulate pagination - responses are returned in order
+        # Note: maxResults=2 and total=3 ensures startAt(0) + maxResults(2) < total(3) for first page
+        http_mocker.get(
+            JiraRequestBuilder.projects_endpoint(_DOMAIN, _EMAIL, _API_TOKEN)
+            .with_any_query_params()
+            .build(),
+            [
+                JiraPaginatedResponseBuilder("values")
+                .with_records(
+                    [
+                        {"id": "10001", "key": "PROJ1", "name": "Project One"},
+                        {"id": "10002", "key": "PROJ2", "name": "Project Two"},
+                    ]
+                )
+                .with_pagination(start_at=0, max_results=2, total=3, is_last=False)
+                .build(),
+                JiraPaginatedResponseBuilder("values")
+                .with_records([{"id": "10003", "key": "PROJ3", "name": "Project Three"}])
+                .with_pagination(start_at=2, max_results=2, total=3, is_last=True)
+                .build(),
+            ],
+        )
+
+        source = get_source(config=config)
+        catalog = CatalogBuilder().with_stream(_STREAM_NAME, SyncMode.full_refresh).build()
+        output = read(source, config=config, catalog=catalog)
+
+        assert len(output.records) == 3
+        assert output.records[0].record.data["id"] == "10001"
+        assert output.records[1].record.data["id"] == "10002"
+        assert output.records[2].record.data["id"] == "10003"
+
+    @HttpMocker()
+    def test_empty_results(self, http_mocker: HttpMocker):
+        """
+        Test that connector handles empty results gracefully.
+
+        Given: An API that returns no projects
+        When: Running a full refresh sync
+        Then: The connector should return zero records without errors
+        """
+        config = ConfigBuilder().with_domain(_DOMAIN).with_email(_EMAIL).with_api_token(_API_TOKEN).build()
+
+        http_mocker.get(
+            JiraRequestBuilder.projects_endpoint(_DOMAIN, _EMAIL, _API_TOKEN)
+            .with_any_query_params()
+            .build(),
+            JiraPaginatedResponseBuilder.empty_page("values"),
+        )
+
+        source = get_source(config=config)
+        catalog = CatalogBuilder().with_stream(_STREAM_NAME, SyncMode.full_refresh).build()
+        output = read(source, config=config, catalog=catalog)
+
+        assert len(output.records) == 0
+        assert not any(log.log.level == "ERROR" for log in output.logs)
+
+    @HttpMocker()
+    def test_bad_request_error_ignored(self, http_mocker: HttpMocker):
+        """
+        Test that connector ignores 400 Bad Request errors.
+
+        The Jira manifest configures 400 errors with action: IGNORE, which means the connector
+        silently ignores bad request errors and continues the sync.
+
+        Given: An API that returns 400 Bad Request
+        When: Running a full refresh sync
+        Then: The connector should ignore the error and complete successfully with 0 records
+        """
+        config = ConfigBuilder().with_domain(_DOMAIN).with_email(_EMAIL).with_api_token(_API_TOKEN).build()
+
+        http_mocker.get(
+            JiraRequestBuilder.projects_endpoint(_DOMAIN, _EMAIL, _API_TOKEN)
+            .with_any_query_params()
+            .build(),
+            JiraErrorResponseBuilder.bad_request("Invalid request parameters"),
+        )
+
+        source = get_source(config=config)
+        catalog = CatalogBuilder().with_stream(_STREAM_NAME, SyncMode.full_refresh).build()
+        output = read(source, config=config, catalog=catalog, expecting_exception=False)
+
+        assert len(output.records) == 0
+        assert not any(log.log.level == "ERROR" for log in output.logs)

--- a/airbyte-integrations/connectors/source-jira/unit_tests/integration/test_users.py
+++ b/airbyte-integrations/connectors/source-jira/unit_tests/integration/test_users.py
@@ -1,0 +1,139 @@
+# Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+
+from datetime import datetime, timezone
+from unittest import TestCase
+
+import freezegun
+from conftest import get_source
+
+from airbyte_cdk.models import SyncMode
+from airbyte_cdk.test.catalog_builder import CatalogBuilder
+from airbyte_cdk.test.entrypoint_wrapper import read
+from airbyte_cdk.test.mock_http import HttpMocker
+from integration.config import ConfigBuilder
+from integration.request_builder import JiraRequestBuilder
+from integration.response_builder import JiraListResponseBuilder, JiraPaginatedResponseBuilder
+
+
+_NOW = datetime.now(timezone.utc)
+_STREAM_NAME = "users"
+_DOMAIN = "test.atlassian.net"
+_EMAIL = "test@example.com"
+_API_TOKEN = "test_api_token"
+
+
+@freezegun.freeze_time(_NOW.isoformat())
+class TestUsersStream(TestCase):
+    """
+    Tests for the Jira 'users' stream.
+
+    The users stream uses OffsetIncrement pagination with page_size 50.
+    It returns a list of users without pagination metadata wrapper.
+    """
+
+    @HttpMocker()
+    def test_full_refresh_single_page(self, http_mocker: HttpMocker):
+        """
+        Test that connector correctly fetches one page of users.
+
+        Given: A configured Jira connector
+        When: Running a full refresh sync for the users stream
+        Then: The connector should make the correct API request and return all records
+        """
+        config = ConfigBuilder().with_domain(_DOMAIN).with_email(_EMAIL).with_api_token(_API_TOKEN).build()
+
+        http_mocker.get(
+            JiraRequestBuilder.users_endpoint(_DOMAIN, _EMAIL, _API_TOKEN)
+            .with_any_query_params()
+            .build(),
+            JiraListResponseBuilder.build(
+                [
+                    {
+                        "accountId": "user-001",
+                        "accountType": "atlassian",
+                        "displayName": "John Doe",
+                        "emailAddress": "john@example.com",
+                        "active": True,
+                    },
+                    {
+                        "accountId": "user-002",
+                        "accountType": "atlassian",
+                        "displayName": "Jane Smith",
+                        "emailAddress": "jane@example.com",
+                        "active": True,
+                    },
+                ]
+            ),
+        )
+
+        source = get_source(config=config)
+        catalog = CatalogBuilder().with_stream(_STREAM_NAME, SyncMode.full_refresh).build()
+        output = read(source, config=config, catalog=catalog)
+
+        assert len(output.records) == 2
+        assert output.records[0].record.data["accountId"] == "user-001"
+        assert output.records[0].record.data["displayName"] == "John Doe"
+        assert output.records[1].record.data["accountId"] == "user-002"
+        assert output.records[1].record.data["displayName"] == "Jane Smith"
+
+    @HttpMocker()
+    def test_pagination_multiple_pages(self, http_mocker: HttpMocker):
+        """
+        Test that connector fetches all pages when pagination is present.
+
+        The users stream uses OffsetIncrement pagination. When the response contains
+        fewer records than the page_size (50), pagination stops.
+
+        Given: An API that returns multiple pages of users
+        When: Running a full refresh sync
+        Then: The connector should follow pagination and return all records
+        """
+        config = ConfigBuilder().with_domain(_DOMAIN).with_email(_EMAIL).with_api_token(_API_TOKEN).build()
+
+        # Use a list of responses to simulate pagination - responses are returned in order
+        # First page returns 50 records (full page), second page returns fewer (last page)
+        first_page_users = [{"accountId": f"user-{i:03d}", "displayName": f"User {i}"} for i in range(50)]
+        second_page_users = [{"accountId": "user-050", "displayName": "User 50"}]
+
+        http_mocker.get(
+            JiraRequestBuilder.users_endpoint(_DOMAIN, _EMAIL, _API_TOKEN)
+            .with_any_query_params()
+            .build(),
+            [
+                JiraListResponseBuilder.build(first_page_users),
+                JiraListResponseBuilder.build(second_page_users),
+            ],
+        )
+
+        source = get_source(config=config)
+        catalog = CatalogBuilder().with_stream(_STREAM_NAME, SyncMode.full_refresh).build()
+        output = read(source, config=config, catalog=catalog)
+
+        assert len(output.records) == 51
+        assert output.records[0].record.data["accountId"] == "user-000"
+        assert output.records[50].record.data["accountId"] == "user-050"
+
+    @HttpMocker()
+    def test_empty_results(self, http_mocker: HttpMocker):
+        """
+        Test that connector handles empty results gracefully.
+
+        Given: An API that returns no users
+        When: Running a full refresh sync
+        Then: The connector should return zero records without errors
+        """
+        config = ConfigBuilder().with_domain(_DOMAIN).with_email(_EMAIL).with_api_token(_API_TOKEN).build()
+
+        http_mocker.get(
+            JiraRequestBuilder.users_endpoint(_DOMAIN, _EMAIL, _API_TOKEN)
+            .with_any_query_params()
+            .build(),
+            JiraListResponseBuilder.empty(),
+        )
+
+        source = get_source(config=config)
+        catalog = CatalogBuilder().with_stream(_STREAM_NAME, SyncMode.full_refresh).build()
+        output = read(source, config=config, catalog=catalog)
+
+        assert len(output.records) == 0
+        assert not any(log.log.level == "ERROR" for log in output.logs)


### PR DESCRIPTION
## What

Adds mock server test infrastructure for the source-jira connector. This is the first step toward comprehensive mock server test coverage for all 43 Jira streams.

Requested by @aaronsteers

Link to Devin run: https://app.devin.ai/sessions/036894f574a94f7094bd17ab68fe499d

## How

Created test infrastructure following patterns from source-harvest and source-sentry:

1. **conftest.py**: Added `get_source()` function and `get_resource_path()` helper
2. **config.py**: Extended `ConfigBuilder` with additional methods (`with_email`, `with_start_date_str`, `with_enable_experimental_streams`, `with_lookback_window_minutes`)
3. **request_builder.py**: New `JiraRequestBuilder` class with factory methods for all Jira API endpoints (both v3 REST API and v1 Agile API)
4. **response_builder.py**: New response builders:
   - `JiraPaginatedResponseBuilder` - offset-based pagination (startAt/maxResults/total/isLast)
   - `JiraJqlPaginatedResponseBuilder` - token-based pagination (nextPageToken)
   - `JiraListResponseBuilder` - simple list responses
   - `JiraObjectResponseBuilder` - single object responses
   - `JiraErrorResponseBuilder` - error responses (400/401/403/404)

## Review guide

1. `unit_tests/integration/request_builder.py` - Verify endpoint paths and auth header generation match Jira API
2. `unit_tests/integration/response_builder.py` - Verify pagination structures match actual Jira API responses
3. `unit_tests/conftest.py` - Review `get_source()` implementation

## User Impact

No user impact - this is test infrastructure only. Actual tests will be added in subsequent commits.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚