### PR TITLE
docs: Add Airbyte knowledge MCP server documentation

### DIFF
--- a/docs/developers/mcp-servers/airbyte-knowledge-mcp.md
+++ b/docs/developers/mcp-servers/airbyte-knowledge-mcp.md
@@ -9,7 +9,7 @@ When you're working with an AI agent on tasks that involve Airbyte, the MCP serv
 The Airbyte knowledge MCP is helpful when your AI agent is:
 
 - Building a custom connector
-- Working with Airbyte's Terraform provider or REST API to configure sources, destinations, and connections
+- Working with PyAirbyte, Airbyte's Terraform provider, or REST API to configure sources, destinations, and connections
 - Troubleshooting sync errors or connection issues
 - Learning about Airbyte's architecture or deployment options
 

--- a/docs/developers/mcp-servers/airbyte-knowledge-mcp.md
+++ b/docs/developers/mcp-servers/airbyte-knowledge-mcp.md
@@ -1,0 +1,50 @@
+# Airbyte knowledge MCP server
+
+The Airbyte knowledge MCP server connects AI agents to comprehensive sources of information about Airbyte. It provides semantic search over Airbyte's documentation, website, OpenAPI specs, YouTube content, and GitHub issues, discussions, and pull requests.
+
+When you're working with an AI agent on tasks that involve Airbyte, the MCP server gives your agent up-to-date context about Airbyte's features, APIs, and best practices without leaving your development environment.
+
+## When to use it
+
+The Airbyte knowledge MCP is helpful when your AI agent is:
+
+- Building a custom connector with the Connector Builder or low-code CDK
+- Working with Airbyte's Terraform provider or REST API
+- Configuring sources, destinations, or connections
+- Troubleshooting sync errors or connection issues
+- Learning about Airbyte's architecture or deployment options
+
+Any time an agent performs a task that requires interacting with Airbyte, the MCP server can provide relevant context.
+
+## Connecting to the MCP server
+
+The server URL is `https://airbyte.mcp.kapa.ai`.
+
+### Cursor and VS Code
+
+If you're using Cursor or VS Code, you can connect with one click through the Ask AI button in the [Airbyte documentation](https://docs.airbyte.com). Click the button, then select the MCP install option from the dropdown menu.
+
+### Claude
+
+For Claude Desktop or Claude Code, run the following command:
+
+```bash
+claude mcp add airbyte-knowledge https://airbyte.mcp.kapa.ai
+```
+
+### Other AI tools
+
+The Airbyte knowledge MCP works with any MCP-compatible tool, including Windsurf and ChatGPT Desktop. Refer to your tool's documentation for instructions on adding MCP servers, and use the server URL `https://airbyte.mcp.kapa.ai`.
+
+## Authentication
+
+When connecting for the first time, you'll be prompted to sign in with any Google account. This authentication is used only to enforce rate limits and prevent abuse of the server. Airbyte does not access your email, name, or other personal data.
+
+## Rate limits
+
+Each authenticated user is limited to 40 requests per hour and 200 requests per day.
+
+## Additional resources
+
+- [Model Context Protocol documentation](https://modelcontextprotocol.io/)
+- [Airbyte documentation](https://docs.airbyte.com)

--- a/docs/developers/mcp-servers/airbyte-knowledge-mcp.md
+++ b/docs/developers/mcp-servers/airbyte-knowledge-mcp.md
@@ -9,7 +9,7 @@ When you're working with an AI agent on tasks that involve Airbyte, the MCP serv
 The Airbyte knowledge MCP is helpful when your AI agent is:
 
 - Building a custom connector
-- Working with Airbyte's Terraform provider, REST API, or connection configuration
+- Working with Airbyte's Terraform provider or REST API to configure sources, destinations, and connections
 - Troubleshooting sync errors or connection issues
 - Learning about Airbyte's architecture or deployment options
 

--- a/docs/developers/mcp-servers/airbyte-knowledge-mcp.md
+++ b/docs/developers/mcp-servers/airbyte-knowledge-mcp.md
@@ -9,7 +9,7 @@ When you're working with an AI agent on tasks that involve Airbyte, the MCP serv
 The Airbyte knowledge MCP is helpful when your AI agent is:
 
 - Building a custom connector
-- Working with Airbyte's Terraform provider, REST API, or connection configuration
+- Working with Airbyte's Terraform provider or REST API to configure sources, destinations, and connections.
 - Troubleshooting sync errors or connection issues
 - Learning about Airbyte's architecture or deployment options
 

--- a/docs/developers/mcp-servers/airbyte-knowledge-mcp.md
+++ b/docs/developers/mcp-servers/airbyte-knowledge-mcp.md
@@ -8,9 +8,8 @@ When you're working with an AI agent on tasks that involve Airbyte, the MCP serv
 
 The Airbyte knowledge MCP is helpful when your AI agent is:
 
-- Building a custom connector with the Connector Builder or low-code CDK
-- Working with Airbyte's Terraform provider or REST API
-- Configuring sources, destinations, or connections
+- Building a custom connector
+- Working with Airbyte's Terraform provider, REST API, or connection configuration
 - Troubleshooting sync errors or connection issues
 - Learning about Airbyte's architecture or deployment options
 
@@ -29,7 +28,7 @@ If you're using Cursor or VS Code, you can connect with one click through the As
 For Claude Desktop or Claude Code, run the following command:
 
 ```bash
-claude mcp add airbyte-knowledge https://airbyte.mcp.kapa.ai
+claude mcp add --transport http airbyte-docs https://airbyte.mcp.kapa.ai
 ```
 
 ### Other AI tools
@@ -47,4 +46,3 @@ Each authenticated user is limited to 40 requests per hour and 200 requests per 
 ## Additional resources
 
 - [Model Context Protocol documentation](https://modelcontextprotocol.io/)
-- [Airbyte documentation](https://docs.airbyte.com)

--- a/docs/developers/mcp-servers/readme.md
+++ b/docs/developers/mcp-servers/readme.md
@@ -4,6 +4,7 @@ import DocCardList from '@theme/DocCardList';
 
 Airbyte provides MCP (Model Context Protocol) servers to enable AI-assisted data integration workflows for different use cases.
 
+- The Airbyte knowledge MCP is a hosted server that connects AI agents to Airbyte's documentation, website, OpenAPI specs, YouTube content, and GitHub issues, discussions, and pull requests.
 - The PyAirbyte MCP is a local MCP server for managing Airbyte connectors through AI assistants.
 - The Connector Builder MCP (coming soon) is an AI-assisted connector development.
 

--- a/docusaurus/sidebar-developers.js
+++ b/docusaurus/sidebar-developers.js
@@ -42,11 +42,11 @@ module.exports = {
             type: "doc",
             id: 'mcp-servers/readme',
           },
-                    items: [
-                      'mcp-servers/airbyte-knowledge-mcp',
-                      'mcp-servers/pyairbyte-mcp',
-                      // 'mcp-servers/connector-builder-mcp',
-                    ],
+          items: [
+            'mcp-servers/airbyte-knowledge-mcp',
+            'mcp-servers/pyairbyte-mcp',
+            // 'mcp-servers/connector-builder-mcp',
+          ],
         },
       ],
     },

--- a/docusaurus/sidebar-developers.js
+++ b/docusaurus/sidebar-developers.js
@@ -42,10 +42,11 @@ module.exports = {
             type: "doc",
             id: 'mcp-servers/readme',
           },
-          items: [
-            'mcp-servers/pyairbyte-mcp',
-            // 'mcp-servers/connector-builder-mcp',
-          ],
+                    items: [
+                      'mcp-servers/airbyte-knowledge-mcp',
+                      'mcp-servers/pyairbyte-mcp',
+                      // 'mcp-servers/connector-builder-mcp',
+                    ],
         },
       ],
     },


### PR DESCRIPTION
## What

Adds public documentation for the Airbyte knowledge MCP server, which connects AI agents to comprehensive sources of information about Airbyte. This server is powered by kapa.ai and indexes Airbyte's documentation, website, OpenAPI specs, YouTube content, and GitHub issues, discussions, and pull requests.

## How

- Creates a new documentation page at `docs/developers/mcp-servers/airbyte-knowledge-mcp.md` covering:
  - What the MCP server provides
  - When to use it (connector building, Terraform/API work, troubleshooting, etc.)
  - Connection instructions for Cursor, VS Code, Claude, and other MCP-compatible tools
  - Authentication and rate limit information
- Updates `docs/developers/mcp-servers/readme.md` to include the new MCP server in the list

## Review guide

1. `docs/developers/mcp-servers/airbyte-knowledge-mcp.md` - New documentation file
2. `docs/developers/mcp-servers/readme.md` - Added one line to list the new MCP server

**Items to verify:**
- [x] Server URL `https://airbyte.mcp.kapa.ai` is correct
- [x] One-click integration via Ask AI button works for Cursor/VS Code
- [x] Claude CLI command `claude mcp add airbyte-knowledge https://airbyte.mcp.kapa.ai` is accurate
- [x] Rate limits (40 requests/hour, 200 requests/day) are correct

## User Impact

Users will have public documentation explaining how to connect their AI agents to Airbyte's knowledge base, improving the developer experience when working with Airbyte using AI-assisted tools.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Requested by @ian-at-airbyte

Link to Devin run: https://app.devin.ai/sessions/7634fc3e815b4cbc9c4e1200d0b27b5f