### PR TITLE
fix(source-zendesk-support): Enable incremental sync for user_fields stream

### DIFF
--- a/airbyte-integrations/connectors/source-zendesk-support/manifest.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-support/manifest.yaml
@@ -188,7 +188,7 @@ definitions:
       primary_key: "id"
 
   user_fields_stream:
-    $ref: "#/definitions/base_stream"
+    $ref: "#/definitions/semi_incremental_stream"
     schema_loader:
       type: InlineSchemaLoader
       schema:
@@ -196,6 +196,7 @@ definitions:
     $parameters:
       name: "user_fields"
       path: "user_fields"
+      cursor_field: "updated_at"
       primary_key: "id"
 
   tags_stream:

--- a/airbyte-integrations/connectors/source-zendesk-support/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-support/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 79c1aa37-dae3-42ae-b333-d1c105477715
-  dockerImageTag: 4.10.18
+  dockerImageTag: 4.10.19
   dockerRepository: airbyte/source-zendesk-support
   documentationUrl: https://docs.airbyte.com/integrations/sources/zendesk-support
   githubIssueLabel: source-zendesk-support

--- a/airbyte-integrations/connectors/source-zendesk-support/unit_tests/mock_server/response_builder.py
+++ b/airbyte-integrations/connectors/source-zendesk-support/unit_tests/mock_server/response_builder.py
@@ -154,6 +154,10 @@ class CustomRolesRecordBuilder(ZendeskSupportRecordBuilder):
         self._record["id"] = id
         return self
 
+    def with_cursor(self, cursor: str) -> "CustomRolesRecordBuilder":
+        self._record["updated_at"] = cursor
+        return self
+
 
 class SchedulesRecordBuilder(ZendeskSupportRecordBuilder):
     @classmethod
@@ -163,6 +167,10 @@ class SchedulesRecordBuilder(ZendeskSupportRecordBuilder):
 
     def with_id(self, id: int) -> "SchedulesRecordBuilder":
         self._record["id"] = id
+        return self
+
+    def with_cursor(self, cursor: str) -> "SchedulesRecordBuilder":
+        self._record["updated_at"] = cursor
         return self
 
 
@@ -612,6 +620,10 @@ class UserFieldsRecordBuilder(ZendeskSupportRecordBuilder):
         self._record["id"] = id
         return self
 
+    def with_cursor(self, cursor: str) -> "UserFieldsRecordBuilder":
+        self._record["updated_at"] = cursor
+        return self
+
 
 class CategoriesRecordBuilder(ZendeskSupportRecordBuilder):
     @classmethod
@@ -643,6 +655,10 @@ class TopicsRecordBuilder(ZendeskSupportRecordBuilder):
 
     def with_id(self, id: int) -> "TopicsRecordBuilder":
         self._record["id"] = id
+        return self
+
+    def with_cursor(self, cursor: str) -> "TopicsRecordBuilder":
+        self._record["updated_at"] = cursor
         return self
 
 

--- a/airbyte-integrations/connectors/source-zendesk-support/unit_tests/mock_server/test_custom_roles.py
+++ b/airbyte-integrations/connectors/source-zendesk-support/unit_tests/mock_server/test_custom_roles.py
@@ -14,7 +14,7 @@ from .response_builder import CustomRolesRecordBuilder, CustomRolesResponseBuild
 from .utils import get_log_messages_by_log_level, read_stream
 
 
-RECENT_CURSOR = ab_datetime_now().subtract(timedelta(days=1)).to_iso8601_string()
+RECENT_CURSOR = ab_datetime_now().subtract(timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 class TestCustomRolesStreamFullRefresh(TestCase):

--- a/airbyte-integrations/connectors/source-zendesk-support/unit_tests/mock_server/test_custom_roles.py
+++ b/airbyte-integrations/connectors/source-zendesk-support/unit_tests/mock_server/test_custom_roles.py
@@ -13,6 +13,8 @@ from .request_builder import ApiTokenAuthenticator, ZendeskSupportRequestBuilder
 from .response_builder import CustomRolesRecordBuilder, CustomRolesResponseBuilder, ErrorResponseBuilder
 from .utils import get_log_messages_by_log_level, read_stream
 
+RECENT_CURSOR = ab_datetime_now().subtract(timedelta(days=1)).to_iso8601_string()
+
 
 class TestCustomRolesStreamFullRefresh(TestCase):
     """
@@ -46,7 +48,7 @@ class TestCustomRolesStreamFullRefresh(TestCase):
 
         http_mocker.get(
             self._base_custom_roles_request(api_token_authenticator).build(),
-            CustomRolesResponseBuilder.custom_roles_response().with_record(CustomRolesRecordBuilder.custom_roles_record()).build(),
+            CustomRolesResponseBuilder.custom_roles_response().with_record(CustomRolesRecordBuilder.custom_roles_record().with_cursor(RECENT_CURSOR)).build(),
         )
 
         output = read_stream("custom_roles", SyncMode.incremental, self._config)
@@ -70,11 +72,11 @@ class TestCustomRolesStreamFullRefresh(TestCase):
         )
 
         # Create records for page 1
-        record1 = CustomRolesRecordBuilder.custom_roles_record().with_id(1001)
-        record2 = CustomRolesRecordBuilder.custom_roles_record().with_id(1002)
+        record1 = CustomRolesRecordBuilder.custom_roles_record().with_id(1001).with_cursor(RECENT_CURSOR)
+        record2 = CustomRolesRecordBuilder.custom_roles_record().with_id(1002).with_cursor(RECENT_CURSOR)
 
         # Create record for page 2
-        record3 = CustomRolesRecordBuilder.custom_roles_record().with_id(1003)
+        record3 = CustomRolesRecordBuilder.custom_roles_record().with_id(1003).with_cursor(RECENT_CURSOR)
 
         # Page 1: has records and provides next_page URL
         http_mocker.get(

--- a/airbyte-integrations/connectors/source-zendesk-support/unit_tests/mock_server/test_custom_roles.py
+++ b/airbyte-integrations/connectors/source-zendesk-support/unit_tests/mock_server/test_custom_roles.py
@@ -13,6 +13,7 @@ from .request_builder import ApiTokenAuthenticator, ZendeskSupportRequestBuilder
 from .response_builder import CustomRolesRecordBuilder, CustomRolesResponseBuilder, ErrorResponseBuilder
 from .utils import get_log_messages_by_log_level, read_stream
 
+
 RECENT_CURSOR = ab_datetime_now().subtract(timedelta(days=1)).to_iso8601_string()
 
 
@@ -48,7 +49,9 @@ class TestCustomRolesStreamFullRefresh(TestCase):
 
         http_mocker.get(
             self._base_custom_roles_request(api_token_authenticator).build(),
-            CustomRolesResponseBuilder.custom_roles_response().with_record(CustomRolesRecordBuilder.custom_roles_record().with_cursor(RECENT_CURSOR)).build(),
+            CustomRolesResponseBuilder.custom_roles_response()
+            .with_record(CustomRolesRecordBuilder.custom_roles_record().with_cursor(RECENT_CURSOR))
+            .build(),
         )
 
         output = read_stream("custom_roles", SyncMode.incremental, self._config)

--- a/airbyte-integrations/connectors/source-zendesk-support/unit_tests/mock_server/test_schedules.py
+++ b/airbyte-integrations/connectors/source-zendesk-support/unit_tests/mock_server/test_schedules.py
@@ -21,6 +21,8 @@ from .request_builder import ApiTokenAuthenticator, ZendeskSupportRequestBuilder
 from .response_builder import ErrorResponseBuilder, SchedulesRecordBuilder, SchedulesResponseBuilder
 from .utils import get_log_messages_by_log_level, read_stream
 
+RECENT_CURSOR = ab_datetime_now().subtract(timedelta(days=1)).to_iso8601_string()
+
 
 class TestSchedulesStreamFullRefresh(TestCase):
     """
@@ -59,7 +61,7 @@ class TestSchedulesStreamFullRefresh(TestCase):
 
         http_mocker.get(
             self._base_schedules_request(api_token_authenticator).build(),
-            SchedulesResponseBuilder.schedules_response().with_record(SchedulesRecordBuilder.schedules_record()).build(),
+            SchedulesResponseBuilder.schedules_response().with_record(SchedulesRecordBuilder.schedules_record().with_cursor(RECENT_CURSOR)).build(),
         )
 
         output = read_stream("schedules", SyncMode.incremental, self._config)
@@ -86,11 +88,11 @@ class TestSchedulesStreamFullRefresh(TestCase):
         )
 
         # Create records for page 1
-        record1 = SchedulesRecordBuilder.schedules_record().with_id(1001)
-        record2 = SchedulesRecordBuilder.schedules_record().with_id(1002)
+        record1 = SchedulesRecordBuilder.schedules_record().with_id(1001).with_cursor(RECENT_CURSOR)
+        record2 = SchedulesRecordBuilder.schedules_record().with_id(1002).with_cursor(RECENT_CURSOR)
 
         # Create record for page 2
-        record3 = SchedulesRecordBuilder.schedules_record().with_id(1003)
+        record3 = SchedulesRecordBuilder.schedules_record().with_id(1003).with_cursor(RECENT_CURSOR)
 
         # Page 1: has records and provides next_page URL
         http_mocker.get(

--- a/airbyte-integrations/connectors/source-zendesk-support/unit_tests/mock_server/test_schedules.py
+++ b/airbyte-integrations/connectors/source-zendesk-support/unit_tests/mock_server/test_schedules.py
@@ -22,7 +22,7 @@ from .response_builder import ErrorResponseBuilder, SchedulesRecordBuilder, Sche
 from .utils import get_log_messages_by_log_level, read_stream
 
 
-RECENT_CURSOR = ab_datetime_now().subtract(timedelta(days=1)).to_iso8601_string()
+RECENT_CURSOR = ab_datetime_now().subtract(timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 class TestSchedulesStreamFullRefresh(TestCase):

--- a/airbyte-integrations/connectors/source-zendesk-support/unit_tests/mock_server/test_schedules.py
+++ b/airbyte-integrations/connectors/source-zendesk-support/unit_tests/mock_server/test_schedules.py
@@ -21,6 +21,7 @@ from .request_builder import ApiTokenAuthenticator, ZendeskSupportRequestBuilder
 from .response_builder import ErrorResponseBuilder, SchedulesRecordBuilder, SchedulesResponseBuilder
 from .utils import get_log_messages_by_log_level, read_stream
 
+
 RECENT_CURSOR = ab_datetime_now().subtract(timedelta(days=1)).to_iso8601_string()
 
 
@@ -61,7 +62,9 @@ class TestSchedulesStreamFullRefresh(TestCase):
 
         http_mocker.get(
             self._base_schedules_request(api_token_authenticator).build(),
-            SchedulesResponseBuilder.schedules_response().with_record(SchedulesRecordBuilder.schedules_record().with_cursor(RECENT_CURSOR)).build(),
+            SchedulesResponseBuilder.schedules_response()
+            .with_record(SchedulesRecordBuilder.schedules_record().with_cursor(RECENT_CURSOR))
+            .build(),
         )
 
         output = read_stream("schedules", SyncMode.incremental, self._config)

--- a/airbyte-integrations/connectors/source-zendesk-support/unit_tests/mock_server/test_topics.py
+++ b/airbyte-integrations/connectors/source-zendesk-support/unit_tests/mock_server/test_topics.py
@@ -13,6 +13,8 @@ from .request_builder import ApiTokenAuthenticator, ZendeskSupportRequestBuilder
 from .response_builder import ErrorResponseBuilder, TopicsRecordBuilder, TopicsResponseBuilder
 from .utils import get_log_messages_by_log_level, read_stream
 
+RECENT_CURSOR = ab_datetime_now().subtract(timedelta(days=1)).to_iso8601_string()
+
 
 class TestTopicsStreamFullRefresh(TestCase):
     """Test topics stream which uses links_next_paginator (cursor-based pagination)."""
@@ -43,7 +45,7 @@ class TestTopicsStreamFullRefresh(TestCase):
 
         http_mocker.get(
             self._base_topics_request(api_token_authenticator).build(),
-            TopicsResponseBuilder.topics_response().with_record(TopicsRecordBuilder.topics_record()).build(),
+            TopicsResponseBuilder.topics_response().with_record(TopicsRecordBuilder.topics_record().with_cursor(RECENT_CURSOR)).build(),
         )
 
         output = read_stream("topics", SyncMode.incremental, self._config)
@@ -64,14 +66,14 @@ class TestTopicsStreamFullRefresh(TestCase):
         http_mocker.get(
             self._base_topics_request(api_token_authenticator).build(),
             TopicsResponseBuilder.topics_response(next_page_http_request)
-            .with_record(TopicsRecordBuilder.topics_record())
+            .with_record(TopicsRecordBuilder.topics_record().with_cursor(RECENT_CURSOR))
             .with_pagination()
             .build(),
         )
 
         http_mocker.get(
             next_page_http_request,
-            TopicsResponseBuilder.topics_response().with_record(TopicsRecordBuilder.topics_record().with_id(67890)).build(),
+            TopicsResponseBuilder.topics_response().with_record(TopicsRecordBuilder.topics_record().with_id(67890).with_cursor(RECENT_CURSOR)).build(),
         )
 
         output = read_stream("topics", SyncMode.full_refresh, self._config)

--- a/airbyte-integrations/connectors/source-zendesk-support/unit_tests/mock_server/test_topics.py
+++ b/airbyte-integrations/connectors/source-zendesk-support/unit_tests/mock_server/test_topics.py
@@ -46,9 +46,7 @@ class TestTopicsStreamFullRefresh(TestCase):
 
         http_mocker.get(
             self._base_topics_request(api_token_authenticator).build(),
-            TopicsResponseBuilder.topics_response()
-            .with_record(TopicsRecordBuilder.topics_record().with_cursor(RECENT_CURSOR))
-            .build(),
+            TopicsResponseBuilder.topics_response().with_record(TopicsRecordBuilder.topics_record().with_cursor(RECENT_CURSOR)).build(),
         )
 
         output = read_stream("topics", SyncMode.incremental, self._config)

--- a/airbyte-integrations/connectors/source-zendesk-support/unit_tests/mock_server/test_topics.py
+++ b/airbyte-integrations/connectors/source-zendesk-support/unit_tests/mock_server/test_topics.py
@@ -14,7 +14,7 @@ from .response_builder import ErrorResponseBuilder, TopicsRecordBuilder, TopicsR
 from .utils import get_log_messages_by_log_level, read_stream
 
 
-RECENT_CURSOR = ab_datetime_now().subtract(timedelta(days=1)).to_iso8601_string()
+RECENT_CURSOR = ab_datetime_now().subtract(timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 class TestTopicsStreamFullRefresh(TestCase):

--- a/airbyte-integrations/connectors/source-zendesk-support/unit_tests/mock_server/test_topics.py
+++ b/airbyte-integrations/connectors/source-zendesk-support/unit_tests/mock_server/test_topics.py
@@ -13,6 +13,7 @@ from .request_builder import ApiTokenAuthenticator, ZendeskSupportRequestBuilder
 from .response_builder import ErrorResponseBuilder, TopicsRecordBuilder, TopicsResponseBuilder
 from .utils import get_log_messages_by_log_level, read_stream
 
+
 RECENT_CURSOR = ab_datetime_now().subtract(timedelta(days=1)).to_iso8601_string()
 
 
@@ -45,7 +46,9 @@ class TestTopicsStreamFullRefresh(TestCase):
 
         http_mocker.get(
             self._base_topics_request(api_token_authenticator).build(),
-            TopicsResponseBuilder.topics_response().with_record(TopicsRecordBuilder.topics_record().with_cursor(RECENT_CURSOR)).build(),
+            TopicsResponseBuilder.topics_response()
+            .with_record(TopicsRecordBuilder.topics_record().with_cursor(RECENT_CURSOR))
+            .build(),
         )
 
         output = read_stream("topics", SyncMode.incremental, self._config)
@@ -73,7 +76,9 @@ class TestTopicsStreamFullRefresh(TestCase):
 
         http_mocker.get(
             next_page_http_request,
-            TopicsResponseBuilder.topics_response().with_record(TopicsRecordBuilder.topics_record().with_id(67890).with_cursor(RECENT_CURSOR)).build(),
+            TopicsResponseBuilder.topics_response()
+            .with_record(TopicsRecordBuilder.topics_record().with_id(67890).with_cursor(RECENT_CURSOR))
+            .build(),
         )
 
         output = read_stream("topics", SyncMode.full_refresh, self._config)

--- a/airbyte-integrations/connectors/source-zendesk-support/unit_tests/mock_server/test_user_fields.py
+++ b/airbyte-integrations/connectors/source-zendesk-support/unit_tests/mock_server/test_user_fields.py
@@ -14,7 +14,7 @@ from .response_builder import ErrorResponseBuilder, UserFieldsRecordBuilder, Use
 from .utils import get_log_messages_by_log_level, read_stream
 
 
-RECENT_CURSOR = ab_datetime_now().subtract(timedelta(days=1)).to_iso8601_string()
+RECENT_CURSOR = ab_datetime_now().subtract(timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 class TestUserFieldsStreamFullRefresh(TestCase):

--- a/airbyte-integrations/connectors/source-zendesk-support/unit_tests/mock_server/test_user_fields.py
+++ b/airbyte-integrations/connectors/source-zendesk-support/unit_tests/mock_server/test_user_fields.py
@@ -13,6 +13,7 @@ from .request_builder import ApiTokenAuthenticator, ZendeskSupportRequestBuilder
 from .response_builder import ErrorResponseBuilder, UserFieldsRecordBuilder, UserFieldsResponseBuilder
 from .utils import get_log_messages_by_log_level, read_stream
 
+
 RECENT_CURSOR = ab_datetime_now().subtract(timedelta(days=1)).to_iso8601_string()
 
 
@@ -40,7 +41,9 @@ class TestUserFieldsStreamFullRefresh(TestCase):
 
         http_mocker.get(
             self._base_user_fields_request(api_token_authenticator).build(),
-            UserFieldsResponseBuilder.user_fields_response().with_record(UserFieldsRecordBuilder.user_fields_record().with_cursor(RECENT_CURSOR)).build(),
+            UserFieldsResponseBuilder.user_fields_response()
+            .with_record(UserFieldsRecordBuilder.user_fields_record().with_cursor(RECENT_CURSOR))
+            .build(),
         )
 
         output = read_stream("user_fields", SyncMode.full_refresh, self._config)

--- a/airbyte-integrations/connectors/source-zendesk-support/unit_tests/mock_server/test_user_fields.py
+++ b/airbyte-integrations/connectors/source-zendesk-support/unit_tests/mock_server/test_user_fields.py
@@ -13,6 +13,8 @@ from .request_builder import ApiTokenAuthenticator, ZendeskSupportRequestBuilder
 from .response_builder import ErrorResponseBuilder, UserFieldsRecordBuilder, UserFieldsResponseBuilder
 from .utils import get_log_messages_by_log_level, read_stream
 
+RECENT_CURSOR = ab_datetime_now().subtract(timedelta(days=1)).to_iso8601_string()
+
 
 class TestUserFieldsStreamFullRefresh(TestCase):
     @property
@@ -38,7 +40,7 @@ class TestUserFieldsStreamFullRefresh(TestCase):
 
         http_mocker.get(
             self._base_user_fields_request(api_token_authenticator).build(),
-            UserFieldsResponseBuilder.user_fields_response().with_record(UserFieldsRecordBuilder.user_fields_record()).build(),
+            UserFieldsResponseBuilder.user_fields_response().with_record(UserFieldsRecordBuilder.user_fields_record().with_cursor(RECENT_CURSOR)).build(),
         )
 
         output = read_stream("user_fields", SyncMode.full_refresh, self._config)
@@ -54,7 +56,7 @@ class TestUserFieldsStreamFullRefresh(TestCase):
         http_mocker.get(
             self._base_user_fields_request(api_token_authenticator).build(),
             UserFieldsResponseBuilder.user_fields_response(next_page_http_request)
-            .with_record(UserFieldsRecordBuilder.user_fields_record())
+            .with_record(UserFieldsRecordBuilder.user_fields_record().with_cursor(RECENT_CURSOR))
             .with_pagination()
             .build(),
         )
@@ -62,7 +64,7 @@ class TestUserFieldsStreamFullRefresh(TestCase):
         http_mocker.get(
             next_page_http_request,
             UserFieldsResponseBuilder.user_fields_response()
-            .with_record(UserFieldsRecordBuilder.user_fields_record().with_id(67890))
+            .with_record(UserFieldsRecordBuilder.user_fields_record().with_id(67890).with_cursor(RECENT_CURSOR))
             .build(),
         )
 

--- a/docs/integrations/sources/zendesk-support.md
+++ b/docs/integrations/sources/zendesk-support.md
@@ -189,6 +189,7 @@ The Zendesk connector ideally should not run into Zendesk API limitations under 
 
 | Version     | Date       | Pull Request                                             | Subject                                                                                                                                                                                                                            |
 |:------------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 4.10.19 | 2026-01-15 | [71789](https://github.com/airbytehq/airbyte/pull/71789) | Enable incremental sync for user_fields stream |
 | 4.10.18 | 2025-12-18 | [70717](https://github.com/airbytehq/airbyte/pull/70717) | Update dependencies |
 | 4.10.17 | 2025-12-02 | [70066](https://github.com/airbytehq/airbyte/pull/70066) | Update dependencies |
 | 4.10.16 | 2025-11-18 | [69538](https://github.com/airbytehq/airbyte/pull/69538) | Update dependencies |


### PR DESCRIPTION
## What

Fixes incremental sync failure for the `user_fields` stream in the Zendesk Support connector.

**Issue**: The stream was configured as a full-refresh stream (`base_stream`) but users were experiencing failures when attempting incremental sync because the stream had no cursor field configured.

**Connection**: https://cloud.airbyte.com/workspaces/42b03076-a926-43bc-8265-ecb8a8c4fdd6/connections/46481aea-e664-4d10-ba91-cd03bb3a1f04/replication

## How

Changed `user_fields_stream` to use `semi_incremental_stream` (instead of `base_stream`) and added `cursor_field: "updated_at"` to enable incremental sync tracking.

This follows the same pattern as the similar `organization_fields_stream` which already uses `semi_incremental_stream` with `updated_at` cursor.

The `semi_incremental_stream` pattern fetches all records but filters client-side based on the cursor field, which is appropriate for endpoints that don't support server-side filtering but do include timestamp fields in responses.

## Review guide

1. `airbyte-integrations/connectors/source-zendesk-support/manifest.yaml` - Verify the change from `base_stream` to `semi_incremental_stream` and addition of `cursor_field`
2. `airbyte-integrations/connectors/source-zendesk-support/metadata.yaml` - Version bump to 4.10.19
3. `docs/integrations/sources/zendesk-support.md` - Changelog entry added
4. `unit_tests/mock_server/response_builder.py` - Added `with_cursor()` methods to record builders
5. `unit_tests/mock_server/test_*.py` - Updated test mocks to use recent cursor values

### Recommended verification
- Confirm the [Zendesk User Fields API](https://developer.zendesk.com/api-reference/ticketing/users/user_fields/) returns `updated_at` in responses (it does per API docs)

### Human review checklist
- [ ] Verify `updated_at` field is present in Zendesk User Fields API responses
- [ ] Confirm `semi_incremental_stream` is the appropriate pattern (vs. full incremental with API-side filtering)
- [ ] Check that test mocks accurately represent expected API behavior

## Updates since last revision

Fixed test failures caused by the `semi_incremental_stream` record filter. The filter excludes records where `updated_at < start_date`, and the test mocks had static timestamps older than the test's start_date (2 years ago).

**Changes:**
- Added `with_cursor()` methods to `UserFieldsRecordBuilder`, `CustomRolesRecordBuilder`, `SchedulesRecordBuilder`, and `TopicsRecordBuilder`
- Updated test files to set recent `updated_at` values on mock records using a `RECENT_CURSOR` constant (1 day ago)
- Fixed code formatting (line length, blank lines) to pass pre-commit checks

**CI Status:** All required checks passing. Connector tests pass (186 tests ✓). The only failing check is "Pre-Release Checks" which is a pre-existing issue with the migration guide header format (unrelated to this PR).

## User Impact

Users can now use incremental sync mode for the `user_fields` stream instead of being forced to use Full Refresh as a workaround.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Requested by: @rwask

Link to Devin run: https://app.devin.ai/sessions/177402b764fb48e09d9a47373cfe030d