### PR TITLE
Bulk load cdk: support running regression tests against legacy docker image

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/destination_process/DockerizedDestination.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/destination_process/DockerizedDestination.kt
@@ -462,9 +462,10 @@ class DockerizedDestination(
 }
 
 class DockerizedDestinationFactory(
-    private val imageName: String,
-    private val imageVersion: String,
+    private val image: String,
 ) : DestinationProcessFactory() {
+    constructor(imageName: String, imageVersion: String) : this("$imageName:$imageVersion")
+
     override fun createDestinationProcess(
         command: String,
         configContents: String?,
@@ -477,7 +478,7 @@ class DockerizedDestinationFactory(
         vararg featureFlags: FeatureFlag,
     ): DestinationProcess {
         return DockerizedDestination(
-            "$imageName:$imageVersion",
+            image,
             command,
             configContents,
             catalog,

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
@@ -360,6 +360,21 @@ abstract class BasicFunctionalityIntegrationTest(
      * for the list of input stream descriptors.
      */
     val tableIdentifierRegressionTestExpectedTableNames: List<TableName> = emptyList(),
+    /**
+     * If set to a nonnull value, the regression tests will run against the image specified here
+     * rather than the current connector version. This is primarily useful for preventing a
+     * regression when migrating a connector from the legacy CDK to the bulk CDK.
+     *
+     * For example, if you're working on destination-databricks, you could:
+     * 1. Implement the connector using the bulk CDK (so that you have a working implementation of
+     * [io.airbyte.cdk.load.component.TestTableOperationsClient], etc.)
+     * 2. Run the regression tests using the bulk CDK connector, to populate the golden files
+     * 3. Set `regressionTestsImageOverride = "airbyte/destination-databricks:3.3.7"` and rerun the
+     * regression tests, to verify no changes
+     *
+     * IMPORTANT: You MUST unset this value before releasing your connector.
+     */
+    regressionTestsImageOverride: String? = null,
 ) :
     IntegrationTest(
         additionalMicronautEnvs = additionalMicronautEnvs,
@@ -379,7 +394,8 @@ abstract class BasicFunctionalityIntegrationTest(
     val updatedConfig = configUpdater.update(configContents)
     val parsedConfig = ValidatedJsonUtils.parseOne(configSpecClass, updatedConfig)
 
-    private val regressionTestFixtures = RegressionTestFixtures(this)
+    private val regressionTestFixtures =
+        RegressionTestFixtures(this, image = regressionTestsImageOverride)
 
     @Test
     open fun testOutOfOrderStateMessages() {

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/RegressionTestFixtures.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/RegressionTestFixtures.kt
@@ -25,6 +25,7 @@ import io.airbyte.cdk.load.data.TimestampTypeWithoutTimezone
 import io.airbyte.cdk.load.data.UnionType
 import io.airbyte.cdk.load.data.UnknownType
 import io.airbyte.cdk.load.test.util.CharacterizationTest
+import io.airbyte.cdk.load.test.util.destination_process.DockerizedDestinationFactory
 import io.airbyte.cdk.load.util.Jsons
 import io.airbyte.cdk.load.write.BasicFunctionalityIntegrationTest.Companion.numberType
 import kotlin.collections.forEach
@@ -36,7 +37,13 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.assertAll
 
-class RegressionTestFixtures(val testSuite: BasicFunctionalityIntegrationTest) {
+class RegressionTestFixtures(
+    val testSuite: BasicFunctionalityIntegrationTest,
+    image: String? = null
+) {
+    private val destinationProcessFactory =
+        image?.let { DockerizedDestinationFactory(image) } ?: testSuite.destinationProcessFactory
+
     fun baseSchemaRegressionTest(filename: String, importType: ImportType) = runTest {
         assumeTrue(testSuite.schemaDumperProvider != null)
         val schemaDumper = testSuite.schemaDumperProvider!!(testSuite.parsedConfig)
@@ -169,6 +176,7 @@ class RegressionTestFixtures(val testSuite: BasicFunctionalityIntegrationTest) {
             testSuite.updatedConfig,
             stream,
             messages = emptyList(),
+            destinationProcessFactory = destinationProcessFactory,
         )
         val actualSchema =
             schemaDumper.discoverSchema(


### PR DESCRIPTION
branched from https://github.com/airbytehq/airbyte/pull/71167

I spent some time trying to hack something into the legacy cdk to support this, ended up just adding a hack in the bulk cdk tests instead.

like the comment says - this is something that you'd run manually once. IMO not worth trying to make this much nicer, since we're hopefully not doing too many more of these migrations. Obviously that means running this test is just A Thing We Have To Remember To Do though, so not super ideal.