### PR TITLE
chore(source-pokeapi): Cleanup after progressive rollout completion

### DIFF
--- a/airbyte-integrations/connectors/source-pokeapi/metadata.yaml
+++ b/airbyte-integrations/connectors/source-pokeapi/metadata.yaml
@@ -1,7 +1,7 @@
 data:
   allowedHosts:
     hosts:
-    - '*'
+      - "*"
   registryOverrides:
     oss:
       enabled: true
@@ -15,6 +15,9 @@ data:
       enabled: false
       packageName: airbyte-source-pokeapi
   connectorBuildOptions:
+    # Please update to the latest version of the connector base image.
+    # https://hub.docker.com/r/airbyte/python-connector-base
+    # Please use the full address with sha256 hash to guarantee build reproducibility.
     baseImage: docker.io/airbyte/source-declarative-manifest:7.6.5@sha256:a5ef859b9f6dde52bd914fbcddb088d4f1ccae4887ffb58b2282b80f119fdcbe
   connectorSubtype: api
   connectorType: source
@@ -25,27 +28,27 @@ data:
   icon: pokeapi.svg
   license: ELv2
   name: PokeAPI
-  releaseDate: '2020-05-14'
+  releaseDate: "2020-05-14"
   releaseStage: alpha
   supportLevel: community
   documentationUrl: https://docs.airbyte.com/integrations/sources/pokeapi
   tags:
-  - cdk:low-code
-  - language:manifest-only
+    - cdk:low-code
+    - language:manifest-only
   connectorTestSuitesOptions:
-  - suite: liveTests
-    testConnections:
-    - name: pokeapi_config_dev_null
-      id: 5a290dcf-b2cf-4768-ac2d-a1aaca90c186
-  - suite: acceptanceTests
-    testSecrets:
-    - name: SECRET_SOURCE-POKEAPI__CREDS
-      fileName: config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
+    - suite: liveTests
+      testConnections:
+        - name: pokeapi_config_dev_null
+          id: 5a290dcf-b2cf-4768-ac2d-a1aaca90c186
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-POKEAPI__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
   externalDocumentationUrls:
-  - title: "Pok\xE9API documentation"
-    url: https://pokeapi.co/docs/v2
-    type: api_reference
-metadataSpecVersion: '1.0'
+    - title: PokéAPI documentation
+      url: https://pokeapi.co/docs/v2
+      type: api_reference
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-pokeapi/metadata.yaml
+++ b/airbyte-integrations/connectors/source-pokeapi/metadata.yaml
@@ -1,7 +1,7 @@
 data:
   allowedHosts:
     hosts:
-      - "*"
+    - '*'
   registryOverrides:
     oss:
       enabled: true
@@ -9,46 +9,43 @@ data:
       enabled: true
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: true
+      enableProgressiveRollout: false
   remoteRegistries:
     pypi:
       enabled: false
       packageName: airbyte-source-pokeapi
   connectorBuildOptions:
-    # Please update to the latest version of the connector base image.
-    # https://hub.docker.com/r/airbyte/python-connector-base
-    # Please use the full address with sha256 hash to guarantee build reproducibility.
     baseImage: docker.io/airbyte/source-declarative-manifest:7.6.5@sha256:a5ef859b9f6dde52bd914fbcddb088d4f1ccae4887ffb58b2282b80f119fdcbe
   connectorSubtype: api
   connectorType: source
   definitionId: 6371b14b-bc68-4236-bfbd-468e8df8e968
-  dockerImageTag: 0.3.48-rc.1
+  dockerImageTag: 0.3.48
   dockerRepository: airbyte/source-pokeapi
   githubIssueLabel: source-pokeapi
   icon: pokeapi.svg
   license: ELv2
   name: PokeAPI
-  releaseDate: "2020-05-14"
+  releaseDate: '2020-05-14'
   releaseStage: alpha
   supportLevel: community
   documentationUrl: https://docs.airbyte.com/integrations/sources/pokeapi
   tags:
-    - cdk:low-code
-    - language:manifest-only
+  - cdk:low-code
+  - language:manifest-only
   connectorTestSuitesOptions:
-    - suite: liveTests
-      testConnections:
-        - name: pokeapi_config_dev_null
-          id: 5a290dcf-b2cf-4768-ac2d-a1aaca90c186
-    - suite: acceptanceTests
-      testSecrets:
-        - name: SECRET_SOURCE-POKEAPI__CREDS
-          fileName: config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
+  - suite: liveTests
+    testConnections:
+    - name: pokeapi_config_dev_null
+      id: 5a290dcf-b2cf-4768-ac2d-a1aaca90c186
+  - suite: acceptanceTests
+    testSecrets:
+    - name: SECRET_SOURCE-POKEAPI__CREDS
+      fileName: config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
   externalDocumentationUrls:
-    - title: PokéAPI documentation
-      url: https://pokeapi.co/docs/v2
-      type: api_reference
-metadataSpecVersion: "1.0"
+  - title: "Pok\xE9API documentation"
+    url: https://pokeapi.co/docs/v2
+    type: api_reference
+metadataSpecVersion: '1.0'


### PR DESCRIPTION
## What

Cleanup of source-pokeapi metadata after successful progressive rollout completion. This PR finalizes the rollout by updating the version tag and disabling progressive rollout.

Related to: https://github.com/airbytehq/airbyte-ops-mcp/issues/310 (End-to-end progressive rollout test)

## How

- Updates `dockerImageTag` from `0.3.48-rc.1` to `0.3.48` (GA version)
- Sets `enableProgressiveRollout` to `false`

Note: The cleanup tool also reformatted the YAML file (indentation and quote style changes). These are cosmetic and don't affect functionality.

## Review guide

1. `airbyte-integrations/connectors/source-pokeapi/metadata.yaml` - Verify the two functional changes:
   - Line 12: `enableProgressiveRollout: false`
   - Line 23: `dockerImageTag: 0.3.48`

## User Impact

No user-facing impact. This is a metadata cleanup after the progressive rollout was finalized via the platform API.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Requested by: @aaronsteers

[Link to Devin run](https://app.devin.ai/sessions/6f1818a6c0b24fcb9c51830c1bf4edd2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/72536">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
