### PR TITLE
chore(destination-s3): update to CDK 0.2.0 with legacy-task-loader toolkit

### DIFF
--- a/airbyte-integrations/connectors/destination-s3/build.gradle
+++ b/airbyte-integrations/connectors/destination-s3/build.gradle
@@ -7,7 +7,8 @@ plugins {
 
 airbyteBulkConnector {
     core = 'load'
-    toolkits = ['load-s3', 'load-avro', 'load-aws']
+    toolkits = ['legacy-task-load-s3', 'legacy-task-load-avro', 'load-aws']
+    useLegacyTaskLoader = true
 }
 
 application {

--- a/airbyte-integrations/connectors/destination-s3/gradle.properties
+++ b/airbyte-integrations/connectors/destination-s3/gradle.properties
@@ -1,3 +1,3 @@
 testExecutionConcurrency=-1
 JunitMethodExecutionTimeout=60m
-cdkVersion=0.1.61
+cdkVersion=0.2.0

--- a/airbyte-integrations/connectors/destination-s3/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: file
   connectorType: destination
   definitionId: 4816b78f-1489-44c1-9060-4b19d5fa9362
-  dockerImageTag: 1.9.5
+  dockerImageTag: 1.9.6
   dockerRepository: airbyte/destination-s3
   githubIssueLabel: destination-s3
   icon: s3.svg

--- a/airbyte-integrations/connectors/destination-s3/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2WriteTest.kt
+++ b/airbyte-integrations/connectors/destination-s3/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2WriteTest.kt
@@ -71,6 +71,11 @@ abstract class S3V2WriteTest(
         dataChannelMedium = dataChannelMedium,
         dataChannelFormat = dataChannelFormat,
     ) {
+    @Test
+    override fun testAppend() {
+        super.testAppend()
+    }
+
     @Disabled("Irrelevant for file destinations")
     @Test
     override fun testAppendSchemaEvolution() {

--- a/docs/integrations/destinations/s3.md
+++ b/docs/integrations/destinations/s3.md
@@ -539,6 +539,7 @@ To see connector limitations, or troubleshoot your S3 connector, see more [in ou
 
 | Version     | Date       | Pull Request                                               | Subject                                                                                                                                              |
 |:------------|:-----------|:-----------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1.9.6 | 2026-01-20 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) | Upgrade CDK to 0.2.0 |
 | 1.9.5 | 2025-11-04 | [69134](https://github.com/airbytehq/airbyte/pull/69134) | Upgrade to Bulk CDK 0.1.61. |
 | 1.9.4 | 2025-10-21 | [67153](https://github.com/airbytehq/airbyte/pull/67153) | Implement new proto schema implementation |
 | 1.9.3 | 2025-10-06 | [67078](https://github.com/airbytehq/airbyte/pull/67078) | Remove memory limit for sync jobs to improve performance and resource utilization. |

--- a/docs/integrations/destinations/s3.md
+++ b/docs/integrations/destinations/s3.md
@@ -539,7 +539,7 @@ To see connector limitations, or troubleshoot your S3 connector, see more [in ou
 
 | Version     | Date       | Pull Request                                               | Subject                                                                                                                                              |
 |:------------|:-----------|:-----------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------|
-| 1.9.6 | 2026-01-20 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) | Upgrade CDK to 0.2.0 |
+| 1.9.6 | 2026-01-20 | [72298](https://github.com/airbytehq/airbyte/pull/72298) | Upgrade CDK to 0.2.0 |
 | 1.9.5 | 2025-11-04 | [69134](https://github.com/airbytehq/airbyte/pull/69134) | Upgrade to Bulk CDK 0.1.61. |
 | 1.9.4 | 2025-10-21 | [67153](https://github.com/airbytehq/airbyte/pull/67153) | Implement new proto schema implementation |
 | 1.9.3 | 2025-10-06 | [67078](https://github.com/airbytehq/airbyte/pull/67078) | Remove memory limit for sync jobs to improve performance and resource utilization. |


### PR DESCRIPTION
## What
Updates destination-s3 to CDK 0.2.0 using legacy-task-loader.

## How
- Bumped CDK version to 0.2.0
- Added `useLegacyTaskLoader = true` and `legacy-task-load-s3` toolkit
- Updated integration tests