### PR TITLE
fix(source-nexus-datasets): add missing registryOverrides and bump to 0.1.1

### DIFF
--- a/airbyte-integrations/connectors/source-nexus-datasets/metadata.yaml
+++ b/airbyte-integrations/connectors/source-nexus-datasets/metadata.yaml
@@ -14,7 +14,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 9e1fe63c-80ad-44fe-8927-10e66c9e209b
-  dockerImageTag: 0.1.0
+  dockerImageTag: 0.1.1
   dockerRepository: airbyte/source-nexus-datasets
   githubIssueLabel: source-nexus-datasets
   icon: nexus-datasets.svg

--- a/airbyte-integrations/connectors/source-nexus-datasets/metadata.yaml
+++ b/airbyte-integrations/connectors/source-nexus-datasets/metadata.yaml
@@ -10,7 +10,6 @@ data:
       enabled: true
   connectorBuildOptions:
     baseImage: docker.io/airbyte/source-declarative-manifest:7.6.2@sha256:cd429a4cfa1f3343b54ffcefd60694c66bb6aa11530bcce6bee610464e190a34
-    #baseImage: docker.io/airbyte/python-connector-base:4.0.2@sha256:9fdb1888c4264cf6fee473649ecb593f56f58e5d0096a87ee0b231777e2e3e73
   connectorSubtype: api
   connectorType: source
   definitionId: 9e1fe63c-80ad-44fe-8927-10e66c9e209b

--- a/airbyte-integrations/connectors/source-nexus-datasets/metadata.yaml
+++ b/airbyte-integrations/connectors/source-nexus-datasets/metadata.yaml
@@ -3,6 +3,11 @@ data:
     pypi:
       enabled: false
       packageName: airbyte-nexus-datasets
+  registryOverrides:
+    cloud:
+      enabled: true
+    oss:
+      enabled: true
   connectorBuildOptions:
     baseImage: docker.io/airbyte/source-declarative-manifest:7.6.2@sha256:cd429a4cfa1f3343b54ffcefd60694c66bb6aa11530bcce6bee610464e190a34
     #baseImage: docker.io/airbyte/python-connector-base:4.0.2@sha256:9fdb1888c4264cf6fee473649ecb593f56f58e5d0096a87ee0b231777e2e3e73

--- a/docs/integrations/sources/nexus-datasets.md
+++ b/docs/integrations/sources/nexus-datasets.md
@@ -124,6 +124,7 @@ Please refer https://developer.infornexus.com/api/authentication-choices/hmac fo
 
 | Version          | Date              | Pull Request | Subject        |
 |------------------|-------------------|--------------|----------------|
-| 0.1.0 | 2025-09-30 | [72789](https://github.com/airbytehq/airbyte/pull/72789) | Nexus datasets connector first version |
+| 0.1.1 | 2026-02-03 | [72789](https://github.com/airbytehq/airbyte/pull/72789) | Add missing registryOverrides to metadata.yaml |
+| 0.1.0 | 2025-09-30 | | Nexus datasets connector first version |
 
 </details>

--- a/docs/integrations/sources/nexus-datasets.md
+++ b/docs/integrations/sources/nexus-datasets.md
@@ -125,6 +125,6 @@ Please refer https://developer.infornexus.com/api/authentication-choices/hmac fo
 | Version          | Date              | Pull Request | Subject        |
 |------------------|-------------------|--------------|----------------|
 | 0.1.1 | 2026-02-03 | [72789](https://github.com/airbytehq/airbyte/pull/72789) | Add missing registryOverrides to metadata.yaml |
-| 0.1.0 | 2025-09-30 | | Nexus datasets connector first version |
+| 0.1.0 | 2025-09-30 | [69349](https://github.com/airbytehq/airbyte/pull/69349) | Nexus datasets connector first version |
 
 </details>

--- a/docs/integrations/sources/nexus-datasets.md
+++ b/docs/integrations/sources/nexus-datasets.md
@@ -124,6 +124,6 @@ Please refer https://developer.infornexus.com/api/authentication-choices/hmac fo
 
 | Version          | Date              | Pull Request | Subject        |
 |------------------|-------------------|--------------|----------------|
-| 0.1.0 | 2025-09-30 |  | Nexus datasets connector first version |
+| 0.1.0 | 2025-09-30 | [72789](https://github.com/airbytehq/airbyte/pull/72789) | Nexus datasets connector first version |
 
 </details>


### PR DESCRIPTION
## What
Fixes the publish failure for source-nexus-datasets caused by missing `registryOverrides` field in metadata.yaml.

Related CI failure: https://github.com/airbytehq/airbyte/actions/runs/21639990002/job/62377169438

The registry entry generation was failing with:
```
KeyError: 'registryOverrides'
```

## How
Added the required `registryOverrides` section to the connector's metadata.yaml, enabling both cloud and oss registries (standard pattern for connectors).

Also bumped the connector version from 0.1.0 to 0.1.1 and updated the changelog accordingly.

## Review guide
1. `airbyte-integrations/connectors/source-nexus-datasets/metadata.yaml` - verify the registryOverrides structure is correct and version is bumped to 0.1.1
2. `docs/integrations/sources/nexus-datasets.md` - verify the changelog entry for 0.1.1 is correct

## User Impact
The connector will be able to publish successfully to the registry.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚

---
Requested by: @darynaishchenko
Link to Devin run: https://app.devin.ai/sessions/7cba7315153f48d4a3cfb9f6df3c1ce1