### PR TITLE
fix(airbyte-ci): use GitHub API for PR file detection in fork PRs

### DIFF
--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/commands.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/commands.py
@@ -259,6 +259,7 @@ async def connectors(
                 ctx.obj["is_local"],
                 ctx.obj["ci_context"],
                 ctx.obj["git_repo_url"],
+                ctx.obj.get("pull_request"),
             )
         )
 


### PR DESCRIPTION
## What

Fixes the `/bump-version` slash command incorrectly bumping the wrong connector when the PR is from a fork that's behind master.

**Issue:** In [PR #71340](https://github.com/airbytehq/airbyte/pull/71340), `/bump-version` bumped `destination-postgres` instead of `source-xero` because the fork's master was behind the main repo's master, causing git diff to detect destination-postgres files as "modified".

Reported in [Slack thread](https://airbytehq-team.slack.com/archives/C09HB1L0F33/p1769619538409859).

## How

When a `pull_request` object is available (i.e., when `--pull-request-number` is provided and a GitHub token exists), the code now uses the GitHub API (`pull_request.get_files()`) to get the list of modified files instead of relying on git diff.

This is more reliable for fork PRs because GitHub already knows which files are changed in the PR, regardless of how far behind the fork is from master.

The change is additive - if no PR object is available (local development, publishing pipelines), it falls back to the existing git diff behavior.

## Review guide

1. `airbyte-ci/connectors/pipelines/pipelines/helpers/git.py` - New `get_modified_files_from_pull_request()` function and updated `get_modified_files()` signature
2. `airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/commands.py` - Passes `pull_request` object to `get_modified_files()`

**Key review points:**
- Verify the fallback behavior is correct (when `pull_request` is `None`)
- Note: A previous attempt to fix this (PR #37616) was reverted because it affected publishing pipelines. This fix is different - it only uses the GitHub API when a PR object is explicitly available, preserving existing behavior for local/publishing workflows.

## User Impact

- `/bump-version` and other `--modified` connector commands will correctly identify changed connectors in fork PRs
- No impact on local development or publishing pipelines (they don't have a PR object)

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Link to Devin run: https://app.devin.ai/sessions/9699d06323464091bac726ca5abab4a1
Requested by: @aaronsteers