### PR TITLE
fix(source-mysql): Map MySQL JSON columns to JSONB type instead of String

### DIFF
--- a/airbyte-integrations/connectors/source-mysql/src/main/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceOperations.kt
+++ b/airbyte-integrations/connectors/source-mysql/src/main/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceOperations.kt
@@ -25,6 +25,7 @@ import io.airbyte.cdk.jdbc.DoubleFieldType
 import io.airbyte.cdk.jdbc.FloatFieldType
 import io.airbyte.cdk.jdbc.IntFieldType
 import io.airbyte.cdk.jdbc.JdbcFieldType
+import io.airbyte.cdk.jdbc.JsonStringFieldType
 import io.airbyte.cdk.jdbc.LocalDateFieldType
 import io.airbyte.cdk.jdbc.LocalDateTimeFieldType
 import io.airbyte.cdk.jdbc.LocalTimeFieldType
@@ -195,7 +196,7 @@ class MySqlSourceOperations :
             MysqlType.LONGTEXT,
             MysqlType.ENUM,
             MysqlType.SET -> StringFieldType
-            MysqlType.JSON -> StringFieldType // TODO: replace this with JsonStringFieldType
+            MysqlType.JSON -> JsonStringFieldType
             MysqlType.TINYBLOB,
             MysqlType.BLOB,
             MysqlType.MEDIUMBLOB,

--- a/airbyte-integrations/connectors/source-mysql/src/test/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceDatatypeIntegrationTest.kt
+++ b/airbyte-integrations/connectors/source-mysql/src/test/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceDatatypeIntegrationTest.kt
@@ -365,7 +365,7 @@ object MySqlSourceDatatypeTestOperations :
                 MySqlSourceDatatypeTestCase(
                     "JSON",
                     jsonValues,
-                    LeafAirbyteSchemaType.STRING, // TODO: fix this bug, should be JSONB
+                    LeafAirbyteSchemaType.JSONB,
                     isGlobal = false // different, more compact rendering with CDC, which is OK
                 ),
                 MySqlSourceDatatypeTestCase(


### PR DESCRIPTION
## Summary

MySQL JSON columns were mapped to `StringFieldType`, causing downstream destinations (like ClickHouse) to create `String` columns instead of native JSON columns even when JSON support was enabled.

This change:
- Updates `MySqlSourceOperations` to use `JsonStringFieldType` for `MysqlType.JSON`
- Updates the datatype integration test to expect `JSONB` instead of `STRING`

This implements the TODO comments.
- `MysqlType.JSON -> StringFieldType // TODO: replace this with JsonStringFieldType`
- `LeafAirbyteSchemaType.STRING, // TODO: fix this bug, should be JSONB`

## Impact

- MySQL JSON columns will now be exposed as JSONB type in Airbyte's schema
- Destinations with JSON support (like ClickHouse with `enable_json: true`) will correctly create native JSON columns

## Test Plan
- [x] Updated `MySqlSourceDatatypeIntegrationTest` to expect `JSONB` instead of `STRING`
- [ ] CI will run integration tests

Resolves: #72224