### PR TITLE
chore(destination-customer-io): update to CDK 0.2.0 with legacy-task-loader toolkit

### DIFF
--- a/airbyte-integrations/connectors/destination-customer-io/build.gradle.kts
+++ b/airbyte-integrations/connectors/destination-customer-io/build.gradle.kts
@@ -11,7 +11,8 @@ plugins {
 
 airbyteBulkConnector {
     core = "load"
-    toolkits = listOf("load-csv", "load-dlq", "load-http", "load-low-code")
+    toolkits = listOf("load-csv", "legacy-task-load-dlq", "load-http", "legacy-task-load-low-code")
+    useLegacyTaskLoader = true
 }
 
 application {

--- a/airbyte-integrations/connectors/destination-customer-io/gradle.properties
+++ b/airbyte-integrations/connectors/destination-customer-io/gradle.properties
@@ -1,2 +1,2 @@
 testExecutionConcurrency=-1
-cdkVersion=0.1.61
+cdkVersion=0.2.0

--- a/airbyte-integrations/connectors/destination-customer-io/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-customer-io/metadata.yaml
@@ -12,7 +12,7 @@ data:
   connectorSubtype: api
   connectorType: destination
   definitionId: c101b15f-2de9-4616-b54f-0ec9d28ca64d
-  dockerImageTag: 0.0.8
+  dockerImageTag: 0.0.9
   dockerRepository: airbyte/destination-customer-io
   githubIssueLabel: destination-customer-io
   icon: icon.svg

--- a/docs/integrations/destinations/customer-io.md
+++ b/docs/integrations/destinations/customer-io.md
@@ -74,7 +74,7 @@ In order to configure this connector, you need to generate your Track API Key an
 
 | Version | Date       | Pull Request                                              | Subject                                                   |
 |:--------|:-----------|:----------------------------------------------------------|:----------------------------------------------------------|
-| 0.0.9 | 2026-01-20 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) | Upgrade CDK to 0.2.0 |
+| 0.0.9 | 2026-01-20 | [72303](https://github.com/airbytehq/airbyte/pull/72303) | Upgrade CDK to 0.2.0 |
 | 0.0.8 | 2025-11-05 | [69132](https://github.com/airbytehq/airbyte/pull/69132) | Upgrade to Bulk CDK 0.1.61. |
 | 0.0.7   | 2025-09-23 | [66571](https://github.com/airbytehq/airbyte/pull/66571)      | Fix person_identify in incremental mode                   |
 | 0.0.6   | 2025-09-16 | [tbd](https://github.com/airbytehq/airbyte/pull/tbd)      | Use low-code discover definition and pin to a CDK version |

--- a/docs/integrations/destinations/customer-io.md
+++ b/docs/integrations/destinations/customer-io.md
@@ -74,6 +74,7 @@ In order to configure this connector, you need to generate your Track API Key an
 
 | Version | Date       | Pull Request                                              | Subject                                                   |
 |:--------|:-----------|:----------------------------------------------------------|:----------------------------------------------------------|
+| 0.0.9 | 2026-01-20 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) | Upgrade CDK to 0.2.0 |
 | 0.0.8 | 2025-11-05 | [69132](https://github.com/airbytehq/airbyte/pull/69132) | Upgrade to Bulk CDK 0.1.61. |
 | 0.0.7   | 2025-09-23 | [66571](https://github.com/airbytehq/airbyte/pull/66571)      | Fix person_identify in incremental mode                   |
 | 0.0.6   | 2025-09-16 | [tbd](https://github.com/airbytehq/airbyte/pull/tbd)      | Use low-code discover definition and pin to a CDK version |


### PR DESCRIPTION
## What
Updates destination-customer-io to CDK 0.2.0 using legacy-task-loader.

## How
- Bumped CDK version to 0.2.0
- Added `useLegacyTaskLoader = true`