### PR TITLE
fix(source-sftp-bulk): fix globs match (directory could match the glob) if // provided in glob

### DIFF
--- a/airbyte-integrations/connectors/source-sftp-bulk/metadata.yaml
+++ b/airbyte-integrations/connectors/source-sftp-bulk/metadata.yaml
@@ -17,7 +17,7 @@ data:
   connectorSubtype: file
   connectorType: source
   definitionId: 31e3242f-dee7-4cdc-a4b8-8e06c5458517
-  dockerImageTag: 1.9.0-rc.1
+  dockerImageTag: 1.9.0-rc.2
   dockerRepository: airbyte/source-sftp-bulk
   documentationUrl: https://docs.airbyte.com/integrations/sources/sftp-bulk
   githubIssueLabel: source-sftp-bulk

--- a/airbyte-integrations/connectors/source-sftp-bulk/pyproject.toml
+++ b/airbyte-integrations/connectors/source-sftp-bulk/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "1.9.0-rc.1"
+version = "1.9.0-rc.2"
 name = "source-sftp-bulk"
 description = "Source implementation for SFTP Bulk."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-sftp-bulk/source_sftp_bulk/stream_reader.py
+++ b/airbyte-integrations/connectors/source-sftp-bulk/source_sftp_bulk/stream_reader.py
@@ -223,6 +223,11 @@ class SourceSFTPBulkStreamReader(AbstractFileBasedStreamReader):
         # Normalize globs to handle root folder correctly
         normalized_globs = []
         for glob_pattern in globs:
+            # Clean up multiple consecutive slashes (e.g., // -> /)
+            # This can happen when patterns are constructed or user-provided
+            while "//" in glob_pattern:
+                glob_pattern = glob_pattern.replace("//", "/")
+
             # If glob doesn't start with /, make it relative to root_folder
             if not glob_pattern.startswith("/"):
                 normalized_globs.append(f"{root_folder.rstrip('/')}/{glob_pattern}")

--- a/airbyte-integrations/connectors/source-sftp-bulk/source_sftp_bulk/stream_reader.py
+++ b/airbyte-integrations/connectors/source-sftp-bulk/source_sftp_bulk/stream_reader.py
@@ -138,6 +138,11 @@ class SourceSFTPBulkStreamReader(AbstractFileBasedStreamReader):
             - dir_path="/data", glob="/*/folder/folder2/*" -> True (could lead to match)
             - dir_path="/data/folder", glob="/*/folder/folder2/*" -> True (partial match)
         """
+
+        if dir_path.startswith("//"):
+            #  wcmatch.glob in filter_files_by_globs_and_start_date makes // and / equal. removing // in the beginning for ease of calculations
+            dir_path = dir_path[1:]
+
         for glob_pattern in globs:
             # Handle recursive wildcard - it matches everything
             if "**" in glob_pattern:
@@ -226,11 +231,11 @@ class SourceSFTPBulkStreamReader(AbstractFileBasedStreamReader):
             # If glob doesn't start with /, make it relative to root_folder
             if not glob_pattern.startswith("/"):
                 normalized_globs.append(f"{root_folder.rstrip('/')}/{glob_pattern}")
-            elif root_folder == "/" and glob_pattern.startswith("/") and not glob_pattern.startswith("//"):
-                # If user provides "/downloads/*.csv" and root is "/", prepend "/" to match "//" URIs
-                normalized_globs.append(f"/{glob_pattern}")
             else:
                 normalized_globs.append(glob_pattern)
+            if glob_pattern.startswith("//"):
+                #  wcmatch.glob in filter_files_by_globs_and_start_date makes // and / equal. removing // in the beginning for ease of calculations
+                normalized_globs.append(glob_pattern[1:])
 
         # Iterate through directories and subdirectories
         while directories:

--- a/airbyte-integrations/connectors/source-sftp-bulk/unit_tests/test_stream_reader_directory_matching.py
+++ b/airbyte-integrations/connectors/source-sftp-bulk/unit_tests/test_stream_reader_directory_matching.py
@@ -160,6 +160,7 @@ class TestGlobNormalization:
         """Test that get_matching_files correctly normalizes globs with double slashes"""
         import logging
         from unittest.mock import MagicMock, patch
+
         import paramiko
         from source_sftp_bulk.spec import SourceSFTPBulkSpec
 
@@ -223,9 +224,11 @@ class TestGlobNormalization:
             # Should match (with // URIs):
             # - //downloads/file_1.csv (matches first glob: //downloads/*.csv)
             # - //data/folder/file_3.txt (matches second glob: //data/folder/**/*.txt)
-            expected_uris = sorted([
-                "//downloads/file_1.csv",
-                "//data/folder/file_3.txt",
-            ])
+            expected_uris = sorted(
+                [
+                    "//downloads/file_1.csv",
+                    "//data/folder/file_3.txt",
+                ]
+            )
 
             assert file_uris == expected_uris, f"Expected {expected_uris} but got {file_uris}"

--- a/docs/integrations/sources/sftp-bulk.md
+++ b/docs/integrations/sources/sftp-bulk.md
@@ -184,6 +184,7 @@ For more information about delivery methods and their limitations, see the [Deli
 
 | Version | Date       | Pull Request                                             | Subject                                                     |
 |:--------|:-----------|:---------------------------------------------------------|:------------------------------------------------------------|
+| 1.9.0-rc.2 | 2026-01-05 | [71038](https://github.com/airbytehq/airbyte/pull/71038) | Fix directory could match globs logic                    |
 | 1.9.0-rc.1 | 2025-12-09 | [69167](https://github.com/airbytehq/airbyte/pull/69167) | Fix OOM on check, update airbyte-cdk version                                                                                                                           |
 | 1.8.9      | 2025-11-24 | | Increase `maxSecondsBetweenMessages` to 3 hours                                                                                                                          |
 | 1.8.8      | 2025-11-10 | [69257](https://github.com/airbytehq/airbyte/pull/69257) | Update error message when file exceeds size limit                                                                                                                      |


### PR DESCRIPTION
## What
An issue was with globs that use "//" in the beginning, despite files were found and returned in `get_mathcing_files` files they had wrong uri with "/" in the beginning - fixed by removing rstrip call. Also updated directory could match the glob logic to replace "//" to "/" as they are treated as the same in the lib.

## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
