### PR TITLE
[source-postgres] Filter op:m events in shutdown cleanup loop

### DIFF
--- a/airbyte-cdk/java/airbyte-cdk/db-sources/src/main/kotlin/io/airbyte/cdk/integrations/debezium/internals/DebeziumRecordIterator.kt
+++ b/airbyte-cdk/java/airbyte-cdk/db-sources/src/main/kotlin/io/airbyte/cdk/integrations/debezium/internals/DebeziumRecordIterator.kt
@@ -233,6 +233,10 @@ class DebeziumRecordIterator<T>(
                 continue
             }
             val changeEventWithMetadata = ChangeEventWithMetadata(event)
+            // #72476: Also filter unhandled event types (like op:m) in shutdown cleanup loop
+            if (!isEventTypeHandled(changeEventWithMetadata)) {
+                continue
+            }
             hasSnapshotFinished = !changeEventWithMetadata.isSnapshotEvent
             return changeEventWithMetadata
         }


### PR DESCRIPTION
## Summary

Fixes #72476

PR #42431 added filtering for `op:m` (message) events in the main processing loop but missed the shutdown cleanup loop (lines 225-242). This causes CDC syncs to intermittently fail when third-party tools like PeerDB or GCP Datastreams emit heartbeat messages via `pg_logical_emit_message()`.

**Changes:**
- Add `isEventTypeHandled()` check to the shutdown cleanup loop
- Add regression test to verify op:m events are filtered in the shutdown path

## What

When Debezium shuts down, any `op:m` events remaining in the `recordsRemainingAfterShutdown` queue were not being filtered, causing them to be passed to `RelationalDbDebeziumEventConverter` which throws `IllegalStateException: ChangeEvent contains no before or after records`.

## How

Add the same `isEventTypeHandled()` check that exists in the main loop (line 189) to the shutdown cleanup loop.