### PR TITLE
ci: Update AI review slash command to use standard naming convention

### DIFF
--- a/.github/pr-welcome-community.md
+++ b/.github/pr-welcome-community.md
@@ -21,6 +21,7 @@ As needed or by request, Airbyte Maintainers can execute the following slash com
 - `/run-regression-tests` - Runs regression tests for the modified connector(s).
 - `/build-connector-images` - Builds and publishes a pre-release docker image for the modified connector(s).
 - `/publish-connectors-prerelease` - Publishes pre-release connector builds (tagged as `{version}-preview.{git-sha}`) for all modified connectors in the PR.
+- `/ai-review` - AI-powered PR review for connector safety and quality gates.
 
 If you have any questions, feel free to ask in the PR comments or join our [Slack community](https://airbytehq.slack.com/).
 

--- a/.github/pr-welcome-internal.md
+++ b/.github/pr-welcome-internal.md
@@ -31,6 +31,8 @@ Airbyte Maintainers (that's you!) can execute the following slash commands on yo
   - `/ai-prove-fix` - Runs prerelease readiness checks, including testing against customer connections.
   - `/ai-canary-prerelease` - Rolls out prerelease to 5-10 connections for canary testing.
   - `/ai-release-watch` - Monitors rollout post-release and tracks sync success rates.
+- AI PR Review:
+  - `/ai-review` - AI-powered PR review for connector safety and quality gates.
 - Documentation:
   - `/ai-docs-review` - Provides AI-powered documentation recommendations for PRs with connector changes.
 - JVM connectors:

--- a/.github/workflows/ai-review-command.yml
+++ b/.github/workflows/ai-review-command.yml
@@ -1,10 +1,22 @@
 name: PR AI Review Command
 
 on:
-  issue_comment:
-    types: [created]
+  workflow_dispatch:
+    inputs:
+      repo:
+        description: "Repo (owner/repo)"
+        required: false
+      gitref:
+        description: "Git ref"
+        required: false
+      pr:
+        description: "PR number"
+        required: true
+      comment-id:
+        description: "Comment ID"
+        required: false
 
-run-name: "PR AI Review for PR #${{ github.event.issue.number }}"
+run-name: "PR AI Review for PR #${{ inputs.pr }}"
 
 permissions:
   contents: read
@@ -13,11 +25,6 @@ permissions:
 
 jobs:
   pr-ai-review:
-    # Only run on PR comments that start with !pr_ai_review
-    if: |
-      github.event.issue.pull_request &&
-      github.event.issue.state == 'open' &&
-      startsWith(github.event.comment.body, '!pr_ai_review')
     runs-on: ubuntu-latest
     steps:
       - name: Get job variables
@@ -42,7 +49,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.get-app-token.outputs.token }}
         run: |
-          PR_URL="${{ github.event.issue.pull_request.url }}"
+          PR_URL="https://api.github.com/repos/${{ github.repository }}/pulls/${{ inputs.pr }}"
           PR_INFO=$(curl -sS -H "Authorization: Bearer $GH_TOKEN" -H "Accept: application/vnd.github+json" "$PR_URL")
           HEAD_SHA=$(echo "$PR_INFO" | jq -r '.head.sha')
           HEAD_REF=$(echo "$PR_INFO" | jq -r '.head.ref')
@@ -50,11 +57,12 @@ jobs:
           echo "head-ref=$HEAD_REF" >> $GITHUB_OUTPUT
 
       - name: Post start comment
+        if: ${{ inputs.comment-id }}
         uses: peter-evans/create-or-update-comment@v4
         with:
           token: ${{ steps.get-app-token.outputs.token }}
-          comment-id: ${{ github.event.comment.id }}
-          issue-number: ${{ github.event.issue.number }}
+          comment-id: ${{ inputs.comment-id }}
+          issue-number: ${{ inputs.pr }}
           body: |
             > **PR AI Review Started**
             >
@@ -64,8 +72,8 @@ jobs:
       - name: Run PR AI Review
         uses: aaronsteers/devin-action@main
         with:
-          comment-id: ${{ github.event.comment.id }}
-          issue-number: ${{ github.event.issue.number }}
+          comment-id: ${{ inputs.comment-id }}
+          issue-number: ${{ inputs.pr }}
           playbook-macro: "!pr_ai_review"
           devin-token: ${{ secrets.DEVIN_AI_API_KEY }}
           github-token: ${{ steps.get-app-token.outputs.token }}

--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -62,6 +62,7 @@ jobs:
             ai-create-docs-pr
             ai-prove-fix
             ai-release-watch
+            ai-review
             approve-regression-tests
             bump-bulk-cdk-version
             bump-progressive-rollout-version


### PR DESCRIPTION
## What

Updates the AI PR review command to use the standard slash command naming convention (`/ai-review`) instead of the non-standard `!pr_ai_review` trigger, and adds it to the advertised slash commands in PR welcome messages.

Requested by @aaronsteers via [Slack](https://airbytehq-team.slack.com/archives/C0A30PKB8HK/p1768236020291229).

Link to Devin run: https://app.devin.ai/sessions/e7b9983c50874700b4bfee926b9705aa

## How

1. Renamed `pr-ai-review-command.yml` → `ai-review-command.yml` to match the `{command}-command.yml` pattern expected by the slash command dispatcher
2. Changed trigger from `issue_comment` with `!pr_ai_review` prefix to `workflow_dispatch` with standard inputs
3. Added `ai-review` to the commands list in `slash-commands.yml`
4. Added `/ai-review` documentation to both internal and community PR welcome messages

## Review guide

1. `.github/workflows/ai-review-command.yml` - Main workflow changes (trigger, inputs, references)
2. `.github/workflows/slash-commands.yml` - Added command to dispatcher
3. `.github/pr-welcome-internal.md` and `.github/pr-welcome-community.md` - Documentation updates

**Key items to verify:**
- [ ] The workflow dispatch inputs match what `slash-commands.yml` passes via `static-args`
- [ ] The PR URL construction (`https://api.github.com/repos/${{ github.repository }}/pulls/${{ inputs.pr }}`) is correct
- [ ] Breaking change: The old `!pr_ai_review` syntax will no longer work - confirm this is acceptable

## User Impact

Users can now trigger AI PR review using the standard `/ai-review` slash command instead of `!pr_ai_review`. The command is now documented in PR welcome messages.

**Breaking change**: The old `!pr_ai_review` trigger syntax will no longer work.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚