### PR TITLE
🐛 source-paypal-transaction: update HTTP response action for 400 error transactions

### DIFF
--- a/airbyte-integrations/connectors/source-paypal-transaction/manifest.yaml
+++ b/airbyte-integrations/connectors/source-paypal-transaction/manifest.yaml
@@ -35,7 +35,7 @@ definitions:
                   - type: HttpResponseFilter
                     http_codes:
                       - 400
-                    action: IGNORE
+                    action: FAIL
                     predicate: >-
                       {{ 'Data for the given start date is not available' in
                       response['message']}}

--- a/airbyte-integrations/connectors/source-paypal-transaction/metadata.yaml
+++ b/airbyte-integrations/connectors/source-paypal-transaction/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: d913b0f2-cc51-4e55-a44c-8ba1697b9239
-  dockerImageTag: 2.6.19
+  dockerImageTag: 2.6.20
   dockerRepository: airbyte/source-paypal-transaction
   documentationUrl: https://docs.airbyte.com/integrations/sources/paypal-transaction
   githubIssueLabel: source-paypal-transaction

--- a/docs/integrations/sources/paypal-transaction.md
+++ b/docs/integrations/sources/paypal-transaction.md
@@ -264,6 +264,7 @@ The below table contains the configuraiton parameters available for this connect
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                      |
 | :------ | :--------- | :------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------- |
+| 2.6.20  | 2025-12-17 | [70967](https://github.com/airbytehq/airbyte/pull/70967) | update HTTP response action for 400 error transactions |
 | 2.6.19 | 2025-11-25 | [69974](https://github.com/airbytehq/airbyte/pull/69974) | Update dependencies |
 | 2.6.18 | 2025-11-18 | [69668](https://github.com/airbytehq/airbyte/pull/69668) | Update dependencies |
 | 2.6.17 | 2025-10-29 | [69044](https://github.com/airbytehq/airbyte/pull/69044) | Update dependencies |


### PR DESCRIPTION
Issue [70968](https://github.com/airbytehq/airbyte/issues/70968)

## What
We are no notified when we have issue with the request ...

## How
**Error handling and rate limiting:**

* Changed the HTTP 400 error handling from `IGNORE` to `FAIL` to ensure that data unavailability errors are surfaced rather than silently ignored.


**Version update:**

* Bumped the connector Docker image tag from `2.6.19` to `2.6.20` to reflect these updates.

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
