### PR TITLE
revert(bulk-cdk): revert schema parsing change in `legacy-task-loader` that failed streams and caused NPE

### DIFF
--- a/airbyte-cdk/bulk/changelog.md
+++ b/airbyte-cdk/bulk/changelog.md
@@ -1,3 +1,7 @@
+## Version 0.2.1
+
+Revert schema parsing change in `legacy-task-loader` that failed streams when handling empty schemas. Schemas without a `type` field now default to object type again.
+
 ## Version 0.2.0
 
 Fully separate `legacy-task-loader` toolkit from `core-load`. Drastically simplify `core-load` by removing legacy abstractions.

--- a/airbyte-cdk/bulk/toolkits/legacy-task-loader/src/main/kotlin/io/airbyte/cdk/load/data/json/JsonSchemaToAirbyteType.kt
+++ b/airbyte-cdk/bulk/toolkits/legacy-task-loader/src/main/kotlin/io/airbyte/cdk/load/data/json/JsonSchemaToAirbyteType.kt
@@ -92,14 +92,9 @@ class JsonSchemaToAirbyteType(
                     // options is supposed to be a list, but fallback to sane behavior if it's not.
                     convertInner(options)
                 }
-            } else if (schema.has("properties") && schema is ObjectNode) {
-                // (technically `schema is ObjectNode` is implied by `schema` having any keys at
-                // all, but the smart cast lets us avoid an explicit cast)
-                // Default to object if no type and not a union type, but has properties
-                convertInner(schema.put("type", "object"))
             } else {
-                // Otherwise, give up
-                UnknownType(schema)
+                // Default to object if no type and not a union type
+                convertInner((schema as ObjectNode).put("type", "object"))
             }
         } else if (schema.isTextual) {
             // "<typename>"

--- a/airbyte-cdk/bulk/toolkits/legacy-task-loader/src/test/kotlin/io/airbyte/cdk/load/data/json/JsonSchemaToAirbyteSchemaTypeTest.kt
+++ b/airbyte-cdk/bulk/toolkits/legacy-task-loader/src/test/kotlin/io/airbyte/cdk/load/data/json/JsonSchemaToAirbyteSchemaTypeTest.kt
@@ -452,9 +452,10 @@ class JsonSchemaToAirbyteSchemaTypeTest {
 
     @Test
     fun testEmptySchema() {
+        // Empty schema defaults to object type (with no properties)
         val schemaNode = Jsons.readTree("{}")
         val airbyteType = defaultJsonSchemaToAirbyteType.convert(schemaNode)
-        assertEquals(UnknownType(Jsons.readTree("""{}""")), airbyteType)
+        assertEquals(ObjectTypeWithoutSchema, airbyteType)
     }
 
     @Test
@@ -466,11 +467,13 @@ class JsonSchemaToAirbyteSchemaTypeTest {
 
     @Test
     fun testImplicitObject() {
+        // Schema with properties but no type defaults to object
+        // Nested empty schema also defaults to object
         val schemaNode = Jsons.readTree("""{"properties": {"foo": {}}}""")
         val airbyteType = defaultJsonSchemaToAirbyteType.convert(schemaNode)
         assertEquals(
             ObjectType(
-                linkedMapOf("foo" to FieldType(UnknownType(Jsons.readTree("{}")), nullable = true)),
+                linkedMapOf("foo" to FieldType(ObjectTypeWithoutSchema, nullable = true)),
                 additionalProperties = false
             ),
             airbyteType,

--- a/airbyte-cdk/bulk/version.properties
+++ b/airbyte-cdk/bulk/version.properties
@@ -1,1 +1,1 @@
-version=0.2.0
+version=0.2.1


### PR DESCRIPTION
## What
Reverts [PR #69109](https://github.com/airbytehq/airbyte/pull/69109/changes) behavior change in the legacy-task-loader toolkit that caused destination syncs to fail when source schemas contain fields with empty schemas {}.

## How
Reverts the schema parsing logic in JsonSchemaToAirbyteType.kt so that schemas without a type field default to object type, rather than being converted to UnknownType.                    
                                                                                                                                                                                             
PR #69109 changed the behavior to only default to object if the schema has properties. Otherwise, it would create UnknownType(schema), which then failed during Avro schema mapping in FailOnAllUnknownTypesExceptNull. 

## User Impact                                                                                                                                                                                             
No expected negative side effects - this restores previous working behavior for object storage destinations like s3

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._