### PR TITLE
ci: add feedback for backtick-wrapped slash commands

### DIFF
--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -5,7 +5,8 @@ on:
 jobs:
   slashCommandDispatch:
     name: Dispatch
-    if: startsWith(github.event.comment.body, '/')
+    # Match commands starting with '/' or wrapped in backticks like '`/command`'
+    if: startsWith(github.event.comment.body, '/') || startsWith(github.event.comment.body, '`/')
     runs-on: ubuntu-24.04
     steps:
       - name: Authenticate as GitHub App
@@ -47,8 +48,26 @@ jobs:
           echo "ref=$REF" >> $GITHUB_OUTPUT
           echo "repo=$REPO" >> $GITHUB_OUTPUT
 
+      - name: Check for backtick-wrapped command
+        id: check-backticks
+        if: startsWith(github.event.comment.body, '`/')
+        run: |
+          echo "backticks_detected=true" >> $GITHUB_OUTPUT
+          echo "::warning::Command appears to be wrapped in backticks. Slash commands should not use markdown formatting."
+
+      - name: Post backtick warning comment
+        if: steps.check-backticks.outputs.backticks_detected == 'true'
+        uses: peter-evans/create-or-update-comment@a35cf36e5301d70b76f316e867e7788a55a31dae # v1.4.5
+        with:
+          comment-id: ${{ github.event.comment.id }}
+          body: |
+            > :warning: **Command not recognized**: Slash commands should not be wrapped in backticks or other markdown formatting.
+            >
+            > Please re-post your command without the backticks. For example, type `/bump-version` directly, not `` `/bump-version` ``.
+
       - name: Slash Command Dispatch (Workflow)
         id: scd
+        if: steps.check-backticks.outputs.backticks_detected != 'true'
         uses: peter-evans/slash-command-dispatch@f996d7b7aae9059759ac55e978cff76d91853301 # v3.0.2
         with:
           token: ${{ steps.get-app-token.outputs.token }}


### PR DESCRIPTION
## What

Adds user feedback when slash commands are wrapped in backticks (markdown code formatting), which prevents them from being recognized.

This was discovered when investigating why `/bump-version` wasn't working on [PR #71319](https://github.com/airbytehq/airbyte/pull/71319#issuecomment-3740465482) - the user had posted `` `/bump-version type=minor` `` with backticks, causing the workflow to silently skip without any feedback.

## How

1. Updated the job's `if` condition to also trigger when comments start with `` `/ `` (backtick + slash)
2. Added a step to detect backtick-wrapped commands
3. Added a step to post a warning comment explaining the issue and asking the user to re-post without backticks
4. Skip the actual slash-command-dispatch action when backticks are detected (since it won't recognize the command anyway)

## Review guide

1. `.github/workflows/slash-commands.yml` - All changes are in this file

**Human review checklist:**
- [ ] Verify the `if` condition logic correctly matches both `/command` and `` `/command` `` patterns
- [ ] Verify the warning message is clear and actionable for users
- [ ] Consider if there are other markdown patterns that could cause similar issues (e.g., triple backticks)

## User Impact

Users who accidentally wrap slash commands in backticks will now receive a helpful error message explaining the issue, instead of the command being silently ignored.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Link to Devin run: https://app.devin.ai/sessions/fe4a539566d4487f87a2202ee18ae5ee
Requested by: AJ Steers (@aaronsteers)