### PR TITLE
improve(Source-Intercom):  `scroll_exists` error

### DIFF
--- a/airbyte-integrations/connectors/source-intercom/manifest.yaml
+++ b/airbyte-integrations/connectors/source-intercom/manifest.yaml
@@ -253,6 +253,10 @@ definitions:
             Intercom-Version: "2.11"
           error_handler:
             type: DefaultErrorHandler
+            max_retries: 5
+            backoff_strategies:
+              - type: ConstantBackoffStrategy
+                backoff_time_in_seconds: 60
             response_filters:
               - type: HttpResponseFilter
                 http_codes:
@@ -269,13 +273,12 @@ definitions:
                 failure_type: transient_error
                 error_message: "Ignoring 404 response, no company records found."
               - type: HttpResponseFilter
-                http_codes:
-                  - 400
-                action: FAIL
+                predicate: "{{ response and ('scroll_exists' in response|string or 'scroll already exists for this workspace' in response|string) }}"
+                action: RESET_PAGINATION
                 failure_type: transient_error
                 error_message: >-
                   Scroll already exists for this workspace. Please ensure you do not have multiple syncs running at the same time.
-                  Intercom API does not allow for you to run the Companies or Company Parts streams in parallel.
+                  Intercom API does not allow for you to run the Companies or Company Segments streams in parallel.
               - type: HttpResponseFilter
                 http_codes:
                   - 500

--- a/airbyte-integrations/connectors/source-intercom/metadata.yaml
+++ b/airbyte-integrations/connectors/source-intercom/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: d8313939-3782-41b0-be29-b3ca20d8dd3a
-  dockerImageTag: 0.13.16-rc.1
+  dockerImageTag: 0.13.16-rc.2
   dockerRepository: airbyte/source-intercom
   documentationUrl: https://docs.airbyte.com/integrations/sources/intercom
   externalDocumentationUrls:

--- a/docs/integrations/sources/intercom.md
+++ b/docs/integrations/sources/intercom.md
@@ -96,6 +96,7 @@ The Intercom connector should not run into Intercom API limitations under normal
 
 | Version     | Date       | Pull Request                                             | Subject                                                                                                                              |
 |:------------|:-----------|:---------------------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------|
+| 0.13.16-rc.2 | 2025-12-11 | [70335](https://github.com/airbytehq/airbyte/pull/70335) | Add Reset pagination handling (retry) for scroll_exists error |
 | 0.13.16-rc.1 | 2025-12-11 | [70335](https://github.com/airbytehq/airbyte/pull/70335) | Fix pagination on companies stream |
 | 0.13.15 | 2025-11-25 | [69563](https://github.com/airbytehq/airbyte/pull/69563) | Update dependencies |
 | 0.13.14 | 2025-11-13 | [69306](https://github.com/airbytehq/airbyte/pull/69306) | Update custom IntercomScrollRetriever to not use deprecated stream_state parameter |


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->

Due to the nature of the Companies and Company Segment endpoints scroll pagination, these streams cannot run in parallel. Currently, intercom has no concurrency level defined, but we default to 2 workers at the CDK.

 If a parallel request is made to start a new scroll, the API will fail with:
 ```
 'GET' request to 'https://api.intercom.io/companies/scroll' failed with status code '400' and error message: 'scroll already exists for this workspace'.
 ```

Ideally, we would have some way to exclude these from concurrency and be able to run them serially. Currently, we can either set the concurrency level to 1 to completely run all syncs serially, but that would impact speed a bit. 

Another approach is to use the RESET_PAGINATION to retry after 1 minute, which is when the scroll should expire. This may help in some cases, but the error can still happen. 

## How
<!--
* Describe how code changes achieve the solution.
-->

For now, this PR updates the error handling to give the connector a way to retry instead of just failing.

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
