### PR TITLE
chore(source-paypal-transaction): Add PayPal deprecation documentation URLs to metadata

### DIFF
--- a/airbyte-integrations/connectors/source-paypal-transaction/metadata.yaml
+++ b/airbyte-integrations/connectors/source-paypal-transaction/metadata.yaml
@@ -89,4 +89,10 @@ data:
     - title: PayPal Status
       url: https://www.paypal-status.com/
       type: status_page
+    - title: PayPal Deprecated Resources
+      url: https://developer.paypal.com/api/rest/deprecated-resources/
+      type: api_deprecations
+    - title: PayPal Lifecycle Definition
+      url: https://developer.paypal.com/docs/archive/lifecycle
+      type: api_deprecations
 metadataSpecVersion: "1.0"


### PR DESCRIPTION
## What

Adds PayPal deprecation documentation URLs to the connector's external documentation metadata. This supports ongoing API deprecation monitoring efforts.

Resolves https://github.com/airbytehq/oncall/issues/10530

- https://github.com/airbytehq/oncall/issues/10530

## How

Adds two new entries to `externalDocumentationUrls` in metadata.yaml:
1. **PayPal Deprecated Resources** - Lists all deprecated PayPal APIs and their replacements
2. **PayPal Lifecycle Definition** - Documents PayPal's deprecation policy and timeline (end of 2026 target for phasing out older integrations)

## Review guide

1. `airbyte-integrations/connectors/source-paypal-transaction/metadata.yaml` - Verify the URLs are valid and the `api_deprecations` type is correct

## User Impact

No user-facing impact. This is a metadata-only change that improves documentation tracking for API deprecation monitoring.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Requested by: Danylo Jablonski (@DanyloGL)

Link to Devin run: https://app.devin.ai/sessions/09b65bd3a8494fffafbd0a01bb935926