### PR TITLE
chore(source-mongodb-v2): use authentication_guide type for auth docs URL

### DIFF
--- a/airbyte-integrations/connectors/source-mongodb-v2/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mongodb-v2/metadata.yaml
@@ -100,5 +100,5 @@ data:
       type: api_release_history
     - title: MongoDB authentication
       url: https://www.mongodb.com/docs/manual/core/authentication/
-      type: other
+      type: authentication_guide
 metadataSpecVersion: "1.0"


### PR DESCRIPTION
## What

Updates the `externalDocumentationUrls` type for the MongoDB authentication documentation from `other` to `authentication_guide`, which is a more semantically accurate classification.

This PR also serves to verify that the fix in airbytehq/airbyte-connector-models#30 is working correctly - the `authentication_guide` enum value was previously missing from the schema validation.

## How

Single metadata field change in `metadata.yaml` - updates the `type` field for the authentication documentation URL entry.

## Review guide

1. `airbyte-integrations/connectors/source-mongodb-v2/metadata.yaml` - verify the type change is semantically correct

## User Impact

No user-facing impact. This is a metadata classification improvement.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Requested by: @aaronsteers
Link to Devin run: https://app.devin.ai/sessions/22135fd3a462404f8f1b2c219d34eaaa
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/72236">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
