### PR TITLE
chore(source-woocommerce): Add changelog URL to external documentation

### DIFF
--- a/airbyte-integrations/connectors/source-woocommerce/metadata.yaml
+++ b/airbyte-integrations/connectors/source-woocommerce/metadata.yaml
@@ -57,4 +57,7 @@ data:
     - title: WooCommerce authentication
       url: https://woocommerce.github.io/woocommerce-rest-api-docs/#authentication
       type: authentication_guide
+    - title: WooCommerce Developer Changelog
+      url: https://developer.woocommerce.com/changelog/
+      type: api_release_history
 metadataSpecVersion: "1.0"


### PR DESCRIPTION
## What

Adds the WooCommerce Developer Changelog URL to the connector's external documentation metadata. This URL was discovered during API deprecation monitoring research and will improve future deprecation monitoring for this connector.

Related: https://github.com/airbytehq/oncall/issues/10531 (no-op audit log from deprecation research)

## How

Adds a new entry to `externalDocumentationUrls` in metadata.yaml with:
- title: "WooCommerce Developer Changelog"
- url: https://developer.woocommerce.com/changelog/
- type: `api_release_history`

## Review guide

1. `airbyte-integrations/connectors/source-woocommerce/metadata.yaml` - verify the new URL entry follows the existing pattern

## User Impact

No user-facing impact. This is metadata used for internal deprecation monitoring.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

**Requested by:** AJ Steers (@aaronsteers)

**Link to Devin run:** https://app.devin.ai/sessions/471bacf81090485b9e9da022c6d267e6