### PR TITLE
ci: remove scijava repository to fix CodeQL dependency resolution

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -51,14 +51,6 @@ dependencyResolutionManagement {
 
         // Maven Central has most of everything.
         mavenCentral()
-        // TODO remove this after jsonschemafriend is republished to jitpack https://github.com/jimblackler/jsonschemafriend/issues/124
-        maven {
-            name 'scijava'
-            url 'https://maven.scijava.org/content/repositories/public'
-            content {
-                includeGroup 'net.jimblackler.jsonschemafriend'
-            }
-        }
         // Jitpack is used to pull dependencies directly from github.
         maven {
             name 'jitpack'


### PR DESCRIPTION
## What

Fixes the CodeQL `language:java-kotlin` scan failure that has been occurring for the past 2 weeks. The scan was failing with:
```
Could not find net.jimblackler.jsonschemafriend:core:0.12.4
```

## How

Removes the `scijava` maven repository from `settings.gradle`. This repository was configured to serve `net.jimblackler.jsonschemafriend` packages but doesn't actually have the `core` module available. The package is available on JitPack, which is already configured as a fallback repository for this package group.

The removed code included a TODO comment suggesting this was a temporary workaround: "TODO remove this after jsonschemafriend is republished to jitpack".

## Review guide

1. `settings.gradle` - Verify that removing scijava won't break any other dependencies (the content filter only included `net.jimblackler.jsonschemafriend`)

## User Impact

CodeQL security scanning for Java/Kotlin code will resume working, providing security analysis coverage that has been missing for ~2 weeks.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Requested by @aaronsteers

Link to Devin run: https://app.devin.ai/sessions/3139bce429044baeb4bda3c41de28fbe