### PR TITLE
deps(source-postgres): Bump driver version

### DIFF
--- a/airbyte-integrations/connectors/source-postgres/build.gradle
+++ b/airbyte-integrations/connectors/source-postgres/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation 'commons-codec:commons-codec:1.16.0'
     implementation 'io.debezium:debezium-embedded:3.0.1.Final'
     implementation 'io.debezium:debezium-connector-postgres:3.0.1.Final'
+    implementation 'org.postgresql:postgresql:42.7.7'
     implementation 'com.azure:azure-identity:1.15.3'
 
     testFixturesApi 'org.testcontainers:postgresql:1.19.0'

--- a/airbyte-integrations/connectors/source-postgres/metadata.yaml
+++ b/airbyte-integrations/connectors/source-postgres/metadata.yaml
@@ -9,7 +9,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: decd338e-5647-4c0b-adf4-da0e75f5a750
-  dockerImageTag: 3.7.0
+  dockerImageTag: 3.7.1-rc.1
   dockerRepository: airbyte/source-postgres
   documentationUrl: https://docs.airbyte.com/integrations/sources/postgres
   githubIssueLabel: source-postgres
@@ -64,6 +64,9 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
+  releases:
+    rolloutConfiguration:
+      enableProgressiveRollout: true
   externalDocumentationUrls:
     - title: PostgreSQL documentation
       url: https://www.postgresql.org/docs/


### PR DESCRIPTION
We were previously using Debezium 42.7.4. This version has an issue where the replication slot can be advanced unintentionally beyond the connection state. When we specified this dependency version, we also forced Debezium to use it. Here we roll forward to 42.7.7, which includes the fix we need. It is also the driver version currently used on Debezium's `main` branch.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌
