### PR TITLE
feat: add /my-prs to allow us to get a list of relevant PRs

### DIFF
--- a/.claude/skills/my-prs/SKILL.md
+++ b/.claude/skills/my-prs/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: my-prs
+description: List PRs opened today that are assigned to me or the move-destinations team, excluding external contributors
+disable-model-invocation: true
+allowed-tools: Bash(gh:*), Bash(date:*), Read
+argument-hint: [days-back]
+---
+
+# My PRs - Daily PR Review Dashboard
+
+This skill fetches and displays PRs that need your attention:
+
+1. **PRs assigned directly to you** (@frifriSF59)
+2. **PRs with review requested from the move-destinations team**
+
+All results are filtered to:
+- Only show PRs opened today (or within `$ARGUMENTS` days if specified)
+- Exclude PRs from users who are not members of the airbytehq organization
+
+## Execution
+
+Run the fetch script to get the PR list:
+
+```bash
+bash .claude/skills/my-prs/scripts/fetch-prs.sh
+```
+
+If an argument is provided (number of days), modify the date filter accordingly:
+- `$ARGUMENTS` = number of days to look back (default: 0 = today only)
+- Example: `/my-prs 3` looks at PRs from the last 3 days
+
+For custom date ranges, use:
+```bash
+gh pr list --repo airbytehq/airbyte --assignee @me --search "created:>=YYYY-MM-DD" --json number,title,author,url
+```
+
+## After Fetching
+
+After displaying the PRs, offer to:
+1. Open a specific PR in the browser (`gh pr view <number> --web`)
+2. Show details of a specific PR (`gh pr view <number>`)
+3. Show the diff of a specific PR (`gh pr diff <number>`)
+4. Check CI status (`gh pr checks <number>`)
+
+## Quick Actions
+
+The user may want to:
+- **Review a PR**: Use `/review <pr-number>` if available
+- **Check PR comments**: `gh pr view <number> --comments`
+- **See who approved**: `gh pr view <number> --json reviews --jq '.reviews[] | select(.state=="APPROVED") | .author.login'`

--- a/.claude/skills/my-prs/scripts/fetch-prs.sh
+++ b/.claude/skills/my-prs/scripts/fetch-prs.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+# Fetch PRs opened today (or N days back) that are assigned to user or move-destinations team
+# Excludes PRs from non-airbytehq org members
+
+set -e
+
+# Days to look back (default: 0 = today only)
+DAYS_BACK=${1:-0}
+
+# Calculate the start date
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    START_DATE=$(date -v-${DAYS_BACK}d +%Y-%m-%d)
+else
+    START_DATE=$(date -d "-${DAYS_BACK} days" +%Y-%m-%d)
+fi
+
+echo "=== PRs Since ${START_DATE} ==="
+echo ""
+
+# Get org members (cached for performance)
+echo "Fetching airbytehq org members..."
+ORG_MEMBERS=$(gh api orgs/airbytehq/members --paginate --jq '.[].login' 2>/dev/null | sort -u)
+
+if [ -z "$ORG_MEMBERS" ]; then
+    echo "Error: Could not fetch org members. Check your GitHub authentication." >&2
+    exit 1
+fi
+
+# Convert to regex pattern for matching (include known bots)
+# Note: gh CLI returns bot authors as "app/bot-name" format
+KNOWN_BOTS="app/devin-ai-integration|app/dependabot|app/github-actions|devin-ai-integration\[bot\]|dependabot\[bot\]|github-actions\[bot\]"
+ORG_MEMBERS_PATTERN=$(echo "$ORG_MEMBERS" | tr '\n' '|' | sed 's/|$//')
+ORG_MEMBERS_PATTERN="${ORG_MEMBERS_PATTERN}|${KNOWN_BOTS}"
+
+echo "Found $(echo "$ORG_MEMBERS" | wc -l | tr -d ' ') org members (+ known bots)."
+echo ""
+
+# Function to filter and display PRs
+filter_and_display_prs() {
+    local prs_json="$1"
+
+    if [ -z "$prs_json" ] || [ "$prs_json" = "[]" ]; then
+        echo "(none)"
+        return
+    fi
+
+    # Get count of PRs from org members
+    local count=$(echo "$prs_json" | jq -c '.[]' 2>/dev/null | while read -r pr; do
+        author=$(echo "$pr" | jq -r '.author.login')
+        if echo "$author" | grep -qE "^($ORG_MEMBERS_PATTERN)$"; then
+            echo "1"
+        fi
+    done | wc -l | tr -d ' ')
+
+    if [ "$count" -eq 0 ]; then
+        echo "(none from org members)"
+        return
+    fi
+
+    # Display PRs from org members
+    echo "$prs_json" | jq -c '.[]' 2>/dev/null | while read -r pr; do
+        author=$(echo "$pr" | jq -r '.author.login')
+
+        # Check if author is org member
+        if echo "$author" | grep -qE "^($ORG_MEMBERS_PATTERN)$"; then
+            number=$(echo "$pr" | jq -r '.number')
+            title=$(echo "$pr" | jq -r '.title')
+            url=$(echo "$pr" | jq -r '.url')
+            created=$(echo "$pr" | jq -r '.createdAt' | cut -d'T' -f1)
+
+            echo "- **#${number}**: ${title}"
+            echo "  - Author: @${author} | Created: ${created}"
+            echo "  - ${url}"
+            echo ""
+        fi
+    done
+}
+
+echo "## PRs Assigned to you:"
+echo ""
+
+ASSIGNED_PRS=$(gh pr list \
+    --repo airbytehq/airbyte \
+    --assignee @me \
+    --search "created:>=${START_DATE}" \
+    --json number,title,author,url,createdAt \
+    --limit 100 2>/dev/null || echo "[]")
+
+filter_and_display_prs "$ASSIGNED_PRS"
+
+echo ""
+echo "## PRs with review requested from move-destinations team:"
+echo ""
+
+# Get move-destinations team members for individual reviewer search
+TEAM_MEMBERS=$(gh api orgs/airbytehq/teams/move-destinations/members --jq '.[].login' 2>/dev/null)
+
+# Build search query for team OR any team member as reviewer
+REVIEWER_SEARCH="team-review-requested:airbytehq/move-destinations"
+while IFS= read -r member; do
+    [ -n "$member" ] && REVIEWER_SEARCH="${REVIEWER_SEARCH} OR review-requested:${member}"
+done <<< "$TEAM_MEMBERS"
+
+TEAM_PRS=$(gh pr list \
+    --repo airbytehq/airbyte \
+    --search "created:>=${START_DATE} (${REVIEWER_SEARCH})" \
+    --json number,title,author,url,createdAt \
+    --limit 100 2>/dev/null || echo "[]")
+
+filter_and_display_prs "$TEAM_PRS"
+
+echo ""
+echo "---"
+echo "PRs from non-airbytehq members have been excluded."
+echo "Tip: Run '/my-prs 7' to see the last week's PRs."


### PR DESCRIPTION
## What

Add a new `/my-prs` claude skill to get a list of relevant PRs for the day.
Example output:

```
📋 Your PR Dashboard

  PRs Assigned to You

  None currently assigned.

  PRs Awaiting Review from move-destinations Team
  ┌─────────────────────────────────────────────────┬─────────────────────────────────────────────────────────────────────────────────────────┬──────────┐
  │                       PR                        │                                          Title                                          │  Author  │
  ├─────────────────────────────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────┼──────────┤
  │ https://github.com/airbytehq/airbyte/pull/72344 │ docs(destination-customer-io): fix changelog dates and PR numbers                       │ devin-ai │
  ├─────────────────────────────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────┼──────────┤
  │ https://github.com/airbytehq/airbyte/pull/72342 │ docs: fix Azure Blob Storage changelog date and metadata field typos                    │ devin-ai │
  ├─────────────────────────────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────┼──────────┤
  │ https://github.com/airbytehq/airbyte/pull/72341 │ docs: fix changelog date for destination-s3 v1.9.6                                      │ devin-ai │
  ├─────────────────────────────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────┼──────────┤
  │ https://github.com/airbytehq/airbyte/pull/72340 │ docs(destination-hubspot): Fix changelog date and add Products to supported objects     │ devin-ai │
  ├─────────────────────────────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────┼──────────┤
  │ https://github.com/airbytehq/airbyte/pull/72339 │ docs(destination-clickhouse): Fix changelog date and document Record Window Size option │ devin-ai │
  ├─────────────────────────────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────┼──────────┤
  │ https://github.com/airbytehq/airbyte/pull/72338 │ docs(destination-snowflake): fix changelog date for v4.0.35                             │ devin-ai │
  └─────────────────────────────────────────────────┴─────────────────────────────────────────────────────────────────────────────────────────┴──────────┘
  ---
  Summary: 6 documentation-related PRs from Devin AI are awaiting review. These all appear to be small fixes for changelog dates and documentation improvements across various destination connectors.

  ★ Insight ─────────────────────────────────────
  All these PRs are from Devin AI (an AI coding assistant) and focus on documentation hygiene - fixing dates in changelogs and correcting typos. This is a common pattern where automated tools catch inconsistencies that humans might miss during version bumps.
  ─────────────────────────────────────────────────

  Quick Actions

  Would you like me to:
  1. Open a PR in your browser - just tell me the number
  2. Show details of a specific PR
  3. View the diff of a PR to see what's changed
  4. Check CI status for any PR
```