### PR TITLE
ci: use dedicated GitHub App token for publish workflow

### DIFF
--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -115,7 +115,8 @@ jobs:
         id: get-app-token
         with:
           owner: "airbytehq"
-          repositories: "airbyte"
+          # Use dynamic repo name since this workflow is also called from airbyte-enterprise
+          repositories: ${{ github.event.repository.name }}
           app-id: ${{ secrets.OCTAVIA_PUBLISH_BOT_APP_ID }}
           private-key: ${{ secrets.OCTAVIA_PUBLISH_BOT_PRIVATE_KEY }}
 
@@ -280,7 +281,8 @@ jobs:
         id: get-app-token
         with:
           owner: "airbytehq"
-          repositories: "airbyte"
+          # Use dynamic repo name since this workflow is also called from airbyte-enterprise
+          repositories: ${{ github.event.repository.name }}
           app-id: ${{ secrets.OCTAVIA_PUBLISH_BOT_APP_ID }}
           private-key: ${{ secrets.OCTAVIA_PUBLISH_BOT_PRIVATE_KEY }}
 
@@ -387,7 +389,8 @@ jobs:
         id: get-app-token
         with:
           owner: "airbytehq"
-          repositories: "airbyte"
+          # Use dynamic repo name since this workflow is also called from airbyte-enterprise
+          repositories: ${{ github.event.repository.name }}
           app-id: ${{ secrets.OCTAVIA_PUBLISH_BOT_APP_ID }}
           private-key: ${{ secrets.OCTAVIA_PUBLISH_BOT_PRIVATE_KEY }}
 

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -110,6 +110,15 @@ jobs:
       # Allow all jobs to run, even if one fails
       fail-fast: false
     steps:
+      - name: Authenticate as GitHub App
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        id: get-app-token
+        with:
+          owner: "airbytehq"
+          repositories: "airbyte"
+          app-id: ${{ secrets.OCTAVIA_PUBLISH_BOT_APP_ID }}
+          private-key: ${{ secrets.OCTAVIA_PUBLISH_BOT_PRIVATE_KEY }}
+
       - name: Checkout Airbyte
         # v4
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
@@ -153,6 +162,8 @@ jobs:
 
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+        with:
+          github-token: ${{ steps.get-app-token.outputs.token }}
 
       - name: Install Poe
         run: |
@@ -263,6 +274,15 @@ jobs:
     outputs:
       docker-image-tag: ${{ steps.connector-metadata.outputs.docker-image-tag }}
     steps:
+      - name: Authenticate as GitHub App
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        id: get-app-token
+        with:
+          owner: "airbytehq"
+          repositories: "airbyte"
+          app-id: ${{ secrets.OCTAVIA_PUBLISH_BOT_APP_ID }}
+          private-key: ${{ secrets.OCTAVIA_PUBLISH_BOT_PRIVATE_KEY }}
+
       - name: Checkout Airbyte
         # v4
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
@@ -290,6 +310,8 @@ jobs:
 
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+        with:
+          github-token: ${{ steps.get-app-token.outputs.token }}
 
       - name: Install Poe
         run: |
@@ -358,6 +380,15 @@ jobs:
       - publish_connector_registry_entries
     if: ${{ always() && contains(needs.*.result, 'failure') && github.ref == 'refs/heads/master' }}
     steps:
+      - name: Authenticate as GitHub App
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        id: get-app-token
+        with:
+          owner: "airbytehq"
+          repositories: "airbyte"
+          app-id: ${{ secrets.OCTAVIA_PUBLISH_BOT_APP_ID }}
+          private-key: ${{ secrets.OCTAVIA_PUBLISH_BOT_PRIVATE_KEY }}
+
       - name: Checkout Airbyte
         # v4
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
@@ -369,7 +400,7 @@ jobs:
         uses: ./.github/actions/match-github-to-slack-user
         env:
           AIRBYTE_TEAM_BOT_SLACK_TOKEN: ${{ secrets.SLACK_AIRBYTE_TEAM_READ_USERS }}
-          GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_API_TOKEN: ${{ steps.get-app-token.outputs.token }}
       - name: Send publish failures to connector-publish-failures channel
         id: slack
         uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -163,6 +163,7 @@ jobs:
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
         with:
+          # We pass a token with dedicated GH rate limit
           github-token: ${{ steps.get-app-token.outputs.token }}
 
       - name: Install Poe
@@ -311,6 +312,7 @@ jobs:
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
         with:
+          # We pass a token with dedicated GH rate limit
           github-token: ${{ steps.get-app-token.outputs.token }}
 
       - name: Install Poe


### PR DESCRIPTION
## What

Fixes GitHub API rate limit failures in the connector publish workflow by using a dedicated GitHub App token instead of the shared installation token.

Example failure: https://github.com/airbytehq/airbyte/actions/runs/21161675389/job/60857403789

The `astral-sh/setup-uv` action and `match-github-to-slack-user` action both make GitHub API calls that can fail when rate limits are exceeded during high-volume publishing.

## How

Added GitHub App authentication using `OCTAVIA_PUBLISH_BOT_APP_ID` and `OCTAVIA_PUBLISH_BOT_PRIVATE_KEY` secrets to three jobs:

1. **publish_connectors** - Passes app token to `setup-uv` action
2. **publish_connector_registry_entries** - Passes app token to `setup-uv` action  
3. **notify-failure-slack-channel** - Passes app token to `match-github-to-slack-user` action (replacing `GITHUB_TOKEN`)

The token is scoped dynamically using `${{ github.event.repository.name }}` since this workflow is also called from `airbyte-enterprise` via `publish_enterprise_connectors.yml`.

This follows the same pattern used by other workflows in the repo (e.g., `poe-command.yml`, `connector-ci-checks.yml`).

## Review guide

1. `.github/workflows/publish_connectors.yml` - All changes are in this file

**Key things to verify:**
- [ ] `OCTAVIA_PUBLISH_BOT_APP_ID` and `OCTAVIA_PUBLISH_BOT_PRIVATE_KEY` secrets are configured in both `airbyte` and `airbyte-enterprise` repositories
- [ ] The GitHub App is installed on both repositories with appropriate permissions
- [ ] `github.event.repository.name` resolves correctly in `workflow_call` context (when called from airbyte-enterprise)

## User Impact

Reduces publish workflow failures caused by GitHub API rate limiting. No negative side effects expected.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

### Updates since last revision
- Added inline comments (`# We pass a token with dedicated GH rate limit`) to explain the purpose of the github-token parameter per review feedback
- Changed `repositories` parameter from hardcoded `"airbyte"` to dynamic `${{ github.event.repository.name }}` to support airbyte-enterprise

---

Requested by: @aaronsteers

Link to Devin run: https://app.devin.ai/sessions/43feee976a5a47a8b5d5473f3c313eb8