### PR TITLE
Clarify default value for S3 Bucket Path

### DIFF
--- a/docs/integrations/destinations/s3.md
+++ b/docs/integrations/destinations/s3.md
@@ -181,7 +181,7 @@ Use an existing or create new
      - See [this](https://docs.aws.amazon.com/AmazonS3/latest/userguide/create-bucket-overview.html)
        to create an S3 bucket.
    - **S3 Bucket Path**
-     - Subdirectory under the above bucket to sync the data into.
+     - Subdirectory under the above bucket to sync the data into. Note: this will default to airbyte-data.
    - **S3 Bucket Region**:
      - See
        [here](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions)

--- a/docs/integrations/destinations/s3.md
+++ b/docs/integrations/destinations/s3.md
@@ -181,7 +181,7 @@ Use an existing or create new
      - See [this](https://docs.aws.amazon.com/AmazonS3/latest/userguide/create-bucket-overview.html)
        to create an S3 bucket.
    - **S3 Bucket Path**
-     - Subdirectory under the above bucket to sync the data into. Note: this will default to airbyte-data.
+     - Subdirectory under the bucket to sync the data into. Note: this defaults to `airbyte-data`.
    - **S3 Bucket Region**:
      - See
        [here](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions)


### PR DESCRIPTION
Added default value note for S3 Bucket Path since for Embedded cusotmers we aren't giving them the option to update.

## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->

## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._