### PR TITLE
fix(ci): update PyAirbyte version and add -preview suffix to prod release detection

### DIFF
--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/registry_entry.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/registry_entry.py
@@ -533,7 +533,9 @@ def generate_and_persist_registry_entry(
 
     # For latest versions that are disabled, delete any existing registry entry to remove it from the registry
     if (
-        "-rc" not in metadata_dict["data"]["dockerImageTag"] and "-dev" not in metadata_dict["data"]["dockerImageTag"]
+        "-rc" not in metadata_dict["data"]["dockerImageTag"]
+        and "-dev" not in metadata_dict["data"]["dockerImageTag"]
+        and "-preview" not in metadata_dict["data"]["dockerImageTag"]
     ) and not metadata_dict["data"]["registryOverrides"][registry_type]["enabled"]:
         logger.info(
             f"{registry_type} is not enabled: deleting existing {registry_type} registry entry for {metadata_dict['data']['dockerRepository']} at latest path."

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/python_connectors.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/python_connectors.py
@@ -25,7 +25,7 @@ from pipelines.helpers.utils import raise_if_not_user
 from pipelines.models.steps import STEP_PARAMS, Step, StepResult
 
 # Pin the PyAirbyte version to avoid updates from breaking CI
-PYAIRBYTE_VERSION = "0.20.2"
+PYAIRBYTE_VERSION = "0.35.1"
 
 
 class PytestStep(Step, ABC):

--- a/airbyte-ci/connectors/pipelines/tests/test_tests/test_python_connectors.py
+++ b/airbyte-ci/connectors/pipelines/tests/test_tests/test_python_connectors.py
@@ -156,7 +156,8 @@ class TestPyAirbyteValidationTests:
         result = await PyAirbyteValidation(context_for_valid_connector)._run(mocker.MagicMock())
         assert isinstance(result, StepResult)
         assert result.status == StepStatus.SUCCESS
-        assert "Getting `spec` output from connector..." in result.stdout
+        # Verify the connector name appears in output (stable across PyAirbyte versions)
+        assert context_for_valid_connector.connector.technical_name in (result.stdout + result.stderr)
 
     async def test__run_validation_skip_unpublished_connector(
         self,

--- a/airbyte-ci/connectors/pipelines/tests/test_tests/test_python_connectors.py
+++ b/airbyte-ci/connectors/pipelines/tests/test_tests/test_python_connectors.py
@@ -111,7 +111,6 @@ class TestUnitTests:
         ]
 
 
-@pytest.mark.skip(reason="PyAirbyte validation tests failing due to CDK module import issues in test environment")
 class TestPyAirbyteValidationTests:
     @pytest.fixture
     def compatible_connector(self):


### PR DESCRIPTION
## What

This PR addresses two issues:

1. **PyAirbyte validation tests** were skipped in airbytehq/airbyte#70970 due to CDK module import issues. The tests were failing with:
```
ModuleNotFoundError: No module named 'airbyte_cdk.sources.declarative.manifest_declarative_source'
```
This module path no longer exists in newer CDK versions - it has been replaced with `yaml_declarative_source` and `concurrent_declarative_source`.

2. **Production release detection** in `registry_entry.py` needed to exclude the new `-preview` suffix (in addition to existing `-rc` and `-dev` checks) to prevent accidental registry entry deletion for prerelease versions.

## How

1. Updated `PYAIRBYTE_VERSION` from `0.20.2` to `0.35.1` (latest version)
2. Removed the `@pytest.mark.skip` decorator from `TestPyAirbyteValidationTests`
3. Added `-preview` suffix check to the production release detection logic in `registry_entry.py`
4. Updated test assertion to use stable connector name check instead of PyAirbyte-specific log message

## Updates since last revision

**Test assertion fix**: The `test__run_validation_success` test was asserting on a PyAirbyte-specific log message (`"Getting `spec` output from connector..."`) that changed between versions. Updated to assert that the connector's technical name appears in the output, which is stable across PyAirbyte versions while still verifying the validation ran for the correct connector.

## Review guide

1. `airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/python_connectors.py` - Version constant update
2. `airbyte-ci/connectors/pipelines/tests/test_tests/test_python_connectors.py` - Skip marker removal + stable test assertion
3. `airbyte-ci/connectors/metadata_service/lib/metadata_service/registry_entry.py` - Added `-preview` to prerelease suffix exclusion list

**Review checklist**:
- [ ] Verify the new test assertion (`connector.technical_name in (stdout + stderr)`) is stable and meaningful
- [ ] Confirm PyAirbyte 0.35.1 is compatible with the CDK version used in the test environment
- [ ] Verify registry_entry.py logic correctly excludes all prerelease suffixes (`-rc`, `-dev`, `-preview`)

## User Impact

- PyAirbyte validation tests will run again in CI for Python connectors
- New `-preview` prerelease versions won't accidentally trigger registry entry deletion
- No end-user impact

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Link to Devin run: https://app.devin.ai/sessions/876b89f18e9140f9b1a94a435db838aa
Requested by: AJ Steers (@aaronsteers)

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._

> [!NOTE]
> **Auto-merge may have been disabled. Please check the PR status to confirm.**