### PR TITLE
chore(source-klaviyo): Remove duplicate changelog URL from external docs

### DIFF
--- a/airbyte-integrations/connectors/source-klaviyo/metadata.yaml
+++ b/airbyte-integrations/connectors/source-klaviyo/metadata.yaml
@@ -46,13 +46,10 @@ data:
       url: https://developers.klaviyo.com/en/docs/api_versioning_and_deprecation_policy
       type: api_reference
     - title: Changelog
-      url: https://developers.klaviyo.com/en/docs/changelog_
+      url: https://developers.klaviyo.com/en/docs/changelog
       type: api_release_history
     - title: Developer Group
       url: https://community.klaviyo.com/groups/developer-group-64
-    - title: Changelog
-      url: https://developers.klaviyo.com/en/docs/changelog
-      type: api_release_history
   tags:
     - cdk:low-code
     - language:manifest-only


### PR DESCRIPTION
## What

Cleans up duplicate and malformed external documentation URLs in the source-klaviyo connector metadata.

Resolves https://github.com/airbytehq/oncall/issues/10369

- https://github.com/airbytehq/oncall/issues/10369

## How

- Removed duplicate "Changelog" entry from `externalDocumentationUrls`
- Fixed the remaining changelog URL by removing the trailing underscore typo (`changelog_` → `changelog`)

The URL with the trailing underscore was a typo that happened to work (it redirects), but having both entries was redundant.

## Review guide

1. `airbyte-integrations/connectors/source-klaviyo/metadata.yaml` - verify the canonical changelog URL is correct

## User Impact

No user-facing impact. This is metadata cleanup only - the connector functionality is unchanged.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Requested by @DanyloGL (Danylo Jablonski)

Link to Devin run: https://app.devin.ai/sessions/6a7ae215283440f49423670d97241b28