### PR TITLE
docs: add externalDocumentationUrls section to metadata.yaml documentation

### DIFF
--- a/docs/platform/connector-development/connector-metadata-file.md
+++ b/docs/platform/connector-development/connector-metadata-file.md
@@ -88,6 +88,24 @@ In the example above, the connector has three tags. Tags are used for two primar
 
 These are just examples of how tags can be used. As a free-form field, the tags list can be customized as required for each connector. This flexibility allows tags to be a powerful tool for managing and discovering connectors.
 
+## The `externalDocumentationUrls` Section
+
+The `externalDocumentationUrls` field allows you to link to external vendor documentation such as API references, changelogs, authentication guides, and deprecation notices. Each entry requires a `title` and `url`, with an optional `type` to categorize the documentation.
+
+```yaml
+externalDocumentationUrls:
+  - title: MongoDB Authentication
+    url: https://www.mongodb.com/docs/manual/core/authentication/
+    type: authentication_guide
+  - title: MongoDB Release Notes
+    url: https://www.mongodb.com/docs/manual/release-notes/
+    type: api_release_history
+```
+
+The supported `type` values are: `api_deprecations`, `api_reference`, `api_release_history`, `authentication_guide`, `data_model_reference`, `developer_community`, `migration_guide`, `openapi_spec`, `other`, `permissions_scopes`, `rate_limits`, `sql_reference`, and `status_page`.
+
+For the complete and authoritative schema definition, see the [airbyte-connector-models](https://github.com/airbytehq/airbyte-connector-models) repository.
+
 ## The `icon` Field
 
 _⚠️ This property is in the process of being refactored to be a file in the connector folder_

--- a/docusaurus/platform_versioned_docs/version-2.0/connector-development/connector-metadata-file.md
+++ b/docusaurus/platform_versioned_docs/version-2.0/connector-development/connector-metadata-file.md
@@ -88,6 +88,24 @@ In the example above, the connector has three tags. Tags are used for two primar
 
 These are just examples of how tags can be used. As a free-form field, the tags list can be customized as required for each connector. This flexibility allows tags to be a powerful tool for managing and discovering connectors.
 
+## The `externalDocumentationUrls` Section
+
+The `externalDocumentationUrls` field allows you to link to external vendor documentation such as API references, changelogs, authentication guides, and deprecation notices. Each entry requires a `title` and `url`, with an optional `type` to categorize the documentation.
+
+```yaml
+externalDocumentationUrls:
+  - title: MongoDB Authentication
+    url: https://www.mongodb.com/docs/manual/core/authentication/
+    type: authentication_guide
+  - title: MongoDB Release Notes
+    url: https://www.mongodb.com/docs/manual/release-notes/
+    type: api_release_history
+```
+
+The supported `type` values are: `api_deprecations`, `api_reference`, `api_release_history`, `authentication_guide`, `data_model_reference`, `developer_community`, `migration_guide`, `openapi_spec`, `other`, `permissions_scopes`, `rate_limits`, `sql_reference`, and `status_page`.
+
+For the complete and authoritative schema definition, see the [airbyte-connector-models](https://github.com/airbytehq/airbyte-connector-models) repository.
+
 ## The `icon` Field
 
 _⚠️ This property is in the process of being refactored to be a file in the connector folder_


### PR DESCRIPTION
## What

Documents the `externalDocumentationUrls` field in the connector metadata.yaml file. This field was recently updated in airbytehq/airbyte-connector-models#30 to support 13 documentation types (previously only 4), and the documentation was missing entirely.

Related to airbytehq/airbyte-ops-mcp#282.

## How

Added a new section to the metadata.yaml documentation that:
- Explains the purpose of `externalDocumentationUrls`
- Provides a YAML example using MongoDB as a reference
- Lists all 13 supported `type` values
- Links to [airbyte-connector-models](https://github.com/airbytehq/airbyte-connector-models) as the authoritative schema source

## Updates since last revision

- Added the same section to the versioned docs (`version-2.0`) to ensure both current and versioned documentation are in sync

## Review guide

1. `docs/platform/connector-development/connector-metadata-file.md` - New section added after the `tags` section
2. `docusaurus/platform_versioned_docs/version-2.0/connector-development/connector-metadata-file.md` - Same section added to versioned docs

## Review checklist for humans

- [ ] Verify the 13 `type` values listed match the schema in [airbyte-connector-models](https://github.com/airbytehq/airbyte-connector-models)
- [ ] Confirm the YAML example is clear and follows best practices

## User Impact

Connector developers will now have documentation on how to configure external documentation URLs in their metadata.yaml files.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Requested by: @aaronsteers
Link to Devin run: https://app.devin.ai/sessions/22135fd3a462404f8f1b2c219d34eaaa