### PR TITLE
docs(connector-builder): Add nested array with metadata example for Download Extractor

### DIFF
--- a/docs/platform/connector-development/connector-builder-ui/record-processing.mdx
+++ b/docs/platform/connector-development/connector-builder-ui/record-processing.mdx
@@ -372,6 +372,46 @@ In some cases the array of actual records is nested multiple levels deep in the 
 
 In this case, **setting the Field Path to `response`,`docs`** selects the nested array.
 
+#### Nested array with metadata
+
+Some APIs return records nested within a response body alongside metadata fields. For example, an analytics API might return:
+
+```json
+{
+  "status": 200,
+  "body": {
+    "results": [
+      {
+        "app": "Call of Duty: Mobile",
+        "source": "TikTok Ads",
+        "start_date": "2025-11-21",
+        "end_date": "2025-11-21",
+        "adn_clicks": 89950,
+        "tracker_clicks": 148,
+        "custom_installs": 6668
+      },
+      {
+        "app": "Call of Duty: Mobile",
+        "source": "Snapchat",
+        "start_date": "2025-11-21",
+        "end_date": "2025-11-21",
+        "adn_clicks": 90409,
+        "tracker_clicks": null,
+        "custom_installs": 760
+      }
+    ],
+    "num_of_rows": 2,
+    "total": {
+      "adn_clicks": 1853058,
+      "tracker_clicks": 2087366,
+      "custom_installs": 260673
+    }
+  }
+}
+```
+
+In this case, **setting the Field Path to `body`,`results`** extracts each object in the `results` array as an individual record. The `status`, `num_of_rows`, and `total` fields are discarded, and each item in the `results` array becomes a separate record.
+
 #### Root array
 
 In some cases, the response body itself is an array of records, like in the [CoinAPI API](https://docs.coinapi.io/market-data/rest-api/quotes):

--- a/docs/platform/connector-development/connector-builder-ui/record-processing.mdx
+++ b/docs/platform/connector-development/connector-builder-ui/record-processing.mdx
@@ -410,7 +410,7 @@ Some APIs return records nested within a response body alongside metadata fields
 }
 ```
 
-In this case, **setting the Field Path to `body`,`results`** extracts each object in the `results` array as an individual record. The `status`, `num_of_rows`, and `total` fields are discarded, and each item in the `results` array becomes a separate record.
+In this case, **setting the Download Extractor Field Path in the Advanced options to `results`** extracts each object in the `results` array as an individual record. The `status`, `num_of_rows`, and `total` fields are discarded, and each item in the `results` array becomes a separate record.
 
 #### Root array
 

--- a/docs/platform/connector-development/connector-builder-ui/record-processing.mdx
+++ b/docs/platform/connector-development/connector-builder-ui/record-processing.mdx
@@ -381,28 +381,15 @@ Some APIs return records nested within a response body alongside metadata fields
   "status": 200,
   "body": {
     "results": [
-      {
-        "app": "Call of Duty: Mobile",
-        "source": "TikTok Ads",
-        "start_date": "2025-11-21",
-        "end_date": "2025-11-21",
-        "adn_clicks": 89950,
-        "tracker_clicks": 148,
-        "custom_installs": 6668
-      },
-      // ..
+      { "id": 1, "name": "record_one" },
+      { "id": 2, "name": "record_two" }
     ],
-    "num_of_rows": 2,
-    "total": {
-      "adn_clicks": 1853058,
-      "tracker_clicks": 2087366,
-      "custom_installs": 260673
-    }
+    "total": { "count": 2 }
   }
 }
 ```
 
-In this case, **setting the Download Extractor Field Path in the Advanced options to `results`** extracts each object in the `results` array as an individual record. The `status`, `num_of_rows`, and `total` fields are discarded, and each item in the `results` array becomes a separate record.
+In this case, **setting the Download Extractor Field Path in the Advanced options to `results`** extracts each object in the `results` array as an individual record. The `status` and `total` fields are discarded, and each item in the `results` array becomes a separate record.
 
 #### Root array
 

--- a/docs/platform/connector-development/connector-builder-ui/record-processing.mdx
+++ b/docs/platform/connector-development/connector-builder-ui/record-processing.mdx
@@ -390,15 +390,7 @@ Some APIs return records nested within a response body alongside metadata fields
         "tracker_clicks": 148,
         "custom_installs": 6668
       },
-      {
-        "app": "Call of Duty: Mobile",
-        "source": "Snapchat",
-        "start_date": "2025-11-21",
-        "end_date": "2025-11-21",
-        "adn_clicks": 90409,
-        "tracker_clicks": null,
-        "custom_installs": 760
-      }
+      // ..
     ],
     "num_of_rows": 2,
     "total": {


### PR DESCRIPTION
## What
Adds a new example to the Connector Builder UI documentation showing how to extract records from a nested array structure that includes metadata fields using the Download Extractor.

This was requested by a user in Slack who needed guidance on extracting records from an API response where the data is nested within `body.results` alongside metadata like `status`, `num_of_rows`, and `total`.

## How
Added a new "Nested array with metadata" subsection under the Field Path documentation in `record-processing.mdx`. The example shows:
- A JSON response with records nested at `body.results`
- Metadata fields (`status`, `num_of_rows`, `total`) that should be discarded
- How setting the Download Extractor Field Path in the Advanced options to `results` extracts each array item as an individual record

## Review guide
1. `docs/platform/connector-development/connector-builder-ui/record-processing.mdx` - New example section added after the existing "Nested array" example

### Human review checklist
- [ ] Verify the wording accurately describes the Download Extractor feature in Advanced options
- [ ] Confirm the example JSON and explanation are clear to users

## User Impact
Users building connectors with the Connector Builder UI will have a clearer example of how to extract records from APIs that return data nested within a response body alongside metadata fields.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚

---
Link to Devin run: https://app.devin.ai/sessions/d2a7242423144ece8861346424f3b4f6
Requested by: Ilja Herdt (@iherdt-airbyte)

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._