### PR TITLE
fix(bulk-cdk): repair legacy toolkit connectors after CDK plugin changes

### DIFF
--- a/airbyte-cdk/bulk/changelog.md
+++ b/airbyte-cdk/bulk/changelog.md
@@ -1,3 +1,7 @@
+## Version 0.2.5
+
+Fix legacy-task-loader base dependency: `implementation` -> `api` for transitive resolution.
+
 # Bulk CDK
 
 The Bulk CDK is Airbyte's Kotlin-based CDK for developing connectors optimized for speed using protobuf encoding for data transfer. It uses Micronaut for dependency injection.

--- a/airbyte-cdk/bulk/toolkits/legacy-task-loader/build.gradle
+++ b/airbyte-cdk/bulk/toolkits/legacy-task-loader/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     api("com.github.f4b6a3:uuid-creator:6.1.1")
     implementation 'commons-codec:commons-codec:1.16.0'
 
-    implementation project(':airbyte-cdk:bulk:core:bulk-cdk-core-base')
+    api "io.airbyte.bulk-cdk:bulk-cdk-core-base:1.0.0"
     implementation 'org.apache.commons:commons-lang3:3.17.0'
 
     // For ranges and rangesets

--- a/airbyte-cdk/bulk/version.properties
+++ b/airbyte-cdk/bulk/version.properties
@@ -1,1 +1,1 @@
-version=0.2.4
+version=0.2.5


### PR DESCRIPTION
## What
Fixes legacy toolkit connectors to work with CDK plugin changes

## How
Exposes transitive base dependency for legacy-toolkit connectors via `api`

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._