### PR TITLE
chore(destination-duckdb, destination-motherduck): Add version lifecycle URL to external docs

### DIFF
--- a/airbyte-integrations/connectors/destination-duckdb/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-duckdb/metadata.yaml
@@ -75,4 +75,7 @@ data:
     - title: SQL reference
       url: https://duckdb.org/docs/sql/introduction
       type: sql_reference
+    - title: MotherDuck Version Lifecycle Schedules
+      url: https://motherduck.com/docs/troubleshooting/version-lifecycle-schedules/
+      type: api_deprecations
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-motherduck/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-motherduck/metadata.yaml
@@ -66,4 +66,7 @@ data:
     - title: MotherDuck Status
       url: https://status.motherduck.com/
       type: status_page
+    - title: MotherDuck Version Lifecycle Schedules
+      url: https://motherduck.com/docs/troubleshooting/version-lifecycle-schedules/
+      type: api_deprecations
 metadataSpecVersion: "1.0"


### PR DESCRIPTION
## What

Adds the MotherDuck Version Lifecycle Schedules URL to the `externalDocumentationUrls` in both `destination-duckdb` and `destination-motherduck` metadata.yaml files.

This URL (https://motherduck.com/docs/troubleshooting/version-lifecycle-schedules/) documents End of Life dates for DuckDB versions supported by MotherDuck, which is critical information for API deprecation monitoring.

**Key finding**: DuckDB 1.2.x (currently used by destination-duckdb v0.5.1) reaches End of Life in **January 2026**.

## How

Added a new entry to `externalDocumentationUrls` in both connector metadata files with:
- `title`: MotherDuck Version Lifecycle Schedules
- `url`: https://motherduck.com/docs/troubleshooting/version-lifecycle-schedules/
- `type`: api_deprecations

## Review guide

1. `airbyte-integrations/connectors/destination-duckdb/metadata.yaml` - new URL entry
2. `airbyte-integrations/connectors/destination-motherduck/metadata.yaml` - new URL entry

## User Impact

No user-facing impact. This is a metadata-only change that improves API deprecation monitoring coverage for these connectors.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Requested by: @aaronsteers

Link to Devin run: https://app.devin.ai/sessions/5f8881d415af4a63b302b8c691229369

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._

> [!NOTE]
> **Auto-merge may have been disabled. Please check the PR status to confirm.**