### PR TITLE
ci: add TK-TODO check workflow

### DIFF
--- a/.github/workflows/tk-todo-check.yml
+++ b/.github/workflows/tk-todo-check.yml
@@ -1,4 +1,4 @@
-name: TK-TODO Check
+name: TK-TODO Check  # IGNORE:TK
 
 on:
   push:
@@ -10,11 +10,11 @@ permissions:
   contents: read
 
 jobs:
-  tk-todo-check:
+  tk-todo-check:  # IGNORE:TK
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Check for TK-TODO markers
+      - name: Check for TK-TODO markers  # IGNORE:TK
         uses: aaronsteers/tk-todo-check-action@v1.0.0

--- a/.github/workflows/tk-todo-check.yml
+++ b/.github/workflows/tk-todo-check.yml
@@ -1,4 +1,4 @@
-name: TK-TODO Check  # IGNORE:TK
+name: TK-TODO Check # IGNORE:TK
 
 on:
   push:
@@ -10,11 +10,11 @@ permissions:
   contents: read
 
 jobs:
-  tk-todo-check:  # IGNORE:TK
+  tk-todo-check: # IGNORE:TK
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Check for TK-TODO markers  # IGNORE:TK
-        uses: aaronsteers/tk-todo-check-action@v1.0.0  # IGNORE:TK
+      - name: Check for TK-TODO markers # IGNORE:TK
+        uses: aaronsteers/tk-todo-check-action@v1.0.0 # IGNORE:TK

--- a/.github/workflows/tk-todo-check.yml
+++ b/.github/workflows/tk-todo-check.yml
@@ -1,0 +1,45 @@
+name: TK-TODO Check  # IGNORE:TK - this workflow checks for TK-TODO markers
+
+on:
+  push:
+    branches:
+      - master
+  pull_request: {}
+
+permissions:
+  contents: read
+
+jobs:
+  tk-todo-check:  # IGNORE:TK
+    name: Check for TK-TODO markers  # IGNORE:TK
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check for TK-TODO markers  # IGNORE:TK
+        run: |
+          # Find all TK-TODO markers (case-insensitive) that don't have IGNORE:TK on the same line  # IGNORE:TK
+          # Exit with error if any are found
+          
+          echo "Checking for TK-TODO markers..."  # IGNORE:TK
+          
+          # Use git ls-files to only check tracked files (excludes gitignored files like sdks/)
+          # grep -i for case-insensitive matching
+          # grep -v for excluding lines with IGNORE:TK
+          # grep -n for line numbers
+          
+          FOUND_TODOS=$(git ls-files | xargs grep -i -n "TK-TODO" 2>/dev/null | grep -i -v "IGNORE:TK" || true)  # IGNORE:TK
+          
+          if [ -n "$FOUND_TODOS" ]; then
+            echo ""
+            echo "ERROR: Found TK-TODO markers that must be resolved before merge:"  # IGNORE:TK
+            echo ""
+            echo "$FOUND_TODOS"
+            echo ""
+            echo "To suppress a TK-TODO, add 'IGNORE:TK' (case-insensitive) on the same line."  # IGNORE:TK
+            echo ""
+            exit 1
+          else
+            echo "No unresolved TK-TODO markers found."  # IGNORE:TK
+          fi

--- a/.github/workflows/tk-todo-check.yml
+++ b/.github/workflows/tk-todo-check.yml
@@ -17,4 +17,4 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Check for TK-TODO markers  # IGNORE:TK
-        uses: aaronsteers/tk-todo-check-action@v1.0.0
+        uses: aaronsteers/tk-todo-check-action@v1.0.0  # IGNORE:TK

--- a/.github/workflows/tk-todo-check.yml
+++ b/.github/workflows/tk-todo-check.yml
@@ -1,4 +1,4 @@
-name: TK-TODO Check # IGNORE:TK - this workflow checks for TK-TODO markers
+name: TK-TODO Check
 
 on:
   push:
@@ -10,36 +10,11 @@ permissions:
   contents: read
 
 jobs:
-  tk-todo-check: # IGNORE:TK
-    name: Check for TK-TODO markers # IGNORE:TK
+  tk-todo-check:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Check for TK-TODO markers # IGNORE:TK
-        run: |
-          # Find all TK-TODO markers (case-insensitive) that don't have IGNORE:TK on the same line # IGNORE:TK
-          # Exit with error if any are found
-
-          echo "Checking for TK-TODO markers..." # IGNORE:TK
-
-          # Use git ls-files to only check tracked files (excludes gitignored files like sdks/)
-          # grep -i for case-insensitive matching
-          # grep -v for excluding lines with IGNORE:TK
-          # grep -n for line numbers
-
-          FOUND_TODOS=$(git ls-files | xargs grep -i -n "TK-TODO" 2>/dev/null | grep -i -v "IGNORE:TK" || true) # IGNORE:TK
-
-          if [ -n "$FOUND_TODOS" ]; then
-            echo ""
-            echo "ERROR: Found TK-TODO markers that must be resolved before merge:" # IGNORE:TK
-            echo ""
-            echo "$FOUND_TODOS"
-            echo ""
-            echo "To suppress a TK-TODO, add 'IGNORE:TK' (case-insensitive) on the same line." # IGNORE:TK
-            echo ""
-            exit 1
-          else
-            echo "No unresolved TK-TODO markers found." # IGNORE:TK
-          fi
+      - name: Check for TK-TODO markers
+        uses: aaronsteers/tk-todo-check-action@v1.0.0

--- a/.github/workflows/tk-todo-check.yml
+++ b/.github/workflows/tk-todo-check.yml
@@ -1,4 +1,4 @@
-name: TK-TODO Check  # IGNORE:TK - this workflow checks for TK-TODO markers
+name: TK-TODO Check # IGNORE:TK - this workflow checks for TK-TODO markers
 
 on:
   push:
@@ -10,36 +10,36 @@ permissions:
   contents: read
 
 jobs:
-  tk-todo-check:  # IGNORE:TK
-    name: Check for TK-TODO markers  # IGNORE:TK
+  tk-todo-check: # IGNORE:TK
+    name: Check for TK-TODO markers # IGNORE:TK
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Check for TK-TODO markers  # IGNORE:TK
+      - name: Check for TK-TODO markers # IGNORE:TK
         run: |
-          # Find all TK-TODO markers (case-insensitive) that don't have IGNORE:TK on the same line  # IGNORE:TK
+          # Find all TK-TODO markers (case-insensitive) that don't have IGNORE:TK on the same line # IGNORE:TK
           # Exit with error if any are found
-          
-          echo "Checking for TK-TODO markers..."  # IGNORE:TK
-          
+
+          echo "Checking for TK-TODO markers..." # IGNORE:TK
+
           # Use git ls-files to only check tracked files (excludes gitignored files like sdks/)
           # grep -i for case-insensitive matching
           # grep -v for excluding lines with IGNORE:TK
           # grep -n for line numbers
-          
-          FOUND_TODOS=$(git ls-files | xargs grep -i -n "TK-TODO" 2>/dev/null | grep -i -v "IGNORE:TK" || true)  # IGNORE:TK
-          
+
+          FOUND_TODOS=$(git ls-files | xargs grep -i -n "TK-TODO" 2>/dev/null | grep -i -v "IGNORE:TK" || true) # IGNORE:TK
+
           if [ -n "$FOUND_TODOS" ]; then
             echo ""
-            echo "ERROR: Found TK-TODO markers that must be resolved before merge:"  # IGNORE:TK
+            echo "ERROR: Found TK-TODO markers that must be resolved before merge:" # IGNORE:TK
             echo ""
             echo "$FOUND_TODOS"
             echo ""
-            echo "To suppress a TK-TODO, add 'IGNORE:TK' (case-insensitive) on the same line."  # IGNORE:TK
+            echo "To suppress a TK-TODO, add 'IGNORE:TK' (case-insensitive) on the same line." # IGNORE:TK
             echo ""
             exit 1
           else
-            echo "No unresolved TK-TODO markers found."  # IGNORE:TK
+            echo "No unresolved TK-TODO markers found." # IGNORE:TK
           fi


### PR DESCRIPTION
## What

Adds a CI workflow that checks for unresolved `TK-TODO` markers in the codebase. This prevents PRs from being merged when they contain temporary markers that indicate work is not yet complete.

This is the same pattern used in `airbyte-ops-mcp` repository.

## How

The workflow:
1. Runs on all PRs and pushes to master
2. Uses `git ls-files` to scan only tracked files (excludes gitignored files)
3. Greps for `TK-TODO` markers (case-insensitive)
4. Excludes lines containing `IGNORE:TK` (for legitimate uses like this workflow itself)
5. Fails the build if any unresolved markers are found

## Review guide

1. `.github/workflows/tk-todo-check.yml` - The entire workflow is new

## User Impact

- PRs with unresolved `TK-TODO` markers will fail CI
- Developers can suppress false positives by adding `IGNORE:TK` on the same line
- No impact on existing workflows or code

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Link to Devin run: https://app.devin.ai/sessions/0f8d3c101b64494c813d5e711eea2662
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/72501">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
