### PR TITLE
ci: add semantic PR title check workflow

### DIFF
--- a/.github/workflows/semantic-pr-check.yml
+++ b/.github/workflows/semantic-pr-check.yml
@@ -1,0 +1,39 @@
+name: "Semantic PR Title Check"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - ready_for_review
+
+permissions:
+  pull-requests: read
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            test
+            chore
+            build
+            ci
+            refactor
+            revert
+            design
+            style
+            perf
+          subjectPattern: ^.+$
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}"
+            didn't match the configured pattern.


### PR DESCRIPTION
## What

Adds a new GitHub Actions workflow to validate that PR titles follow the conventional commit format (e.g., `feat:`, `fix:`, `docs:`). This aligns the airbyte monorepo with other Airbyte repositories that already have this validation.

## How

Introduces a new workflow file `.github/workflows/semantic-pr-check.yml` that uses the `amannn/action-semantic-pull-request@v5` action to validate PR titles on:
- PR opened
- PR title edited
- New commits pushed (synchronize)
- Draft PR marked ready for review

The workflow allows the following conventional commit types: `feat`, `fix`, `docs`, `test`, `chore`, `build`, `ci`, `refactor`, `revert`, `design`, `style`, `perf`.

## Review guide

1. `.github/workflows/semantic-pr-check.yml` - Review the allowed types list to ensure it matches the conventions used in this repo

## User Impact

PRs with non-semantic titles will show a failing check. This helps maintain consistent PR naming conventions and enables automated changelog generation.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

**Requested by:** @aaronsteers
**Link to Devin run:** https://app.devin.ai/sessions/9c86b01fddb14dd0a5fd73a4f019c7b2