### PR TITLE
chore(destination-hubspot): update to CDK 0.2.0 with legacy-task-loader toolkit

### DIFF
--- a/airbyte-integrations/connectors/destination-hubspot/build.gradle.kts
+++ b/airbyte-integrations/connectors/destination-hubspot/build.gradle.kts
@@ -11,7 +11,8 @@ plugins {
 
 airbyteBulkConnector {
     core = "load"
-    toolkits = listOf("load-csv", "load-dlq", "load-http", "load-low-code")
+    toolkits = listOf("load-csv", "legacy-task-load-dlq", "load-http", "legacy-task-load-low-code")
+    useLegacyTaskLoader = true
 }
 
 application {

--- a/airbyte-integrations/connectors/destination-hubspot/gradle.properties
+++ b/airbyte-integrations/connectors/destination-hubspot/gradle.properties
@@ -1,2 +1,2 @@
 testExecutionConcurrency=-1
-cdkVersion=0.1.61
+cdkVersion=0.2.0

--- a/airbyte-integrations/connectors/destination-hubspot/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-hubspot/metadata.yaml
@@ -12,7 +12,7 @@ data:
   connectorSubtype: api
   connectorType: destination
   definitionId: c8ccd253-8525-4bbd-801c-f0b84ac71f61
-  dockerImageTag: 0.0.8
+  dockerImageTag: 0.0.9
   dockerRepository: airbyte/destination-hubspot
   githubIssueLabel: destination-hubspot
   icon: hubspot.svg

--- a/docs/integrations/destinations/hubspot.md
+++ b/docs/integrations/destinations/hubspot.md
@@ -101,6 +101,7 @@ Hubspot has **scopes** for each API call. Each stream is tied to a scope and wil
 
 | Version | Date       | Pull Request                                                    | Subject                                   |
 |:--------|:-----------|:----------------------------------------------------------------|:------------------------------------------|
+| 0.0.9 | 2026-01-20 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) | Upgrade CDK to 0.2.0 |
 | 0.0.8 | 2025-11-05 | [69131](https://github.com/airbytehq/airbyte/pull/69131) | Upgrade to Bulk CDK 0.1.61. |
 | 0.0.7   | 2025-09-24 | [66684](https://github.com/airbytehq/airbyte/pull/66684)        | Pin to CDK artifact                       |
 | 0.0.6   | 2025-09-10 | [65986](https://github.com/airbytehq/airbyte/pull/65986)        | Adding product object                     |

--- a/docs/integrations/destinations/hubspot.md
+++ b/docs/integrations/destinations/hubspot.md
@@ -101,7 +101,7 @@ Hubspot has **scopes** for each API call. Each stream is tied to a scope and wil
 
 | Version | Date       | Pull Request                                                    | Subject                                   |
 |:--------|:-----------|:----------------------------------------------------------------|:------------------------------------------|
-| 0.0.9 | 2026-01-20 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) | Upgrade CDK to 0.2.0 |
+| 0.0.9 | 2026-01-20 | [72304](https://github.com/airbytehq/airbyte/pull/72304) | Upgrade CDK to 0.2.0 |
 | 0.0.8 | 2025-11-05 | [69131](https://github.com/airbytehq/airbyte/pull/69131) | Upgrade to Bulk CDK 0.1.61. |
 | 0.0.7   | 2025-09-24 | [66684](https://github.com/airbytehq/airbyte/pull/66684)        | Pin to CDK artifact                       |
 | 0.0.6   | 2025-09-10 | [65986](https://github.com/airbytehq/airbyte/pull/65986)        | Adding product object                     |


### PR DESCRIPTION
## What
Updates destination-hubspot to CDK 0.2.0 using legacy-task-loader.

## How
- Bumped CDK version to 0.2.0
- Added `useLegacyTaskLoader = true`