### PR TITLE
fix(ci): update generate_dev_tag to use new prerelease format

### DIFF
--- a/poe-tasks/build-and-publish-java-connectors-with-tag.sh
+++ b/poe-tasks/build-and-publish-java-connectors-with-tag.sh
@@ -7,7 +7,7 @@
 #   --name <name>:    Specifies the connector name (e.g., destination-bigquery).
 #                    
 #   --release-type:   Specifies the release type:
-#                     - pre-release: Builds with a dev tag (version-dev.githash).
+#                     - pre-release: Builds with a preview tag (version-preview.githash).
 #                     - main-release: Builds with the exact version from metadata.yaml.
 #                     Defaults to pre-release if not specified.
 #

--- a/poe-tasks/lib/util.sh
+++ b/poe-tasks/lib/util.sh
@@ -54,13 +54,13 @@ get_only_connector() {
   echo "${connectors[@]:0:1}"
 }
 
-# Generate the prerelease image tag (e.g. `1.2.3-dev.abcde12345`).
+# Generate the prerelease image tag (e.g. `1.2.3-preview.abcde12`).
 generate_dev_tag() {
   local base="$1"
-  # force a 10-char short hash to match existing airbyte-ci behaviour.
+  # Use 7-char short hash to match the new prerelease format.
   local hash
-  hash=$(git rev-parse --short=10 HEAD)
-  echo "${base}-dev.${hash}"
+  hash=$(git rev-parse --short=7 HEAD)
+  echo "${base}-preview.${hash}"
 }
 
 # Authenticate to gcloud using the contents of a variable.


### PR DESCRIPTION
## What

Fixes the prerelease workflow failures caused by a mismatch in version tag formats after PR #70970 changed the prerelease format from `-dev.{10-char-sha}` to `-preview.{7-char-sha}`.

The workflow was failing with 404 errors because:
- `upload-connector-metadata.sh` uploaded metadata to: `1.1.2-dev.8f187d69fb`
- `publish_connectors.yml` looked for: `1.1.2-preview.8f187d6`

Example failed run: https://github.com/airbytehq/airbyte/actions/runs/20346390582

## How

Updates `generate_dev_tag()` in `poe-tasks/lib/util.sh` to generate the new format:
- Changes `-dev.` suffix to `-preview.`
- Changes SHA length from 10 characters to 7 characters

Also updates the comment in `build-and-publish-java-connectors-with-tag.sh` to reflect the new format.

## Review guide

1. `poe-tasks/lib/util.sh` - The main fix: `generate_dev_tag()` function now outputs `-preview.{7-char-sha}`
2. `poe-tasks/build-and-publish-java-connectors-with-tag.sh` - Comment-only change for consistency

**Note:** The function name `generate_dev_tag` is now a misnomer since it generates "preview" tags, but renaming it would require updating all callers and is out of scope for this bug fix.

## User Impact

Prerelease connector publishing via `/publish-connectors-prerelease` will work again.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Requested by: AJ Steers (@aaronsteers)

Link to Devin run: https://app.devin.ai/sessions/ef3cd2dbaef64295baf423d6efff5e7f