### PR TITLE
ci: Fix trailing whitespace in ai-create-docs-pr-command.yml

### DIFF
--- a/.github/workflows/ai-create-docs-pr-command.yml
+++ b/.github/workflows/ai-create-docs-pr-command.yml
@@ -53,7 +53,7 @@ jobs:
           PR_NUMBER="${{ inputs.pr }}"
           GITREF="${{ inputs.gitref }}"
           REPO="${{ inputs.repo }}"
-          
+
           if [ -n "$PR_NUMBER" ] && [ "$PR_NUMBER" != "0" ]; then
             echo "context=pr" >> $GITHUB_OUTPUT
             echo "pr-number=$PR_NUMBER" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## What

Fixes the formatting check failure on master caused by trailing whitespace in the `ai-create-docs-pr-command.yml` workflow file.

Related: [Failed Action Run](https://github.com/airbytehq/airbyte/actions/runs/20731604035)

## How

Removes trailing whitespace on line 56 of the workflow file. The line had spaces after the `REPO` variable assignment that prettier flagged as a formatting violation.

## Review guide

1. `.github/workflows/ai-create-docs-pr-command.yml` - Single whitespace change

## User Impact

None - this is a CI-only fix with no functional changes.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Requested by: @aaronsteers

Link to Devin run: https://app.devin.ai/sessions/06c55c8e7d554153ab1ee1bd9fe48d61