### PR TITLE
ci: Fix slash command result detection to properly report success/failure

### DIFF
--- a/.github/workflows/connector-ci-checks.yml
+++ b/.github/workflows/connector-ci-checks.yml
@@ -31,7 +31,7 @@ on:
     outputs:
       result:
         description: "The result of the checks, e.g. 'success' if successful."
-        value: ${{ jobs.connector-ci-checks-summary.result }}
+        value: ${{ jobs.connector-ci-checks-summary.outputs.result }}
       commit-sha:
         description: "The commit SHA of the current branch, used to report test results."
         value: ${{ jobs.generate-matrix.outputs.commit-sha }}
@@ -470,6 +470,8 @@ jobs:
       - pre-release-checks
       - connectors-lint
     runs-on: ubuntu-24.04
+    outputs:
+      result: ${{ steps.evaluate-status.outputs.result }}
     steps:
       - name: Evaluate Status
         id: evaluate-status


### PR DESCRIPTION
## What

Fixes the `/run-connector-tests` slash command always reporting "job completed successfully" even when tests fail. See [this comment](https://github.com/airbytehq/airbyte/pull/70221#issuecomment-3599287191) for an example where the command reported success despite test failures.

## How

The workflow output was using `jobs.connector-ci-checks-summary.result` which returns the **job's completion status** (success if the job runs without errors), not the step's output that evaluates whether the actual tests passed or failed.

Fixed by:
1. Adding an `outputs` section to the `connector-ci-checks-summary` job to expose the `evaluate-status` step output
2. Updating the workflow output to reference `jobs.connector-ci-checks-summary.outputs.result` instead of `jobs.connector-ci-checks-summary.result`

## Review guide

1. `.github/workflows/connector-ci-checks.yml` - Two small changes:
   - Line 34: Changed workflow output reference from `.result` to `.outputs.result`
   - Lines 473-474: Added job `outputs` section to expose the step output

## User Impact

Slash commands like `/run-connector-tests` will now correctly report failure when tests fail, instead of always showing success.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Link to Devin run: https://app.devin.ai/sessions/38464f16eb5f495cb72a77841632c875
Requested by: AJ Steers (@aaronsteers)