### PR TITLE
chore(source-sendgrid): Update stale OpenAPI specification URL

### DIFF
--- a/airbyte-integrations/connectors/source-sendgrid/metadata.yaml
+++ b/airbyte-integrations/connectors/source-sendgrid/metadata.yaml
@@ -23,7 +23,7 @@ data:
       url: https://docs.sendgrid.com/api-reference/how-to-use-the-sendgrid-v3-api/authentication
       type: api_reference
     - title: SendGrid API OpenAPI specification
-      url: https://github.com/sendgrid/sendgrid-oai
+      url: https://github.com/twilio/sendgrid-oai
       type: openapi_spec
   githubIssueLabel: source-sendgrid
   icon: sendgrid.svg


### PR DESCRIPTION
## What

Updates the external documentation URL for the SendGrid OpenAPI specification in the connector's metadata.yaml. The old repository (`sendgrid/sendgrid-oai`) was archived on July 15, 2024 and now returns a 404 error. The specification has been moved to `twilio/sendgrid-oai`.

Discovered during API deprecation monitoring research for the SendGrid connector.

Resolves https://github.com/airbytehq/oncall/issues/10449

- https://github.com/airbytehq/oncall/issues/10449

## How

Simple URL update from `https://github.com/sendgrid/sendgrid-oai` to `https://github.com/twilio/sendgrid-oai` in the `externalDocumentationUrls` section of metadata.yaml.

## Review guide

1. `airbyte-integrations/connectors/source-sendgrid/metadata.yaml` - single line URL change

## User Impact

No functional impact. This is a metadata-only change that fixes a broken documentation link.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Requested by: @DanyloGL

Link to Devin run: https://app.devin.ai/sessions/c9738eaf4e684edeacf2e705fce23836