### PR TITLE
ci: Update workflow-actions reference from SHA to @main

### DIFF
--- a/.github/workflows/label-github-issues-by-context.yml
+++ b/.github/workflows/label-github-issues-by-context.yml
@@ -16,7 +16,7 @@ jobs:
         uses: nick-fields/private-action-loader@6fa713597d3de3707f8b7a3029a5c262f32c5bca # v3.0.12
         with:
           pal-repo-token: "${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}"
-          pal-repo-name: airbytehq/workflow-actions@2a848ffce5eaf8da66d4176b66f55dd2e1007016
+          pal-repo-name: airbytehq/workflow-actions@main
           # the following input gets passed to the private
           token: "${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}"
           # ref: https://github.com/airbytehq/workflow-actions/blob/main/src/bin_issue.ts

--- a/.github/workflows/label-prs-by-context.yml
+++ b/.github/workflows/label-prs-by-context.yml
@@ -18,7 +18,7 @@ jobs:
         uses: nick-fields/private-action-loader@6fa713597d3de3707f8b7a3029a5c262f32c5bca # v3.0.12
         with:
           pal-repo-token: "${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}"
-          pal-repo-name: airbytehq/workflow-actions@2a848ffce5eaf8da66d4176b66f55dd2e1007016
+          pal-repo-name: airbytehq/workflow-actions@main
           # the following input gets passed to the private action
           token: "${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}"
           command: "pull"


### PR DESCRIPTION
## What

Updates the auto-labeling workflows to reference `workflow-actions@main` instead of a pinned SHA (`2a848ffce5eaf8da66d4176b66f55dd2e1007016`).

The pinned SHA was stale - the `@production` tag in workflow-actions was last updated Feb 3, 2025, leaving 13+ merged PRs undeployed. This was addressed in [airbytehq/workflow-actions#130](https://github.com/airbytehq/workflow-actions/pull/130) which deprecated the `@production` tag in favor of `@main`.

## How

Updated `pal-repo-name` in both workflow files from the pinned SHA to `@main`:
- `label-github-issues-by-context.yml` - Auto-labels issues
- `label-prs-by-context.yml` - Auto-labels PRs

## Review guide

1. `.github/workflows/label-github-issues-by-context.yml`
2. `.github/workflows/label-prs-by-context.yml`

## Human Review Checklist

- [ ] Confirm workflow-actions@main is stable (the Sentry workflow completed successfully after the switch in workflow-actions repo)
- [ ] Verify this aligns with deprecating the @production tag strategy

## User Impact

Auto-labeling for issues and PRs will now use the latest workflow-actions code, including recent fixes like:
- Bot account login normalization (PR #126)
- Sentry lookback optimization (PR #131)
- Various team routing updates

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

**Link to Devin run**: https://app.devin.ai/sessions/69b0d35f4def419bb1333255042784b2
**Requested by**: AJ Steers (@aaronsteers)