### PR TITLE
refactor(bulk-cdk): add back namespace constants to core load and add READMEs

### DIFF
--- a/airbyte-cdk/bulk/changelog.md
+++ b/airbyte-cdk/bulk/changelog.md
@@ -1,4 +1,4 @@
-## 0.1.106
+## Version 0.1.106
 
 **Load CDK**
 
@@ -9,7 +9,7 @@
 
 load cdk: schema regression tests use .json extension
 
-## 0.1.104
+## Version 0.1.104
 
 **Load CDK**
 

--- a/airbyte-cdk/bulk/changelog.md
+++ b/airbyte-cdk/bulk/changelog.md
@@ -1,8 +1,15 @@
+## 0.1.106
+
+**Load CDK**
+
+* Add `DEFAULT_AIRBYTE_INTERNAL_NAMESPACE` constant to `core-load` table package
+* Add README documentation to `legacy-task-loader` and `legacy-task-load-db` toolkits
+
 ## Version 0.1.105
 
 load cdk: schema regression tests use .json extension
 
-## Version 0.1.104
+## 0.1.104
 
 **Load CDK**
 

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/table/NamespaceConstants.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/table/NamespaceConstants.kt
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.table
+
+const val DEFAULT_AIRBYTE_INTERNAL_NAMESPACE = "airbyte_internal"

--- a/airbyte-cdk/bulk/toolkits/legacy-task-load-db/README.md
+++ b/airbyte-cdk/bulk/toolkits/legacy-task-load-db/README.md
@@ -1,0 +1,36 @@
+# legacy-task-load-db
+
+> **DEPRECATED**: This toolkit is for legacy (non-dataflow) database connectors only.
+
+This toolkit contains database-specific loading infrastructure for connectors that use the legacy task-based architecture. It includes typing/deduping utilities, SQL generation, and table operations that predate the modern dataflow pipeline.
+
+## Do Not Use For New Connectors
+
+New database connectors should use `core-load` with the dataflow pipeline. This toolkit should only be used and updated for the existing connectors that depend on it.
+
+## Connectors Using This Toolkit
+
+- destination-bigquery
+- destination-mssql
+
+## Configuration
+
+To use this toolkit, add it to your connector's toolkits list along with `useLegacyTaskLoader`:
+
+```groovy
+airbyteBulkConnector {
+    core = 'load'
+    toolkits = ['legacy-task-load-db']
+    useLegacyTaskLoader = true
+}
+```
+
+## Contents
+
+- `legacy_typing_deduping/` - Typing and deduping table operations
+- `direct_load_table/` - Direct load table operations
+- Database handler interfaces and SQL generation utilities
+
+## Migration Path
+
+Connectors should migrate to the modern dataflow pipeline when possible. The dataflow architecture provides better performance, cleaner separation of concerns, and is the actively maintained code path.

--- a/airbyte-cdk/bulk/toolkits/legacy-task-loader/README.md
+++ b/airbyte-cdk/bulk/toolkits/legacy-task-loader/README.md
@@ -1,0 +1,34 @@
+# legacy-task-loader
+
+> **DEPRECATED**: This toolkit is for legacy (non-dataflow) connectors only.
+
+This toolkit contains the pre-dataflow task-based loading infrastructure from CDK version 0.1.73. It exists to support existing connectors that have not yet migrated to the modern dataflow pipeline architecture.
+
+## Do Not Use For New Connectors
+
+New connectors should use `core-load` and the dataflow pipeline. This toolkit should only be used and updated for the existing connectors that depend on it.
+
+## Connectors Using This Toolkit
+
+- destination-bigquery
+- destination-azure-blob-storage
+- destination-s3
+- destination-mssql
+- destination-customer-io
+- destination-hubspot
+- destination-s3-data-lake
+
+## Configuration
+
+To use this toolkit, add `useLegacyTaskLoader = true` in your connector's build.gradle:
+
+```groovy
+airbyteBulkConnector {
+    core = 'load'
+    useLegacyTaskLoader = true
+}
+```
+
+## Migration Path
+
+Connectors should migrate to the modern dataflow pipeline when possible. The dataflow architecture provides better performance, cleaner separation of concerns, and is the actively maintained code path.

--- a/airbyte-cdk/bulk/version.properties
+++ b/airbyte-cdk/bulk/version.properties
@@ -1,1 +1,1 @@
-version=0.1.105
+version=0.1.106


### PR DESCRIPTION
## What
Adds default internal namespace back to core load

Adds readme's for the legacy toolkits

## How
`NamespaceConstants` instead of `DbConstants`
Adds `README`s

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._