### PR TITLE
ci: Fix pdoc3 docs formatting - truncate .index suffix and fix indentation

### DIFF
--- a/.github/workflows/pyairbyte-docs-generate.yml
+++ b/.github/workflows/pyairbyte-docs-generate.yml
@@ -103,6 +103,8 @@ jobs:
             module_path="${rel_path%.md}"
             # Replace slashes with dots for the title (Python module notation)
             module_title=$(echo "$module_path" | tr '/' '.')
+            # Truncate ".index" suffix from title (index.md files represent the parent module)
+            module_title="${module_title%.index}"
             # Replace slashes with dashes for the id (URL-safe)
             unique_id=$(echo "$module_path" | tr '/' '-')
             # Create a temp file with frontmatter and original content
@@ -117,6 +119,60 @@ jobs:
             mv "${file}.tmp" "$file"
           done
           echo "Added Docusaurus frontmatter to all generated files"
+
+      - name: Fix pdoc3 Indentation for CommonMark
+        run: |
+          # pdoc3 indents content by 4 spaces as part of its definition-list formatting.
+          # In CommonMark, 4-space indentation creates code blocks, causing headers and
+          # paragraphs to render as monospace text.
+          # This step de-indents the content while preserving fenced code blocks.
+          python3 << 'EOF'
+          import os
+          import re
+
+          def fix_pdoc3_indentation(content):
+              """De-indent pdoc3 output while preserving fenced code blocks."""
+              lines = content.split('\n')
+              result = []
+              in_fenced_code = False
+              
+              for line in lines:
+                  # Track fenced code blocks (``` or ~~~)
+                  stripped = line.lstrip()
+                  if stripped.startswith('```') or stripped.startswith('~~~'):
+                      in_fenced_code = not in_fenced_code
+                      result.append(line)
+                      continue
+                  
+                  # Don't modify lines inside fenced code blocks
+                  if in_fenced_code:
+                      result.append(line)
+                      continue
+                  
+                  # De-indent lines that start with exactly 4 spaces
+                  # This fixes pdoc3's definition-list indentation
+                  if line.startswith('    ') and not line.startswith('        '):
+                      result.append(line[4:])
+                  else:
+                      result.append(line)
+              
+              return '\n'.join(result)
+
+          # Process all markdown files
+          base_dir = 'docs/developers/pyairbyte/reference'
+          for root, dirs, files in os.walk(base_dir):
+              for filename in files:
+                  if filename.endswith('.md'):
+                      filepath = os.path.join(root, filename)
+                      with open(filepath, 'r', encoding='utf-8') as f:
+                          content = f.read()
+                      fixed_content = fix_pdoc3_indentation(content)
+                      with open(filepath, 'w', encoding='utf-8') as f:
+                          f.write(fixed_content)
+                      print(f"Fixed indentation: {filepath}")
+
+          print("Fixed pdoc3 indentation in all generated markdown files")
+          EOF
 
       - name: Escape Curly Braces for MDX Compatibility
         run: |


### PR DESCRIPTION
## What

Fixes two formatting issues in the pdoc3-generated PyAirbyte API documentation:

1. **Module titles showing `.index` suffix**: Files like `airbyte/caches/index.md` were displaying `title: airbyte.caches.index` instead of `title: airbyte.caches`
2. **Monospace formatting bleeding across sections**: Headers like `### Static methods` were rendering as monospace text instead of proper H3 headers

## How

1. **Truncate `.index` suffix**: Added `module_title="${module_title%.index}"` to strip the `.index` suffix from the frontmatter title field. The `id` field is left unchanged to maintain URL stability.

2. **Fix pdoc3 indentation**: Added a new post-processing step that de-indents pdoc3's output. pdoc3 indents content by 4 spaces as part of its definition-list formatting, but CommonMark interprets 4-space indentation as code blocks. The script:
   - De-indents lines starting with exactly 4 spaces
   - Preserves fenced code blocks (``` or ~~~)
   - Leaves lines with 8+ spaces unchanged (nested content)

## Review guide

1. `.github/workflows/pyairbyte-docs-generate.yml` - All changes are in this file
   - Line 106-107: `.index` suffix truncation
   - Lines 123-175: New indentation fix step

**Key areas to verify:**
- The de-indentation logic correctly handles edge cases (nested lists, deeply indented content)
- Fenced code blocks are properly preserved

## User Impact

PyAirbyte API documentation will display cleaner module titles (e.g., `airbyte.caches` instead of `airbyte.caches.index`) and headers/paragraphs will render correctly instead of as monospace text.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

**Link to Devin run:** https://app.devin.ai/sessions/baf05c33f48e4415b8af70f5d41b78ee
**Requested by:** AJ Steers (aj@airbyte.io) / @aaronsteers