### PR TITLE
ci: Add /force-merge slash command for approved PRs

### DIFF
--- a/.github/workflows/force-merge-command.yml
+++ b/.github/workflows/force-merge-command.yml
@@ -144,7 +144,7 @@ jobs:
           token: ${{ secrets.SLACK_BOT_TOKEN_AIRBYTE_TEAM }}
           method: chat.postMessage
           payload: |
-            channel: ${{ vars.FORCE_MERGE_SLACK_CHANNEL_ID }}
+            channel: C04928XA0LB
             text: "PR force-merged: ${{ steps.job-vars.outputs.pr_title }}"
             blocks:
               - type: section

--- a/.github/workflows/force-merge-command.yml
+++ b/.github/workflows/force-merge-command.yml
@@ -121,7 +121,6 @@ jobs:
 
       - name: Force merge PR
         id: merge
-        if: steps.check-approval.outputs.approved == 'true'
         env:
           GH_TOKEN: ${{ steps.get-app-token.outputs.token }}
         shell: bash

--- a/.github/workflows/force-merge-command.yml
+++ b/.github/workflows/force-merge-command.yml
@@ -144,7 +144,7 @@ jobs:
           token: ${{ secrets.SLACK_BOT_TOKEN_AIRBYTE_TEAM }}
           method: chat.postMessage
           payload: |
-            channel: C04928XA0LB
+            channel: C04928XA0LB # The `#dev-ci` channel
             text: "PR force-merged: ${{ steps.job-vars.outputs.pr_title }}"
             blocks:
               - type: section

--- a/.github/workflows/force-merge-command.yml
+++ b/.github/workflows/force-merge-command.yml
@@ -1,0 +1,166 @@
+name: Force Merge PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: "Pull request number to force merge."
+        type: number
+        required: true
+      comment-id:
+        description: "Optional. The comment-id of the slash command. Used to update the comment with the status."
+        required: false
+
+      # These must be declared, but they are unused and ignored.
+      # TODO: Infer 'repo' and 'gitref' from PR number on other workflows, so we can remove these.
+      repo:
+        description: "Repo (Ignored)"
+        required: false
+        default: "airbytehq/airbyte"
+      gitref:
+        description: "Ref (Ignored)"
+        required: false
+
+run-name: "Force Merge PR #${{ github.event.inputs.pr }}"
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.inputs.pr }}
+  # Cancel any previous runs on the same branch if they are still in progress
+  cancel-in-progress: true
+
+jobs:
+  force-merge:
+    name: "Force Merge PR"
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Authenticate as GitHub App
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        id: get-app-token
+        with:
+          owner: "airbytehq"
+          repositories: "airbyte"
+          app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
+          private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
+
+      - name: Get job variables
+        id: job-vars
+        env:
+          GH_TOKEN: ${{ steps.get-app-token.outputs.token }}
+        shell: bash
+        run: |
+          PR_JSON=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.inputs.pr }})
+          echo "repo=$(echo "$PR_JSON" | jq -r .head.repo.full_name)" >> $GITHUB_OUTPUT
+          echo "branch=$(echo "$PR_JSON" | jq -r .head.ref)" >> $GITHUB_OUTPUT
+          echo "pr_title=$(echo "$PR_JSON" | jq -r .title)" >> $GITHUB_OUTPUT
+          echo "pr_url=$(echo "$PR_JSON" | jq -r .html_url)" >> $GITHUB_OUTPUT
+          echo "run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> $GITHUB_OUTPUT
+
+      - name: Append comment with job run link
+        id: first-comment-action
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        with:
+          comment-id: ${{ github.event.inputs.comment-id }}
+          issue-number: ${{ github.event.inputs.pr }}
+          body: |
+
+            > Force-merge job started... [Check job output.][1]
+
+            [1]: ${{ steps.job-vars.outputs.run-url }}
+
+      - name: Check PR approval status
+        id: check-approval
+        env:
+          GH_TOKEN: ${{ steps.get-app-token.outputs.token }}
+        shell: bash
+        run: |
+          # Get PR reviews
+          REVIEWS=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.inputs.pr }}/reviews)
+
+          # Check if there's at least one approved review
+          # We need to check the latest review from each reviewer, as reviews can be dismissed or changed
+          APPROVED=$(echo "$REVIEWS" | jq -r '
+            group_by(.user.login) |
+            map(sort_by(.submitted_at) | last) |
+            map(select(.state == "APPROVED")) |
+            length
+          ')
+
+          if [ "$APPROVED" -gt 0 ]; then
+            echo "approved=true" >> $GITHUB_OUTPUT
+            echo "PR has $APPROVED approval(s)"
+          else
+            echo "approved=false" >> $GITHUB_OUTPUT
+            echo "PR does not have any approvals"
+          fi
+
+      - name: Reject - PR not approved
+        if: steps.check-approval.outputs.approved != 'true'
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        with:
+          comment-id: ${{ steps.first-comment-action.outputs.comment-id }}
+          reactions: "-1"
+          body: |
+            > **Force merge rejected:** This PR has not been approved yet.
+            >
+            > A PR must have at least one approval before it can be force-merged.
+            >
+            > **Options:**
+            > - Request a review from a team member with write access
+            > - Use `/ai-review` to get an AI-powered code review if no human reviewer is available
+
+      - name: Fail if not approved
+        if: steps.check-approval.outputs.approved != 'true'
+        run: |
+          echo "::error::PR is not approved. Force merge requires at least one approval."
+          exit 1
+
+      - name: Force merge PR
+        id: merge
+        if: steps.check-approval.outputs.approved == 'true'
+        env:
+          GH_TOKEN: ${{ steps.get-app-token.outputs.token }}
+        shell: bash
+        run: |
+          # Merge the PR using squash merge
+          gh pr merge ${{ github.event.inputs.pr }} \
+            --repo ${{ github.repository }} \
+            --squash \
+            --admin
+
+          echo "merged=true" >> $GITHUB_OUTPUT
+
+      - name: Post success comment
+        if: steps.merge.outputs.merged == 'true'
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        with:
+          comment-id: ${{ steps.first-comment-action.outputs.comment-id }}
+          reactions: hooray
+          body: |
+            > **Force merge successful!** This PR has been merged.
+
+      - name: Post to Slack
+        if: steps.merge.outputs.merged == 'true'
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        with:
+          token: ${{ secrets.SLACK_BOT_TOKEN_AIRBYTE_TEAM }}
+          method: chat.postMessage
+          payload: |
+            channel: ${{ vars.FORCE_MERGE_SLACK_CHANNEL_ID }}
+            text: "PR force-merged: ${{ steps.job-vars.outputs.pr_title }}"
+            blocks:
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: "*PR Force-Merged*\n<${{ steps.job-vars.outputs.pr_url }}|${{ steps.job-vars.outputs.pr_title }}>"
+              - type: context
+                elements:
+                  - type: mrkdwn
+                    text: "Initiated by: ${{ github.actor }} | <https://github.com/${{ github.repository }}/issues/${{ github.event.inputs.pr }}#issuecomment-${{ github.event.inputs.comment-id }}|View command>"
+
+      - name: Append failure comment
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        if: failure() && steps.check-approval.outputs.approved == 'true'
+        with:
+          comment-id: ${{ steps.first-comment-action.outputs.comment-id }}
+          reactions: confused
+          body: |
+            > **Force merge failed.** Please check the [job output](${{ steps.job-vars.outputs.run-url }}) for details.

--- a/.github/workflows/force-merge-command.yml
+++ b/.github/workflows/force-merge-command.yml
@@ -22,6 +22,12 @@ on:
         required: false
 
 run-name: "Force Merge PR #${{ github.event.inputs.pr }}"
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.inputs.pr }}
   # Cancel any previous runs on the same branch if they are still in progress
@@ -154,7 +160,7 @@ jobs:
               - type: context
                 elements:
                   - type: mrkdwn
-                    text: "Initiated by: ${{ github.actor }} | <https://github.com/${{ github.repository }}/issues/${{ github.event.inputs.pr }}#issuecomment-${{ github.event.inputs.comment-id }}|View command>"
+                    text: "Initiated by: ${{ github.actor }} | <https://github.com/${{ github.repository }}/pull/${{ github.event.inputs.pr }}|View PR>"
 
       - name: Append failure comment
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0

--- a/.github/workflows/force-merge-command.yml
+++ b/.github/workflows/force-merge-command.yml
@@ -109,9 +109,8 @@ jobs:
             >
             > A PR must have at least one approval before it can be force-merged.
             >
-            > **Options:**
-            > - Request a review from a team member with write access
-            > - Use `/ai-review` to get an AI-powered code review if no human reviewer is available
+            > Please request approval from a human reviewer
+            > or use `/ai-review` to request an AI-powered approval.
 
       - name: Fail if not approved
         if: steps.check-approval.outputs.approved != 'true'

--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -69,6 +69,7 @@ jobs:
             bump-version
             build-connector-images
             connector-performance
+            force-merge
             format-fix
             poe
             publish-connectors-prerelease


### PR DESCRIPTION
## What

Adds a new `/force-merge` slash command that allows maintainers to force-merge approved PRs, bypassing CI checks while still requiring human approval.

Requested by @aaronsteers in [Slack thread](https://airbytehq-team.slack.com/archives/C08PWJ16LUC/p1768247651606919).

Link to Devin run: https://app.devin.ai/sessions/c0408d6848ea4ceeaf457960607965a8

## How

1. **New workflow file** (`force-merge-command.yml`): Handles the force-merge logic
   - Checks if PR has at least one approval (considers latest review from each reviewer)
   - If approved: merges using `gh pr merge --admin --squash`
   - If not approved: posts rejection comment suggesting `/ai-review`
   - Posts success notification to Slack channel `#dev-ci`

2. **Updated slash-commands.yml**: Registers `force-merge` as a recognized command

## Review guide

1. `.github/workflows/force-merge-command.yml` - Main workflow logic
   - Lines 26-29: Explicit permissions block
   - Lines 78-99: Approval check logic using jq
   - Lines 119-132: Force merge with `--admin` flag
   - Lines 143-160: Slack notification

2. `.github/workflows/slash-commands.yml` - Single line addition

## Human review checklist

- [ ] Verify the OCTAVIA_BOT GitHub App has admin permissions to use `--admin` flag on `gh pr merge`
- [ ] Verify Slack channel ID `C04928XA0LB` is correct for `#dev-ci`
- [ ] Verify `SLACK_BOT_TOKEN_AIRBYTE_TEAM` secret has permissions to post to that channel

## User Impact

Maintainers can use `/force-merge` on any PR to:
- Merge approved PRs immediately without waiting for CI
- Get clear rejection message with alternatives if PR isn't approved

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

## Updates since last revision

- Added explicit `permissions:` block to address security scanner feedback
- Fixed Slack notification link to use PR URL instead of potentially broken comment URL
- Removed redundant approval check on merge step (workflow hard fails before reaching merge if not approved)