### PR TITLE
chore(source-datagen): Test pre-release workflow for progressive rollout (do not merge)

### DIFF
--- a/airbyte-integrations/connectors/source-datagen/metadata.yaml
+++ b/airbyte-integrations/connectors/source-datagen/metadata.yaml
@@ -25,6 +25,9 @@ data:
     oss:
       enabled: true
   releaseStage: alpha
+  releases:
+    rolloutConfiguration:
+      enableProgressiveRollout: false
   supportLevel: community
   tags:
     - language:java


### PR DESCRIPTION
## What

Test PR for validating the pre-release workflow for progressive rollouts. This is part of an end-to-end test to verify that we can:
1. Trigger a pre-release publish from a PR branch (without merging)
2. Use the `start_connector_rollout` MCP tool with automated strategy on the pre-release version

**This PR should NOT be merged** - it exists solely for testing the pre-release publish workflow.

Related tracking issue: https://github.com/airbytehq/airbyte-ops-mcp/issues/312

## How

Adds a `releases.rolloutConfiguration` section to the metadata.yaml with `enableProgressiveRollout: false`. The flag is intentionally set to `false` since we're testing whether the pre-release workflow works independently of this flag.

## Review guide

1. `airbyte-integrations/connectors/source-datagen/metadata.yaml` - Only change, adds rolloutConfiguration structure

## User Impact

No user impact - this is a test PR that will not be merged.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Requested by: @aaronsteers
Devin session: https://app.devin.ai/sessions/6f1818a6c0b24fcb9c51830c1bf4edd2