### PR TITLE
ci: Clean up PyAirbyte source before PR creation

### DIFF
--- a/.github/workflows/pyairbyte-docs-generate.yml
+++ b/.github/workflows/pyairbyte-docs-generate.yml
@@ -114,6 +114,14 @@ jobs:
             cat docs/developers/pyairbyte/reference/sidebar.json
           fi
 
+      - name: Cleanup PyAirbyte Source
+        run: |
+          # Remove the cloned PyAirbyte source directory to prevent it from being
+          # committed as a submodule (it contains a .git directory)
+          rm -rf pyairbyte-source
+          rm -f pydoc-markdown.yml
+          echo "Cleaned up temporary files"
+
       - name: Check for Changes
         id: changes
         run: |


### PR DESCRIPTION
## What

Fixes CI failures on auto-generated PyAirbyte docs PRs caused by the cloned `pyairbyte-source` directory being committed as a submodule.

Error from [PR #71109](https://github.com/airbytehq/airbyte/pull/71109):
```
fatal: No url found for submodule path 'pyairbyte-source' in .gitmodules
```

## How

Adds a cleanup step that removes the `pyairbyte-source/` directory and `pydoc-markdown.yml` config file after docs generation but before the PR creation step.

The cloned PyAirbyte directory contains a `.git` directory, which causes git to treat it as a submodule when committed. CI jobs that checkout with `submodules: true` then fail because there's no corresponding entry in `.gitmodules`.

## Review guide

1. `.github/workflows/pyairbyte-docs-generate.yml` - Single new step added between "Update Sidebar" and "Check for Changes"

## User Impact

Auto-generated PyAirbyte docs PRs will pass CI checks that previously failed due to the submodule error.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

*Requested by @aaronsteers*

*Link to Devin run: https://app.devin.ai/sessions/baf05c33f48e4415b8af70f5d41b78ee*