### PR TITLE
deps(source-postgres): use pg jdbc driver version from debezium

### DIFF
--- a/airbyte-integrations/connectors/source-postgres/build.gradle
+++ b/airbyte-integrations/connectors/source-postgres/build.gradle
@@ -17,7 +17,8 @@ dependencies {
     implementation 'com.azure:azure-identity:1.17.0'
     // version specified by the debezium bom dependency in the cdc toolkit
     implementation 'io.debezium:debezium-connector-postgres'
-    implementation 'org.postgresql:postgresql:42.7.7'
+    // Use Postgres JDBC driver version specified by Debezium
+    implementation 'org.postgresql:postgresql'
 
     testImplementation 'org.testcontainers:postgresql:1.21.3'
     testImplementation("io.mockk:mockk:1.14.7")


### PR DESCRIPTION
Let Debezium determine the Postgres JDBC driver version. Currently, this puts us on 42.6.1. More recent Debezium releases use 42.7.7. Either is good. The important thing is to skip over low 42.7.x versions which advance the replication slot unexpectedly: https://github.com/pgjdbc/pgjdbc/issues/3138

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌
