### PR TITLE
chore(destination-azure-blob-storage): update to CDK 0.2.0 with legacy-task-loader toolkit

### DIFF
--- a/airbyte-integrations/connectors/destination-azure-blob-storage/build.gradle
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage/build.gradle
@@ -7,7 +7,8 @@ plugins {
 
 airbyteBulkConnector {
     core = 'load'
-    toolkits = ['load-object-storage', 'load-azure-blob-storage']
+    toolkits = ['legacy-task-load-object-storage', 'legacy-task-load-azure-blob-storage']
+    useLegacyTaskLoader = true
 }
 
 application {

--- a/airbyte-integrations/connectors/destination-azure-blob-storage/gradle.properties
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage/gradle.properties
@@ -1,3 +1,3 @@
 testExecutionConcurrency=-1
-cdkVersion=0.1.61
+cdkVersion=0.2.0
 JunitMethodExecutionTimeout=5m

--- a/airbyte-integrations/connectors/destination-azure-blob-storage/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage/metadata.yaml
@@ -22,7 +22,7 @@ data:
             type: GSM
   connectorType: destination
   definitionId: b4c5d105-31fd-4817-96b6-cb923bfc04cb
-  dockerImageTag: 1.1.4
+  dockerImageTag: 1.1.5
   dockerRepository: airbyte/destination-azure-blob-storage
   documentationUrl: https://docs.airbyte.com/integrations/destinations/azure-blob-storage
   githubIssueLabel: destination-azure-blob-storage

--- a/docs/integrations/destinations/azure-blob-storage.md
+++ b/docs/integrations/destinations/azure-blob-storage.md
@@ -139,6 +139,7 @@ With root level flattening, the output JSONL is:
 
 | Version  | Date       | Pull Request                                               | Subject                                                                                                                                                         |
 |:---------|:-----------|:-----------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1.1.5 | 2026-01-20 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) | Upgrade CDK to 0.2.0 |
 | 1.1.4 | 2025-11-05 | [69127](https://github.com/airbytehq/airbyte/pull/69127) | Upgrade to Bulk CDK 0.1.61. |
 | 1.1.3 | 2025-10-21 | [67153](https://github.com/airbytehq/airbyte/pull/67153) | Implement new proto schema implementation |
 | 1.1.2 | 2025-10-06 | [67078](https://github.com/airbytehq/airbyte/pull/67078) | Remove memory limit for sync jobs to improve performance and resource utilization. |

--- a/docs/integrations/destinations/azure-blob-storage.md
+++ b/docs/integrations/destinations/azure-blob-storage.md
@@ -139,7 +139,7 @@ With root level flattening, the output JSONL is:
 
 | Version  | Date       | Pull Request                                               | Subject                                                                                                                                                         |
 |:---------|:-----------|:-----------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 1.1.5 | 2026-01-20 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) | Upgrade CDK to 0.2.0 |
+| 1.1.5 | 2026-01-20 | [72301](https://github.com/airbytehq/airbyte/pull/72301) | Upgrade CDK to 0.2.0 |
 | 1.1.4 | 2025-11-05 | [69127](https://github.com/airbytehq/airbyte/pull/69127) | Upgrade to Bulk CDK 0.1.61. |
 | 1.1.3 | 2025-10-21 | [67153](https://github.com/airbytehq/airbyte/pull/67153) | Implement new proto schema implementation |
 | 1.1.2 | 2025-10-06 | [67078](https://github.com/airbytehq/airbyte/pull/67078) | Remove memory limit for sync jobs to improve performance and resource utilization. |


### PR DESCRIPTION
## What
Updates destination-azure-blob-storage to CDK 0.2.0 using legacy-task-loader.

## How
- Bumped CDK version to 0.2.0
- Added `useLegacyTaskLoader = true`