### PR TITLE
ci: fix /bump-version command by restoring PAT for github_token

### DIFF
--- a/.github/workflows/bump-version-command.yml
+++ b/.github/workflows/bump-version-command.yml
@@ -98,7 +98,7 @@ jobs:
           context: "manual"
           gcs_credentials: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
           sentry_dsn: ${{ secrets.SENTRY_AIRBYTE_CI_DSN }}
-          github_token: ${{ steps.get-app-token.outputs.token }}
+          github_token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
           git_repo_url: https://github.com/${{ steps.job-vars.outputs.repo }}.git
           subcommand: |
             connectors --modified bump-version \


### PR DESCRIPTION
## What

Fixes the broken `/bump-version` slash command. The command was failing because it referenced a non-existent step output for the `github_token` parameter.

Reported in: https://github.com/airbytehq/airbyte/pull/71319#issuecomment-3740465482

## How

In PR #65948, the `github_token` was changed from `${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}` to `${{ steps.get-app-token.outputs.token }}`. However, no step with id `get-app-token` exists in this workflow, so the token was undefined.

This PR restores the original PAT reference. Note that the workflow comment (lines 58-61) explicitly states that a PAT is still required for this workflow because it needs permissions to add commits to both the main repo and forks.

## Review guide

1. `.github/workflows/bump-version-command.yml` - Single line change restoring the PAT secret reference

**Human review checklist:**
- [ ] Verify `GH_PAT_MAINTENANCE_OCTAVIA` secret exists and has appropriate permissions

## User Impact

The `/bump-version` slash command will work again, allowing maintainers to bump connector versions via PR comments.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Link to Devin run: https://app.devin.ai/sessions/fe4a539566d4487f87a2202ee18ae5ee
Requested by: AJ Steers (@aaronsteers)