### PR TITLE
feat(source-pokeapi): Enable progressive rollout with RC 0.3.48-rc.1

### DIFF
--- a/airbyte-integrations/connectors/source-pokeapi/metadata.yaml
+++ b/airbyte-integrations/connectors/source-pokeapi/metadata.yaml
@@ -5,10 +5,8 @@ data:
   registryOverrides:
     oss:
       enabled: true
-      dockerImageTag: "0.3.47"
     cloud:
       enabled: true
-      dockerImageTag: "0.3.47"
   releases:
     rolloutConfiguration:
       enableProgressiveRollout: true
@@ -24,7 +22,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 6371b14b-bc68-4236-bfbd-468e8df8e968
-  dockerImageTag: 0.4.0-rc.1
+  dockerImageTag: 0.3.48-rc.1
   dockerRepository: airbyte/source-pokeapi
   githubIssueLabel: source-pokeapi
   icon: pokeapi.svg

--- a/airbyte-integrations/connectors/source-pokeapi/metadata.yaml
+++ b/airbyte-integrations/connectors/source-pokeapi/metadata.yaml
@@ -5,8 +5,13 @@ data:
   registryOverrides:
     oss:
       enabled: true
+      dockerImageTag: "0.3.47"
     cloud:
       enabled: true
+      dockerImageTag: "0.3.47"
+  releases:
+    rolloutConfiguration:
+      enableProgressiveRollout: true
   remoteRegistries:
     pypi:
       enabled: false
@@ -19,7 +24,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 6371b14b-bc68-4236-bfbd-468e8df8e968
-  dockerImageTag: 0.3.47
+  dockerImageTag: 0.4.0-rc.1
   dockerRepository: airbyte/source-pokeapi
   githubIssueLabel: source-pokeapi
   icon: pokeapi.svg

--- a/docs/integrations/sources/pokeapi.md
+++ b/docs/integrations/sources/pokeapi.md
@@ -39,6 +39,7 @@ The PokéAPI uses the same [JSONSchema](https://json-schema.org/understanding-js
 
 | Version | Date       | Pull Request                                             | Subject                                         |
 | :------ | :--------- | :------------------------------------------------------- | :---------------------------------------------- |
+| 0.3.48-rc.1 | 2026-01-30 | [72491](https://github.com/airbytehq/airbyte/pull/72491) | Enable progressive rollout for testing |
 | 0.3.47 | 2026-01-20 | [72186](https://github.com/airbytehq/airbyte/pull/72186) | Update dependencies |
 | 0.3.46 | 2026-01-14 | [71541](https://github.com/airbytehq/airbyte/pull/71541) | Update dependencies |
 | 0.3.45 | 2025-12-18 | [70514](https://github.com/airbytehq/airbyte/pull/70514) | Update dependencies |


### PR DESCRIPTION
## What

This PR sets up source-pokeapi for progressive rollout testing. It introduces a release candidate version (0.3.48-rc.1) with progressive rollout enabled.

This is part of an end-to-end test of the progressive rollout tooling being developed in [airbyte-ops-mcp#246](https://github.com/airbytehq/airbyte-ops-mcp/pull/246).

Related: [airbyte-ops-mcp#310](https://github.com/airbytehq/airbyte-ops-mcp/issues/310) (E2E test checklist)

## How

1. Bumped `dockerImageTag` from `0.3.47` to `0.3.48-rc.1` (patch version RC)
2. Added `releases.rolloutConfiguration.enableProgressiveRollout: true` to enable the progressive rollout system
3. Added changelog entry

**Note:** No `registryOverrides` version pins are added - the progressive rollout system handles version pinning automatically. Adding manual pins would conflict with the rollout process.

## Review guide

1. `airbyte-integrations/connectors/source-pokeapi/metadata.yaml` - Version bump and rollout config
2. `docs/integrations/sources/pokeapi.md` - Changelog entry

Key things to verify:
- RC version follows semver format (0.3.48-rc.1)
- `enableProgressiveRollout: true` is correctly nested under `releases.rolloutConfiguration`
- No `dockerImageTag` pins in `registryOverrides` (this is intentional)

## User Impact

- **Existing users**: The rollout system will manage version distribution
- **New users during rollout**: Will gradually receive 0.3.48-rc.1 based on rollout percentage
- **Note**: The connector code itself has not changed - this is purely a metadata change to test the progressive rollout infrastructure

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

This is a metadata-only change. Reverting would restore the previous version configuration.

---

**Requested by:** @aaronsteers
**Link to Devin run:** https://app.devin.ai/sessions/6f1818a6c0b24fcb9c51830c1bf4edd2
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/72491">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
