### PR TITLE
deps(destination-s3): upgrade CDK to 0.2.1 to resolve sync failures with empty schemas

### DIFF
--- a/airbyte-integrations/connectors/destination-s3/gradle.properties
+++ b/airbyte-integrations/connectors/destination-s3/gradle.properties
@@ -1,3 +1,3 @@
 testExecutionConcurrency=-1
 JunitMethodExecutionTimeout=60m
-cdkVersion=0.2.0
+cdkVersion=0.2.1

--- a/airbyte-integrations/connectors/destination-s3/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: file
   connectorType: destination
   definitionId: 4816b78f-1489-44c1-9060-4b19d5fa9362
-  dockerImageTag: 1.9.6
+  dockerImageTag: 1.9.7
   dockerRepository: airbyte/destination-s3
   githubIssueLabel: destination-s3
   icon: s3.svg

--- a/docs/integrations/destinations/s3.md
+++ b/docs/integrations/destinations/s3.md
@@ -539,7 +539,7 @@ To see connector limitations, or troubleshoot your S3 connector, see more [in ou
 
 | Version     | Date       | Pull Request                                               | Subject                                                                                                                                              |
 |:------------|:-----------|:-----------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------|
-| 1.9.7 | 2026-01-26 | [TBD](https://github.com/airbytehq/airbyte/pull/TBD) | Fix sync failures for sources with empty schemas by upgrading CDK to 0.2.1 |
+| 1.9.7 | 2026-01-26 | [72354](https://github.com/airbytehq/airbyte/pull/72354) | Fix sync failures for sources with empty schemas by upgrading CDK to 0.2.1 |
 | 1.9.6 | 2026-01-20 | [72298](https://github.com/airbytehq/airbyte/pull/72298) | Upgrade CDK to 0.2.0 |
 | 1.9.5 | 2025-11-04 | [69134](https://github.com/airbytehq/airbyte/pull/69134) | Upgrade to Bulk CDK 0.1.61. |
 | 1.9.4 | 2025-10-21 | [67153](https://github.com/airbytehq/airbyte/pull/67153) | Implement new proto schema implementation |

--- a/docs/integrations/destinations/s3.md
+++ b/docs/integrations/destinations/s3.md
@@ -539,6 +539,7 @@ To see connector limitations, or troubleshoot your S3 connector, see more [in ou
 
 | Version     | Date       | Pull Request                                               | Subject                                                                                                                                              |
 |:------------|:-----------|:-----------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1.9.7 | 2026-01-26 | [TBD](https://github.com/airbytehq/airbyte/pull/TBD) | Fix sync failures for sources with empty schemas by upgrading CDK to 0.2.1 |
 | 1.9.6 | 2026-01-20 | [72298](https://github.com/airbytehq/airbyte/pull/72298) | Upgrade CDK to 0.2.0 |
 | 1.9.5 | 2025-11-04 | [69134](https://github.com/airbytehq/airbyte/pull/69134) | Upgrade to Bulk CDK 0.1.61. |
 | 1.9.4 | 2025-10-21 | [67153](https://github.com/airbytehq/airbyte/pull/67153) | Implement new proto schema implementation |


### PR DESCRIPTION
### What
Upgrade CDK to 0.2.1 to fix sync failures when source schemas contain empty schema fields.

### How
CDK 0.2.1 reverts a schema parsing change that caused FailOnAllUnknownTypesExceptNull to fail on schemas without a type field (e.g., {}).

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._

> [!NOTE]
> **Auto-merge may have been disabled. Please check the PR status to confirm.**