### PR TITLE
🐛 Source CockroachDB: fix database name encoding for special characters

### DIFF
--- a/airbyte-integrations/connectors/source-cockroachdb/metadata.yaml
+++ b/airbyte-integrations/connectors/source-cockroachdb/metadata.yaml
@@ -13,7 +13,7 @@ data:
     - suite: integrationTests
   connectorType: source
   definitionId: 9fa5862c-da7c-11eb-8d19-0242ac130003
-  dockerImageTag: 0.2.5
+  dockerImageTag: 0.2.6
   dockerRepository: airbyte/source-cockroachdb
   documentationUrl: https://docs.airbyte.com/integrations/sources/cockroachdb
   githubIssueLabel: source-cockroachdb

--- a/airbyte-integrations/connectors/source-cockroachdb/src/main/java/io/airbyte/integrations/source/cockroachdb/CockroachDbSource.java
+++ b/airbyte-integrations/connectors/source-cockroachdb/src/main/java/io/airbyte/integrations/source/cockroachdb/CockroachDbSource.java
@@ -21,6 +21,8 @@ import io.airbyte.cdk.integrations.source.jdbc.AbstractJdbcSource;
 import io.airbyte.cdk.integrations.source.jdbc.dto.JdbcPrivilegeDto;
 import io.airbyte.commons.functional.CheckedFunction;
 import io.airbyte.commons.json.Jsons;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.JDBCType;
 import java.sql.PreparedStatement;
@@ -54,11 +56,12 @@ public class CockroachDbSource extends AbstractJdbcSource<JDBCType> {
   public JsonNode toDatabaseConfig(final JsonNode config) {
 
     final List<String> additionalParameters = new ArrayList<>();
+    final String encodedDatabaseName = URLEncoder.encode(config.get(JdbcUtils.DATABASE_KEY).asText(), StandardCharsets.UTF_8);
 
     final StringBuilder jdbcUrl = new StringBuilder(String.format("jdbc:postgresql://%s:%s/%s?",
         config.get(JdbcUtils.HOST_KEY).asText(),
         config.get(JdbcUtils.PORT_KEY).asText(),
-        config.get(JdbcUtils.DATABASE_KEY).asText()));
+        encodedDatabaseName));
 
     if (config.get(JdbcUtils.JDBC_URL_PARAMS_KEY) != null && !config.get(JdbcUtils.JDBC_URL_PARAMS_KEY).asText().isEmpty()) {
       jdbcUrl.append(config.get(JdbcUtils.JDBC_URL_PARAMS_KEY).asText()).append(AMPERSAND);

--- a/airbyte-integrations/connectors/source-cockroachdb/src/test/java/io/airbyte/integrations/source/cockroachdb/CockroachDbSourceUnitTest.java
+++ b/airbyte-integrations/connectors/source-cockroachdb/src/test/java/io/airbyte/integrations/source/cockroachdb/CockroachDbSourceUnitTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.source.cockroachdb;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableMap;
+import io.airbyte.cdk.db.jdbc.JdbcUtils;
+import io.airbyte.commons.json.Jsons;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for CockroachDbSource that don't require a running CockroachDB instance.
+ */
+class CockroachDbSourceUnitTest {
+
+  @Test
+  void testJdbcUrlWithEncodedDatabaseName() {
+    // Test with a database name containing special characters that require URL encoding
+    final JsonNode config = Jsons.jsonNode(ImmutableMap.of(
+        JdbcUtils.HOST_KEY, "localhost",
+        JdbcUtils.PORT_KEY, 26257,
+        JdbcUtils.USERNAME_KEY, "user",
+        JdbcUtils.DATABASE_KEY, "my database/test",
+        JdbcUtils.SSL_KEY, false));
+
+    final JsonNode jdbcConfig = new CockroachDbSource().toDatabaseConfig(config);
+    final String jdbcUrl = jdbcConfig.get(JdbcUtils.JDBC_URL_KEY).asText();
+
+    // Space encodes to + and / encodes to %2F
+    assertTrue(jdbcUrl.contains("my+database%2Ftest"),
+        "Database name should be URL-encoded in JDBC URL, got: " + jdbcUrl);
+  }
+
+  @Test
+  void testJdbcUrlWithHyphenatedDatabaseName() {
+    // Hyphens are unreserved characters and do not need to be encoded
+    final JsonNode config = Jsons.jsonNode(ImmutableMap.of(
+        JdbcUtils.HOST_KEY, "localhost",
+        JdbcUtils.PORT_KEY, 26257,
+        JdbcUtils.USERNAME_KEY, "user",
+        JdbcUtils.DATABASE_KEY, "test-db",
+        JdbcUtils.SSL_KEY, false));
+
+    final JsonNode jdbcConfig = new CockroachDbSource().toDatabaseConfig(config);
+    final String jdbcUrl = jdbcConfig.get(JdbcUtils.JDBC_URL_KEY).asText();
+
+    // Hyphen should remain as-is (not encoded)
+    assertTrue(jdbcUrl.contains("/test-db?"),
+        "Hyphenated database name should be preserved in JDBC URL, got: " + jdbcUrl);
+  }
+
+  @Test
+  void testJdbcUrlWithNormalDatabaseName() {
+    final JsonNode config = Jsons.jsonNode(ImmutableMap.of(
+        JdbcUtils.HOST_KEY, "localhost",
+        JdbcUtils.PORT_KEY, 26257,
+        JdbcUtils.USERNAME_KEY, "user",
+        JdbcUtils.DATABASE_KEY, "normaldb",
+        JdbcUtils.SSL_KEY, false));
+
+    final JsonNode jdbcConfig = new CockroachDbSource().toDatabaseConfig(config);
+    final String jdbcUrl = jdbcConfig.get(JdbcUtils.JDBC_URL_KEY).asText();
+
+    assertTrue(jdbcUrl.contains("/normaldb?"),
+        "Normal database name should remain unchanged in JDBC URL, got: " + jdbcUrl);
+  }
+
+}
+

--- a/docs/integrations/sources/cockroachdb.md
+++ b/docs/integrations/sources/cockroachdb.md
@@ -98,6 +98,7 @@ Your database user should now be ready for use with Airbyte.
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                   |
 | :------ | :--------- | :------------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------- |
+| 0.2.6 | 2025-12-12 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) | Fix database name encoding for special characters |
 | 0.2.5 | 2025-07-10 | [62914](https://github.com/airbytehq/airbyte/pull/62914) | Convert to new gradle build flow |
 | 0.2.4 | 2025-01-10 | [51484](https://github.com/airbytehq/airbyte/pull/51484) | Use a non root base image |
 | 0.2.3 | 2024-12-18 | [49915](https://github.com/airbytehq/airbyte/pull/49915) | Use a base image: airbyte/java-connector-base:1.0.0 |


### PR DESCRIPTION
URL-encode database names in JDBC URLs to handle special characters like spaces and slashes. Follows pattern from PostgresSource.

## What

Fixes an issue where database names containing special characters (spaces, slashes, etc.) cause JDBC connection warnings or failures in the CockroachDB source connector. Database names like `my database` or `test/db` were being passed directly into JDBC URLs without encoding.

## How

- Added `URLEncoder.encode()` with `StandardCharsets.UTF_8` to the `toDatabaseConfig` method in `CockroachDbSource.java`
- This encodes special characters in database names before constructing the JDBC URL (e.g., spaces become `+`, slashes become `%2F`)
- Follows the same pattern already used by `PostgresSource` and `SingleStoreSource` connectors
- Added unit tests to verify encoding behavior for special characters, hyphenated names, and normal names

## Review guide

1. `airbyte-integrations/connectors/source-cockroachdb/src/main/java/io/airbyte/integrations/source/cockroachdb/CockroachDbSource.java` - Core fix
2. `airbyte-integrations/connectors/source-cockroachdb/src/test/java/io/airbyte/integrations/source/cockroachdb/CockroachDbSourceUnitTest.java` - New unit tests

## User Impact

- Users can now use database names containing special characters without manual URL encoding
- Eliminates JDBC URL warnings for database names with special characters
- No breaking changes - existing database names continue to work as before

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌