### PR TITLE
test(destination-clickhouse): fix failing tests

### DIFF
--- a/airbyte-integrations/connectors/destination-clickhouse/src/test-integration/kotlin/io/airbyte/integrations/destination/clickhouse/component/ClickhouseTestTableOperationsClient.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/test-integration/kotlin/io/airbyte/integrations/destination/clickhouse/component/ClickhouseTestTableOperationsClient.kt
@@ -11,9 +11,13 @@ import io.airbyte.cdk.load.component.TestTableOperationsClient
 import io.airbyte.cdk.load.data.AirbyteValue
 import io.airbyte.cdk.load.schema.model.TableName
 import io.airbyte.cdk.load.util.serializeToString
+import io.github.oshai.kotlinlogging.KotlinLogging
 import io.micronaut.context.annotation.Requires
 import jakarta.inject.Singleton
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.future.await
+
+private val logger = KotlinLogging.logger {}
 
 @Requires(env = ["component"])
 @Singleton
@@ -39,6 +43,7 @@ class ClickhouseTestTableOperationsClient(
     }
 
     override suspend fun readTable(table: TableName): List<Map<String, Any>> {
+        waitForPendingOperations(table)
         val qualifiedTableName = "`${table.namespace}`.`${table.name}`"
         val resp = client.query("SELECT * FROM $qualifiedTableName").await()
         val schema = client.getTableSchema(qualifiedTableName)
@@ -55,5 +60,40 @@ class ClickhouseTestTableOperationsClient(
             records.add(record)
         }
         return records
+    }
+
+    /**
+     * Wait for Clickhouse to finish processing the table. This is necessary for e.g. ALTER TABLE to
+     * complete. If we don't do this, then we may receive a view of the table which does not reflect
+     * its "latest" version.
+     */
+    private suspend fun waitForPendingOperations(table: TableName) {
+        while (true) {
+            val operations =
+                client
+                    .queryRecords(
+                        """
+                SELECT *
+                FROM system.mutations
+                WHERE database = {database:String}
+                  AND table = {table:String}
+            """.trimIndent(),
+                        mapOf(
+                            "database" to table.namespace,
+                            "table" to table.name,
+                        )
+                    )
+                    .await()
+            val pendingOperations =
+                operations.filter { !it.getBoolean("is_done") }.map { it.getString("command") }
+            if (pendingOperations.isEmpty()) {
+                break
+            } else {
+                logger.info {
+                    "Table ${table.toPrettyString()} has pending operations ($pendingOperations). Sleeping."
+                }
+                delay(1000)
+            }
+        }
     }
 }


### PR DESCRIPTION
tests are failing b/c we race the clickhouse engine on ALTER TABLE. Wait for the engine to do its thing.

(there's an option to make the ALTER TABLE synchronous, but that would slow down actual syncs. This change means that only tests are affected.)

example failure - the problem is that `column_to_drop` is in the actual record, b/c clickhouse hasn't dropped it when we go to query the table
```
ClickhouseTableSchemaEvolutionTest > apply changeset - handle sync mode dedup() FAILED
    org.opentest4j.AssertionFailedError: Expected records were not in the overwritten table. ==> expected: <***_airbyte_extracted_at=2025-01-22T00:00Z[UTC], _airbyte_generation_id=1, _airbyte_meta=***, _airbyte_raw_id=fcc784dd-bf06-468e-ad59-666d5aaceae8, id=1234, to_change=42, to_retain=to_retain original value, updated_at=5678***> but was: <***_airbyte_extracted_at=2025-01-22T00:00Z[UTC], _airbyte_generation_id=1, _airbyte_meta=***, _airbyte_raw_id=fcc784dd-bf06-468e-ad59-666d5aaceae8, id=1234, to_change=42, to_drop=to_drop original value, to_retain=to_retain original value, updated_at=5678***>
```