### PR TITLE
fix(bulk-cdk): handle max long Java value in JDBC partition factory

### DIFF
--- a/airbyte-cdk/bulk/changelog.md
+++ b/airbyte-cdk/bulk/changelog.md
@@ -1,8 +1,8 @@
-## Version 0.1.96
+## Version 0.1.98
 
 **Extract CDK**
 
-* Fix a bug causing and attempt to pull a negative number of rows.
+* Fix a bug causing query limit pull a negative number of rows.
 
 ## Version 0.1.97
 

--- a/airbyte-cdk/bulk/changelog.md
+++ b/airbyte-cdk/bulk/changelog.md
@@ -1,3 +1,9 @@
+## Version 0.1.96
+
+**Extract CDK**
+
+* Fix a bug causing and attempt to pull a negative number of rows.
+
 ## Version 0.1.97
 
 load cdk: slightly refactor schema mapper suite

--- a/airbyte-cdk/bulk/toolkits/extract-jdbc/src/main/kotlin/io/airbyte/cdk/read/DefaultJdbcStreamState.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-jdbc/src/main/kotlin/io/airbyte/cdk/read/DefaultJdbcStreamState.kt
@@ -29,10 +29,16 @@ class DefaultJdbcStreamState(
         get() = fetchSize ?: sharedState.constants.defaultFetchSize
 
     override val limit: Long
-        get() =
-            (fetchSizeOrDefault * transient.get().limitState.current).let {
-                sharedState.constants.maxSequentialQueryLimit?.coerceAtMost(it) ?: it
-            }
+        get() {
+            val fetchSize = fetchSizeOrDefault.toLong()
+            val current = transient.get().limitState.current
+
+            // Prevent overflow: use Math.multiplyExact which throws on overflow
+            val product = runCatching { Math.multiplyExact(fetchSize, current) }
+                .getOrElse { Long.MAX_VALUE }
+
+            return sharedState.constants.maxSequentialQueryLimit?.coerceAtMost(product) ?: product
+        }
 
     private val transient = AtomicReference(Transient.initial)
 

--- a/airbyte-cdk/bulk/toolkits/extract-jdbc/src/main/kotlin/io/airbyte/cdk/read/DefaultJdbcStreamState.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-jdbc/src/main/kotlin/io/airbyte/cdk/read/DefaultJdbcStreamState.kt
@@ -34,8 +34,8 @@ class DefaultJdbcStreamState(
             val current = transient.get().limitState.current
 
             // Prevent overflow: use Math.multiplyExact which throws on overflow
-            val product = runCatching { Math.multiplyExact(fetchSize, current) }
-                .getOrElse { Long.MAX_VALUE }
+            val product =
+                runCatching { Math.multiplyExact(fetchSize, current) }.getOrElse { Long.MAX_VALUE }
 
             return sharedState.constants.maxSequentialQueryLimit?.coerceAtMost(product) ?: product
         }

--- a/airbyte-cdk/bulk/version.properties
+++ b/airbyte-cdk/bulk/version.properties
@@ -1,1 +1,1 @@
-version=0.1.97
+version=0.1.98


### PR DESCRIPTION
Fixing a bug causing us to attempt pulling negative number of rows due to Long max value overflow
