### PR TITLE
test(bulk-cdk): add DataCoercionSuite test case for string containing null character

### DIFF
--- a/airbyte-cdk/bulk/changelog.md
+++ b/airbyte-cdk/bulk/changelog.md
@@ -1,3 +1,7 @@
+## Version 0.1.108
+
+load cdk: DataCoercionSuite tests null character in strings
+
 ## Version 0.1.107
 
 base cdk: add utility to start ssh tunnel + return endpoint

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/component/DataCoercionFixtures.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/component/DataCoercionFixtures.kt
@@ -630,6 +630,7 @@ object DataCoercionStringFixtures {
     const val SHORT_STRING = "short string"
     const val LONG_STRING = "long string"
     const val SPECIAL_CHARS_STRING = "special chars string"
+    const val NULL_CHAR_STRING = "null char string"
 
     val strings =
         listOf(
@@ -648,6 +649,11 @@ object DataCoercionStringFixtures {
                 SPECIAL_CHARS_STRING,
                 StringValue("`~!@#$%^&*()-=_+[]\\{}|o'O\",./<>?)Δ⅀↑∀"),
                 "`~!@#$%^&*()-=_+[]\\{}|o'O\",./<>?)Δ⅀↑∀"
+            ),
+            case(
+                NULL_CHAR_STRING,
+                StringValue("asdf-\u0000-qwer"),
+                "asdf-\u0000-qwer",
             ),
         )
 

--- a/airbyte-cdk/bulk/version.properties
+++ b/airbyte-cdk/bulk/version.properties
@@ -1,1 +1,1 @@
-version=0.1.107
+version=0.1.108


### PR DESCRIPTION
as title.

claude (and chatgpt) for some reason are _really_ convinced that Redshift doesn't support this. But it works totally fine afaict. Add a test case to validate.