### PR TITLE
feat: add root-level dependabot config to test atomic updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+updates:
+  # Python dependencies - scan from root to test if updates are atomic per-manifest
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "chore(deps): "
+    open-pull-requests-limit: 10
+    # No grouping - each dependency update should be separate
+
+  # Gradle dependencies - scan from root
+  - package-ecosystem: gradle
+    directory: "/"
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "chore(deps): "
+    open-pull-requests-limit: 10
+
+  # Docker base images - scan from root
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "chore(deps): "
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## What

This PR adds a `.github/dependabot.yml` configuration to test whether Dependabot version updates create atomic PRs per-manifest when scanning from the repository root, similar to how Dependabot Security Alerts automatically create isolated PRs per-manifest.

This is an **experiment** to validate the hypothesis that root-level scanning (`directory: "/"`) will produce connector-isolated dependency update PRs without requiring explicit directory entries for each of the 400+ connectors.

## How

Created a minimal `.github/dependabot.yml` with three ecosystem entries (pip, gradle, docker), all configured to scan from the root directory:

- **No grouping** - Intentionally omitted to observe natural PR isolation behavior
- **Weekly schedule** - Standard cadence for version updates
- **10 PR limit per ecosystem** - Allows enough PRs to observe the pattern without flooding

## Review guide

1. `.github/dependabot.yml` - Single file addition with straightforward config

**Key questions to validate after merge:**
- Do Dependabot PRs target individual connector directories, or do they combine updates across connectors?
- Does the behavior match Dependabot Security Alerts (which are naturally atomic)?

## User Impact

- Dependabot will begin creating version update PRs after merge
- If the hypothesis is correct: isolated PRs per connector (good)
- If incorrect: PRs may combine updates across connectors, requiring config adjustment

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

This only adds a configuration file. Reverting will simply disable Dependabot version updates.

---

**Link to Devin run**: https://app.devin.ai/sessions/6b00bde8ead14d03ba2a85ecf15654ac
**Requested by**: AJ Steers (@aaronsteers)