### PR TITLE
ci: fix empty branch display in pre-release publish message

### DIFF
--- a/.github/workflows/publish-connectors-prerelease-command.yml
+++ b/.github/workflows/publish-connectors-prerelease-command.yml
@@ -32,8 +32,8 @@ on:
         required: false
         type: number
       pr:
-        description: "The pull request number, if applicable"
-        required: false
+        description: "The pull request number (required)"
+        required: true
         type: number
       connector:
         description: "Single connector name to publish (e.g., destination-pinecone). If not provided, auto-detects from PR changes (fails if 0 or 2+ connectors modified)."
@@ -55,37 +55,12 @@ jobs:
       short-sha: ${{ steps.get-sha.outputs.short-sha }}
       connector-name: ${{ steps.resolve-connector.outputs.connector-name }}
       connector-version: ${{ steps.connector-version.outputs.connector-version }}
-      effective-gitref: ${{ steps.resolve-gitref.outputs.effective-gitref }}
     steps:
-      - name: Resolve effective gitref from PR number
-        id: resolve-gitref
-        run: |
-          set -euo pipefail
-
-          # When PR number is provided, use refs/pull/{pr}/head directly (no API call needed)
-          # This is the canonical way to reference PR code and cannot be overridden by callers
-          if [[ -n "${{ inputs.pr }}" ]]; then
-            EFFECTIVE_REF="refs/pull/${{ inputs.pr }}/head"
-            echo "Using PR ref: $EFFECTIVE_REF"
-            echo "effective-gitref=$EFFECTIVE_REF" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-
-          # Fallback for non-PR invocations (e.g., manual dispatch without PR)
-          # Use inputs.gitref if provided, otherwise github.ref_name
-          if [[ -n "${{ inputs.gitref }}" ]]; then
-            echo "Using provided gitref: ${{ inputs.gitref }}"
-            echo "effective-gitref=${{ inputs.gitref }}" >> $GITHUB_OUTPUT
-          else
-            echo "Using github.ref_name: ${{ github.ref_name }}"
-            echo "effective-gitref=${{ github.ref_name }}" >> $GITHUB_OUTPUT
-          fi
-
       - name: Checkout to get commit SHA
         uses: actions/checkout@v4
         with:
           repository: ${{ inputs.repo || github.repository }}
-          ref: ${{ steps.resolve-gitref.outputs.effective-gitref }}
+          ref: refs/pull/${{ inputs.pr }}/head
           fetch-depth: 0
 
       - name: Get short SHA
@@ -172,7 +147,7 @@ jobs:
     with:
       connectors: ${{ format('--name={0}', needs.init.outputs.connector-name) }}
       release-type: pre-release
-      gitref: ${{ needs.init.outputs.effective-gitref }}
+      gitref: refs/pull/${{ inputs.pr }}/head
     secrets: inherit
 
   post-completion:

--- a/.github/workflows/publish-connectors-prerelease-command.yml
+++ b/.github/workflows/publish-connectors-prerelease-command.yml
@@ -57,35 +57,29 @@ jobs:
       connector-version: ${{ steps.connector-version.outputs.connector-version }}
       effective-gitref: ${{ steps.resolve-gitref.outputs.effective-gitref }}
     steps:
-      - name: Resolve effective gitref
+      - name: Resolve effective gitref from PR number
         id: resolve-gitref
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
-          # Priority: inputs.gitref > PR head ref > github.ref_name
-          if [[ -n "${{ inputs.gitref }}" ]]; then
-            echo "Using provided gitref: ${{ inputs.gitref }}"
-            echo "effective-gitref=${{ inputs.gitref }}" >> $GITHUB_OUTPUT
+          # When PR number is provided, use refs/pull/{pr}/head directly (no API call needed)
+          # This is the canonical way to reference PR code and cannot be overridden by callers
+          if [[ -n "${{ inputs.pr }}" ]]; then
+            EFFECTIVE_REF="refs/pull/${{ inputs.pr }}/head"
+            echo "Using PR ref: $EFFECTIVE_REF"
+            echo "effective-gitref=$EFFECTIVE_REF" >> $GITHUB_OUTPUT
             exit 0
           fi
 
-          # If PR number is provided, fetch the head ref from the PR
-          if [[ -n "${{ inputs.pr }}" ]]; then
-            echo "Fetching head ref from PR #${{ inputs.pr }}..."
-            PR_HEAD_REF=$(gh pr view ${{ inputs.pr }} --repo ${{ inputs.repo || github.repository }} --json headRefName --jq '.headRefName')
-            if [[ -n "$PR_HEAD_REF" ]]; then
-              echo "Resolved PR head ref: $PR_HEAD_REF"
-              echo "effective-gitref=$PR_HEAD_REF" >> $GITHUB_OUTPUT
-              exit 0
-            fi
-            echo "::warning::Could not resolve PR head ref, falling back to github.ref_name"
+          # Fallback for non-PR invocations (e.g., manual dispatch without PR)
+          # Use inputs.gitref if provided, otherwise github.ref_name
+          if [[ -n "${{ inputs.gitref }}" ]]; then
+            echo "Using provided gitref: ${{ inputs.gitref }}"
+            echo "effective-gitref=${{ inputs.gitref }}" >> $GITHUB_OUTPUT
+          else
+            echo "Using github.ref_name: ${{ github.ref_name }}"
+            echo "effective-gitref=${{ github.ref_name }}" >> $GITHUB_OUTPUT
           fi
-
-          # Fallback to github.ref_name (may be 'master' if workflow dispatched on default branch)
-          echo "Using fallback github.ref_name: ${{ github.ref_name }}"
-          echo "effective-gitref=${{ github.ref_name }}" >> $GITHUB_OUTPUT
 
       - name: Checkout to get commit SHA
         uses: actions/checkout@v4
@@ -164,7 +158,7 @@ jobs:
             > **Pre-release Connector Publish Started**
             >
             > Publishing pre-release build for connector `${{ steps.resolve-connector.outputs.connector-name }}`.
-            > Branch: `${{ steps.resolve-gitref.outputs.effective-gitref }}`
+            > PR: [#${{ inputs.pr }}](https://github.com/${{ inputs.repo || github.repository }}/pull/${{ inputs.pr }})
             >
             > Pre-release versions will be tagged as `{version}-preview.${{ steps.get-sha.outputs.short-sha }}`
             > and are available for version pinning via the scoped_configuration API.

--- a/.github/workflows/publish-connectors-prerelease-command.yml
+++ b/.github/workflows/publish-connectors-prerelease-command.yml
@@ -55,12 +55,43 @@ jobs:
       short-sha: ${{ steps.get-sha.outputs.short-sha }}
       connector-name: ${{ steps.resolve-connector.outputs.connector-name }}
       connector-version: ${{ steps.connector-version.outputs.connector-version }}
+      effective-gitref: ${{ steps.resolve-gitref.outputs.effective-gitref }}
     steps:
+      - name: Resolve effective gitref
+        id: resolve-gitref
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          # Priority: inputs.gitref > PR head ref > github.ref_name
+          if [[ -n "${{ inputs.gitref }}" ]]; then
+            echo "Using provided gitref: ${{ inputs.gitref }}"
+            echo "effective-gitref=${{ inputs.gitref }}" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # If PR number is provided, fetch the head ref from the PR
+          if [[ -n "${{ inputs.pr }}" ]]; then
+            echo "Fetching head ref from PR #${{ inputs.pr }}..."
+            PR_HEAD_REF=$(gh pr view ${{ inputs.pr }} --repo ${{ inputs.repo || github.repository }} --json headRefName --jq '.headRefName')
+            if [[ -n "$PR_HEAD_REF" ]]; then
+              echo "Resolved PR head ref: $PR_HEAD_REF"
+              echo "effective-gitref=$PR_HEAD_REF" >> $GITHUB_OUTPUT
+              exit 0
+            fi
+            echo "::warning::Could not resolve PR head ref, falling back to github.ref_name"
+          fi
+
+          # Fallback to github.ref_name (may be 'master' if workflow dispatched on default branch)
+          echo "Using fallback github.ref_name: ${{ github.ref_name }}"
+          echo "effective-gitref=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+
       - name: Checkout to get commit SHA
         uses: actions/checkout@v4
         with:
           repository: ${{ inputs.repo || github.repository }}
-          ref: ${{ inputs.gitref || '' }}
+          ref: ${{ steps.resolve-gitref.outputs.effective-gitref }}
           fetch-depth: 0
 
       - name: Get short SHA
@@ -133,7 +164,7 @@ jobs:
             > **Pre-release Connector Publish Started**
             >
             > Publishing pre-release build for connector `${{ steps.resolve-connector.outputs.connector-name }}`.
-            > Branch: `${{ inputs.gitref || github.ref_name }}`
+            > Branch: `${{ steps.resolve-gitref.outputs.effective-gitref }}`
             >
             > Pre-release versions will be tagged as `{version}-preview.${{ steps.get-sha.outputs.short-sha }}`
             > and are available for version pinning via the scoped_configuration API.
@@ -147,7 +178,7 @@ jobs:
     with:
       connectors: ${{ format('--name={0}', needs.init.outputs.connector-name) }}
       release-type: pre-release
-      gitref: ${{ inputs.gitref }}
+      gitref: ${{ needs.init.outputs.effective-gitref }}
     secrets: inherit
 
   post-completion:

--- a/.github/workflows/publish-connectors-prerelease-command.yml
+++ b/.github/workflows/publish-connectors-prerelease-command.yml
@@ -24,7 +24,7 @@ on:
         default: "airbytehq/airbyte"
         type: string
       gitref:
-        description: "The git reference (branch or tag)"
+        description: "The git reference (branch or tag). NOTE: This input is ignored; the workflow always uses refs/pull/{pr}/head from the PR number."
         required: false
         type: string
       comment-id:

--- a/.github/workflows/publish-connectors-prerelease-command.yml
+++ b/.github/workflows/publish-connectors-prerelease-command.yml
@@ -133,7 +133,7 @@ jobs:
             > **Pre-release Connector Publish Started**
             >
             > Publishing pre-release build for connector `${{ steps.resolve-connector.outputs.connector-name }}`.
-            > Branch: `${{ inputs.gitref }}`
+            > Branch: `${{ inputs.gitref || github.ref_name }}`
             >
             > Pre-release versions will be tagged as `{version}-preview.${{ steps.get-sha.outputs.short-sha }}`
             > and are available for version pinning via the scoped_configuration API.


### PR DESCRIPTION
## What

Fixes the empty "Branch:" field in pre-release connector publish messages. When `/publish-connectors-prerelease` is invoked (via slash command or MCP tool), the status comment shows `Branch: `` ` instead of the actual branch name.

Example of the bug (from [airbytehq/airbyte#71063](https://github.com/airbytehq/airbyte/pull/71063#issuecomment-3703975949)):
> Branch: ``

## How

Simplified the workflow to always derive the git ref from the PR number:

1. Made `pr` a required input (was optional)
2. Use `refs/pull/${{ inputs.pr }}/head` inline for checkout and downstream `publish_connectors.yml` call
3. Changed comment display from `Branch: ...` to `PR: #...` with a clickable link
4. Added note to `gitref` input description that it's ignored (kept for slash command dispatch compatibility)

**Key design decisions:**
- PR number is the single source of truth - no fallback logic needed
- `gitref` input is kept but ignored (required by slash command dispatch static args)
- No GitHub API calls needed - `refs/pull/{pr}/head` is the canonical way to reference PR code

## Review guide

1. `.github/workflows/publish-connectors-prerelease-command.yml` - All changes in this file

**Human review checklist:**
- [ ] Verify `refs/pull/{pr}/head` works correctly for checkout and downstream `publish_connectors.yml`
- [ ] Confirm the UX change from "Branch: ..." to "PR: #..." is acceptable
- [ ] Verify existing callers (slash command dispatcher, MCP tool) always pass PR number
- [ ] Consider if fork PRs need special handling (should work since `refs/pull/{pr}/head` is in the base repo)

## User Impact

Pre-release publish status comments will now correctly display a clickable PR link instead of showing an empty branch value.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

---

Link to Devin run: https://app.devin.ai/sessions/8a26b7fcb0234672aced61d260dd706d
Requested by: AJ Steers (@aaronsteers)