### PR TITLE
chore(source-linkedin-ads): Update external documentation URL

### DIFF
--- a/airbyte-integrations/connectors/source-linkedin-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-linkedin-ads/metadata.yaml
@@ -16,7 +16,7 @@ data:
   documentationUrl: https://docs.airbyte.com/integrations/sources/linkedin-ads
   externalDocumentationUrls:
     - title: Changelog
-      url: https://learn.microsoft.com/en-us/linkedin/marketing/integrations/recent-changes?view=li-lms-2024-10
+      url: https://learn.microsoft.com/en-us/linkedin/marketing/integrations/recent-changes
       type: api_release_history
   githubIssueLabel: source-linkedin-ads
   icon: linkedin.svg


### PR DESCRIPTION
## What

Updates the external documentation URL for the LinkedIn Marketing API changelog to remove an outdated view parameter.

Related oncall issue: https://github.com/airbytehq/oncall/issues/10434

## How

Removes the `?view=li-lms-2024-10` query parameter from the changelog URL. The old URL redirects to the latest API version anyway, so using the base URL ensures the link always points to current documentation without requiring future updates.

## Review guide

1. `airbyte-integrations/connectors/source-linkedin-ads/metadata.yaml` - Single line URL change

## User Impact

No user impact. This is a metadata-only change that improves the accuracy of external documentation links used for API deprecation monitoring.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

**Requested by:** Danylo Jablonski (@DanyloGL)

**Link to Devin run:** https://app.devin.ai/sessions/3282f8dca13e48c0bd09622cb11a392e