### PR TITLE
feat: Centralize prerelease version tag computation via airbyte-ops-mcp CLI

### DIFF
--- a/.github/actions/connector-image-build-push/action.yml
+++ b/.github/actions/connector-image-build-push/action.yml
@@ -139,9 +139,11 @@ runs:
           CONNECTOR_VERSION_TAG="${{ inputs.tag-override }}"
           echo "🏷 Using provided tag override: $CONNECTOR_VERSION_TAG"
         elif [[ "${{ inputs.release-type }}" == "pre-release" ]]; then
-          hash=$(git rev-parse --short=7 HEAD)
-          CONNECTOR_VERSION_TAG="${CONNECTOR_VERSION}-preview.${hash}"
-          echo "🏷 Using pre-release tag: $CONNECTOR_VERSION_TAG"
+          # Pre-release builds MUST use tag-override (computed by airbyte-ops-mcp CLI)
+          echo "❌ Pre-release builds require tag-override input."
+          echo "   Use airbyte-ops-mcp CLI to compute the prerelease tag:"
+          echo "   airbyte-ops registry connector compute-prerelease-tag --base-version X.Y.Z --sha COMMIT_SHA"
+          exit 1
         else
           CONNECTOR_VERSION_TAG="$CONNECTOR_VERSION"
           echo "🏷 Using main release tag: $CONNECTOR_VERSION_TAG"

--- a/.github/workflows/publish-connectors-prerelease-command.yml
+++ b/.github/workflows/publish-connectors-prerelease-command.yml
@@ -48,14 +48,6 @@ jobs:
   init:
     name: Initialize Pre-release Publish
     runs-on: ubuntu-24.04
-    outputs:
-      run-url: ${{ steps.job-vars.outputs.run-url }}
-      pr-number: ${{ steps.job-vars.outputs.pr-number }}
-      comment-id: ${{ steps.append-start-comment.outputs.comment-id }}
-      short-sha: ${{ steps.get-sha.outputs.short-sha }}
-      connector-name: ${{ steps.resolve-connector.outputs.connector-name }}
-      connector-version: ${{ steps.connector-version.outputs.connector-version }}
-      prerelease-tag: ${{ steps.compute-prerelease-tag.outputs.prerelease-tag }}
     steps:
       - name: Checkout to get commit SHA
         uses: actions/checkout@v4
@@ -161,6 +153,14 @@ jobs:
             > and are available for version pinning via the scoped_configuration API.
             >
             > [View workflow run](${{ steps.job-vars.outputs.run-url }})
+    outputs:
+      run-url: ${{ steps.job-vars.outputs.run-url }}
+      pr-number: ${{ steps.job-vars.outputs.pr-number }}
+      comment-id: ${{ steps.append-start-comment.outputs.comment-id }}
+      short-sha: ${{ steps.get-sha.outputs.short-sha }}
+      connector-name: ${{ steps.resolve-connector.outputs.connector-name }}
+      connector-version: ${{ steps.connector-version.outputs.connector-version }}
+      prerelease-tag: ${{ steps.compute-prerelease-tag.outputs.prerelease-tag }}
 
   publish:
     name: Publish Pre-release

--- a/.github/workflows/publish-connectors-prerelease-command.yml
+++ b/.github/workflows/publish-connectors-prerelease-command.yml
@@ -129,18 +129,16 @@ jobs:
         id: compute-prerelease-tag
         run: |
           set -euo pipefail
-          BASE_VERSION="${{ steps.connector-version.outputs.connector-version }}"
+          CONNECTOR_NAME="${{ steps.resolve-connector.outputs.connector-name }}"
           SHORT_SHA="${{ steps.get-sha.outputs.short-sha }}"
-
-          if [[ -z "$BASE_VERSION" ]]; then
-            echo "::error::Base version is empty. Cannot compute prerelease tag."
-            exit 1
-          fi
+          BASE_VERSION="${{ steps.connector-version.outputs.connector-version }}"
 
           # Use airbyte-ops-mcp CLI to compute the prerelease tag (single source of truth)
+          # Pass --base-version to avoid GitHub API call since we already have the version locally
           PRERELEASE_TAG=$(uvx airbyte-internal-ops registry connector compute-prerelease-tag \
-            --base-version "$BASE_VERSION" \
-            --sha "$SHORT_SHA")
+            --connector-name "$CONNECTOR_NAME" \
+            --sha "$SHORT_SHA" \
+            --base-version "$BASE_VERSION")
 
           echo "Computed prerelease tag: $PRERELEASE_TAG"
           echo "prerelease-tag=$PRERELEASE_TAG" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/publish-connectors-prerelease-command.yml
+++ b/.github/workflows/publish-connectors-prerelease-command.yml
@@ -55,6 +55,7 @@ jobs:
       short-sha: ${{ steps.get-sha.outputs.short-sha }}
       connector-name: ${{ steps.resolve-connector.outputs.connector-name }}
       connector-version: ${{ steps.connector-version.outputs.connector-version }}
+      prerelease-tag: ${{ steps.compute-prerelease-tag.outputs.prerelease-tag }}
     steps:
       - name: Checkout to get commit SHA
         uses: actions/checkout@v4
@@ -121,6 +122,29 @@ jobs:
           fi
           echo "connector-version=$VERSION" >> "$GITHUB_OUTPUT"
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+
+      - name: Compute prerelease tag
+        id: compute-prerelease-tag
+        run: |
+          set -euo pipefail
+          BASE_VERSION="${{ steps.connector-version.outputs.connector-version }}"
+          SHORT_SHA="${{ steps.get-sha.outputs.short-sha }}"
+
+          if [[ -z "$BASE_VERSION" ]]; then
+            echo "::error::Base version is empty. Cannot compute prerelease tag."
+            exit 1
+          fi
+
+          # Use airbyte-ops-mcp CLI to compute the prerelease tag (single source of truth)
+          PRERELEASE_TAG=$(uvx airbyte-internal-ops registry connector compute-prerelease-tag \
+            --base-version "$BASE_VERSION" \
+            --sha "$SHORT_SHA")
+
+          echo "Computed prerelease tag: $PRERELEASE_TAG"
+          echo "prerelease-tag=$PRERELEASE_TAG" >> "$GITHUB_OUTPUT"
+
       - name: Append start comment
         id: append-start-comment
         if: inputs.comment-id != '' || inputs.pr != ''
@@ -148,6 +172,7 @@ jobs:
       connectors: ${{ format('--name={0}', needs.init.outputs.connector-name) }}
       release-type: pre-release
       gitref: refs/pull/${{ inputs.pr }}/head
+      prerelease-tag: ${{ needs.init.outputs.prerelease-tag }}
     secrets: inherit
 
   post-completion:

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -25,6 +25,10 @@ on:
         description: "Git ref (branch or SHA) to build connectors from. Used by pre-release workflow to build from PR branches."
         required: false
         type: string
+      prerelease-tag:
+        description: "Pre-computed prerelease tag (e.g., '1.2.3-preview.abcdef1'). Required for pre-release builds. Computed by airbyte-ops-mcp CLI."
+        required: false
+        type: string
     outputs:
       docker-image-tag:
         description: "Docker image tag used when publishing. For single-connector callers only; multi-connector callers should not rely on this output."
@@ -229,6 +233,7 @@ jobs:
         with:
           connector-name: ${{ matrix.connector }}
           release-type: ${{ needs.publish_options.outputs.release-type }}
+          tag-override: ${{ inputs.prerelease-tag }}
           dry-run: "false"
           docker-hub-username: ${{ secrets.DOCKER_HUB_USERNAME }}
           docker-hub-password: ${{ secrets.DOCKER_HUB_PASSWORD }}
@@ -305,8 +310,13 @@ jobs:
           echo "connector-version=$(poe -qq get-version)" | tee -a $GITHUB_OUTPUT
           CONNECTOR_VERSION=$(poe -qq get-version)
           if [[ "${{ inputs.release-type }}" == "pre-release" ]]; then
-            hash=$(git rev-parse --short=7 HEAD)
-            echo "docker-image-tag=${CONNECTOR_VERSION}-preview.${hash}" | tee -a $GITHUB_OUTPUT
+            # Use pre-computed prerelease tag if provided (single source of truth)
+            if [[ -n "${{ inputs.prerelease-tag }}" ]]; then
+              echo "docker-image-tag=${{ inputs.prerelease-tag }}" | tee -a $GITHUB_OUTPUT
+            else
+              echo "::error::Pre-release build requires prerelease-tag input. Use airbyte-ops-mcp CLI to compute the tag."
+              exit 1
+            fi
             echo "release-type-flag=--pre-release" | tee -a $GITHUB_OUTPUT
           else
             echo "docker-image-tag=${CONNECTOR_VERSION}" | tee -a $GITHUB_OUTPUT

--- a/poe-tasks/lib/util.sh
+++ b/poe-tasks/lib/util.sh
@@ -55,17 +55,13 @@ get_only_connector() {
 }
 
 # Generate the prerelease image tag (e.g. `1.2.3-preview.abcde12`).
-# DEPRECATED: Use airbyte-ops-mcp CLI instead for single source of truth:
-#   airbyte-ops registry connector compute-prerelease-tag --base-version X.Y.Z --sha COMMIT_SHA
-# This function is kept for backward compatibility but should not be used in new code.
+# DEPRECATED: This function has been removed. Use airbyte-ops-mcp CLI instead:
+#   airbyte-ops registry connector compute-prerelease-tag --connector-name <name> --sha <sha>
 generate_dev_tag() {
-  local base="$1"
-  echo "WARNING: generate_dev_tag() is deprecated. Use airbyte-ops-mcp CLI instead:" >&2
-  echo "  airbyte-ops registry connector compute-prerelease-tag --base-version $base --sha \$(git rev-parse --short=7 HEAD)" >&2
-  # Use 7-char short hash to match the new prerelease format.
-  local hash
-  hash=$(git rev-parse --short=7 HEAD)
-  echo "${base}-preview.${hash}"
+  echo "ERROR: generate_dev_tag() has been removed." >&2
+  echo "Use airbyte-ops-mcp CLI instead:" >&2
+  echo "  uvx airbyte-internal-ops registry connector compute-prerelease-tag --connector-name <name> --sha <sha>" >&2
+  exit 1
 }
 
 # Authenticate to gcloud using the contents of a variable.

--- a/poe-tasks/lib/util.sh
+++ b/poe-tasks/lib/util.sh
@@ -55,8 +55,13 @@ get_only_connector() {
 }
 
 # Generate the prerelease image tag (e.g. `1.2.3-preview.abcde12`).
+# DEPRECATED: Use airbyte-ops-mcp CLI instead for single source of truth:
+#   airbyte-ops registry connector compute-prerelease-tag --base-version X.Y.Z --sha COMMIT_SHA
+# This function is kept for backward compatibility but should not be used in new code.
 generate_dev_tag() {
   local base="$1"
+  echo "WARNING: generate_dev_tag() is deprecated. Use airbyte-ops-mcp CLI instead:" >&2
+  echo "  airbyte-ops registry connector compute-prerelease-tag --base-version $base --sha \$(git rev-parse --short=7 HEAD)" >&2
   # Use 7-char short hash to match the new prerelease format.
   local hash
   hash=$(git rev-parse --short=7 HEAD)


### PR DESCRIPTION
## What

Centralizes pre-release version tag computation to use a single source of truth from the `airbyte-ops-mcp` CLI, removing redundant tag calculations across multiple workflow files.

Related: airbytehq/airbyte-ops-mcp#185, airbytehq/airbyte-ops-mcp#187

## How

1. **publish-connectors-prerelease-command.yml**: Computes the prerelease tag once using `uvx airbyte-internal-ops registry connector compute-prerelease-tag --connector-name ... --sha ... --base-version ...` and passes it to downstream workflows
2. **publish_connectors.yml**: Accepts new `prerelease-tag` input and passes it to the build action; hard-fails if pre-release is requested without this input
3. **connector-image-build-push/action.yml**: Removes local tag computation for pre-release; now requires `tag-override` input for pre-release builds
4. **poe-tasks/lib/util.sh**: `generate_dev_tag()` now hard-fails with an error message directing users to the CLI

## Review guide

1. `.github/workflows/publish-connectors-prerelease-command.yml` - New uv installation and CLI call to compute tag
2. `.github/workflows/publish_connectors.yml` - New input parameter and hard-fail logic
3. `.github/actions/connector-image-build-push/action.yml` - Removed local computation, added hard-fail
4. `poe-tasks/lib/util.sh` - Hard-fail on deprecated function

**⚠️ Review checklist:**
- [ ] Confirm `airbyte-internal-ops` is the correct PyPI package name for the CLI
- [ ] Verify no other workflows call `publish_connectors.yml` with `release-type: pre-release` that would break
- [ ] Verify no other scripts call `generate_dev_tag()` that would break

✅ airbytehq/airbyte-ops-mcp#187 is now merged

## User Impact

Pre-release connector builds will now use a centralized tag format. No user-facing changes, but workflow failures will occur if the CLI is unavailable or if callers don't provide the required `prerelease-tag` input.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

### Updates since last revision

- Moved `outputs` section after `steps` in the init job per review feedback (style fix)
- Changed `generate_dev_tag()` from deprecation warning to hard-fail per review feedback

---
Link to Devin run: https://app.devin.ai/sessions/b8371c6ce0834e218b837542714d3147
Requested by: AJ Steers (aj@airbyte.io) (@aaronsteers)