### PR TITLE
ci: circumvent cloudflare block with docker client header

### DIFF
--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/docker_hub.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/docker_hub.py
@@ -19,7 +19,7 @@ def get_docker_hub_auth_token() -> str:
     auth_url = "https://hub.docker.com/v2/users/login/"
     auth_data = {"username": docker_username, "password": docker_password}
     # make request look like docker client to avoid cloudflare blocks in CI
-    headers = {'User-Agent': 'Docker-Client/24.0.0 (linux)'}
+    headers = {"User-Agent": "Docker-Client/24.0.0 (linux)"}
     response = requests.post(auth_url, json=auth_data, headers=headers)
 
     if response.status_code != 200:

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/docker_hub.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/docker_hub.py
@@ -18,9 +18,12 @@ def get_docker_hub_auth_token() -> str:
 
     auth_url = "https://hub.docker.com/v2/users/login/"
     auth_data = {"username": docker_username, "password": docker_password}
-    response = requests.post(auth_url, json=auth_data)
+    # make request look like docker client to avoid cloudflare blocks in CI
+    headers = {'User-Agent': 'Docker-Client/24.0.0 (linux)'}
+    response = requests.post(auth_url, json=auth_data, headers=headers)
 
     if response.status_code != 200:
+        print(f"Failed to log in to Docker Hub - {response.status_code}: {response.text}")
         raise ValueError("Failed to authenticate with Docker Hub. Please check your credentials.")
 
     token = response.json().get("token")


### PR DESCRIPTION
Get around cloudflare blocking our docker login requests by specifying the docker client as the user-agent in our request.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌
