### PR TITLE
docs: add section on obtaining operator bearer token via client credentials endpoint

### DIFF
--- a/docs/ai-agents/embedded/api/authentication.md
+++ b/docs/ai-agents/embedded/api/authentication.md
@@ -14,6 +14,52 @@ The Airbyte Embedded API uses a hierarchical authentication system with three ty
 
 The Operator Bearer Token provides full organization-level access and is used for administrative operations.
 
+### Obtaining an operator bearer token
+
+To obtain an Operator Bearer Token, use the client credentials endpoint with your application credentials.
+
+#### Endpoint
+
+```bash
+POST https://api.airbyte.ai/api/v1/account/applications/token
+
+```
+
+#### Request body
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `client_id` | string | Yes | Your application client ID |
+| `client_secret` | string | Yes | Your application client secret |
+
+You can find your credentials in the Airbyte Cloud dashboard under **Settings > Applications**.
+
+#### Request example
+
+```bash
+curl -X POST https://api.airbyte.ai/api/v1/account/applications/token \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "client_id": "your_client_id",
+    "client_secret": "your_client_secret"
+  }'
+
+```
+
+#### Response example
+
+```json
+{
+  "access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+  "token_type": "bearer",
+  "expires_in": 900,
+  "organization_id": "12345678-1234-1234-1234-123456789012"
+}
+
+```
+
+The `access_token` in the response is your Operator Bearer Token. Use this token in the `Authorization` header for all subsequent API calls.
+
 ### Use cases
 
 - Creating and managing source templates


### PR DESCRIPTION
## What
The authentication.md documentation for Airbyte Embedded API explains how to use the Operator Bearer Token but doesn't explain how to obtain one. This PR adds a new section documenting the client credentials endpoint (`POST /api/v1/account/applications/token`) that developers use to get their initial bearer token.

## How
Added a new "Obtaining an operator bearer token" subsection under the "Operator bearer token" section that includes:
- The endpoint URL
- Request body parameters (`client_id`, `client_secret`)
- Where to find credentials in the Airbyte Cloud dashboard
- A curl example
- Example response format

## Review guide
1. `docs/ai-agents/embedded/api/authentication.md` - Review the new section for accuracy and consistency with the existing documentation style

**Items to verify:**
- The response format matches the actual API response (specifically the fields: `access_token`, `token_type`, `expires_in`, `organization_id`)
- The credentials location "Settings > Applications" is accurate for the current Airbyte Cloud UI
- This endpoint is already documented in the [widget quickstart](https://docs.airbyte.com/ai-agents/embedded/widget/quickstart) - ensure consistency

## User Impact
Developers integrating with the Airbyte Embedded API will have clearer documentation on how to obtain their initial bearer token, making the authentication flow easier to understand and implement.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚

---
Requested by: @aldogonzalez8
Link to Devin run: https://app.devin.ai/sessions/d778f015016d4831afb0b27938b3cc56

<img width="1550" height="1035" alt="image" src="https://github.com/user-attachments/assets/8030e0f9-89ba-4072-9de3-dbf82a7566b8" />
