### PR TITLE
chore(connectors_qa): Add version bump hints to QA check error messages

### DIFF
--- a/airbyte-ci/connectors/connectors_qa/src/connectors_qa/checks/version.py
+++ b/airbyte-ci/connectors/connectors_qa/src/connectors_qa/checks/version.py
@@ -139,7 +139,9 @@ class CheckVersionIncrement(Check):
                     f"The dockerImageTag in {consts.METADATA_FILE_NAME} appears to be lower than the "
                     f"version on the default branch. Master version is {master_version}, current "
                     f"version is {current_version}. "
-                    f"Update your PR branch from the default branch to get the latest connector version.",
+                    f"Update your PR branch from the default branch to get the latest connector version. "
+                    f"Maintainers can use the `/bump-version` PR slash command. "
+                    f"AI agents can use the `bump_version_in_repo` tool from the `airbyte-ops-mcp` MCP server.",
                 )
             if current_version == master_version:
                 # Allow version to stay the same if registryOverrides.cloud.dockerImageTag or
@@ -149,7 +151,9 @@ class CheckVersionIncrement(Check):
                         connector,
                         f"The dockerImageTag in {consts.METADATA_FILE_NAME} was not incremented. "
                         f"Master version is {master_version}, current version is {current_version}. "
-                        f"Ignore this message if you do not intend to re-release the connector.",
+                        f"Ignore this message if you do not intend to re-release the connector. "
+                        f"Maintainers can use the `/bump-version` PR slash command. "
+                        f"AI agents can use the `bump_version_in_repo` tool from the `airbyte-ops-mcp` MCP server.",
                     )
                 else:
                     same_versions_but_has_registry_override = True

--- a/airbyte-ci/connectors/connectors_qa/tests/unit_tests/test_checks/test_version.py
+++ b/airbyte-ci/connectors/connectors_qa/tests/unit_tests/test_checks/test_version.py
@@ -46,7 +46,7 @@ class TestVersionIncrementCheck:
         assert result.status == CheckStatus.FAILED
         assert (
             result.message
-            == f"The dockerImageTag in {consts.METADATA_FILE_NAME} was not incremented. Master version is 1.0.0, current version is 1.0.0. Ignore this message if you do not intend to re-release the connector."
+            == f"The dockerImageTag in {consts.METADATA_FILE_NAME} was not incremented. Master version is 1.0.0, current version is 1.0.0. Ignore this message if you do not intend to re-release the connector. Maintainers can use the `/bump-version` PR slash command. AI agents can use the `bump_version_in_repo` tool from the `airbyte-ops-mcp` MCP server."
         )
 
     def test_validate_failure_decrement(self, mock_connector, mocker):
@@ -56,7 +56,7 @@ class TestVersionIncrementCheck:
         assert result.status == CheckStatus.FAILED
         assert (
             result.message
-            == f"The dockerImageTag in {consts.METADATA_FILE_NAME} appears to be lower than the version on the default branch. Master version is 1.1.0, current version is 1.0.0. Update your PR branch from the default branch to get the latest connector version."
+            == f"The dockerImageTag in {consts.METADATA_FILE_NAME} appears to be lower than the version on the default branch. Master version is 1.1.0, current version is 1.0.0. Update your PR branch from the default branch to get the latest connector version. Maintainers can use the `/bump-version` PR slash command. AI agents can use the `bump_version_in_repo` tool from the `airbyte-ops-mcp` MCP server."
         )
 
     def test_validate_success_rc_increment(self, mock_connector, mocker):


### PR DESCRIPTION
## What

Improves the developer experience when version increment QA checks fail by adding actionable hints to the error messages. This helps both human maintainers and AI agents quickly resolve version bump issues.

## How

Updated two error messages in `CheckVersionIncrement` to include:
- A hint for maintainers about the `/bump-version` PR slash command
- A hint for AI agents about the `bump_version_in_repo` tool from the `airbyte-ops-mcp` MCP server

Updated corresponding unit test assertions to match the new message strings.

## Review guide

1. `airbyte-ci/connectors/connectors_qa/src/connectors_qa/checks/version.py` - The two updated error messages (lines 139-145 and 151-157)
2. `airbyte-ci/connectors/connectors_qa/tests/unit_tests/test_checks/test_version.py` - Updated test assertions

**Please verify:**
- [ ] The `/bump-version` slash command name is correct
- [ ] The `airbyte-ops-mcp` MCP server name is correct
- [ ] The message wording is clear and helpful

## User Impact

When a connector PR fails the version increment check, developers will now see helpful hints on how to fix the issue using either the slash command (for maintainers) or the MCP tool (for AI agents).

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Requested by: @aaronsteers

Link to Devin run: https://app.devin.ai/sessions/4d5e205cec5f4a8d8da06da31e023802