### PR TITLE
ci: Use GitHub App token for PyAirbyte docs PR creation

### DIFF
--- a/.github/workflows/pyairbyte-docs-generate.yml
+++ b/.github/workflows/pyairbyte-docs-generate.yml
@@ -124,11 +124,21 @@ jobs:
             echo "has_changes=true" >> $GITHUB_OUTPUT
           fi
 
+      - name: Authenticate as GitHub App
+        if: steps.changes.outputs.has_changes == 'true'
+        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+        id: get-app-token
+        with:
+          owner: "airbytehq"
+          repositories: "airbyte"
+          app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
+          private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
+
       - name: Create Pull Request
         if: steps.changes.outputs.has_changes == 'true'
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.get-app-token.outputs.token }}
           commit-message: "docs: Update PyAirbyte API reference documentation for v${{ steps.version.outputs.version }}"
           title: "docs: Update PyAirbyte API reference documentation for v${{ steps.version.outputs.version }}"
           body: |


### PR DESCRIPTION
## What

Fixes an issue where the "Build Airbyte Docs" workflow wasn't triggered on PRs created by the PyAirbyte docs generation workflow.

GitHub suppresses workflow triggers for events caused by `GITHUB_TOKEN` to prevent recursive workflows. When the docs generation workflow created PRs using `GITHUB_TOKEN`, downstream `pull_request`-triggered workflows like `docs-build.yml` never ran.

## How

- Added a new step to authenticate as the Octavia Bot GitHub App using `actions/create-github-app-token`
- Changed `peter-evans/create-pull-request` to use the app token instead of `GITHUB_TOKEN`
- The authentication step only runs when there are actual changes to commit (same condition as the PR creation step)

This follows the same pattern already used in `docs-build.yml` (lines 112-119).

## Review guide

1. `.github/workflows/pyairbyte-docs-generate.yml` - The only file changed. Verify the new "Authenticate as GitHub App" step matches the pattern in `docs-build.yml`.

## User Impact

PRs created by the PyAirbyte docs generation workflow will now properly trigger the docs build workflow, enabling preview deployments and build verification.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

*Requested by @aaronsteers*

*Link to Devin run: https://app.devin.ai/sessions/baf05c33f48e4415b8af70f5d41b78ee*