### PR TITLE
feat(bulk-cdk): add utility function to start SSH tunnel and return endpoint

### DIFF
--- a/airbyte-cdk/bulk/changelog.md
+++ b/airbyte-cdk/bulk/changelog.md
@@ -1,3 +1,7 @@
+## Version 0.1.107
+
+base cdk: add utility to start ssh tunnel + return endpoint
+
 ## Version 0.1.106
 
 **Load CDK**

--- a/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/ssh/TunnelSession.kt
+++ b/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/ssh/TunnelSession.kt
@@ -45,6 +45,23 @@ internal constructor(
     }
 }
 
+fun startTunnelAndGetEndpoint(
+    ssh: SshTunnelMethodConfiguration,
+    hostname: String,
+    port: Int,
+): String =
+    when (ssh) {
+        is SshKeyAuthTunnelMethod,
+        is SshPasswordAuthTunnelMethod -> {
+            val remote = SshdSocketAddress(hostname, port)
+            val sshConnectionOptions: SshConnectionOptions =
+                SshConnectionOptions.fromAdditionalProperties(emptyMap())
+            val tunnel = createTunnelSession(remote, ssh, sshConnectionOptions)
+            "${tunnel.address.hostName}:${tunnel.address.port}"
+        }
+        is SshNoTunnelMethod -> "$hostname:$port"
+    }
+
 /** Creates an open [TunnelSession]. */
 fun createTunnelSession(
     remote: SshdSocketAddress,

--- a/airbyte-cdk/bulk/version.properties
+++ b/airbyte-cdk/bulk/version.properties
@@ -1,1 +1,1 @@
-version=0.1.106
+version=0.1.107


### PR DESCRIPTION
useful for clickhouse/redshift/postgres. See clickhouse PR https://github.com/airbytehq/airbyte/pull/71784

(can't do postgres b/c it's on an old CDK version; I'll bump the redshift v2 pr to use this after merging)