### PR TITLE
Destination Postgres: Update tableExists to always drop and return false

### DIFF
--- a/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/client/PostgresAirbyteClient.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/client/PostgresAirbyteClient.kt
@@ -74,15 +74,21 @@ class PostgresAirbyteClient(
     }
 
     override suspend fun tableExists(table: TableName): Boolean {
-        return executeQuery(
-            """
+        val exists =
+            executeQuery(
+                """
             SELECT EXISTS(
                 SELECT 1 FROM information_schema.tables
                 WHERE table_schema = '${table.namespace}'
                 AND table_name = '${table.name}'
             )
             """
-        ) { rs -> rs.next() && rs.getBoolean(1) }
+            ) { rs -> rs.next() && rs.getBoolean(1) }
+
+        if (exists) {
+            dropTable(table)
+        }
+        return false
     }
 
     override suspend fun createNamespace(namespace: String) {


### PR DESCRIPTION
## Description
This PR modifies the `tableExists` method in `PostgresAirbyteClient`.
The logic has been updated to:
1. Check if the table exists.
2. Drop the table if it is found.
3. Always return `false`.

## Context
This change ensures that we always proceed with a clean state by forcing the dropping of existing tables. This simulates the table being missing to downstream logic, ensuring that any necessary recreation or initialization steps are always triggered.