### PR TITLE
chore(source-gcs): Add release notes URL to external documentation

### DIFF
--- a/airbyte-integrations/connectors/source-gcs/metadata.yaml
+++ b/airbyte-integrations/connectors/source-gcs/metadata.yaml
@@ -73,6 +73,9 @@ data:
             type: GSM
             alias: airbyte-connector-testing-secret-store
   externalDocumentationUrls:
+    - title: Cloud Storage release notes
+      url: https://cloud.google.com/storage/docs/release-notes
+      type: api_release_history
     - title: Google Cloud Storage documentation
       url: https://cloud.google.com/storage/docs
       type: api_reference


### PR DESCRIPTION
## What

Adds the Google Cloud Storage release notes URL to the connector's external documentation metadata. This was identified during API deprecation monitoring research as a missing URL that would be useful for future deprecation checks.

Related audit log: https://github.com/airbytehq/oncall/issues/10520

## How

Adds a new entry to the `externalDocumentationUrls` array in `metadata.yaml` with:
- URL: https://cloud.google.com/storage/docs/release-notes
- Type: `api_release_history`

## Review guide

1. `airbyte-integrations/connectors/source-gcs/metadata.yaml` - Single file change adding the release notes URL

## User Impact

No user-facing impact. This is a metadata-only change that improves the connector's documentation references for internal tooling and deprecation monitoring.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Link to Devin run: https://app.devin.ai/sessions/2c647fd9101740fe9dd20f93dc1a97dd
Requested by: AJ Steers (@aaronsteers)