### PR TITLE
Bulk load CDK: data coercion test calls ValueCoercer.map

### DIFF
--- a/airbyte-cdk/bulk/changelog.md
+++ b/airbyte-cdk/bulk/changelog.md
@@ -1,3 +1,7 @@
+## Version 0.1.92
+
+load cdk: datacoercion suite calls ValueCoercer.map
+
 ## Version 0.1.91
 
 load cdk: upsert records test uses proper target schema

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/component/TableOperationsTestHarness.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/component/TableOperationsTestHarness.kt
@@ -145,7 +145,8 @@ class TableOperationsTestHarness(
                 "test",
                 airbyteMetaField = null,
             )
-        val validatedValue = coercer.validate(inputValueAsEnrichedAirbyteValue)
+        val mappedValue = coercer.map(inputValueAsEnrichedAirbyteValue)
+        val validatedValue = coercer.validate(mappedValue)
         val valueToInsert: AirbyteValue
         val changeReason: Reason?
         when (validatedValue) {
@@ -158,7 +159,7 @@ class TableOperationsTestHarness(
                 changeReason = validatedValue.reason
             }
             ValidationResult.Valid -> {
-                valueToInsert = inputValue
+                valueToInsert = mappedValue.abValue
                 changeReason = null
             }
         }

--- a/airbyte-cdk/bulk/version.properties
+++ b/airbyte-cdk/bulk/version.properties
@@ -1,1 +1,1 @@
-version=0.1.91
+version=0.1.92


### PR DESCRIPTION
this is to support destinations that do type-changing stuff in `map`. Without this, e.g. snowflake would need to override the input value on certain fixtures.

(this will fix test failures like https://github.com/airbytehq/airbyte/runs/58490836476)

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._