### PR TITLE
docs(source-klaviyo): Add scope-to-stream mapping table for API key configuration

### DIFF
--- a/docs/integrations/sources/klaviyo.md
+++ b/docs/integrations/sources/klaviyo.md
@@ -15,8 +15,24 @@ This page contains the setup guide and reference information for the [Klaviyo](h
 
 ### Step 1: Set up Klaviyo
 
-1. Create a [Klaviyo account](https://www.klaviyo.com)
-2. Create a [Private API key](https://help.klaviyo.com/hc/en-us/articles/115005062267-How-to-Manage-Your-Account-s-API-Keys#your-private-api-keys3). Make sure you selected all [scopes](https://help.klaviyo.com/hc/en-us/articles/7423954176283) corresponding to the streams you would like to replicate. You can find which scope is required for a specific stream by navigating to the relevant API documentation for the streams Airbyte supports.
+1. Create a [Klaviyo account](https://www.klaviyo.com).
+2. Create a [Private API key](https://help.klaviyo.com/hc/en-us/articles/115005062267-How-to-Manage-Your-Account-s-API-Keys#your-private-api-keys3). When creating your API key, you must select the [scopes](https://help.klaviyo.com/hc/en-us/articles/7423954176283) that correspond to the streams you want to replicate. The following table shows which scope is required for each stream:
+
+| Stream | Required Scope |
+|:-------|:---------------|
+| Campaigns | `campaigns:read` |
+| Campaigns Detailed | `campaigns:read` |
+| Email Templates | `templates:read` |
+| Events | `events:read` |
+| Events Detailed | `events:read` |
+| Flows | `flows:read` |
+| Global Exclusions | `profiles:read` |
+| Lists | `lists:read` |
+| Lists Detailed | `lists:read` |
+| Metrics | `metrics:read` |
+| Profiles | `profiles:read` |
+
+For example, if you want to sync the Campaigns, Events, and Profiles streams, you need to enable the `campaigns:read`, `events:read`, and `profiles:read` scopes on your API key.
 
 ### Step 2: Set up the Klaviyo connector in Airbyte
 


### PR DESCRIPTION
## What

Addresses user feedback that the Klaviyo connector documentation was unclear about which OAuth scopes are required for each stream. The previous documentation said "You can find which scope is required for a specific stream by navigating to the relevant API documentation" which created a confusing circular reference.

User feedback: "Still don't know what scope to set in Klaviyo. This page seems to be saying 'check this page'. Recursive loop? But no answer."

## How

Added a clear table mapping each Airbyte stream to its required Klaviyo API scope:

| Stream | Required Scope |
|:-------|:---------------|
| Campaigns | `campaigns:read` |
| Campaigns Detailed | `campaigns:read` |
| Email Templates | `templates:read` |
| Events | `events:read` |
| Events Detailed | `events:read` |
| Flows | `flows:read` |
| Global Exclusions | `profiles:read` |
| Lists | `lists:read` |
| Lists Detailed | `lists:read` |
| Metrics | `metrics:read` |
| Profiles | `profiles:read` |

The scope mappings were derived by:
1. Examining the connector's `manifest.yaml` to identify which API endpoints each stream uses
2. Cross-referencing with [Klaviyo's API documentation](https://developers.klaviyo.com/en/reference/api_overview) to confirm the required scopes for each endpoint

## Review guide

1. `docs/integrations/sources/klaviyo.md` - Verify the scope-to-stream mappings are accurate

## User Impact

Users will now have clear, actionable guidance on which scopes to enable when creating their Klaviyo API key, eliminating the need to navigate through multiple documentation pages.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Requested by: @ian-at-airbyte

Link to Devin run: https://app.devin.ai/sessions/4a0d43e90d2041a2aa5db0e845eb540c

I am an AI assistant (Devin) and have proposed these documentation updates based on user feedback about unclear scope requirements. Reviewers can merge, modify, or close this PR as appropriate.