### PR TITLE
Fix: Klaviyo source connector was using wrong field name for incremental ingestion of Global Exceptions causing all ingestions to be full refreshes

### DIFF
--- a/airbyte-integrations/connectors/source-klaviyo/manifest.yaml
+++ b/airbyte-integrations/connectors/source-klaviyo/manifest.yaml
@@ -156,7 +156,7 @@ definitions:
             cursor_value: "{{ response.get('links', {}).get('next') }}"
       incremental_sync:
         type: DatetimeBasedCursor
-        cursor_field: updated
+        cursor_field: timestamp
         cursor_datetime_formats:
           - "%Y-%m-%dT%H:%M:%S.%f%z"
           - "%Y-%m-%dT%H:%M:%S%z"


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->

Klaviyo source connector is doing full refreshes on every run of Global Exceptions because the manifest.yaml was using the field name as updated but the latest API version uses the field named timestamp

## How
<!--
* Describe how code changes achieve the solution.
-->

Just changed the field name in the YAML

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

1. manifest.yaml

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

Users will be able to run incremental ingestion of globalexceptions again.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X] YES 💚
- [ ] NO ❌
