### PR TITLE
ci: Whitelist tryangul from enforce-draft-pr-status workflow

### DIFF
--- a/.github/workflows/enforce-draft-pr-status.yml
+++ b/.github/workflows/enforce-draft-pr-status.yml
@@ -23,7 +23,7 @@ jobs:
     # - PR title contains "[ready]" (opt-out)
     # - PR has opt-out label (skip-draft-status, auto-merge, auto-merge/bypass-ci-checks, dependencies)
     # - PR is from Dependabot
-    # - PR is from a whitelisted user (tryangul)
+    # - PR is from a whitelisted user
     if: |
       github.event.pull_request.draft == false &&
       !contains(github.event.pull_request.title, '[ready]') &&

--- a/.github/workflows/enforce-draft-pr-status.yml
+++ b/.github/workflows/enforce-draft-pr-status.yml
@@ -23,13 +23,15 @@ jobs:
     # - PR title contains "[ready]" (opt-out)
     # - PR has opt-out label (skip-draft-status, auto-merge, auto-merge/bypass-ci-checks, dependencies)
     # - PR is from Dependabot
+    # - PR is from a whitelisted user (tryangul)
     if: |
       github.event.pull_request.draft == false &&
       !contains(github.event.pull_request.title, '[ready]') &&
       !contains(toJson(github.event.pull_request.labels.*.name), 'skip-draft-status') &&
       !contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge') &&
       !contains(toJson(github.event.pull_request.labels.*.name), 'dependencies') &&
-      github.event.pull_request.user.login != 'dependabot[bot]'
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
+      github.event.pull_request.user.login != 'tryangul'
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## What

Adds `tryangul` (Ryan) to the whitelist of users exempt from the automatic draft PR conversion workflow.

## How

Adds a condition to skip the `enforce-draft-pr-status` workflow when the PR author is `tryangul`, similar to the existing exemption for `dependabot[bot]`.

## Review guide

1. `.github/workflows/enforce-draft-pr-status.yml` - Single condition added to the `if` block

## User Impact

PRs created by `tryangul` will no longer be automatically converted to draft status.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

## Human review checklist

- [ ] Verify `tryangul` is the correct GitHub username for Ryan

---

**Requested by**: @aaronsteers
**Link to Devin run**: https://app.devin.ai/sessions/6ead5b05da4442ecb3c89c2e5f565f98
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/72248">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
