### PR TITLE
deps(destination-azure-blob-storage): upgrade CDK to 0.2.1 to resolve sync failures with empty schemas

### DIFF
--- a/airbyte-integrations/connectors/destination-azure-blob-storage/gradle.properties
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage/gradle.properties
@@ -1,3 +1,3 @@
 testExecutionConcurrency=-1
-cdkVersion=0.2.0
+cdkVersion=0.2.1
 JunitMethodExecutionTimeout=5m

--- a/airbyte-integrations/connectors/destination-azure-blob-storage/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage/metadata.yaml
@@ -22,7 +22,7 @@ data:
             type: GSM
   connectorType: destination
   definitionId: b4c5d105-31fd-4817-96b6-cb923bfc04cb
-  dockerImageTag: 1.1.5
+  dockerImageTag: 1.1.6
   dockerRepository: airbyte/destination-azure-blob-storage
   documentationUrl: https://docs.airbyte.com/integrations/destinations/azure-blob-storage
   githubIssueLabel: destination-azure-blob-storage

--- a/docs/integrations/destinations/azure-blob-storage.md
+++ b/docs/integrations/destinations/azure-blob-storage.md
@@ -139,6 +139,7 @@ With root level flattening, the output JSONL is:
 
 | Version  | Date       | Pull Request                                               | Subject                                                                                                                                                         |
 |:---------|:-----------|:-----------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1.1.6 | 2026-01-26 | [TBD](https://github.com/airbytehq/airbyte/pull/TBD) | Fix sync failures for sources with empty schemas by upgrading CDK to 0.2.1 |
 | 1.1.5 | 2026-01-20 | [72301](https://github.com/airbytehq/airbyte/pull/72301) | Upgrade CDK to 0.2.0 |
 | 1.1.4 | 2025-11-05 | [69127](https://github.com/airbytehq/airbyte/pull/69127) | Upgrade to Bulk CDK 0.1.61. |
 | 1.1.3 | 2025-10-21 | [67153](https://github.com/airbytehq/airbyte/pull/67153) | Implement new proto schema implementation |

--- a/docs/integrations/destinations/azure-blob-storage.md
+++ b/docs/integrations/destinations/azure-blob-storage.md
@@ -139,7 +139,7 @@ With root level flattening, the output JSONL is:
 
 | Version  | Date       | Pull Request                                               | Subject                                                                                                                                                         |
 |:---------|:-----------|:-----------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 1.1.6 | 2026-01-26 | [TBD](https://github.com/airbytehq/airbyte/pull/TBD) | Fix sync failures for sources with empty schemas by upgrading CDK to 0.2.1 |
+| 1.1.6 | 2026-01-26 | [72355](https://github.com/airbytehq/airbyte/pull/72355) | Fix sync failures for sources with empty schemas by upgrading CDK to 0.2.1 |
 | 1.1.5 | 2026-01-20 | [72301](https://github.com/airbytehq/airbyte/pull/72301) | Upgrade CDK to 0.2.0 |
 | 1.1.4 | 2025-11-05 | [69127](https://github.com/airbytehq/airbyte/pull/69127) | Upgrade to Bulk CDK 0.1.61. |
 | 1.1.3 | 2025-10-21 | [67153](https://github.com/airbytehq/airbyte/pull/67153) | Implement new proto schema implementation |


### PR DESCRIPTION
### What
Upgrade CDK to 0.2.1 to fix sync failures when source schemas contain empty schema fields.

### How
CDK 0.2.1 reverts a schema parsing change that caused FailOnAllUnknownTypesExceptNull to fail on schemas without a type field (e.g., {}).

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._