### PR TITLE
fix(destination-gcs-data-lake): Add TempTableNameGenerator bean to fix DI failure

### DIFF
--- a/airbyte-integrations/connectors/destination-gcs-data-lake/src/main/kotlin/io/airbyte/integrations/destination/gcs_data_lake/GcsDataLakeBeanFactory.kt
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/src/main/kotlin/io/airbyte/integrations/destination/gcs_data_lake/GcsDataLakeBeanFactory.kt
@@ -8,6 +8,9 @@ import io.airbyte.cdk.load.command.Dedupe
 import io.airbyte.cdk.load.command.DestinationCatalog
 import io.airbyte.cdk.load.dataflow.config.AggregatePublishingConfig
 import io.airbyte.cdk.load.dataflow.config.DataFlowSocketConfig
+import io.airbyte.cdk.load.table.DefaultTempTableNameGenerator
+import io.airbyte.cdk.load.table.TempTableNameGenerator
+import io.airbyte.integrations.destination.gcs_data_lake.spec.GcsDataLakeConfiguration
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.micronaut.context.annotation.Factory
 import io.micronaut.context.annotation.Requires
@@ -17,6 +20,10 @@ import jakarta.inject.Singleton
 @Factory
 class GcsDataLakeBeanFactory {
     private val log = KotlinLogging.logger {}
+
+    @Singleton
+    fun tempTableNameGenerator(config: GcsDataLakeConfiguration): TempTableNameGenerator =
+        DefaultTempTableNameGenerator(internalNamespace = config.namespace)
 
     @Singleton
     fun aggregatePublishingConfig(): AggregatePublishingConfig {

--- a/airbyte-integrations/connectors/destination-gcs-data-lake/src/test/kotlin/io/airbyte/integrations/destination/gcs_data_lake/GcsDataLakeBeanFactoryTest.kt
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/src/test/kotlin/io/airbyte/integrations/destination/gcs_data_lake/GcsDataLakeBeanFactoryTest.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.gcs_data_lake
+
+import io.airbyte.cdk.load.table.DefaultTempTableNameGenerator
+import io.airbyte.integrations.destination.gcs_data_lake.spec.BigLakeCatalogConfiguration
+import io.airbyte.integrations.destination.gcs_data_lake.spec.GcsCatalogConfiguration
+import io.airbyte.integrations.destination.gcs_data_lake.spec.GcsDataLakeConfiguration
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+
+internal class GcsDataLakeBeanFactoryTest {
+
+    @Test
+    fun testTempTableNameGeneratorCreation() {
+        val namespace = "test_namespace"
+        val config = createTestConfiguration(namespace)
+        val factory = GcsDataLakeBeanFactory()
+
+        val generator = factory.tempTableNameGenerator(config)
+
+        assertNotNull(generator)
+        assertEquals(DefaultTempTableNameGenerator::class, generator::class)
+    }
+
+    @Test
+    fun testTempTableNameGeneratorUsesConfigNamespace() {
+        val namespace = "my_custom_namespace"
+        val config = createTestConfiguration(namespace)
+        val factory = GcsDataLakeBeanFactory()
+
+        val generator = factory.tempTableNameGenerator(config)
+
+        assertNotNull(generator)
+    }
+
+    private fun createTestConfiguration(namespace: String): GcsDataLakeConfiguration {
+        return GcsDataLakeConfiguration(
+            gcsBucketName = "test-bucket",
+            serviceAccountJson = """{"type": "service_account", "project_id": "test-project"}""",
+            gcpProjectId = "test-project",
+            gcpLocation = "us-central1",
+            gcsEndpoint = null,
+            namespace = namespace,
+            gcsCatalogConfiguration = GcsCatalogConfiguration(
+                warehouseLocation = "gs://test-bucket/warehouse",
+                mainBranchName = "main",
+                catalogConfiguration = BigLakeCatalogConfiguration(
+                    catalogName = "test_catalog",
+                    gcpLocation = "us-central1",
+                ),
+            ),
+        )
+    }
+}

--- a/airbyte-integrations/connectors/destination-gcs-data-lake/src/test/kotlin/io/airbyte/integrations/destination/gcs_data_lake/GcsDataLakeBeanFactoryTest.kt
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/src/test/kotlin/io/airbyte/integrations/destination/gcs_data_lake/GcsDataLakeBeanFactoryTest.kt
@@ -45,14 +45,16 @@ internal class GcsDataLakeBeanFactoryTest {
             gcpLocation = "us-central1",
             gcsEndpoint = null,
             namespace = namespace,
-            gcsCatalogConfiguration = GcsCatalogConfiguration(
-                warehouseLocation = "gs://test-bucket/warehouse",
-                mainBranchName = "main",
-                catalogConfiguration = BigLakeCatalogConfiguration(
-                    catalogName = "test_catalog",
-                    gcpLocation = "us-central1",
+            gcsCatalogConfiguration =
+                GcsCatalogConfiguration(
+                    warehouseLocation = "gs://test-bucket/warehouse",
+                    mainBranchName = "main",
+                    catalogConfiguration =
+                        BigLakeCatalogConfiguration(
+                            catalogName = "test_catalog",
+                            gcpLocation = "us-central1",
+                        ),
                 ),
-            ),
         )
     }
 }


### PR DESCRIPTION
## What
Fixes a Micronaut dependency injection failure in the GCS Data Lake destination connector that causes the error:
```
Failed to inject value for parameter [internalNamespace] of class: io.airbyte.cdk.load.table.DefaultTempTableNameGenerator
Message: Multiple possible bean candidates found: [List<String>]
```

This bug was introduced in PR #71258 when the connector was updated to use the new `TableSchemaMapper` pattern. The `GcsDataLakeTableSchemaMapper` requires a `TempTableNameGenerator` bean, but the connector was missing the explicit bean factory method.

## How
Added the missing `tempTableNameGenerator` bean factory method to `GcsDataLakeBeanFactory`, following the same pattern used by other connectors like [Snowflake](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/SnowflakeBeanFactory.kt#L66-L69) and BigQuery.

Also added a unit test to prevent this regression in the future.

## Review guide
1. `GcsDataLakeBeanFactory.kt` - The fix: adds the `tempTableNameGenerator` bean factory method
2. `GcsDataLakeBeanFactoryTest.kt` - New unit test verifying bean creation

**Note for reviewers:** The original bug passed CI because the integration tests (which would have caught this) require GCS secrets and were skipped. The PR #71258 CI showed "3 tests - 1 ✅ - 2 💤 (skipped)".

### Human review checklist
- [ ] Verify `config.namespace` is the correct value to pass to `DefaultTempTableNameGenerator` (matches what other connectors use for `internalNamespace`)
- [ ] Confirm the bean factory method signature matches what `GcsDataLakeTableSchemaMapper` expects for injection

## User Impact
- Users on connector versions 1.0.3+ were unable to run the Check operation, receiving a DI failure error
- This fix restores normal connector functionality
- Workaround: Users can pin to connector version 1.0.2 until this fix is released

## Can this PR be safely reverted and rolled back?
- [x] YES 💚

---
Requested by: @lleadbet
Link to Devin run: https://app.devin.ai/sessions/63707d1ae76e4305997184f3da38b30c