### PR TITLE
docs(source-google-ads): document empty list field format change from v4.1.0

### DIFF
--- a/docs/integrations/sources/google-ads.md
+++ b/docs/integrations/sources/google-ads.md
@@ -328,6 +328,34 @@ This source is constrained by the [Google Ads API limits](https://developers.goo
 Due to a limitation in the Google Ads API which does not allow getting performance data at a granularity level smaller than a day, the Google Ads connector usually pulls data up until the previous day. For example, if the sync runs on Wednesday at 5 PM, then data up until Tuesday midnight is pulled. Data for Wednesday is exported only if a sync runs after Wednesday (for example, 12:01 AM on Thursday) and so on. This avoids syncing partial performance data, only to have to resync it again once the full day's data has been recorded by Google. For example, without this functionality, a sync which runs on Wednesday at 5 PM would get ads performance data for Wednesday between 12:01 AM - 5 PM on Wednesday, then it would need to run again at the end of the day to get all of Wednesday's data.
 </HideInUI>
 
+## Limitations & Troubleshooting
+
+### Empty Array Fields Now Return Null
+
+Starting with version 4.1.0, there is a change in how empty array/list fields are represented in the data:
+
+**What changed:**
+- Array fields that were previously empty (e.g., `[]`) are now returned as `null`
+- This affects custom queries from version 4.1.0 and other streams that were migrated to low-code
+
+**Why this changed:**
+- Prior to 4.1.0, custom queries used the Google Ads Python library (protobuf-based), which represents empty repeated fields as empty arrays `[]`
+- Starting with 4.1.0, custom queries use the REST API (JSON-based), where empty/unset array fields are returned as `null`
+- This same behavior also applies to other streams when they were migrated to low-code
+
+**Example affected fields:**
+- `metrics.interaction_event_types`
+- Other array/list type fields across various streams
+
+**How to resolve:**
+To maintain consistent data format in your destination:
+1. Clear (reset) the affected streams after upgrading to version 4.1.0 or later
+2. Perform a full re-sync of the data
+3. All historical and new data will then use the new format (null instead of empty arrays)
+
+**Note:** This is not a bug but a behavioral difference between the Google Ads Python library and the REST API. The new format (null for empty arrays) is the standard JSON representation.
+
+
 ## Changelog
 
 <details>


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->
Documents a behavioural change in the Google Ads connector starting from v4.1.0, where empty array/list fields now return `null` instead of empty arrays `[]`. This change affects custom queries and other streams that were migrated to low-code.

Related to customer issue where users noticed inconsistent data format for array fields like `metrics.interaction_event_types` after upgrading to v4.1.0+. https://github.com/airbytehq/oncall/issues/10638


## How
<!--
* Describe how code changes achieve the solution.
-->
Added a new "Empty Array Fields Now Return Null" section to the Troubleshooting section of the Google Ads connector documentation (`docs/integrations/sources/google-ads.md`).

The documentation includes:
  - Clear explanation of what changed (empty arrays → null)
  - Root cause (migration from Google Ads Python library/protobuf to REST API/JSON)
  - Affected versions (4.1.0+ for custom queries, other streams when migrated to low-code)
  - Example affected fields
  - Step-by-step resolution guide (reset affected streams and re-sync)
  - Clarification that this is expected behavior, not a bug


## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
