### PR TITLE
fix: Update PyAirbyte docs workflow to clone source instead of installing from PyPI

### DIFF
--- a/.github/workflows/pyairbyte-docs-generate.yml
+++ b/.github/workflows/pyairbyte-docs-generate.yml
@@ -58,9 +58,14 @@ jobs:
             echo "version=${LATEST_VERSION}" >> $GITHUB_OUTPUT
           fi
 
-      - name: Install PyAirbyte
+      - name: Clone PyAirbyte Repository
         run: |
-          pip install airbyte==${{ steps.version.outputs.version }}
+          # Clone PyAirbyte at the specific version tag
+          # pydoc-markdown needs source files, not installed packages
+          git clone --depth 1 --branch "v${{ steps.version.outputs.version }}" \
+            https://github.com/airbytehq/PyAirbyte.git pyairbyte-source
+          echo "Cloned PyAirbyte v${{ steps.version.outputs.version }}"
+          ls -la pyairbyte-source/
 
       - name: Create pydoc-markdown Configuration
         run: |
@@ -68,13 +73,11 @@ jobs:
           loaders:
             - type: python
               search_path:
-                - .
+                - ./pyairbyte-source
               packages:
                 - airbyte
 
           processors:
-            - type: filter
-              skip_empty_modules: true
             - type: smart
             - type: crossref
 
@@ -88,11 +91,8 @@ jobs:
               escape_html_in_docstring: true
               render_module_header: true
               descriptive_class_title: true
-              add_method_class_prefix: false
-              add_member_class_prefix: false
               signature_with_def: true
               signature_code_block: true
-              render_typehint_in_data_header: true
           EOF
 
       - name: Generate API Documentation


### PR DESCRIPTION
## What

Fixes the PyAirbyte API docs generation workflow that was producing empty documentation. The workflow merged in airbytehq/airbyte#71102 generated a PR with empty sidebar (`"items": []`) instead of the expected 100+ module documentation files.

## How

The root cause was that `pydoc-markdown`'s python loader with `search_path: [.]` looks for source files in the current directory, but the PyAirbyte package was installed in site-packages (not accessible via that path).

Changes:
- Clone PyAirbyte repo at the version tag instead of `pip install`
- Update `search_path` to point to the cloned source directory (`./pyairbyte-source`)
- Remove `skip_empty_modules` filter that was masking the discovery issue
- Simplify markdown config options

Tested locally: the updated configuration generates 113 markdown files with proper sidebar structure.

## Review guide

1. `.github/workflows/pyairbyte-docs-generate.yml` - the only file changed

Key things to verify:
- The tag format `v${{ steps.version.outputs.version }}` matches PyAirbyte's release tag convention (e.g., `v0.35.5`)
- The removed config options (`add_method_class_prefix`, `add_member_class_prefix`, `render_typehint_in_data_header`) are acceptable to remove

## User Impact

The PyAirbyte API reference documentation will now be properly generated with all modules/submodules, matching the coverage at https://airbytehq.github.io/PyAirbyte/airbyte.html

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Link to Devin run: https://app.devin.ai/sessions/baf05c33f48e4415b8af70f5d41b78ee
Requested by: AJ Steers (aj@airbyte.io) / @aaronsteers