### PR TITLE
docs(ai-agents): fix API URLs and add context for hosted execution mode

### DIFF
--- a/docs/ai-agents/execution-mode/readme.md
+++ b/docs/ai-agents/execution-mode/readme.md
@@ -91,13 +91,17 @@ curl --location 'https://api.airbyte.ai/api/v1/embedded/scoped-token' \
 
 Create a connector with your API credentials. Airbyte stores these credentials securely in Airbyte Cloud.
 
+You'll need:
+- **source_template_id**: The template ID for the connector type (available from your Airbyte Cloud workspace settings)
+- **workspace_id**: Your workspace ID (returned in the scoped token response)
+
 ```bash
-curl -X POST "https://api.airbyte.ai/v1/integrations/sources" \
-    -H "Authorization: Bearer {SCOPED_TOKEN}" \
+curl -X POST "https://api.airbyte.ai/api/v1/integrations/sources" \
+    -H "Authorization: Bearer <scoped_token>" \
     -H "Content-Type: application/json" \
     -d '{
-      "source_template_id": "{SOURCE_TEMPLATE_ID}",
-      "workspace_id": "{WORKSPACE_ID}",
+      "source_template_id": "<source_template_id>",
+      "workspace_id": "<workspace_id>",
       "name": "...",
       "auth_config": {
          ...
@@ -129,7 +133,7 @@ connector = GongConnector(
 ...
 ```
 
-Once initialized, the connector works the same way as in local mode. The connector handles authentication and routing through Airbyte Cloud automatically.
+Once initialized, the connector works the same way as in local mode. The SDK handles the token exchange (application token → scoped token) automatically, so you don't need to manage tokens manually.
 
 </TabItem>
 <TabItem value="api" label="API">

--- a/docs/ai-agents/execution-mode/readme.md
+++ b/docs/ai-agents/execution-mode/readme.md
@@ -92,8 +92,8 @@ curl --location 'https://api.airbyte.ai/api/v1/embedded/scoped-token' \
 Create a connector with your API credentials. Airbyte stores these credentials securely in Airbyte Cloud.
 
 You'll need:
-- **source_template_id**: The template ID for the connector type (available from your Airbyte Cloud workspace settings)
-- **workspace_id**: Your workspace ID (returned in the scoped token response)
+- **source_template_id**: The ID of the source template for the connector type. List available templates by calling `GET /api/v1/embedded/source-templates` with your scoped token.
+- **workspace_id**: Your workspace ID. Retrieve it by calling `GET /api/v1/embedded/scoped-token/info` with your scoped token.
 
 ```bash
 curl -X POST "https://api.airbyte.ai/api/v1/integrations/sources" \

--- a/docs/ai-agents/execution-mode/readme.md
+++ b/docs/ai-agents/execution-mode/readme.md
@@ -92,6 +92,7 @@ curl --location 'https://api.airbyte.ai/api/v1/embedded/scoped-token' \
 Create a connector with your API credentials. Airbyte stores these credentials securely in Airbyte Cloud.
 
 You'll need:
+
 - **source_template_id**: The ID of the source template for the connector type. List available templates by calling `GET /api/v1/embedded/source-templates` with your scoped token.
 - **workspace_id**: Your workspace ID. Retrieve it by calling `GET /api/v1/embedded/scoped-token/info` with your scoped token.
 


### PR DESCRIPTION
This PR targets the following PR:
- #71762

---

## What

Fixes API URL accuracy and improves documentation clarity for the hosted execution mode page, based on review feedback.

Requested by @ian-at-airbyte

## How

1. **Fixed API URL**: Added missing `/api/` prefix to the Create connector endpoint (`/v1/integrations/sources` → `/api/v1/integrations/sources`)
2. **Standardized placeholder style**: Changed from `{CURLY_BRACES}` to `<angle_brackets>` for consistency with the rest of the document
3. **Added context for required parameters**: Specified exact API endpoints for obtaining `source_template_id` and `workspace_id`
4. **Clarified SDK behavior**: Updated Python section to explain that the SDK handles token exchange automatically

## Review guide

1. `docs/ai-agents/execution-mode/readme.md` - All changes in this single file

**Key areas to verify:**
- [ ] Confirm the corrected URL `https://api.airbyte.ai/api/v1/integrations/sources` is accurate
- [ ] Verify `GET /api/v1/embedded/source-templates` is the correct endpoint for listing source templates
- [ ] Verify `GET /api/v1/embedded/scoped-token/info` is the correct endpoint for retrieving workspace_id

## User Impact

Users will see accurate API URLs and clearer guidance on required parameters when setting up hosted execution mode.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

---

Link to Devin run: https://app.devin.ai/sessions/319b343c1e5842d7ab69d4dcdb3f84ec