### PR TITLE
Update to CDK 0.2.0 with legacy-task-loader toolkit and load-aws depe…

### DIFF
--- a/airbyte-integrations/connectors/destination-s3-data-lake/build.gradle
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/build.gradle
@@ -7,7 +7,8 @@ plugins {
 
 airbyteBulkConnector {
     core = 'load'
-    toolkits = ['load-iceberg-parquet', 'load-aws']
+    toolkits = ['load-iceberg-parquet', 'legacy-task-load-s3', 'load-aws']
+    useLegacyTaskLoader = true
 }
 
 application {

--- a/airbyte-integrations/connectors/destination-s3-data-lake/gradle.properties
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/gradle.properties
@@ -1,3 +1,3 @@
 testExecutionConcurrency=-1
-cdkVersion=0.1.101
+cdkVersion=0.2.0
 JunitMethodExecutionTimeout=10m

--- a/airbyte-integrations/connectors/destination-s3-data-lake/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/metadata.yaml
@@ -32,7 +32,7 @@ data:
             alias: airbyte-connector-testing-secret-store
   connectorType: destination
   definitionId: 716ca874-520b-4902-9f80-9fad66754b89
-  dockerImageTag: 0.3.42
+  dockerImageTag: 0.3.43
   dockerRepository: airbyte/destination-s3-data-lake
   documentationUrl: https://docs.airbyte.com/integrations/destinations/s3-data-lake
   githubIssueLabel: destination-s3-data-lake

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeWriteTest.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeWriteTest.kt
@@ -88,7 +88,6 @@ class GlueWriteTest :
                 minimumGenerationId = 0,
                 syncId = 42,
                 namespaceMapper = NamespaceMapper(),
-                tableSchema = emptyTableSchema,
             )
         // Glue downcases stream IDs, and also coerces to alphanumeric+underscore.
         // So these two streams will collide.
@@ -134,7 +133,6 @@ class GlueWriteTest :
                 minimumGenerationId = 0,
                 syncId = 42,
                 namespaceMapper = NamespaceMapper(),
-                tableSchema = emptyTableSchema,
             )
 
         runSync(

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/test/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeStreamLoaderTest.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/test/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeStreamLoaderTest.kt
@@ -24,10 +24,6 @@ import io.airbyte.cdk.load.message.Meta.Companion.COLUMN_NAME_AB_EXTRACTED_AT
 import io.airbyte.cdk.load.message.Meta.Companion.COLUMN_NAME_AB_GENERATION_ID
 import io.airbyte.cdk.load.message.Meta.Companion.COLUMN_NAME_AB_META
 import io.airbyte.cdk.load.message.Meta.Companion.COLUMN_NAME_AB_RAW_ID
-import io.airbyte.cdk.load.schema.model.ColumnSchema
-import io.airbyte.cdk.load.schema.model.StreamTableSchema
-import io.airbyte.cdk.load.schema.model.TableName
-import io.airbyte.cdk.load.schema.model.TableNames
 import io.airbyte.cdk.load.toolkits.iceberg.parquet.ColumnTypeChangeBehavior
 import io.airbyte.cdk.load.toolkits.iceberg.parquet.IcebergSuperTypeFinder
 import io.airbyte.cdk.load.toolkits.iceberg.parquet.IcebergTableSynchronizer
@@ -58,18 +54,6 @@ internal class S3DataLakeStreamLoaderTest {
     @MockK(relaxed = true)
     private lateinit var streamStateStore: StreamStateStore<S3DataLakeStreamState>
 
-    private val emptyTableSchema =
-        StreamTableSchema(
-            columnSchema =
-                ColumnSchema(
-                    inputSchema = mapOf(),
-                    inputToFinalColumnNames = mapOf(),
-                    finalSchema = mapOf(),
-                ),
-            importType = Append,
-            tableNames = TableNames(finalTableName = TableName("namespace", "test")),
-        )
-
     @BeforeEach
     fun setup() {
         every { streamStateStore.put(any(), any()) } returns Unit
@@ -94,7 +78,6 @@ internal class S3DataLakeStreamLoaderTest {
                 unmappedName = "name",
                 namespaceMapper =
                     NamespaceMapper(namespaceDefinitionType = NamespaceDefinitionType.SOURCE),
-                tableSchema = emptyTableSchema,
             )
         val icebergSchema =
             Schema(
@@ -207,7 +190,6 @@ internal class S3DataLakeStreamLoaderTest {
                 unmappedName = "name",
                 namespaceMapper =
                     NamespaceMapper(namespaceDefinitionType = NamespaceDefinitionType.SOURCE),
-                tableSchema = emptyTableSchema,
             )
         val icebergSchema =
             Schema(
@@ -325,7 +307,6 @@ internal class S3DataLakeStreamLoaderTest {
                 unmappedName = "name",
                 namespaceMapper =
                     NamespaceMapper(namespaceDefinitionType = NamespaceDefinitionType.SOURCE),
-                tableSchema = emptyTableSchema,
             )
         val columns =
             listOf(
@@ -476,7 +457,6 @@ internal class S3DataLakeStreamLoaderTest {
                 unmappedName = "name",
                 namespaceMapper =
                     NamespaceMapper(namespaceDefinitionType = NamespaceDefinitionType.SOURCE),
-                tableSchema = emptyTableSchema,
             )
         val icebergConfiguration: S3DataLakeConfiguration = mockk()
         val s3DataLakeUtil: S3DataLakeUtil = mockk()

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/test/kotlin/io/airbyte/integrations/destination/s3_data_lake/io/S3DataLakeTableCleanerTest.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/test/kotlin/io/airbyte/integrations/destination/s3_data_lake/io/S3DataLakeTableCleanerTest.kt
@@ -9,10 +9,6 @@ import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.command.ImportType
 import io.airbyte.cdk.load.command.NamespaceMapper
 import io.airbyte.cdk.load.data.ObjectTypeWithoutSchema
-import io.airbyte.cdk.load.schema.model.ColumnSchema
-import io.airbyte.cdk.load.schema.model.StreamTableSchema
-import io.airbyte.cdk.load.schema.model.TableName
-import io.airbyte.cdk.load.schema.model.TableNames
 import io.airbyte.cdk.load.toolkits.iceberg.parquet.io.IcebergTableCleaner
 import io.airbyte.cdk.load.toolkits.iceberg.parquet.io.IcebergUtil
 import io.mockk.Runs
@@ -34,18 +30,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 
 internal class S3DataLakeTableCleanerTest {
-    private val emptyTableSchema =
-        StreamTableSchema(
-            columnSchema =
-                ColumnSchema(
-                    inputSchema = mapOf(),
-                    inputToFinalColumnNames = mapOf(),
-                    finalSchema = mapOf(),
-                ),
-            importType = Append,
-            tableNames = TableNames(finalTableName = TableName("namespace", "test")),
-        )
-
     private fun mockStream(
         importType: ImportType = Append,
         generationId: Long = 1,
@@ -60,7 +44,6 @@ internal class S3DataLakeTableCleanerTest {
             minimumGenerationId = minimumGenerationId,
             syncId = 1,
             namespaceMapper = NamespaceMapper(),
-            tableSchema = emptyTableSchema,
         )
 
     @Test

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/test/kotlin/io/airbyte/integrations/destination/s3_data_lake/io/S3DataLakeUtilTest.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/test/kotlin/io/airbyte/integrations/destination/s3_data_lake/io/S3DataLakeUtilTest.kt
@@ -31,10 +31,6 @@ import io.airbyte.cdk.load.message.Meta.Companion.COLUMN_NAME_AB_EXTRACTED_AT
 import io.airbyte.cdk.load.message.Meta.Companion.COLUMN_NAME_AB_GENERATION_ID
 import io.airbyte.cdk.load.message.Meta.Companion.COLUMN_NAME_AB_META
 import io.airbyte.cdk.load.message.Meta.Companion.COLUMN_NAME_AB_RAW_ID
-import io.airbyte.cdk.load.schema.model.ColumnSchema
-import io.airbyte.cdk.load.schema.model.StreamTableSchema
-import io.airbyte.cdk.load.schema.model.TableName
-import io.airbyte.cdk.load.schema.model.TableNames
 import io.airbyte.cdk.load.toolkits.iceberg.parquet.SimpleTableIdGenerator
 import io.airbyte.cdk.load.toolkits.iceberg.parquet.io.AIRBYTE_CDC_DELETE_COLUMN
 import io.airbyte.cdk.load.toolkits.iceberg.parquet.io.IcebergUtil
@@ -70,18 +66,6 @@ internal class S3DataLakeUtilTest {
     private lateinit var s3DataLakeUtil: S3DataLakeUtil
     private lateinit var icebergUtil: IcebergUtil
     private val tableIdGenerator = SimpleTableIdGenerator()
-
-    private val emptyTableSchema =
-        StreamTableSchema(
-            columnSchema =
-                ColumnSchema(
-                    inputSchema = mapOf(),
-                    inputToFinalColumnNames = mapOf(),
-                    finalSchema = mapOf(),
-                ),
-            importType = Append,
-            tableNames = TableNames(finalTableName = TableName("namespace", "test")),
-        )
 
     @BeforeEach
     fun setup() {
@@ -222,7 +206,6 @@ internal class S3DataLakeUtilTest {
                 unmappedName = "name",
                 namespaceMapper =
                     NamespaceMapper(namespaceDefinitionType = NamespaceDefinitionType.SOURCE),
-                tableSchema = emptyTableSchema,
             )
         val airbyteRecord =
             EnrichedDestinationRecordAirbyteValue(
@@ -287,7 +270,6 @@ internal class S3DataLakeUtilTest {
                 unmappedName = "name",
                 namespaceMapper =
                     NamespaceMapper(namespaceDefinitionType = NamespaceDefinitionType.SOURCE),
-                tableSchema = emptyTableSchema,
             )
         val airbyteRecord =
             EnrichedDestinationRecordAirbyteValue(
@@ -357,7 +339,6 @@ internal class S3DataLakeUtilTest {
                 unmappedName = "name",
                 namespaceMapper =
                     NamespaceMapper(namespaceDefinitionType = NamespaceDefinitionType.SOURCE),
-                tableSchema = emptyTableSchema,
             )
         val airbyteRecord =
             EnrichedDestinationRecordAirbyteValue(
@@ -526,7 +507,6 @@ internal class S3DataLakeUtilTest {
                 unmappedName = "name",
                 namespaceMapper =
                     NamespaceMapper(namespaceDefinitionType = NamespaceDefinitionType.SOURCE),
-                tableSchema = emptyTableSchema,
             )
         val schema = icebergUtil.toIcebergSchema(stream = stream)
         assertEquals(primaryKeys.toSet(), schema.identifierFieldNames())
@@ -630,7 +610,6 @@ internal class S3DataLakeUtilTest {
                 unmappedName = "name",
                 namespaceMapper =
                     NamespaceMapper(namespaceDefinitionType = NamespaceDefinitionType.SOURCE),
-                tableSchema = emptyTableSchema,
             )
         val schema = icebergUtil.toIcebergSchema(stream = stream)
         assertEquals(emptySet<String>(), schema.identifierFieldNames())

--- a/docs/integrations/destinations/s3-data-lake.md
+++ b/docs/integrations/destinations/s3-data-lake.md
@@ -375,6 +375,7 @@ Now, you can identify the latest version of the 'Alice' record by querying wheth
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                                         |
 |:--------|:-----------|:-----------------------------------------------------------|:--------------------------------------------------------------------------------------------------------------------------------|
+| 0.3.43  | 2026-01-20 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX)   | Upgrade CDK to 0.2.0                                                                                                            |
 | 0.3.42  | 2026-01-12 | [70205](https://github.com/airbytehq/airbyte/pull/70205)   | Implement support for scope and OAuth server URI attributes for Polaris catalog                                                 |
 | 0.3.41  | 2025-11-07 | [69232](https://github.com/airbytehq/airbyte/pull/69232) | Upgrade to Bulk CDK 0.1.69. Changes to handle changes in commit patterns                                                        |
 | 0.3.40  | 2025-11-05 | [69133](https://github.com/airbytehq/airbyte/pull/69133) | Upgrade to Bulk CDK 0.1.61.                                                                                                     |


### PR DESCRIPTION
## What
Updates destination-s3-data-lake to CDK 0.2.0 using legacy-task-loader.

## How
- Bumped CDK version to 0.2.0
- Added `useLegacyTaskLoader = true` and `load-aws` toolkit
- Updated integration and unit tests

**Note:** Integration tests have dependency issues due to `load-iceberg-parquet` depending on `core-load` while connector uses `legacy-task-loader`. The `BasicFunctionalityIntegrationTest` constructor signatures differ between the two, causing `NoSuchMethodError`. Fix requires aligning signatures (add `supportFileTransfer` and `useDataFlowPipeline` params to core-load).