### PR TITLE
chore(source-paypal-transaction): Add api_deprecations URL to external documentation

### DIFF
--- a/airbyte-integrations/connectors/source-paypal-transaction/metadata.yaml
+++ b/airbyte-integrations/connectors/source-paypal-transaction/metadata.yaml
@@ -89,4 +89,7 @@ data:
     - title: PayPal Status
       url: https://www.paypal-status.com/
       type: status_page
+    - title: PayPal Deprecated Resources
+      url: https://developer.paypal.com/api/rest/deprecated-resources/
+      type: api_deprecations
 metadataSpecVersion: "1.0"


### PR DESCRIPTION
## What

Adds PayPal's Deprecated Resources documentation URL to the connector's external documentation URLs. This was identified during API deprecation monitoring research.

Related oncall issue: https://github.com/airbytehq/oncall/issues/10530

## How

Added a new entry to `externalDocumentationUrls` in metadata.yaml pointing to PayPal's deprecated resources page with type `api_deprecations`.

## Review guide

1. `airbyte-integrations/connectors/source-paypal-transaction/metadata.yaml` - Single addition of a new external documentation URL entry

## User Impact

No user-facing impact. This is a metadata-only change that helps track upstream API deprecations for future connector maintenance.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Requested by: AJ Steers (@aaronsteers)
Link to Devin run: https://app.devin.ai/sessions/2f2dd54c67f0410ea38285960a61f35d