### PR TITLE
ci: Delete /run-live-tests slash command

### DIFF
--- a/.github/pr-welcome-community.md
+++ b/.github/pr-welcome-community.md
@@ -18,7 +18,6 @@ As needed or by request, Airbyte Maintainers can execute the following slash com
 - `/bump-version` - Bumps connector versions.
 - `/run-connector-tests` - Runs connector tests.
 - `/run-cat-tests` - Runs CAT tests.
-- `/run-live-tests` - Runs live tests for the modified connector(s).
 - `/run-regression-tests` - Runs regression tests for the modified connector(s).
 - `/build-connector-images` - Builds and publishes a pre-release docker image for the modified connector(s).
 - `/publish-connectors-prerelease` - Publishes pre-release connector builds (tagged as `{version}-preview.{git-sha}`) for all modified connectors in the PR.

--- a/.github/pr-welcome-internal.md
+++ b/.github/pr-welcome-internal.md
@@ -7,7 +7,6 @@ Here are some helpful tips and reminders for your convenience.
 - [Breaking Changes Guide](https://docs.airbyte.com/platform/connector-development/connector-breaking-changes) - Breaking changes, migration guides, and upgrade deadlines
 - [Developing Connectors Locally](https://docs.airbyte.com/platform/connector-development/local-connector-development)
 - [Managing Connector Secrets](https://docs.airbyte.com/platform/connector-development/local-connector-development#managing-connector-secrets)
-- [On-Demand Live Tests](https://github.com/airbytehq/airbyte/actions/workflows/live_tests.yml)
 - [On-Demand Regression Tests](https://github.com/airbytehq/airbyte/actions/workflows/regression_tests.yml)
 - [`#connector-ci-issues`](https://airbytehq-team.slack.com/archives/C05KSGM8MNC)
 - [`#connector-publish-updates`](https://airbytehq-team.slack.com/archives/C056HGD1QSW)
@@ -25,7 +24,6 @@ Airbyte Maintainers (that's you!) can execute the following slash commands on yo
   - Creates a release candidate version (e.g., `2.16.10-rc.1`) with `enableProgressiveRollout: true`
   - Example: `/bump-progressive-rollout-version changelog="Add new feature for progressive rollout"`
 - `/run-cat-tests` - Runs legacy CAT tests (Connector Acceptance Tests)
-- `/run-live-tests` - Runs live tests for the modified connector(s).
 - `/run-regression-tests` - Runs regression tests for the modified connector(s).
 - `/build-connector-images` - Builds and publishes a pre-release docker image for the modified connector(s).
 - `/publish-connectors-prerelease` - Publishes pre-release connector builds (tagged as `{version}-preview.{git-sha}`) for all modified connectors in the PR.

--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -72,7 +72,6 @@ jobs:
             publish-java-cdk
             run-cat-tests
             run-connector-tests
-            run-live-tests
             run-regression-tests
             test-performance
             update-connector-cdk-version


### PR DESCRIPTION
## What

Removes the `/run-live-tests` slash command and its documentation references. Users should use `/run-regression-tests` instead.

This aligns with terminology changes in [airbyte-ops-mcp#172](https://github.com/airbytehq/airbyte-ops-mcp/pull/172) where "live tests" is now reserved for scenarios involving actual live connection pinning to prereleases, while "regression tests" encompasses all connector validation testing.

## How

- Removed `run-live-tests` from the slash command dispatch list in `slash-commands.yml`
- Removed `/run-live-tests` documentation from both PR welcome messages
- Removed the "On-Demand Live Tests" workflow link from internal PR welcome message

## Review guide

1. `.github/workflows/slash-commands.yml` - Command removal from dispatch list
2. `.github/pr-welcome-community.md` - Documentation removal
3. `.github/pr-welcome-internal.md` - Documentation and link removal

## User Impact

Users who previously used `/run-live-tests` will need to use `/run-regression-tests` instead. The `/run-regression-tests` command provides equivalent functionality.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

**Requested by:** AJ Steers (@aaronsteers)
**Link to Devin run:** https://app.devin.ai/sessions/737654ea235e437489cd0fe376e29504