### PR TITLE
ci(bulk-cdk): publish bulk load cdk for schema regression tests

### DIFF
--- a/airbyte-cdk/bulk/changelog.md
+++ b/airbyte-cdk/bulk/changelog.md
@@ -1,3 +1,7 @@
+## Version 0.1.102
+
+load cdk: add schema regression test
+
 ## Version 0.1.101
 
 load cdk: Introduce scope and oauth server uri attributes in iceberg polaris spec

--- a/airbyte-cdk/bulk/version.properties
+++ b/airbyte-cdk/bulk/version.properties
@@ -1,1 +1,1 @@
-version=0.1.101
+version=0.1.102


### PR DESCRIPTION
publish cdk from https://github.com/airbytehq/airbyte/pull/70979. Somehow I was able to merge without this???