### PR TITLE
chore: collapse welcome message content by default

### DIFF
--- a/.github/pr-welcome-community.md
+++ b/.github/pr-welcome-community.md
@@ -40,6 +40,6 @@ As needed or by request, Airbyte Maintainers can execute the following slash com
 - If you enable [BYO Connector Credentials](https://docs.airbyte.com/platform/connector-development/local-connector-development#managing-connector-secrets) within your fork, you can view your test results [here](https://github.com/{{ .repo_name }}/actions/workflows/run-connector-tests-command.yml):
   [![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/{{ .repo_name }}/run-connector-tests-command.yml?style=for-the-badge&label=Fork%20CI%20Status)](https://github.com/{{ .repo_name }}/actions/workflows/run-connector-tests-command.yml)
 
-</details>
-
 [📝 _Edit this welcome message._](https://github.com/airbytehq/airbyte/blob/master/.github/pr-welcome-community.md)
+
+</details>

--- a/.github/pr-welcome-community.md
+++ b/.github/pr-welcome-community.md
@@ -9,9 +9,6 @@ If you have any questions, feel free to ask in the PR comments or join our [Slac
 
 ### PR Slash Commands
 
-<details>
-<summary>Show details</summary>
-
 As needed or by request, Airbyte Maintainers can execute the following slash commands on your PR:
 
 - `/format-fix` - Fixes most formatting issues.
@@ -23,12 +20,7 @@ As needed or by request, Airbyte Maintainers can execute the following slash com
 - `/publish-connectors-prerelease` - Publishes pre-release connector builds (tagged as `{version}-preview.{git-sha}`) for all modified connectors in the PR.
 - `/ai-review` - AI-powered PR review for connector safety and quality gates.
 
-</details>
-
 ### Tips for Working with CI
-
-<details>
-<summary>Show details</summary>
 
 1. **Pre-Release Checks.** Please pay attention to these, as they contain standard checks on the metadata.yaml file, docs requirements, etc. If you need help resolving a pre-release check, please ask a maintainer.
    - Note: If you are creating a new connector, please be sure to replace the default `logo.svg` file with a suitable icon.
@@ -37,23 +29,16 @@ As needed or by request, Airbyte Maintainers can execute the following slash com
 
 </details>
 
-</details>
-
 <details>
 <summary><b>📚 Show Repo Guidance</b></summary>
 
 ### Helpful Resources
-
-<details>
-<summary>Show details</summary>
 
 - [PR Guidelines](https://docs.airbyte.com/contributing-to-airbyte): Check our guidelines for contributions.
 - [Breaking Changes Guide](https://docs.airbyte.com/platform/connector-development/connector-breaking-changes): Guide to breaking changes, migration guides, and upgrade deadlines.
 - [Developing Connectors Locally](https://docs.airbyte.com/platform/connector-development/local-connector-development): Learn how to set up your environment and develop connectors locally.
 - If you enable [BYO Connector Credentials](https://docs.airbyte.com/platform/connector-development/local-connector-development#managing-connector-secrets) within your fork, you can view your test results [here](https://github.com/{{ .repo_name }}/actions/workflows/run-connector-tests-command.yml):
   [![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/{{ .repo_name }}/run-connector-tests-command.yml?style=for-the-badge&label=Fork%20CI%20Status)](https://github.com/{{ .repo_name }}/actions/workflows/run-connector-tests-command.yml)
-
-</details>
 
 </details>
 

--- a/.github/pr-welcome-community.md
+++ b/.github/pr-welcome-community.md
@@ -2,6 +2,11 @@
 
 Thank you for your contribution from **{{ .repo_name }}**! We're excited to have you in the Airbyte community.
 
+If you have any questions, feel free to ask in the PR comments or join our [Slack community](https://airbytehq.slack.com/).
+
+<details>
+<summary><b>📚 Show Repo Guidance</b></summary>
+
 <details>
 <summary>Helpful Resources</summary>
 
@@ -29,7 +34,10 @@ As needed or by request, Airbyte Maintainers can execute the following slash com
 
 </details>
 
-If you have any questions, feel free to ask in the PR comments or join our [Slack community](https://airbytehq.slack.com/).
+</details>
+
+<details>
+<summary><b>💡 Show Tips and Tricks</b></summary>
 
 <details>
 <summary>Tips for Working with CI</summary>
@@ -38,6 +46,8 @@ If you have any questions, feel free to ask in the PR comments or join our [Slac
    - Note: If you are creating a new connector, please be sure to replace the default `logo.svg` file with a suitable icon.
 2. **Connector CI Tests.** Some failures here may be expected if your tests require credentials. Please review these results to ensure (1) unit tests are passing, if applicable, and (2) integration tests pass to the degree possible and expected.
 3. **(Optional.) [BYO Connector Credentials](https://docs.airbyte.com/platform/connector-development/local-connector-development#managing-connector-secrets) for tests in your fork.** You can _optionally_ set up your fork with BYO credentials for your connector. This can significantly speed up your review, ensuring your changes are fully tested before the maintainers begin their review.
+
+</details>
 
 </details>
 

--- a/.github/pr-welcome-community.md
+++ b/.github/pr-welcome-community.md
@@ -2,7 +2,8 @@
 
 Thank you for your contribution from **{{ .repo_name }}**! We're excited to have you in the Airbyte community.
 
-### Helpful Resources
+<details>
+<summary>Helpful Resources</summary>
 
 - [PR Guidelines](https://docs.airbyte.com/contributing-to-airbyte): Check our guidelines for contributions.
 - [Breaking Changes Guide](https://docs.airbyte.com/platform/connector-development/connector-breaking-changes): Guide to breaking changes, migration guides, and upgrade deadlines.
@@ -10,7 +11,10 @@ Thank you for your contribution from **{{ .repo_name }}**! We're excited to have
 - If you enable [BYO Connector Credentials](https://docs.airbyte.com/platform/connector-development/local-connector-development#managing-connector-secrets) within your fork, you can view your test results [here](https://github.com/{{ .repo_name }}/actions/workflows/run-connector-tests-command.yml):
   [![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/{{ .repo_name }}/run-connector-tests-command.yml?style=for-the-badge&label=Fork%20CI%20Status)](https://github.com/{{ .repo_name }}/actions/workflows/run-connector-tests-command.yml)
 
-### PR Slash Commands
+</details>
+
+<details>
+<summary>PR Slash Commands</summary>
 
 As needed or by request, Airbyte Maintainers can execute the following slash commands on your PR:
 
@@ -23,13 +27,18 @@ As needed or by request, Airbyte Maintainers can execute the following slash com
 - `/publish-connectors-prerelease` - Publishes pre-release connector builds (tagged as `{version}-preview.{git-sha}`) for all modified connectors in the PR.
 - `/ai-review` - AI-powered PR review for connector safety and quality gates.
 
+</details>
+
 If you have any questions, feel free to ask in the PR comments or join our [Slack community](https://airbytehq.slack.com/).
 
-### Tips for Working with CI
+<details>
+<summary>Tips for Working with CI</summary>
 
 1. **Pre-Release Checks.** Please pay attention to these, as they contain standard checks on the metadata.yaml file, docs requirements, etc. If you need help resolving a pre-release check, please ask a maintainer.
    - Note: If you are creating a new connector, please be sure to replace the default `logo.svg` file with a suitable icon.
 2. **Connector CI Tests.** Some failures here may be expected if your tests require credentials. Please review these results to ensure (1) unit tests are passing, if applicable, and (2) integration tests pass to the degree possible and expected.
 3. **(Optional.) [BYO Connector Credentials](https://docs.airbyte.com/platform/connector-development/local-connector-development#managing-connector-secrets) for tests in your fork.** You can _optionally_ set up your fork with BYO credentials for your connector. This can significantly speed up your review, ensuring your changes are fully tested before the maintainers begin their review.
+
+</details>
 
 [📝 _Edit this welcome message._](https://github.com/airbytehq/airbyte/blob/master/.github/pr-welcome-community.md)

--- a/.github/pr-welcome-community.md
+++ b/.github/pr-welcome-community.md
@@ -5,21 +5,12 @@ Thank you for your contribution from **{{ .repo_name }}**! We're excited to have
 If you have any questions, feel free to ask in the PR comments or join our [Slack community](https://airbytehq.slack.com/).
 
 <details>
-<summary><b>📚 Show Repo Guidance</b></summary>
+<summary><b>💡 Show Tips and Tricks</b></summary>
+
+### PR Slash Commands
 
 <details>
-<summary>Helpful Resources</summary>
-
-- [PR Guidelines](https://docs.airbyte.com/contributing-to-airbyte): Check our guidelines for contributions.
-- [Breaking Changes Guide](https://docs.airbyte.com/platform/connector-development/connector-breaking-changes): Guide to breaking changes, migration guides, and upgrade deadlines.
-- [Developing Connectors Locally](https://docs.airbyte.com/platform/connector-development/local-connector-development): Learn how to set up your environment and develop connectors locally.
-- If you enable [BYO Connector Credentials](https://docs.airbyte.com/platform/connector-development/local-connector-development#managing-connector-secrets) within your fork, you can view your test results [here](https://github.com/{{ .repo_name }}/actions/workflows/run-connector-tests-command.yml):
-  [![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/{{ .repo_name }}/run-connector-tests-command.yml?style=for-the-badge&label=Fork%20CI%20Status)](https://github.com/{{ .repo_name }}/actions/workflows/run-connector-tests-command.yml)
-
-</details>
-
-<details>
-<summary>PR Slash Commands</summary>
+<summary>Show details</summary>
 
 As needed or by request, Airbyte Maintainers can execute the following slash commands on your PR:
 
@@ -34,18 +25,33 @@ As needed or by request, Airbyte Maintainers can execute the following slash com
 
 </details>
 
-</details>
+### Tips for Working with CI
 
 <details>
-<summary><b>💡 Show Tips and Tricks</b></summary>
-
-<details>
-<summary>Tips for Working with CI</summary>
+<summary>Show details</summary>
 
 1. **Pre-Release Checks.** Please pay attention to these, as they contain standard checks on the metadata.yaml file, docs requirements, etc. If you need help resolving a pre-release check, please ask a maintainer.
    - Note: If you are creating a new connector, please be sure to replace the default `logo.svg` file with a suitable icon.
 2. **Connector CI Tests.** Some failures here may be expected if your tests require credentials. Please review these results to ensure (1) unit tests are passing, if applicable, and (2) integration tests pass to the degree possible and expected.
 3. **(Optional.) [BYO Connector Credentials](https://docs.airbyte.com/platform/connector-development/local-connector-development#managing-connector-secrets) for tests in your fork.** You can _optionally_ set up your fork with BYO credentials for your connector. This can significantly speed up your review, ensuring your changes are fully tested before the maintainers begin their review.
+
+</details>
+
+</details>
+
+<details>
+<summary><b>📚 Show Repo Guidance</b></summary>
+
+### Helpful Resources
+
+<details>
+<summary>Show details</summary>
+
+- [PR Guidelines](https://docs.airbyte.com/contributing-to-airbyte): Check our guidelines for contributions.
+- [Breaking Changes Guide](https://docs.airbyte.com/platform/connector-development/connector-breaking-changes): Guide to breaking changes, migration guides, and upgrade deadlines.
+- [Developing Connectors Locally](https://docs.airbyte.com/platform/connector-development/local-connector-development): Learn how to set up your environment and develop connectors locally.
+- If you enable [BYO Connector Credentials](https://docs.airbyte.com/platform/connector-development/local-connector-development#managing-connector-secrets) within your fork, you can view your test results [here](https://github.com/{{ .repo_name }}/actions/workflows/run-connector-tests-command.yml):
+  [![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/{{ .repo_name }}/run-connector-tests-command.yml?style=for-the-badge&label=Fork%20CI%20Status)](https://github.com/{{ .repo_name }}/actions/workflows/run-connector-tests-command.yml)
 
 </details>
 

--- a/.github/pr-welcome-internal.md
+++ b/.github/pr-welcome-internal.md
@@ -53,6 +53,6 @@ Airbyte Maintainers (that's you!) can execute the following slash commands on yo
 - [`#connector-publish-updates`](https://airbytehq-team.slack.com/archives/C056HGD1QSW)
 - [`#connector-build-statuses`](https://airbytehq-team.slack.com/archives/C02TYE9QL9M)
 
-</details>
-
 [📝 _Edit this welcome message._](https://github.com/airbytehq/airbyte/blob/master/.github/pr-welcome-internal.md)
+
+</details>

--- a/.github/pr-welcome-internal.md
+++ b/.github/pr-welcome-internal.md
@@ -3,6 +3,9 @@
 Here are some helpful tips and reminders for your convenience.
 
 <details>
+<summary><b>📚 Show Repo Guidance</b></summary>
+
+<details>
 <summary>Helpful Resources</summary>
 
 - [Breaking Changes Guide](https://docs.airbyte.com/platform/connector-development/connector-breaking-changes) - Breaking changes, migration guides, and upgrade deadlines
@@ -14,6 +17,11 @@ Here are some helpful tips and reminders for your convenience.
 - [`#connector-build-statuses`](https://airbytehq-team.slack.com/archives/C02TYE9QL9M)
 
 </details>
+
+</details>
+
+<details>
+<summary><b>💡 Show Tips and Tricks</b></summary>
 
 <details>
 <summary>PR Slash Commands</summary>
@@ -48,6 +56,8 @@ Airbyte Maintainers (that's you!) can execute the following slash commands on yo
   - `/poe source example lock` - Alias for `/poe connector source-example lock`.
   - `/poe source example use-cdk-branch my/branch` - Pin the `source-example` CDK reference to the branch name specified.
   - `/poe source example use-cdk-latest` - Update the `source-example` CDK dependency to the latest available version.
+
+</details>
 
 </details>
 

--- a/.github/pr-welcome-internal.md
+++ b/.github/pr-welcome-internal.md
@@ -7,9 +7,6 @@ Here are some helpful tips and reminders for your convenience.
 
 ### PR Slash Commands
 
-<details>
-<summary>Show details</summary>
-
 Airbyte Maintainers (that's you!) can execute the following slash commands on your PR:
 
 - `/format-fix` - Fixes most formatting issues.
@@ -43,15 +40,10 @@ Airbyte Maintainers (that's you!) can execute the following slash commands on yo
 
 </details>
 
-</details>
-
 <details>
 <summary><b>📚 Show Repo Guidance</b></summary>
 
 ### Helpful Resources
-
-<details>
-<summary>Show details</summary>
 
 - [Breaking Changes Guide](https://docs.airbyte.com/platform/connector-development/connector-breaking-changes) - Breaking changes, migration guides, and upgrade deadlines
 - [Developing Connectors Locally](https://docs.airbyte.com/platform/connector-development/local-connector-development)
@@ -60,8 +52,6 @@ Airbyte Maintainers (that's you!) can execute the following slash commands on yo
 - [`#connector-ci-issues`](https://airbytehq-team.slack.com/archives/C05KSGM8MNC)
 - [`#connector-publish-updates`](https://airbytehq-team.slack.com/archives/C056HGD1QSW)
 - [`#connector-build-statuses`](https://airbytehq-team.slack.com/archives/C02TYE9QL9M)
-
-</details>
 
 </details>
 

--- a/.github/pr-welcome-internal.md
+++ b/.github/pr-welcome-internal.md
@@ -2,7 +2,8 @@
 
 Here are some helpful tips and reminders for your convenience.
 
-### Helpful Resources
+<details>
+<summary>Helpful Resources</summary>
 
 - [Breaking Changes Guide](https://docs.airbyte.com/platform/connector-development/connector-breaking-changes) - Breaking changes, migration guides, and upgrade deadlines
 - [Developing Connectors Locally](https://docs.airbyte.com/platform/connector-development/local-connector-development)
@@ -12,7 +13,10 @@ Here are some helpful tips and reminders for your convenience.
 - [`#connector-publish-updates`](https://airbytehq-team.slack.com/archives/C056HGD1QSW)
 - [`#connector-build-statuses`](https://airbytehq-team.slack.com/archives/C02TYE9QL9M)
 
-### PR Slash Commands
+</details>
+
+<details>
+<summary>PR Slash Commands</summary>
 
 Airbyte Maintainers (that's you!) can execute the following slash commands on your PR:
 
@@ -44,5 +48,7 @@ Airbyte Maintainers (that's you!) can execute the following slash commands on yo
   - `/poe source example lock` - Alias for `/poe connector source-example lock`.
   - `/poe source example use-cdk-branch my/branch` - Pin the `source-example` CDK reference to the branch name specified.
   - `/poe source example use-cdk-latest` - Update the `source-example` CDK dependency to the latest available version.
+
+</details>
 
 [📝 _Edit this welcome message._](https://github.com/airbytehq/airbyte/blob/master/.github/pr-welcome-internal.md)

--- a/.github/pr-welcome-internal.md
+++ b/.github/pr-welcome-internal.md
@@ -3,28 +3,12 @@
 Here are some helpful tips and reminders for your convenience.
 
 <details>
-<summary><b>📚 Show Repo Guidance</b></summary>
-
-<details>
-<summary>Helpful Resources</summary>
-
-- [Breaking Changes Guide](https://docs.airbyte.com/platform/connector-development/connector-breaking-changes) - Breaking changes, migration guides, and upgrade deadlines
-- [Developing Connectors Locally](https://docs.airbyte.com/platform/connector-development/local-connector-development)
-- [Managing Connector Secrets](https://docs.airbyte.com/platform/connector-development/local-connector-development#managing-connector-secrets)
-- [On-Demand Regression Tests](https://github.com/airbytehq/airbyte/actions/workflows/regression_tests.yml)
-- [`#connector-ci-issues`](https://airbytehq-team.slack.com/archives/C05KSGM8MNC)
-- [`#connector-publish-updates`](https://airbytehq-team.slack.com/archives/C056HGD1QSW)
-- [`#connector-build-statuses`](https://airbytehq-team.slack.com/archives/C02TYE9QL9M)
-
-</details>
-
-</details>
-
-<details>
 <summary><b>💡 Show Tips and Tricks</b></summary>
 
+### PR Slash Commands
+
 <details>
-<summary>PR Slash Commands</summary>
+<summary>Show details</summary>
 
 Airbyte Maintainers (that's you!) can execute the following slash commands on your PR:
 
@@ -56,6 +40,26 @@ Airbyte Maintainers (that's you!) can execute the following slash commands on yo
   - `/poe source example lock` - Alias for `/poe connector source-example lock`.
   - `/poe source example use-cdk-branch my/branch` - Pin the `source-example` CDK reference to the branch name specified.
   - `/poe source example use-cdk-latest` - Update the `source-example` CDK dependency to the latest available version.
+
+</details>
+
+</details>
+
+<details>
+<summary><b>📚 Show Repo Guidance</b></summary>
+
+### Helpful Resources
+
+<details>
+<summary>Show details</summary>
+
+- [Breaking Changes Guide](https://docs.airbyte.com/platform/connector-development/connector-breaking-changes) - Breaking changes, migration guides, and upgrade deadlines
+- [Developing Connectors Locally](https://docs.airbyte.com/platform/connector-development/local-connector-development)
+- [Managing Connector Secrets](https://docs.airbyte.com/platform/connector-development/local-connector-development#managing-connector-secrets)
+- [On-Demand Regression Tests](https://github.com/airbytehq/airbyte/actions/workflows/regression_tests.yml)
+- [`#connector-ci-issues`](https://airbytehq-team.slack.com/archives/C05KSGM8MNC)
+- [`#connector-publish-updates`](https://airbytehq-team.slack.com/archives/C056HGD1QSW)
+- [`#connector-build-statuses`](https://airbytehq-team.slack.com/archives/C02TYE9QL9M)
 
 </details>
 


### PR DESCRIPTION
## What

Wraps the content sections in PR welcome messages with HTML `<details>` tags so they are collapsed by default, reducing visual noise in PR comments.

## How

Updated both `.github/pr-welcome-community.md` and `.github/pr-welcome-internal.md` to wrap each section (Helpful Resources, PR Slash Commands, Tips for Working with CI) in `<details>/<summary>` HTML tags.

## Review guide

1. `.github/pr-welcome-community.md` - Community contributor welcome message
2. `.github/pr-welcome-internal.md` - Internal team member welcome message

**Key things to verify:**
- The `<details>` tags render correctly in GitHub PR comments
- Template variables like `{{ .repo_name }}` still work inside collapsed sections
- The GitHub Actions badge image in the community welcome renders properly inside the details block

## User Impact

PR welcome messages will now show collapsed sections by default, making the initial comment more compact. Users can expand any section they need.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Link to Devin run: https://app.devin.ai/sessions/e4b88f0ca94c4ddfad32892a2be58fe6
Requested by: AJ Steers (@aaronsteers)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/72279">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
