### PR TITLE
ci: Switch to workflow_dispatch pattern for issue and PR labeling

### DIFF
--- a/.github/workflows/label-github-issues-by-context.yml
+++ b/.github/workflows/label-github-issues-by-context.yml
@@ -3,6 +3,8 @@ on:
   issues:
     types: [opened, labeled, unlabeled]
 
+permissions: {}
+
 jobs:
   auto-label-issues:
     name: "Add Labels to Issues. Safe to Merge on fail"

--- a/.github/workflows/label-github-issues-by-context.yml
+++ b/.github/workflows/label-github-issues-by-context.yml
@@ -4,20 +4,29 @@ on:
     types: [opened, labeled, unlabeled]
 
 jobs:
-  shared-issues:
-    name: "Add Labels to Issues.  Safe to Merge on fail"
+  auto-label-issues:
+    name: "Add Labels to Issues. Safe to Merge on fail"
     runs-on: ubuntu-24.04
     steps:
-      # TODO: Replace PAT with a GitHub App token.
-      # The "private-action-loader" action does not seem to be compatible with it,
-      # so we should consider moving off of this specialized action and onto a normal
-      # action step.
-      - name: Run Issue Command from workflow-actions
-        uses: nick-fields/private-action-loader@6fa713597d3de3707f8b7a3029a5c262f32c5bca # v3.0.12
+      - name: Authenticate as GitHub App
+        uses: actions/create-github-app-token@v2
+        id: get-app-token
         with:
-          pal-repo-token: "${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}"
-          pal-repo-name: airbytehq/workflow-actions@2a848ffce5eaf8da66d4176b66f55dd2e1007016
-          # the following input gets passed to the private
-          token: "${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}"
-          # ref: https://github.com/airbytehq/workflow-actions/blob/main/src/bin_issue.ts
-          command: "issue"
+          owner: "airbytehq"
+          repositories: "airbyte,workflow-actions"
+          app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
+          private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
+
+      - name: Dispatch to workflow-actions
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          workflow: auto-labeling.yml
+          repo: airbytehq/workflow-actions
+          token: ${{ steps.get-app-token.outputs.token }}
+          inputs: |
+            {
+              "github_repo": "${{ github.repository }}",
+              "type": "issue",
+              "number": "${{ github.event.issue.number }}",
+              "action": "${{ github.event.action }}"
+            }

--- a/.github/workflows/label-prs-by-context.yml
+++ b/.github/workflows/label-prs-by-context.yml
@@ -6,19 +6,29 @@ on:
     types: [opened, labeled, unlabeled, ready_for_review, synchronize, reopened]
 
 jobs:
-  shared-pr-labeller:
-    name: "Add Labels to PRs.  Safe to Merge on fail"
+  auto-label-prs:
+    name: "Add Labels to PRs. Safe to Merge on fail"
     runs-on: ubuntu-24.04
     steps:
-      # TODO: Replace PAT with a GitHub App token.
-      # The "private-action-loader" action does not seem to be compatible with it,
-      # so we should consider moving off of this specialized action onto a normal
-      # action step.
-      - name: Run Issue Command from workflow-actions
-        uses: nick-fields/private-action-loader@6fa713597d3de3707f8b7a3029a5c262f32c5bca # v3.0.12
+      - name: Authenticate as GitHub App
+        uses: actions/create-github-app-token@v2
+        id: get-app-token
         with:
-          pal-repo-token: "${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}"
-          pal-repo-name: airbytehq/workflow-actions@2a848ffce5eaf8da66d4176b66f55dd2e1007016
-          # the following input gets passed to the private action
-          token: "${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}"
-          command: "pull"
+          owner: "airbytehq"
+          repositories: "airbyte,workflow-actions"
+          app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
+          private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
+
+      - name: Dispatch to workflow-actions
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          workflow: auto-labeling.yml
+          repo: airbytehq/workflow-actions
+          token: ${{ steps.get-app-token.outputs.token }}
+          inputs: |
+            {
+              "github_repo": "${{ github.repository }}",
+              "type": "pull",
+              "number": "${{ github.event.pull_request.number }}",
+              "action": "${{ github.event.action }}"
+            }

--- a/.github/workflows/label-prs-by-context.yml
+++ b/.github/workflows/label-prs-by-context.yml
@@ -5,6 +5,8 @@ on:
   pull_request_target:
     types: [opened, labeled, unlabeled, ready_for_review, synchronize, reopened]
 
+permissions: {}
+
 jobs:
   auto-label-prs:
     name: "Add Labels to PRs. Safe to Merge on fail"


### PR DESCRIPTION
## What

Replaces the `nick-fields/private-action-loader` approach with the cleaner `workflow_dispatch` pattern for triggering auto-labeling workflows. This eliminates the need to load private actions and switches from PAT-based auth to GitHub App tokens.

**Depends on:** https://github.com/airbytehq/workflow-actions/pull/133

## How

1. Authenticate using GitHub App token via `actions/create-github-app-token@v2` instead of PAT
2. Dispatch to the new `auto-labeling.yml` workflow in workflow-actions using `benc-uk/workflow-dispatch@v1`
3. Pass context (repo, number, action type) as workflow inputs
4. Add explicit `permissions: {}` block to limit GITHUB_TOKEN permissions (security best practice)

This follows the same pattern already used by sentry-ignore and sentry-merge commands in the oncall repo.

## Review guide

1. `.github/workflows/label-github-issues-by-context.yml` - Issue labeling workflow
2. `.github/workflows/label-prs-by-context.yml` - PR labeling workflow

**Key review points:**
- [ ] Verify `OCTAVIA_BOT_APP_ID` and `OCTAVIA_BOT_PRIVATE_KEY` secrets exist in this repo
- [ ] Verify the GitHub App has access to both `airbyte` and `workflow-actions` repos
- [ ] Ensure https://github.com/airbytehq/workflow-actions/pull/133 is merged before this PR
- [ ] Verify the JSON input format matches what `auto-labeling.yml` expects (`github_repo`, `type`, `number`, `action`)

## User Impact

No user-facing changes. Auto-labeling for issues and PRs will continue to work as before, but using a cleaner dispatch pattern internally.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

**Link to Devin run**: https://app.devin.ai/sessions/69b0d35f4def419bb1333255042784b2
**Requested by**: AJ Steers (@aaronsteers)