### PR TITLE
ci: add poe_tasks.toml to get tests running in CI

### DIFF
--- a/airbyte-integrations/connectors/destination-gcs-data-lake/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/metadata.yaml
@@ -21,7 +21,7 @@ data:
             alias: airbyte-connector-testing-secret-store
   connectorType: destination
   definitionId: 8c8a2d3e-1b4f-4a9c-9e7d-6f5a4b3c2d1e
-  dockerImageTag: 1.0.4
+  dockerImageTag: 1.0.5
   dockerRepository: airbyte/destination-gcs-data-lake
   documentationUrl: https://docs.airbyte.com/integrations/destinations/gcs-data-lake
   githubIssueLabel: destination-gcs-data-lake

--- a/airbyte-integrations/connectors/destination-gcs-data-lake/poe_tasks.toml
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/poe_tasks.toml
@@ -1,0 +1,3 @@
+include = [
+    "${POE_GIT_DIR}/poe-tasks/gradle-connector-tasks.toml",
+]

--- a/airbyte-integrations/connectors/destination-gcs-data-lake/src/main/kotlin/io/airbyte/integrations/destination/gcs_data_lake/GcsDataLakeBeanFactory.kt
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/src/main/kotlin/io/airbyte/integrations/destination/gcs_data_lake/GcsDataLakeBeanFactory.kt
@@ -8,6 +8,8 @@ import io.airbyte.cdk.load.command.Dedupe
 import io.airbyte.cdk.load.command.DestinationCatalog
 import io.airbyte.cdk.load.dataflow.config.AggregatePublishingConfig
 import io.airbyte.cdk.load.dataflow.config.DataFlowSocketConfig
+import io.airbyte.cdk.load.table.DefaultTempTableNameGenerator
+import io.airbyte.cdk.load.table.TempTableNameGenerator
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.micronaut.context.annotation.Factory
 import io.micronaut.context.annotation.Requires
@@ -20,6 +22,8 @@ class GcsDataLakeBeanFactory {
 
     @Singleton
     fun aggregatePublishingConfig(): AggregatePublishingConfig {
+        log.info { "NOOP code change for CI to pick up" }
+
         // NOT speed mode
         return AggregatePublishingConfig(
             maxRecordsPerAgg = 10_000_000_000L,
@@ -28,6 +32,11 @@ class GcsDataLakeBeanFactory {
             maxBufferedAggregates = 5,
         )
     }
+
+    // TODO: There's a bug preventing the DefaultTempTableNameGenerator Singleton in the CDK
+    // from being loaded. So this is necessary for now.
+    @Singleton
+    fun tempTableNameGenerator(): TempTableNameGenerator = DefaultTempTableNameGenerator()
 
     /**
      * Socket configuration for GCS Data Lake destination.

--- a/airbyte-integrations/connectors/destination-gcs-data-lake/src/test-integration/kotlin/io/airbyte/integrations/destination/gcs_data_lake/GcsDataLakeWriteTest.kt
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/src/test-integration/kotlin/io/airbyte/integrations/destination/gcs_data_lake/GcsDataLakeWriteTest.kt
@@ -14,9 +14,14 @@ import io.airbyte.cdk.load.data.icerberg.parquet.IcebergConfigUpdater
 import io.airbyte.cdk.load.data.icerberg.parquet.IcebergDataDumper
 import io.airbyte.cdk.load.data.icerberg.parquet.IcebergExpectedRecordMapper
 import io.airbyte.cdk.load.message.InputRecord
+import io.airbyte.cdk.load.table.DefaultTempTableNameGenerator
 import io.airbyte.cdk.load.test.util.OutputRecord
 import io.airbyte.cdk.load.write.*
 import io.airbyte.integrations.destination.gcs_data_lake.catalog.BigLakeTableIdGenerator
+import io.airbyte.integrations.destination.gcs_data_lake.schema.GcsDataLakeTableSchemaMapper
+import io.airbyte.integrations.destination.gcs_data_lake.spec.BigLakeCatalogConfiguration
+import io.airbyte.integrations.destination.gcs_data_lake.spec.GcsCatalogConfiguration
+import io.airbyte.integrations.destination.gcs_data_lake.spec.GcsDataLakeConfiguration
 import io.airbyte.integrations.destination.gcs_data_lake.spec.GcsDataLakeSpecification
 import java.nio.file.Files
 import kotlin.test.assertContains
@@ -38,7 +43,29 @@ class BigLakeWriteTest :
             BigLakeDataDumper(
                 delegateDataDumper =
                     IcebergDataDumper(
-                        tableIdGenerator = BigLakeTableIdGenerator("test_database"),
+                        tableIdGenerator =
+                            BigLakeTableIdGenerator(
+                                GcsDataLakeTableSchemaMapper(
+                                    // STUB: the only thing we actually use is `namespace`
+                                    GcsDataLakeConfiguration(
+                                        gcsBucketName = "",
+                                        serviceAccountJson = "",
+                                        gcpProjectId = null,
+                                        gcpLocation = "",
+                                        gcsEndpoint = null,
+                                        namespace = "test_database",
+                                        gcsCatalogConfiguration =
+                                            GcsCatalogConfiguration(
+                                                warehouseLocation = "",
+                                                mainBranchName = "",
+                                                catalogConfiguration =
+                                                    BigLakeCatalogConfiguration("", "")
+                                            ),
+                                        numProcessRecordsWorkers = 1
+                                    ),
+                                    tempTableNameGenerator = DefaultTempTableNameGenerator(),
+                                )
+                            ),
                         getCatalog = { spec ->
                             GcsDataLakeTestUtil.getCatalog(GcsDataLakeTestUtil.getConfig(spec))
                         }

--- a/docs/integrations/destinations/gcs-data-lake.md
+++ b/docs/integrations/destinations/gcs-data-lake.md
@@ -204,6 +204,7 @@ If compaction runs simultaneously with the sync, it would delete files from the 
 
 | Version | Date       | Pull Request                                                 | Subject                                                                               |
 |:--------|:-----------|:-------------------------------------------------------------|:--------------------------------------------------------------------------------------|
+| 1.0.5   | 2026-01-14 | [TBD](https://github.com/airbytehq/airbyte/pull/TBD)         | Restore integration tests in CI. Workaround DI error.                                 |
 | 1.0.4   | 2026-01-12 | [71227](https://github.com/airbytehq/airbyte/pull/71227)     | Add speed mode support with PROTOBUF serialization                                    |
 | 1.0.3   | 2026-01-12 | [71258](https://github.com/airbytehq/airbyte/pull/71258)     | Migrate to TableSchemaMapper from deprecated ColumnNameMapper pattern                 |
 | 1.0.2   | 2025-11-13 | [69317](https://github.com/airbytehq/airbyte/pull/69317)     | Connector generally available                                                         |


### PR DESCRIPTION
## What
Attempt to get GCS data lake tests running in CI

Fix GCS data lake and cuts release

## How
Adds `poe_tasks.toml`
Adds another bean for TempTableNameGenerator (there's a bug with the instantiation of the default one in the CDK)
