### PR TITLE
ci: add --configure-on-demand to poe gradle tasks and scope upgradeCdk to specific connector

### DIFF
--- a/.github/workflows/cdk-connector-compatibility-test.yml
+++ b/.github/workflows/cdk-connector-compatibility-test.yml
@@ -89,7 +89,7 @@ jobs:
 
       - name: Run CDK upgrade # Run tests against local CDK version
         if: matrix.connector
-        run: ./gradlew upgradeCdk --cdkVersion=local
+        run: ./gradlew :airbyte-integrations:connectors:${{ matrix.connector }}:upgradeCdk --cdkVersion=local
 
       - name: Run Unit Tests
         id: run-unit-tests

--- a/poe-tasks/gradle-connector-tasks.toml
+++ b/poe-tasks/gradle-connector-tasks.toml
@@ -64,7 +64,7 @@ set -eu # Ensure we return non-zero exit code upon failure
 
 connector_name=$(basename "$PWD")
 echo "Running: ./gradlew :airbyte-integrations:connectors:${connector_name}:${task_and_args}"
-${POE_ROOT}/gradlew :airbyte-integrations:connectors:${connector_name}:${task_and_args}
+${POE_ROOT}/gradlew :airbyte-integrations:connectors:${connector_name}:${task_and_args} --configure-on-demand
 '''
 args = [
   { name = "task_and_args", positional = true, multiple = true, help = "Gradle task name and its arguments" }


### PR DESCRIPTION
## What
Fixes failures in CI running unit tests related to building unrelated connectors 

## How
  1) Scopes upgradeCdk command to specific connector in CI to avoid evaluating all projects
  2) Adds --configure-on-demand flag to test command to prevent configuration-phase failures from unrelated connectors

## Other
I'm not sure if we are actually calling `tasks.gradle` or the actual gradle binary in CI. If we aren't running the poe task, 2) will not have effect, but investigating / fixing this is another ticket.

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/72246">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
