### PR TITLE
feat(source-faker): Enable progressive rollout with RC 6.3.0-rc.1

### DIFF
--- a/airbyte-integrations/connectors/source-faker/metadata.yaml
+++ b/airbyte-integrations/connectors/source-faker/metadata.yaml
@@ -9,71 +9,72 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: dfd88b22-b603-4c3d-aad7-3701784586b1
-  dockerImageTag: 6.2.38
+  dockerImageTag: 6.3.0-rc.1
   dockerRepository: airbyte/source-faker
   documentationUrl: https://docs.airbyte.com/integrations/sources/faker
   externalDocumentationUrls:
-    - title: Python Faker Library Documentation
-      url: https://faker.readthedocs.io/en/master/
-      type: api_reference
-    - title: Faker Changelog
-      url: https://github.com/joke2k/faker/blob/master/CHANGELOG.md
-      type: api_release_history
+  - title: Python Faker Library Documentation
+    url: https://faker.readthedocs.io/en/master/
+    type: api_reference
+  - title: Faker Changelog
+    url: https://github.com/joke2k/faker/blob/master/CHANGELOG.md
+    type: api_release_history
   githubIssueLabel: source-faker
   icon: icon.svg
   license: ELv2
   name: Sample Data
   registryOverrides:
     cloud:
-      dockerImageTag: 6.2.24
+      dockerImageTag: 6.2.38
       enabled: true
     oss:
-      dockerImageTag: 6.2.24
+      dockerImageTag: 6.2.38
       enabled: true
   releaseStage: beta
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
     breakingChanges:
       4.0.0:
         message: This is a breaking change message
-        upgradeDeadline: "2023-07-19"
+        upgradeDeadline: '2023-07-19'
       5.0.0:
-        message: ID and products.year fields are changing to be integers instead of floats.
-        upgradeDeadline: "2023-08-31"
+        message: ID and products.year fields are changing to be integers instead of
+          floats.
+        upgradeDeadline: '2023-08-31'
       6.0.0:
         message: Declare 'id' columns as primary keys.
-        upgradeDeadline: "2024-04-01"
+        upgradeDeadline: '2024-04-01'
   remoteRegistries:
     pypi:
       enabled: true
       packageName: airbyte-source-faker
   resourceRequirements:
     jobSpecific:
-      - jobType: sync
-        resourceRequirements:
-          cpu_limit: "4.0"
-          cpu_request: "1.0"
+    - jobType: sync
+      resourceRequirements:
+        cpu_limit: '4.0'
+        cpu_request: '1.0'
   suggestedStreams:
     streams:
-      - users
-      - products
-      - purchases
+    - users
+    - products
+    - purchases
   supportLevel: community
   tags:
-    - language:python
-    - cdk:python
+  - language:python
+  - cdk:python
   connectorTestSuitesOptions:
-    - suite: liveTests
-      testConnections:
-        - name: faker_config_dev_null
-          id: 73abc3a9-3fea-4e7c-b58d-2c8236464a95
-    - suite: unitTests
-    - suite: acceptanceTests
-      testSecrets:
-        - name: SECRET_SOURCE-FAKER_CREDS
-          fileName: config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-metadataSpecVersion: "1.0"
+  - suite: liveTests
+    testConnections:
+    - name: faker_config_dev_null
+      id: 73abc3a9-3fea-4e7c-b58d-2c8236464a95
+  - suite: unitTests
+  - suite: acceptanceTests
+    testSecrets:
+    - name: SECRET_SOURCE-FAKER_CREDS
+      fileName: config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+metadataSpecVersion: '1.0'


### PR DESCRIPTION
## What

End-to-end test of the progressive rollout process using source-faker as a test connector. This validates the MCP tools and CLI commands built in airbytehq/airbyte-ops-mcp#246.

Related: airbytehq/airbyte-ops-mcp#310

## How

- Set `dockerImageTag` to `6.3.0-rc.1` (release candidate version)
- Pin Cloud and OSS users to `6.2.38` via `registryOverrides` (current stable version)
- Enable progressive rollout via `releases.rolloutConfiguration.enableProgressiveRollout: true`

**Note:** The YAML file was reformatted by the `airbyte-ops repo connector setup-progressive-rollout` CLI tool, which uses `yaml.dump`. This changes indentation style but is semantically equivalent.

## Review guide

1. `airbyte-integrations/connectors/source-faker/metadata.yaml` - Focus on the key changes:
   - Line 12: `dockerImageTag: 6.3.0-rc.1`
   - Lines 26-30: `registryOverrides` pins to `6.2.38`
   - Line 34: `enableProgressiveRollout: true`

## User Impact

- **Cloud/OSS users**: Will remain on version `6.2.38` (pinned via registryOverrides)
- **Progressive rollout**: Once the rollout workflow is started, users will be gradually migrated to `6.3.0-rc.1`
- This is a **test PR** to validate the progressive rollout tooling

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

**Requested by:** @aaronsteers
**Link to Devin run:** https://app.devin.ai/sessions/6f1818a6c0b24fcb9c51830c1bf4edd2