### PR TITLE
perf(bulk-cdk): use dedicated dispatcher and limited parallelism for final flushes

### DIFF
--- a/airbyte-cdk/bulk/changelog.md
+++ b/airbyte-cdk/bulk/changelog.md
@@ -1,3 +1,7 @@
+## Version 0.1.99
+
+load cdk: Enforce maximum parallelism for final aggregate flushes.
+
 ## Version 0.1.98
 
 **Extract CDK**

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/config/DispatcherBeanFactory.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/config/DispatcherBeanFactory.kt
@@ -52,4 +52,9 @@ class DispatcherBeanFactory {
     @Named("streamFinalizeDispatcher")
     @Singleton
     fun streamFinalizeDispatcher() = Dispatchers.Default.limitedParallelism(10)
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Named("finalFlushDispatcher")
+    @Singleton
+    fun finalFlushDispatcher() = Dispatchers.Default.limitedParallelism(10)
 }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/config/InputBeanFactory.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/config/InputBeanFactory.kt
@@ -136,6 +136,7 @@ class InputBeanFactory {
         aggregatePublishingConfig: AggregatePublishingConfig,
         @Named("aggregationDispatcher") aggregationDispatcher: CoroutineDispatcher,
         @Named("flushDispatcher") flushDispatcher: CoroutineDispatcher,
+        @Named("finalFlushDispatcher") finalFlushDispatcher: CoroutineDispatcher,
     ): List<DataFlowPipeline> =
         inputFlows.map {
             val aggStore = aggregateStoreFactory.make()
@@ -145,6 +146,7 @@ class InputBeanFactory {
                     aggStore,
                     stateHistogramStore,
                     statsStore,
+                    finalFlushDispatcher,
                 )
 
             DataFlowPipeline(

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/pipeline/PipelineCompletionHandler.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/pipeline/PipelineCompletionHandler.kt
@@ -8,6 +8,7 @@ import io.airbyte.cdk.load.dataflow.aggregate.AggregateStore
 import io.airbyte.cdk.load.dataflow.state.StateHistogramStore
 import io.airbyte.cdk.load.dataflow.state.stats.CommittedStatsStore
 import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
@@ -16,6 +17,7 @@ class PipelineCompletionHandler(
     private val aggStore: AggregateStore,
     private val stateHistogramStore: StateHistogramStore,
     private val statsStore: CommittedStatsStore,
+    private val dispatcher: CoroutineDispatcher,
 ) {
     private val log = KotlinLogging.logger {}
 
@@ -31,7 +33,7 @@ class PipelineCompletionHandler(
         log.info { "Flushing ${remainingAggregates.size} final aggregates..." }
         remainingAggregates
             .map {
-                async {
+                async(dispatcher) {
                     it.value.flush()
                     stateHistogramStore.acceptFlushedCounts(it.partitionCountsHistogram)
                     statsStore.acceptStats(

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/config/InputBeanFactoryTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/config/InputBeanFactoryTest.kt
@@ -246,6 +246,7 @@ class InputBeanFactoryTest {
                 aggregatePublishingConfig = aggregatePublishingConfig,
                 aggregationDispatcher = aggregationDispatcher,
                 flushDispatcher = flushDispatcher,
+                finalFlushDispatcher = flushDispatcher,
             )
 
         // Then
@@ -283,6 +284,7 @@ class InputBeanFactoryTest {
                 aggregatePublishingConfig = aggregatePublishingConfig,
                 aggregationDispatcher = aggregationDispatcher,
                 flushDispatcher = flushDispatcher,
+                finalFlushDispatcher = flushDispatcher,
             )
 
         // Then
@@ -335,6 +337,7 @@ class InputBeanFactoryTest {
                 aggregatePublishingConfig = aggregatePublishingConfig,
                 aggregationDispatcher = aggregationDispatcher,
                 flushDispatcher = flushDispatcher,
+                finalFlushDispatcher = flushDispatcher,
             )
 
         // Then

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/pipeline/PipelineCompletionHandlerTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/pipeline/PipelineCompletionHandlerTest.kt
@@ -45,6 +45,7 @@ class PipelineCompletionHandlerTest {
                 aggStore = aggStore,
                 stateHistogramStore = stateHistogramStore,
                 statsStore = statsStore,
+                dispatcher = kotlinx.coroutines.Dispatchers.Unconfined,
             )
     }
 

--- a/airbyte-cdk/bulk/version.properties
+++ b/airbyte-cdk/bulk/version.properties
@@ -1,1 +1,1 @@
-version=0.1.98
+version=0.1.99


### PR DESCRIPTION
## What
Runs final aggregate flushes on a dedicated dispatcher with limited parallelism

## Why
For destinations that allow a high number of max open aggregates we may go _too_ parallel and saturate underlying resources (connection pools, etc.)
