### PR TITLE
ci(bulk-cdk): add wrapper job to report bulk CDK version compatibility

### DIFF
--- a/.github/workflows/java-cdk-tests.yml
+++ b/.github/workflows/java-cdk-tests.yml
@@ -114,3 +114,18 @@ jobs:
           concurrent: true
           # TODO: be able to remove the skipSlowTests property
           arguments: --scan :airbyte-cdk:check -DskipSlowTests=true
+
+  bulk-cdk-version-check-result:
+    name: Bulk CDK version check result
+    runs-on: ubuntu-24.04
+    if: always()
+    needs:
+      - run-check-bulk-cdk-version
+    steps:
+      - name: Report status
+        run: |
+          if [[ "${{ needs.run-check-bulk-cdk-version.result }}" == "success" || "${{ needs.run-check-bulk-cdk-version.result }}" == "skipped" ]]; then
+            exit 0
+          else
+            exit 1
+          fi


### PR DESCRIPTION
closes https://github.com/airbytehq/airbyte-internal-issues/issues/15638.

after this is merged, I'll add `Bulk CDK version check result` as a required check in the branch protection rules. Which should hopefully be enough? (we can't just add the required check, b/c that will block non-bulk-cdk PRs. So we need to add this wrapper check to populate the check result on other PRs)

(disclosure, claude-generated code. it matches my understanding of how to do this though.)