### PR TITLE
test: Dummy PR to test enforce-draft-pr-status workflow

### DIFF
--- a/.github/workflows/enforce-draft-pr-status.yml
+++ b/.github/workflows/enforce-draft-pr-status.yml
@@ -70,3 +70,4 @@ jobs:
             > To skip draft status in future PRs, please include `[ready]` in your PR title or add the `skip-draft-status` label when creating your PR.
             >
             > </details>
+


### PR DESCRIPTION
## What

This is a **test PR** created to verify that the newly merged `enforce-draft-pr-status` workflow functions correctly. This PR was intentionally created as "ready for review" (not draft) to trigger the workflow.

**Expected behavior:** The workflow should automatically:
1. Convert this PR to draft status
2. Add a comment explaining the draft policy

## How

Added a trailing newline to `.github/workflows/enforce-draft-pr-status.yml` - this is a no-op change purely to create a PR for testing purposes.

## Review guide

No code review needed - this is a test PR that should be **closed after verifying the workflow behavior**.

1. Check that this PR was converted to draft status
2. Check that the workflow added an explanatory comment with the Note block and collapsible section

## User Impact

None - this is a test PR with no functional changes.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

**Requested by**: @aaronsteers
**Link to Devin run**: https://app.devin.ai/sessions/41972af9ad72451c8443605775cc2105