### PR TITLE
chore(source-twilio): Update stale authentication documentation URL

### DIFF
--- a/airbyte-integrations/connectors/source-twilio/metadata.yaml
+++ b/airbyte-integrations/connectors/source-twilio/metadata.yaml
@@ -70,7 +70,7 @@ data:
       url: https://www.twilio.com/en-us/changelog
       type: api_release_history
     - title: Twilio authentication
-      url: https://www.twilio.com/docs/iam/credentials/api-credentials
+      url: https://www.twilio.com/docs/iam/api-keys
       type: authentication_guide
     - title: Twilio API OpenAPI specification
       url: https://github.com/twilio/twilio-oai


### PR DESCRIPTION
## What

Updates a stale external documentation URL in the source-twilio connector's metadata. The previous authentication guide URL (`https://www.twilio.com/docs/iam/credentials/api-credentials`) now returns a 404 error.

Resolves https://github.com/airbytehq/oncall/issues/10446

- https://github.com/airbytehq/oncall/issues/10446

## How

Replaced the broken URL with the current Twilio API keys documentation page: `https://www.twilio.com/docs/iam/api-keys`

## Review guide

1. `airbyte-integrations/connectors/source-twilio/metadata.yaml` - Single URL change in `externalDocumentationUrls`

## User Impact

No runtime impact. This only affects the external documentation links displayed in connector metadata.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Requested by: @DanyloGL

Link to Devin run: https://app.devin.ai/sessions/aa90998b729c4789a97b8b3ce94b7629