### PR TITLE
ci: add auto-heal to stale metadata workflow

### DIFF
--- a/.github/workflows/resolve-stale-metadata.yml
+++ b/.github/workflows/resolve-stale-metadata.yml
@@ -1,4 +1,4 @@
-name: Publish Stale Metadata Report
+name: Resolve Stale Metadata
 
 on:
   workflow_dispatch:
@@ -8,14 +8,20 @@ on:
         required: false
         type: string
   schedule:
-    - cron: "0 * * * *" # Run every hour
+    - cron: "0 */2 * * *" # Run every 2 hours
 
 permissions:
   contents: read
 
 jobs:
-  publish-stale-metadata-report:
-    name: Publish Stale Metadata Report
+  generate-connector-registries:
+    name: Generate Connector Registries
+    uses: ./.github/workflows/generate-connector-registries.yml
+    secrets: inherit
+
+  check-stale-metadata:
+    name: Check for Stale Metadata
+    needs: [generate-connector-registries]
     runs-on: ubuntu-24.04
 
     steps:


### PR DESCRIPTION
## What

Adds auto-healing capability to the stale metadata detection workflow. Instead of just detecting and alerting on stale metadata, the workflow now proactively regenerates connector registries before checking for staleness.

This addresses the issue where stale metadata alerts would fire even when the fix is simply to regenerate the registries from existing GCS metadata.

## How

1. Renamed `publish-stale-metadata-report.yml` → `resolve-stale-metadata.yml` to reflect its new purpose
2. Added a new job that calls `generate-connector-registries.yml` before the stale check runs
3. The stale check job now depends on registry generation completing first
4. Changed schedule from hourly to every 2 hours to reduce unnecessary runs (registry generation takes ~4-5 min even when nothing is stale)

## Review guide

1. `.github/workflows/resolve-stale-metadata.yml` - verify the `uses:` syntax for calling the reusable workflow is correct, and that `secrets: inherit` properly passes required secrets

## User Impact

- Stale metadata alerts should be significantly reduced since the workflow now auto-heals before checking
- If staleness persists after registry regeneration (indicating a real issue), alerts will still fire
- Slightly longer window between checks (2 hours vs 1 hour)

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Requested by: @aaronsteers
Link to Devin run: https://app.devin.ai/sessions/43feee976a5a47a8b5d5473f3c313eb8

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._

> [!NOTE]
> **Auto-merge may have been disabled. Please check the PR status to confirm.**