### PR TITLE
ci: Add auto-merge label to PyAirbyte docs generation workflow

### DIFF
--- a/.github/workflows/pyairbyte-docs-generate.yml
+++ b/.github/workflows/pyairbyte-docs-generate.yml
@@ -287,4 +287,5 @@ jobs:
           labels: |
             area/documentation
             auto-generated
+            auto-merge
           delete-branch: true


### PR DESCRIPTION
## What

Adds the `auto-merge` label to PRs created by the PyAirbyte API docs generation workflow. This was originally suggested by @ian-at-airbyte in [this comment](https://github.com/airbytehq/airbyte/pull/71102#discussion_r2662466591) on the workflow's initial PR.

This change serves two purposes:
1. Bypasses the new `enforce-draft-pr-status` workflow (which uses `auto-merge` as an opt-out label)
2. Enables auto-merge for these auto-generated documentation PRs

## How

Added `auto-merge` to the labels list in the `peter-evans/create-pull-request` action configuration.

## Review guide

1. `.github/workflows/pyairbyte-docs-generate.yml` - Single line addition of `auto-merge` label

## User Impact

Auto-generated PyAirbyte API documentation PRs will now:
- Not be converted to draft status by the enforce-draft-pr-status workflow
- Be eligible for auto-merge once CI passes

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

**Requested by**: @aaronsteers
**Link to Devin run**: https://app.devin.ai/sessions/41972af9ad72451c8443605775cc2105