### PR TITLE
chore(source-monday): Add changelog and API versioning URLs to external documentation

### DIFF
--- a/airbyte-integrations/connectors/source-monday/metadata.yaml
+++ b/airbyte-integrations/connectors/source-monday/metadata.yaml
@@ -86,6 +86,12 @@ data:
     - title: monday.com API reference
       url: https://developer.monday.com/api-reference/docs
       type: api_reference
+    - title: monday.com API Changelog
+      url: https://developer.monday.com/api-reference/changelog
+      type: api_release_history
+    - title: monday.com API Versioning
+      url: https://developer.monday.com/api-reference/docs/api-versioning
+      type: api_deprecations
     - title: monday.com authentication
       url: https://developer.monday.com/api-reference/docs/authentication
       type: authentication_guide


### PR DESCRIPTION
## What

Adds external documentation URLs for the monday.com API changelog and API versioning pages to the source-monday connector metadata. These URLs are valuable for API deprecation monitoring and were discovered during a deprecation research investigation.

Resolves https://github.com/airbytehq/oncall/issues/10528

- https://github.com/airbytehq/oncall/issues/10528

## How

Added two new entries to the `externalDocumentationUrls` section in `metadata.yaml`:
- **API Changelog** (`api_release_history`): https://developer.monday.com/api-reference/changelog
- **API Versioning** (`api_deprecations`): https://developer.monday.com/api-reference/docs/api-versioning

## Review guide

1. `airbyte-integrations/connectors/source-monday/metadata.yaml` - verify the URLs are correct and the `type` values are appropriate

## User Impact

No user-facing impact. This change improves internal tooling for API deprecation monitoring by making changelog and versioning documentation URLs available in the connector metadata.

## Can this PR be safely reverted and rolled back?

- [x] YES

---

Requested by: Danylo Jablonski (@DanyloGL)

Link to Devin run: https://app.devin.ai/sessions/ee4a66d920cc492bbe4fbdb3833de384