### PR TITLE
test: revert Okta SSO docs change (PR #72416) to test docs build hypothesis

### DIFF
--- a/docs/platform/access-management/sso-providers/okta.md
+++ b/docs/platform/access-management/sso-providers/okta.md
@@ -62,18 +62,6 @@ For security purposes, when a user who owns [applications](/platform/enterprise-
 
 4. Click **Save**.
 
-5. (Optional) To allow users to access Airbyte directly from their Okta dashboard, configure IdP-Initiated Login. In the **General** tab of your Airbyte application, scroll to **Login initiated by** and configure the following settings:
-
-    - **Login initiated by**: `Either Okta or App`
-
-    - **Application visibility**: Check `Display application icon to users`
-
-    - **Login flow**: `Redirect to app to initiate login (OIDC Compliant)`
-
-    - **Initiate login URI**: `https://cloud.airbyte.com`
-
-    Click **Save**. After this configuration, users see an Airbyte tile in their Okta dashboard and can click it to sign into Airbyte.
-
 ### Part 2: Domain verification
 
 Before you can enable SSO, you must prove to Airbyte that you or your organization own the domain on which you want to enable SSO. You can enable as many domains as you need.
@@ -208,15 +196,6 @@ Once your Okta app is set up, you're ready to deploy Airbyte with SSO. Take note
 * Client ID
 * Client Secret
 
-(Optional) To allow users to access Airbyte directly from their Okta dashboard, configure IdP-Initiated Login. In the **General** tab of your Airbyte application, scroll to **Login initiated by** and configure the following settings:
-
-- **Login initiated by**: `Either Okta or App`
-- **Application visibility**: Check `Display application icon to users`
-- **Login flow**: `Redirect to app to initiate login (OIDC Compliant)`
-- **Initiate login URI**: Your Airbyte domain (for example, `https://airbyte.internal.mycompany.com`)
-
-Click **Save**. After this configuration, users see an Airbyte tile in their Okta dashboard and can click it to sign into Airbyte.
-
 Visit the [implementation guide](../../enterprise-setup/implementation-guide.md) for instructions on how to deploy Airbyte Enterprise using `kubernetes`, `kubectl` and `helm`.
 
 ## Self-Managed Enterprise with Okta Generic OIDC
@@ -267,18 +246,6 @@ Follow these steps to set up an Okta app integration for Airbyte. If you need mo
 6. Click **Save**. Okta takes you to your app page.
 
 7. On the app page, make sure you have **Require PKCE as additional verification** enabled. Leave other values as defaults.
-
-8. (Optional) To allow users to access Airbyte directly from their Okta dashboard, configure IdP-Initiated Login. In the **General** tab of your Airbyte application, scroll to **Login initiated by** and configure the following settings:
-
-    - **Login initiated by**: `Either Okta or App`
-
-    - **Application visibility**: Check `Display application icon to users`
-
-    - **Login flow**: `Redirect to app to initiate login (OIDC Compliant)`
-
-    - **Initiate login URI**: Your Airbyte domain (for example, `https://airbyte.example.com`)
-
-    Click **Save**. After this configuration, users see an Airbyte tile in their Okta dashboard and can click it to sign into Airbyte.
 
 ### Add an authorization server {#sme-auth-server}
 

--- a/docusaurus/platform_versioned_docs/version-1.6/access-management/sso-providers/okta.md
+++ b/docusaurus/platform_versioned_docs/version-1.6/access-management/sso-providers/okta.md
@@ -58,15 +58,6 @@ On the following screen you'll need to configure all parameters for your Okta ap
       <dd>You can control whether everyone in your Okta organization should be able to access Airbyte using their Okta account or limit it only to a subset of your users by selecting specific groups who should get access.</dd>
     </dl>
 
-    (Optional) To allow users to access Airbyte directly from their Okta dashboard, configure IdP-Initiated Login. In the **General** tab of your Airbyte application, scroll to **Login initiated by** and configure the following settings:
-
-    * **Login initiated by**: `Either Okta or App`
-    * **Application visibility**: Check `Display application icon to users`
-    * **Login flow**: `Redirect to app to initiate login (OIDC Compliant)`
-    * **Initiate login URI**: `https://cloud.airbyte.com`
-
-    Click **Save**. After this configuration, users see an Airbyte tile in their Okta dashboard and can click it to sign into Airbyte.
-
     You'll need to pass your Airbyte contact the following information of the created application. After that we'll setup SSO for you and let you know once it's ready.
 
     * Your **Okta domain** (it's not specific to this application, see [Find your Okta domain](https://developer.okta.com/docs/guides/find-your-domain/main/))
@@ -110,15 +101,6 @@ For security purposes, existing [Applications](https://reference.airbyte.com/ref
       <dt>**Assignments > Controlled Access**</dt>
       <dd>You can control whether everyone in your Okta organization should be able to access Airbyte using their Okta account or limit it only to a subset of your users by selecting specific groups who should get access.</dd>
     </dl>
-
-    (Optional) To allow users to access Airbyte directly from their Okta dashboard, configure IdP-Initiated Login. In the **General** tab of your Airbyte application, scroll to **Login initiated by** and configure the following settings:
-
-    * **Login initiated by**: `Either Okta or App`
-    * **Application visibility**: Check `Display application icon to users`
-    * **Login flow**: `Redirect to app to initiate login (OIDC Compliant)`
-    * **Initiate login URI**: Your Airbyte domain (for example, `https://airbyte.internal.mycompany.com`)
-
-    Click **Save**. After this configuration, users see an Airbyte tile in their Okta dashboard and can click it to sign into Airbyte.
 
     Once your Okta app is set up, you're ready to deploy Airbyte with SSO. Take note of the following configuration values, as you will need them to configure Airbyte to use your new Okta SSO app integration:
 

--- a/docusaurus/platform_versioned_docs/version-1.7/access-management/sso-providers/okta.md
+++ b/docusaurus/platform_versioned_docs/version-1.7/access-management/sso-providers/okta.md
@@ -58,15 +58,6 @@ On the following screen you'll need to configure all parameters for your Okta ap
       <dd>You can control whether everyone in your Okta organization should be able to access Airbyte using their Okta account or limit it only to a subset of your users by selecting specific groups who should get access.</dd>
     </dl>
 
-    (Optional) To allow users to access Airbyte directly from their Okta dashboard, configure IdP-Initiated Login. In the **General** tab of your Airbyte application, scroll to **Login initiated by** and configure the following settings:
-
-    * **Login initiated by**: `Either Okta or App`
-    * **Application visibility**: Check `Display application icon to users`
-    * **Login flow**: `Redirect to app to initiate login (OIDC Compliant)`
-    * **Initiate login URI**: `https://cloud.airbyte.com`
-
-    Click **Save**. After this configuration, users see an Airbyte tile in their Okta dashboard and can click it to sign into Airbyte.
-
     You'll need to **securely** share the following information from the newly created application with your Airbyte contact. After that we'll setup SSO for you and let you know once it's ready.
 
     * Your **Okta domain** (it's not specific to this application, see [Find your Okta domain](https://developer.okta.com/docs/guides/find-your-domain/main/))
@@ -110,15 +101,6 @@ On the following screen you'll need to configure all parameters for your Okta ap
       <dt>**Assignments > Controlled Access**</dt>
       <dd>You can control whether everyone in your Okta organization should be able to access Airbyte using their Okta account or limit it only to a subset of your users by selecting specific groups who should get access.</dd>
     </dl>
-
-    (Optional) To allow users to access Airbyte directly from their Okta dashboard, configure IdP-Initiated Login. In the **General** tab of your Airbyte application, scroll to **Login initiated by** and configure the following settings:
-
-    * **Login initiated by**: `Either Okta or App`
-    * **Application visibility**: Check `Display application icon to users`
-    * **Login flow**: `Redirect to app to initiate login (OIDC Compliant)`
-    * **Initiate login URI**: Your Airbyte domain (for example, `https://airbyte.internal.mycompany.com`)
-
-    Click **Save**. After this configuration, users see an Airbyte tile in their Okta dashboard and can click it to sign into Airbyte.
 
     Once your Okta app is set up, you're ready to deploy Airbyte with SSO. Take note of the following configuration values, as you will need them to configure Airbyte to use your new Okta SSO app integration:
 

--- a/docusaurus/platform_versioned_docs/version-1.8/access-management/sso-providers/okta.md
+++ b/docusaurus/platform_versioned_docs/version-1.8/access-management/sso-providers/okta.md
@@ -62,18 +62,6 @@ Follow these steps to set up SSO in Airbyte Cloud.
 
 3. Click **Save**.
 
-4. (Optional) To allow users to access Airbyte directly from their Okta dashboard, configure IdP-Initiated Login. In the **General** tab of your Airbyte application, scroll to **Login initiated by** and configure the following settings:
-
-    - **Login initiated by**: `Either Okta or App`
-
-    - **Application visibility**: Check `Display application icon to users`
-
-    - **Login flow**: `Redirect to app to initiate login (OIDC Compliant)`
-
-    - **Initiate login URI**: `https://cloud.airbyte.com`
-
-    Click **Save**. After this configuration, users see an Airbyte tile in their Okta dashboard and can click it to sign into Airbyte.
-
 #### Configure SSO in Airbyte
 
 :::info
@@ -172,15 +160,6 @@ Once your Okta app is set up, you're ready to deploy Airbyte with SSO. Take note
 * Client ID
 * Client Secret
 
-(Optional) To allow users to access Airbyte directly from their Okta dashboard, configure IdP-Initiated Login. In the **General** tab of your Airbyte application, scroll to **Login initiated by** and configure the following settings:
-
-- **Login initiated by**: `Either Okta or App`
-- **Application visibility**: Check `Display application icon to users`
-- **Login flow**: `Redirect to app to initiate login (OIDC Compliant)`
-- **Initiate login URI**: Your Airbyte domain (for example, `https://airbyte.internal.mycompany.com`)
-
-Click **Save**. After this configuration, users see an Airbyte tile in their Okta dashboard and can click it to sign into Airbyte.
-
 Visit the [implementation guide](../../enterprise-setup/implementation-guide.md) for instructions on how to deploy Airbyte Enterprise using `kubernetes`, `kubectl` and `helm`.
 
 ## Self-Managed Enterprise with Okta Generic OIDC
@@ -231,18 +210,6 @@ Follow these steps to set up an Okta app integration for Airbyte. If you need mo
 6. Click **Save**. Okta takes you to your app page.
 
 7. On the app page, make sure you have **Require PKCE as additional verification** enabled. Leave other values as defaults.
-
-8. (Optional) To allow users to access Airbyte directly from their Okta dashboard, configure IdP-Initiated Login. In the **General** tab of your Airbyte application, scroll to **Login initiated by** and configure the following settings:
-
-    - **Login initiated by**: `Either Okta or App`
-
-    - **Application visibility**: Check `Display application icon to users`
-
-    - **Login flow**: `Redirect to app to initiate login (OIDC Compliant)`
-
-    - **Initiate login URI**: Your Airbyte domain (for example, `https://airbyte.example.com`)
-
-    Click **Save**. After this configuration, users see an Airbyte tile in their Okta dashboard and can click it to sign into Airbyte.
 
 ### Add an authorization server {#sme-auth-server}
 

--- a/docusaurus/platform_versioned_docs/version-2.0/access-management/sso-providers/okta.md
+++ b/docusaurus/platform_versioned_docs/version-2.0/access-management/sso-providers/okta.md
@@ -62,18 +62,6 @@ For security purposes, when a user who owns [applications](/platform/enterprise-
 
 4. Click **Save**.
 
-5. (Optional) To allow users to access Airbyte directly from their Okta dashboard, configure IdP-Initiated Login. In the **General** tab of your Airbyte application, scroll to **Login initiated by** and configure the following settings:
-
-    - **Login initiated by**: `Either Okta or App`
-
-    - **Application visibility**: Check `Display application icon to users`
-
-    - **Login flow**: `Redirect to app to initiate login (OIDC Compliant)`
-
-    - **Initiate login URI**: `https://cloud.airbyte.com`
-
-    Click **Save**. After this configuration, users see an Airbyte tile in their Okta dashboard and can click it to sign into Airbyte.
-
 ### Part 2: Configure and test SSO in Airbyte
 
 1. In Airbyte, click **Organization settings** > **General**.
@@ -173,15 +161,6 @@ Once your Okta app is set up, you're ready to deploy Airbyte with SSO. Take note
 * Client ID
 * Client Secret
 
-(Optional) To allow users to access Airbyte directly from their Okta dashboard, configure IdP-Initiated Login. In the **General** tab of your Airbyte application, scroll to **Login initiated by** and configure the following settings:
-
-- **Login initiated by**: `Either Okta or App`
-- **Application visibility**: Check `Display application icon to users`
-- **Login flow**: `Redirect to app to initiate login (OIDC Compliant)`
-- **Initiate login URI**: Your Airbyte domain (for example, `https://airbyte.internal.mycompany.com`)
-
-Click **Save**. After this configuration, users see an Airbyte tile in their Okta dashboard and can click it to sign into Airbyte.
-
 Visit the [implementation guide](../../enterprise-setup/implementation-guide.md) for instructions on how to deploy Airbyte Enterprise using `kubernetes`, `kubectl` and `helm`.
 
 ## Self-Managed Enterprise with Okta Generic OIDC
@@ -232,18 +211,6 @@ Follow these steps to set up an Okta app integration for Airbyte. If you need mo
 6. Click **Save**. Okta takes you to your app page.
 
 7. On the app page, make sure you have **Require PKCE as additional verification** enabled. Leave other values as defaults.
-
-8. (Optional) To allow users to access Airbyte directly from their Okta dashboard, configure IdP-Initiated Login. In the **General** tab of your Airbyte application, scroll to **Login initiated by** and configure the following settings:
-
-    - **Login initiated by**: `Either Okta or App`
-
-    - **Application visibility**: Check `Display application icon to users`
-
-    - **Login flow**: `Redirect to app to initiate login (OIDC Compliant)`
-
-    - **Initiate login URI**: Your Airbyte domain (for example, `https://airbyte.example.com`)
-
-    Click **Save**. After this configuration, users see an Airbyte tile in their Okta dashboard and can click it to sign into Airbyte.
 
 ### Add an authorization server {#sme-auth-server}
 


### PR DESCRIPTION
## What

**DO NOT MERGE** - This is a diagnostic PR to test whether PR #72416 (Okta SSO IdP-Initiated Login docs) is causing the docs build CI job to hang.

Multiple PRs have been force-merged on Jan 28-29 with reasons like "Docs building borked" and "build is stuck". The docs build hangs indefinitely at the webpack bundling phase (`[INFO] [en] Creating an optimized production build...`).

This PR reverts commit `0006d36922a` to test if the Okta SSO documentation changes are the cause.

## How

Reverts the IdP-Initiated Login documentation additions from PR #72416 across:
- `docs/platform/access-management/sso-providers/okta.md`
- Versioned docs (1.6, 1.7, 1.8, 2.0)

## Review guide

1. **Do not review for merge** - this is a test PR
2. Watch the "Build Airbyte Docs" CI job to see if it completes or hangs
3. Compare with companion test PRs:
   - #72444 (dummy commit baseline)
   - #72445 (Sonar API spec revert)

**Note:** Timeline analysis shows docs builds were passing for ~1.5 hours after PR #72416 was merged, so this may not be the root cause.

## User Impact

None - this is a test PR that should not be merged.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Requested by: AJ Steers (@aaronsteers)
Link to Devin run: https://app.devin.ai/sessions/d59e2834c35040089295aaf66b3ea690