### PR TITLE
deps(source-postgres): use `pgjdbc` version `42.6.1`

### DIFF
--- a/airbyte-cdk/java/airbyte-cdk/datastore-postgres/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/datastore-postgres/build.gradle
@@ -2,7 +2,7 @@ dependencies {
     implementation project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-dependencies')
     implementation project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-core')
 
-    api 'org.postgresql:postgresql:42.7.4'
+    api 'org.postgresql:postgresql:42.6.1'
 
     testFixturesApi testFixtures(project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-core'))
 

--- a/airbyte-cdk/java/airbyte-cdk/datastore-postgres/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/datastore-postgres/build.gradle
@@ -2,7 +2,7 @@ dependencies {
     implementation project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-dependencies')
     implementation project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-core')
 
-    api 'org.postgresql:postgresql:42.6.1'
+    api 'org.postgresql:postgresql:42.7.4'
 
     testFixturesApi testFixtures(project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-core'))
 

--- a/airbyte-integrations/connectors/source-postgres/build.gradle
+++ b/airbyte-integrations/connectors/source-postgres/build.gradle
@@ -16,7 +16,7 @@ java {
 airbyteJavaConnector {
     cdkVersionRequired = '0.48.14'
     features = ['db-sources', 'datastore-postgres']
-    useLocalCdk = false
+    useLocalCdk = true
 }
 
 application {
@@ -29,7 +29,7 @@ dependencies {
     implementation 'commons-codec:commons-codec:1.16.0'
     implementation 'io.debezium:debezium-embedded:3.0.1.Final'
     implementation 'io.debezium:debezium-connector-postgres:3.0.1.Final'
-    implementation 'org.postgresql:postgresql:42.7.7'
+    implementation 'org.postgresql:postgresql'
     implementation 'com.azure:azure-identity:1.15.3'
 
     testFixturesApi 'org.testcontainers:postgresql:1.19.0'

--- a/airbyte-integrations/connectors/source-postgres/build.gradle
+++ b/airbyte-integrations/connectors/source-postgres/build.gradle
@@ -29,7 +29,11 @@ dependencies {
     implementation 'commons-codec:commons-codec:1.16.0'
     implementation 'io.debezium:debezium-embedded:3.0.1.Final'
     implementation 'io.debezium:debezium-connector-postgres:3.0.1.Final'
-    implementation 'org.postgresql:postgresql'
+    implementation('org.postgresql:postgresql') {
+        version {
+            strictly '42.6.1'
+        }
+    }
     implementation 'com.azure:azure-identity:1.15.3'
 
     testFixturesApi 'org.testcontainers:postgresql:1.19.0'

--- a/airbyte-integrations/connectors/source-postgres/build.gradle
+++ b/airbyte-integrations/connectors/source-postgres/build.gradle
@@ -16,7 +16,7 @@ java {
 airbyteJavaConnector {
     cdkVersionRequired = '0.48.14'
     features = ['db-sources', 'datastore-postgres']
-    useLocalCdk = true
+    useLocalCdk = false
 }
 
 application {

--- a/airbyte-integrations/connectors/source-postgres/metadata.yaml
+++ b/airbyte-integrations/connectors/source-postgres/metadata.yaml
@@ -9,7 +9,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: decd338e-5647-4c0b-adf4-da0e75f5a750
-  dockerImageTag: 3.7.1
+  dockerImageTag: 3.7.2
   dockerRepository: airbyte/source-postgres
   documentationUrl: https://docs.airbyte.com/integrations/sources/postgres
   githubIssueLabel: source-postgres
@@ -29,7 +29,7 @@ data:
   tags:
     - language:java
   connectorBuildOptions:
-    baseImage: docker.io/airbyte/java-connector-base:2.0.1@sha256:ec89bd1a89e825514dd2fc8730ba299a3ae1544580a078df0e35c5202c2085b3
+    baseImage: docker.io/airbyte/java-connector-base:2.0.3@sha256:119b8506bca069bbc8357a275936c7e2b0994e6947b81f1bf8d6ce9e16db7d47
   connectorTestSuitesOptions:
     - suite: unitTests
     - suite: integrationTests

--- a/airbyte-integrations/connectors/source-postgres/metadata.yaml
+++ b/airbyte-integrations/connectors/source-postgres/metadata.yaml
@@ -68,7 +68,7 @@ data:
             alias: airbyte-connector-testing-secret-store
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
   externalDocumentationUrls:
     - title: PostgreSQL documentation
       url: https://www.postgresql.org/docs/

--- a/airbyte-integrations/connectors/source-postgres/metadata.yaml
+++ b/airbyte-integrations/connectors/source-postgres/metadata.yaml
@@ -29,7 +29,7 @@ data:
   tags:
     - language:java
   connectorBuildOptions:
-    baseImage: docker.io/airbyte/java-connector-base:2.0.3@sha256:119b8506bca069bbc8357a275936c7e2b0994e6947b81f1bf8d6ce9e16db7d47
+    baseImage: docker.io/airbyte/java-connector-base:2.0.4@sha256:5f343797cfcf021ca98ba9bdf5970ef66cbf6222d8cc17b0d61d13860a5bcc2b
   connectorTestSuitesOptions:
     - suite: unitTests
     - suite: integrationTests

--- a/airbyte-integrations/connectors/source-postgres/metadata.yaml
+++ b/airbyte-integrations/connectors/source-postgres/metadata.yaml
@@ -9,7 +9,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: decd338e-5647-4c0b-adf4-da0e75f5a750
-  dockerImageTag: 3.7.2
+  dockerImageTag: 3.7.2-rc.1
   dockerRepository: airbyte/source-postgres
   documentationUrl: https://docs.airbyte.com/integrations/sources/postgres
   githubIssueLabel: source-postgres


### PR DESCRIPTION
Force postgres driver version 42.6.1, downgrading from the version specified in `datastore-postgres` in the CDK to the version specified by Debezium. This addresses the bug where a replication slot can be advanced too far.

In addition, we take in the new java base image to address some CVEs.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌
