### PR TITLE
ci: implement true auto-heal for stale metadata

### DIFF
--- a/.github/workflows/resolve-stale-metadata.yml
+++ b/.github/workflows/resolve-stale-metadata.yml
@@ -48,7 +48,7 @@ jobs:
         working-directory: airbyte-ci/connectors/metadata_service/lib
         run: poetry install
 
-      - name: Run stale metadata report task
+      - name: Run stale metadata report task with auto-heal
         env:
           GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
           SLACK_TOKEN: ${{ secrets.SLACK_BOT_TOKEN_AIRBYTE_TEAM }}
@@ -56,4 +56,4 @@ jobs:
         working-directory: airbyte-ci/connectors/metadata_service/lib
         shell: bash
         run: |
-          poetry run metadata_service publish-stale-metadata-report prod-airbyte-cloud-connector-metadata-service
+          poetry run metadata_service publish-stale-metadata-report prod-airbyte-cloud-connector-metadata-service --repo-root ${{ github.workspace }}

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/commands.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/commands.py
@@ -117,11 +117,20 @@ def upload(metadata_file_path: pathlib.Path, docs_path: pathlib.Path, bucket_nam
 
 @metadata_service.command(help="Generate and publish a stale metadata report to Slack.")
 @click.argument("bucket-name", type=click.STRING, required=True)
-def publish_stale_metadata_report(bucket_name: str):
+@click.option(
+    "--repo-root",
+    type=click.Path(exists=True, path_type=pathlib.Path),
+    required=False,
+    default=None,
+    help="The root path of the repository. If provided, enables auto-healing of stale connectors by uploading their metadata to GCS.",
+)
+def publish_stale_metadata_report(bucket_name: str, repo_root: pathlib.Path):
     click.echo(f"Starting stale metadata report for bucket: {bucket_name}")
+    if repo_root:
+        click.echo(f"Auto-heal enabled with repo root: {repo_root}")
     logger.debug("Starting stale metadata report generation and publishing process")
     try:
-        report_published, error_message = generate_and_publish_stale_metadata_report(bucket_name)
+        report_published, error_message = generate_and_publish_stale_metadata_report(bucket_name, repo_root=repo_root)
         if not report_published:
             logger.warning(f"Failed to publish the report to Slack: '{error_message}'.")
             click.secho(f"WARNING: The stale metadata report could not be published: '{error_message}'", fg="red")


### PR DESCRIPTION
## What

Implements true auto-healing for stale metadata by uploading connector metadata to GCS when staleness is detected. This follows up on #72216 which only regenerated registries (which doesn't fix the root cause of staleness).

The previous approach called `generate-connector-registries.yml` before checking for staleness, but that only regenerates registry JSON files from metadata **already in GCS**. It doesn't fix the actual problem: when GitHub master has newer metadata.yaml versions than what's in GCS.

## How

1. Added `_auto_heal_stale_connectors()` function that:
   - Takes a list of stale connector docker repositories
   - For each stale connector, constructs the local path to its metadata.yaml
   - Uploads the metadata to GCS using `upload_metadata_to_gcs()` with `disable_dockerhub_checks=True`

2. Modified `generate_and_publish_stale_metadata_report()` to:
   - Accept optional `repo_root` parameter
   - If stale connectors are found and `repo_root` is provided, attempt auto-heal
   - Re-check for staleness after auto-heal
   - Only alert if still stale after auto-heal attempt

3. Updated CLI command to accept `--repo-root` option

4. Updated workflow to pass `--repo-root ${{ github.workspace }}`

## Review guide

1. `airbyte-ci/connectors/metadata_service/lib/metadata_service/stale_metadata_report.py` - Core auto-heal logic. Pay attention to:
   - Path construction in `_get_docs_path_for_connector()` - assumes standard naming conventions
   - Error handling in `_auto_heal_stale_connectors()` - continues on failure per-connector
   - Use of `disable_dockerhub_checks=True` - bypasses Docker image validation

2. `airbyte-ci/connectors/metadata_service/lib/metadata_service/commands.py` - CLI changes

3. `.github/workflows/resolve-stale-metadata.yml` - Workflow changes

## User Impact

- Stale metadata should now be automatically fixed when the workflow runs
- If auto-heal fails or staleness persists, alerts will still fire to Slack
- Reduces manual intervention needed to fix stale metadata issues

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Requested by: @aaronsteers
Link to Devin run: https://app.devin.ai/sessions/43feee976a5a47a8b5d5473f3c313eb8