### PR TITLE
fix(metadata-service): separate version pinning from published version in registry entries

### DIFF
--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/registry_entry.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/registry_entry.py
@@ -56,10 +56,12 @@ class RegistryEntryInfo:
     metadata_file_path: str
 
 
-def _apply_metadata_overrides(metadata_data: dict, registry_type: str, bucket_name: str, metadata_blob: storage.Blob) -> dict:
+def _apply_metadata_overrides(
+    metadata_data: dict, registry_type: str, bucket_name: str, metadata_blob: storage.Blob, is_release_candidate: bool = False
+) -> dict:
     connector_type = metadata_data["connectorType"]
 
-    overridden_metadata_data = _apply_overrides_from_registry(metadata_data, registry_type)
+    overridden_metadata_data = _apply_overrides_from_registry(metadata_data, registry_type, is_release_candidate=is_release_candidate)
 
     # remove fields that are not needed in the registry
     del overridden_metadata_data["registryOverrides"]
@@ -108,12 +110,13 @@ def _apply_metadata_overrides(metadata_data: dict, registry_type: str, bucket_na
 
 
 @deep_copy_params
-def _apply_overrides_from_registry(metadata_data: dict, override_registry_key: str) -> dict:
+def _apply_overrides_from_registry(metadata_data: dict, override_registry_key: str, is_release_candidate: bool = False) -> dict:
     """Apply the overrides from the registry to the metadata data.
 
     Args:
         metadata_data (dict): The metadata data field.
         override_registry_key (str): The key of the registry to override the metadata with.
+        is_release_candidate (bool): If True, skip applying dockerImageTag override to preserve the RC version.
 
     Returns:
         dict: The metadata data field with the overrides applied.
@@ -123,6 +126,13 @@ def _apply_overrides_from_registry(metadata_data: dict, override_registry_key: s
 
     # remove any None values from the override registry
     override_registry = {k: v for k, v in override_registry.items() if v is not None}
+
+    # For release candidate entries, we should NOT apply the dockerImageTag override.
+    # The RC registry entry should use the actual RC version (e.g., 0.1.0-rc.1), not the
+    # pinned production version (e.g., 0.0.45). This is critical for progressive rollouts
+    # to work correctly - the platform needs to see the RC version in the registry entry.
+    if is_release_candidate and "dockerImageTag" in override_registry:
+        del override_registry["dockerImageTag"]
 
     metadata_data.update(override_registry)
 
@@ -474,6 +484,22 @@ def generate_and_persist_registry_entry(
             send_slack_message(PUBLISH_UPDATE_CHANNEL, message)
             raise
 
+        # For RC versions, we also need metadata without the dockerImageTag override applied.
+        # This ensures the RC registry entry shows the actual RC version (e.g., 0.1.0-rc.1)
+        # instead of a pinned production version (e.g., 0.0.45).
+        is_rc_version = "-rc" in metadata_dict["data"]["dockerImageTag"]
+        rc_overridden_metadata_data = None
+        if is_rc_version:
+            try:
+                rc_overridden_metadata_data = _apply_metadata_overrides(
+                    metadata_data, registry_type, bucket_name, metadata_blob, is_release_candidate=True
+                )
+            except Exception as e:
+                logger.exception(f"Error applying RC metadata overrides")
+                message = f"*🤖 🔴 _Registry Entry Generation_ FAILED*:\nRegistry Entry: `{registry_type}.json`\nConnector: `{metadata_data['dockerRepository']}`\nGCS Bucket: `{bucket_name}`."
+                send_slack_message(PUBLISH_UPDATE_CHANNEL, message)
+                raise
+
         registry_entry_blob_paths = _get_registry_blob_information(metadata_dict, registry_type, overridden_metadata_data, is_prerelease)
 
         logger.info("Parsing spec file.")
@@ -485,28 +511,42 @@ def generate_and_persist_registry_entry(
         overridden_metadata_data["spec"] = spec_cache.download_spec(cached_spec)
         logger.info("Spec file parsed and added to metadata.")
 
+        # If we have RC metadata, also add the spec to it
+        if rc_overridden_metadata_data is not None:
+            rc_overridden_metadata_data["spec"] = overridden_metadata_data["spec"]
+
         logger.info("Parsing registry entry model.")
         _, RegistryEntryModel = _get_connector_type_from_registry_entry(overridden_metadata_data)
         registry_entry_model = RegistryEntryModel.parse_obj(overridden_metadata_data)
         logger.info("Registry entry model parsed.")
 
+        # Also parse the RC registry entry model if needed
+        rc_registry_entry_model = None
+        if rc_overridden_metadata_data is not None:
+            rc_registry_entry_model = RegistryEntryModel.parse_obj(rc_overridden_metadata_data)
+
         # Persist the registry entry to the GCS bucket.
         for registry_entry_info in registry_entry_blob_paths:
             registry_entry_blob_path = registry_entry_info.entry_blob_path
             metadata_blob_path = registry_entry_info.metadata_file_path
+
+            # Use the RC-specific registry entry model for release_candidate paths
+            is_rc_entry = "/release_candidate/" in registry_entry_blob_path
+            current_registry_entry_model = rc_registry_entry_model if (is_rc_entry and rc_registry_entry_model is not None) else registry_entry_model
+
             try:
                 logger.info(
                     f"Persisting `{metadata_data['dockerRepository']}` {registry_type} registry entry to `{registry_entry_blob_path}`"
                 )
 
                 # set the correct metadata blob path on the registry entry
-                registry_entry_model = copy.deepcopy(registry_entry_model)
-                generated_fields: Optional[GeneratedFields] = registry_entry_model.generated
+                current_registry_entry_model = copy.deepcopy(current_registry_entry_model)
+                generated_fields: Optional[GeneratedFields] = current_registry_entry_model.generated
                 if generated_fields is not None:
                     source_file_info: Optional[SourceFileInfo] = generated_fields.source_file_info
                     if source_file_info is not None:
                         source_file_info.metadata_file_path = metadata_blob_path
-                _persist_connector_registry_entry(bucket_name, registry_entry_model, registry_entry_blob_path)
+                _persist_connector_registry_entry(bucket_name, current_registry_entry_model, registry_entry_blob_path)
 
                 message = f"*🤖 🟢 _Registry Entry Generation_ SUCCESS*:\nRegistry Entry: `{registry_type}.json`\nConnector: `{metadata_data['dockerRepository']}`\nGCS Bucket: `{bucket_name}`\nPath: `{registry_entry_blob_path}`."
                 send_slack_message(PUBLISH_UPDATE_CHANNEL, message)

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/registry_entry.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/registry_entry.py
@@ -532,7 +532,9 @@ def generate_and_persist_registry_entry(
 
             # Use the RC-specific registry entry model for release_candidate paths
             is_rc_entry = "/release_candidate/" in registry_entry_blob_path
-            current_registry_entry_model = rc_registry_entry_model if (is_rc_entry and rc_registry_entry_model is not None) else registry_entry_model
+            current_registry_entry_model = (
+                rc_registry_entry_model if (is_rc_entry and rc_registry_entry_model is not None) else registry_entry_model
+            )
 
             try:
                 logger.info(

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/registry_entry.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/registry_entry.py
@@ -492,10 +492,7 @@ def generate_and_persist_registry_entry(
 
         # For normal (non-RC, non-prerelease) publishes, we also need metadata with the dockerImageTag
         # override applied for the latest entry. This preserves version pinning behavior.
-        is_normal_publish = (
-            not is_prerelease
-            and "-rc" not in metadata_dict["data"]["dockerImageTag"]
-        )
+        is_normal_publish = not is_prerelease and "-rc" not in metadata_dict["data"]["dockerImageTag"]
         latest_overridden_metadata_data = None
         if is_normal_publish:
             try:

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/registry_entry.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/registry_entry.py
@@ -478,8 +478,6 @@ def generate_and_persist_registry_entry(
     # If the connector is not enabled on the given registry, skip generateing and persisting the registry entry.
     if metadata_dict["data"]["registryOverrides"][registry_type]["enabled"]:
         metadata_data = metadata_dict["data"]
-
-        # Generate metadata for versioned/RC entries (skip dockerImageTag override - use actual published version)
         try:
             overridden_metadata_data = _apply_metadata_overrides(
                 metadata_data, registry_type, bucket_name, metadata_blob, skip_docker_image_tag=True
@@ -489,21 +487,6 @@ def generate_and_persist_registry_entry(
             message = f"*🤖 🔴 _Registry Entry Generation_ FAILED*:\nRegistry Entry: `{registry_type}.json`\nConnector: `{metadata_data['dockerRepository']}`\nGCS Bucket: `{bucket_name}`."
             send_slack_message(PUBLISH_UPDATE_CHANNEL, message)
             raise
-
-        # For normal (non-RC, non-prerelease) publishes, we also need metadata with the dockerImageTag
-        # override applied for the latest entry. This preserves version pinning behavior.
-        is_normal_publish = not is_prerelease and "-rc" not in metadata_dict["data"]["dockerImageTag"]
-        latest_overridden_metadata_data = None
-        if is_normal_publish:
-            try:
-                latest_overridden_metadata_data = _apply_metadata_overrides(
-                    metadata_data, registry_type, bucket_name, metadata_blob, skip_docker_image_tag=False
-                )
-            except Exception as e:
-                logger.exception(f"Error applying metadata overrides for latest entry")
-                message = f"*🤖 🔴 _Registry Entry Generation_ FAILED*:\nRegistry Entry: `{registry_type}.json`\nConnector: `{metadata_data['dockerRepository']}`\nGCS Bucket: `{bucket_name}`."
-                send_slack_message(PUBLISH_UPDATE_CHANNEL, message)
-                raise
 
         registry_entry_blob_paths = _get_registry_blob_information(metadata_dict, registry_type, overridden_metadata_data, is_prerelease)
 
@@ -516,35 +499,28 @@ def generate_and_persist_registry_entry(
         overridden_metadata_data["spec"] = spec_cache.download_spec(cached_spec)
         logger.info("Spec file parsed and added to metadata.")
 
-        # If we have latest metadata, also add the spec to it (using the pinned version's spec)
-        if latest_overridden_metadata_data is not None:
-            latest_cached_spec = spec_cache.find_spec_cache_with_fallback(
-                latest_overridden_metadata_data["dockerRepository"],
-                latest_overridden_metadata_data["dockerImageTag"],
-                registry_type,
-            )
-            latest_overridden_metadata_data["spec"] = spec_cache.download_spec(latest_cached_spec)
-
         logger.info("Parsing registry entry model.")
         _, RegistryEntryModel = _get_connector_type_from_registry_entry(overridden_metadata_data)
         registry_entry_model = RegistryEntryModel.parse_obj(overridden_metadata_data)
         logger.info("Registry entry model parsed.")
-
-        # Also parse the latest registry entry model if needed
-        latest_registry_entry_model = None
-        if latest_overridden_metadata_data is not None:
-            latest_registry_entry_model = RegistryEntryModel.parse_obj(latest_overridden_metadata_data)
 
         # Persist the registry entry to the GCS bucket.
         for registry_entry_info in registry_entry_blob_paths:
             registry_entry_blob_path = registry_entry_info.entry_blob_path
             metadata_blob_path = registry_entry_info.metadata_file_path
 
-            # Use the latest-specific registry entry model for latest paths (version pinning)
-            is_latest_entry = "/latest/" in registry_entry_blob_path
-            current_registry_entry_model = (
-                latest_registry_entry_model if (is_latest_entry and latest_registry_entry_model is not None) else registry_entry_model
-            )
+            # For latest entries, apply the dockerImageTag override (version pinning behavior)
+            if "/latest/" in registry_entry_blob_path:
+                latest_metadata = _apply_metadata_overrides(
+                    metadata_data, registry_type, bucket_name, metadata_blob, skip_docker_image_tag=False
+                )
+                latest_spec = spec_cache.find_spec_cache_with_fallback(
+                    latest_metadata["dockerRepository"], latest_metadata["dockerImageTag"], registry_type
+                )
+                latest_metadata["spec"] = spec_cache.download_spec(latest_spec)
+                current_registry_entry_model = RegistryEntryModel.parse_obj(latest_metadata)
+            else:
+                current_registry_entry_model = registry_entry_model
 
             try:
                 logger.info(

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/registry_entry.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/registry_entry.py
@@ -117,9 +117,8 @@ def _apply_overrides_from_registry(metadata_data: dict, override_registry_key: s
         metadata_data: The metadata data field.
         override_registry_key: The key of the registry to override the metadata with.
         skip_docker_image_tag: If True (default), skip applying dockerImageTag override.
-            This should be True for versioned and RC entries (which should reflect the actual
-            version being published), and False for latest entries (which should reflect
-            the pinned version for version pinning behavior).
+            This should be True for the version being published, and False for latest
+            entries (which should reflect the overridden/pinned version, if applicable).
 
     Returns:
         The metadata data field with the overrides applied.
@@ -130,9 +129,6 @@ def _apply_overrides_from_registry(metadata_data: dict, override_registry_key: s
     # remove any None values from the override registry
     override_registry = {k: v for k, v in override_registry.items() if v is not None}
 
-    # Skip dockerImageTag override unless explicitly requested (for latest entries).
-    # Versioned and RC registry entries should always reflect the actual version being
-    # published, not a pinned version. Only latest entries should use the pinned version.
     if skip_docker_image_tag and "dockerImageTag" in override_registry:
         del override_registry["dockerImageTag"]
 
@@ -206,7 +202,7 @@ def _apply_package_info_fields(metadata_data: dict, bucket_name: str) -> dict:
                 if package.get("package_name") == "airbyte-cdk":
                     # Note: Prefix the version with the python slug as the python cdk is the only one we have
                     # versions available for.
-                    cdk_version = f'{PYTHON_CDK_SLUG}:{package.get("version")}'
+                    cdk_version = f"{PYTHON_CDK_SLUG}:{package.get('version')}"
                     break
             package_info_fields = set_with(package_info_fields, "cdk_version", cdk_version, default_none_to_dict)
     except Exception as e:

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/registry_entry.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/registry_entry.py
@@ -56,10 +56,12 @@ class RegistryEntryInfo:
     metadata_file_path: str
 
 
-def _apply_metadata_overrides(metadata_data: dict, registry_type: str, bucket_name: str, metadata_blob: storage.Blob) -> dict:
+def _apply_metadata_overrides(
+    metadata_data: dict, registry_type: str, bucket_name: str, metadata_blob: storage.Blob, skip_docker_image_tag: bool = True
+) -> dict:
     connector_type = metadata_data["connectorType"]
 
-    overridden_metadata_data = _apply_overrides_from_registry(metadata_data, registry_type)
+    overridden_metadata_data = _apply_overrides_from_registry(metadata_data, registry_type, skip_docker_image_tag=skip_docker_image_tag)
 
     # remove fields that are not needed in the registry
     del overridden_metadata_data["registryOverrides"]
@@ -108,15 +110,19 @@ def _apply_metadata_overrides(metadata_data: dict, registry_type: str, bucket_na
 
 
 @deep_copy_params
-def _apply_overrides_from_registry(metadata_data: dict, override_registry_key: str) -> dict:
+def _apply_overrides_from_registry(metadata_data: dict, override_registry_key: str, skip_docker_image_tag: bool = True) -> dict:
     """Apply the overrides from the registry to the metadata data.
 
     Args:
-        metadata_data (dict): The metadata data field.
-        override_registry_key (str): The key of the registry to override the metadata with.
+        metadata_data: The metadata data field.
+        override_registry_key: The key of the registry to override the metadata with.
+        skip_docker_image_tag: If True (default), skip applying dockerImageTag override.
+            This should be True for versioned and RC entries (which should reflect the actual
+            version being published), and False for latest entries (which should reflect
+            the pinned version for version pinning behavior).
 
     Returns:
-        dict: The metadata data field with the overrides applied.
+        The metadata data field with the overrides applied.
     """
     override_registry = metadata_data["registryOverrides"][override_registry_key]
     del override_registry["enabled"]
@@ -124,11 +130,10 @@ def _apply_overrides_from_registry(metadata_data: dict, override_registry_key: s
     # remove any None values from the override registry
     override_registry = {k: v for k, v in override_registry.items() if v is not None}
 
-    # Never override dockerImageTag. The registry entry for any given version should
-    # always reflect the actual version being published, not a pinned version.
-    # The existence of a pinned version in registryOverrides is a separate concern
-    # from which version is being published.
-    if "dockerImageTag" in override_registry:
+    # Skip dockerImageTag override unless explicitly requested (for latest entries).
+    # Versioned and RC registry entries should always reflect the actual version being
+    # published, not a pinned version. Only latest entries should use the pinned version.
+    if skip_docker_image_tag and "dockerImageTag" in override_registry:
         del override_registry["dockerImageTag"]
 
     metadata_data.update(override_registry)
@@ -473,13 +478,35 @@ def generate_and_persist_registry_entry(
     # If the connector is not enabled on the given registry, skip generateing and persisting the registry entry.
     if metadata_dict["data"]["registryOverrides"][registry_type]["enabled"]:
         metadata_data = metadata_dict["data"]
+
+        # Generate metadata for versioned/RC entries (skip dockerImageTag override - use actual published version)
         try:
-            overridden_metadata_data = _apply_metadata_overrides(metadata_data, registry_type, bucket_name, metadata_blob)
+            overridden_metadata_data = _apply_metadata_overrides(
+                metadata_data, registry_type, bucket_name, metadata_blob, skip_docker_image_tag=True
+            )
         except Exception as e:
             logger.exception(f"Error applying metadata overrides")
             message = f"*🤖 🔴 _Registry Entry Generation_ FAILED*:\nRegistry Entry: `{registry_type}.json`\nConnector: `{metadata_data['dockerRepository']}`\nGCS Bucket: `{bucket_name}`."
             send_slack_message(PUBLISH_UPDATE_CHANNEL, message)
             raise
+
+        # For normal (non-RC, non-prerelease) publishes, we also need metadata with the dockerImageTag
+        # override applied for the latest entry. This preserves version pinning behavior.
+        is_normal_publish = (
+            not is_prerelease
+            and "-rc" not in metadata_dict["data"]["dockerImageTag"]
+        )
+        latest_overridden_metadata_data = None
+        if is_normal_publish:
+            try:
+                latest_overridden_metadata_data = _apply_metadata_overrides(
+                    metadata_data, registry_type, bucket_name, metadata_blob, skip_docker_image_tag=False
+                )
+            except Exception as e:
+                logger.exception(f"Error applying metadata overrides for latest entry")
+                message = f"*🤖 🔴 _Registry Entry Generation_ FAILED*:\nRegistry Entry: `{registry_type}.json`\nConnector: `{metadata_data['dockerRepository']}`\nGCS Bucket: `{bucket_name}`."
+                send_slack_message(PUBLISH_UPDATE_CHANNEL, message)
+                raise
 
         registry_entry_blob_paths = _get_registry_blob_information(metadata_dict, registry_type, overridden_metadata_data, is_prerelease)
 
@@ -492,28 +519,49 @@ def generate_and_persist_registry_entry(
         overridden_metadata_data["spec"] = spec_cache.download_spec(cached_spec)
         logger.info("Spec file parsed and added to metadata.")
 
+        # If we have latest metadata, also add the spec to it (using the pinned version's spec)
+        if latest_overridden_metadata_data is not None:
+            latest_cached_spec = spec_cache.find_spec_cache_with_fallback(
+                latest_overridden_metadata_data["dockerRepository"],
+                latest_overridden_metadata_data["dockerImageTag"],
+                registry_type,
+            )
+            latest_overridden_metadata_data["spec"] = spec_cache.download_spec(latest_cached_spec)
+
         logger.info("Parsing registry entry model.")
         _, RegistryEntryModel = _get_connector_type_from_registry_entry(overridden_metadata_data)
         registry_entry_model = RegistryEntryModel.parse_obj(overridden_metadata_data)
         logger.info("Registry entry model parsed.")
 
+        # Also parse the latest registry entry model if needed
+        latest_registry_entry_model = None
+        if latest_overridden_metadata_data is not None:
+            latest_registry_entry_model = RegistryEntryModel.parse_obj(latest_overridden_metadata_data)
+
         # Persist the registry entry to the GCS bucket.
         for registry_entry_info in registry_entry_blob_paths:
             registry_entry_blob_path = registry_entry_info.entry_blob_path
             metadata_blob_path = registry_entry_info.metadata_file_path
+
+            # Use the latest-specific registry entry model for latest paths (version pinning)
+            is_latest_entry = "/latest/" in registry_entry_blob_path
+            current_registry_entry_model = (
+                latest_registry_entry_model if (is_latest_entry and latest_registry_entry_model is not None) else registry_entry_model
+            )
+
             try:
                 logger.info(
                     f"Persisting `{metadata_data['dockerRepository']}` {registry_type} registry entry to `{registry_entry_blob_path}`"
                 )
 
                 # set the correct metadata blob path on the registry entry
-                registry_entry_model = copy.deepcopy(registry_entry_model)
-                generated_fields: Optional[GeneratedFields] = registry_entry_model.generated
+                current_registry_entry_model = copy.deepcopy(current_registry_entry_model)
+                generated_fields: Optional[GeneratedFields] = current_registry_entry_model.generated
                 if generated_fields is not None:
                     source_file_info: Optional[SourceFileInfo] = generated_fields.source_file_info
                     if source_file_info is not None:
                         source_file_info.metadata_file_path = metadata_blob_path
-                _persist_connector_registry_entry(bucket_name, registry_entry_model, registry_entry_blob_path)
+                _persist_connector_registry_entry(bucket_name, current_registry_entry_model, registry_entry_blob_path)
 
                 message = f"*🤖 🟢 _Registry Entry Generation_ SUCCESS*:\nRegistry Entry: `{registry_type}.json`\nConnector: `{metadata_data['dockerRepository']}`\nGCS Bucket: `{bucket_name}`\nPath: `{registry_entry_blob_path}`."
                 send_slack_message(PUBLISH_UPDATE_CHANNEL, message)

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/registry_entry.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/registry_entry.py
@@ -511,9 +511,12 @@ def generate_and_persist_registry_entry(
         overridden_metadata_data["spec"] = spec_cache.download_spec(cached_spec)
         logger.info("Spec file parsed and added to metadata.")
 
-        # If we have RC metadata, also add the spec to it
+        # If we have RC metadata, fetch the spec using the RC version's dockerImageTag
         if rc_overridden_metadata_data is not None:
-            rc_overridden_metadata_data["spec"] = overridden_metadata_data["spec"]
+            rc_cached_spec = spec_cache.find_spec_cache_with_fallback(
+                rc_overridden_metadata_data["dockerRepository"], rc_overridden_metadata_data["dockerImageTag"], registry_type
+            )
+            rc_overridden_metadata_data["spec"] = spec_cache.download_spec(rc_cached_spec)
 
         logger.info("Parsing registry entry model.")
         _, RegistryEntryModel = _get_connector_type_from_registry_entry(overridden_metadata_data)

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/registry_entry.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/registry_entry.py
@@ -56,12 +56,10 @@ class RegistryEntryInfo:
     metadata_file_path: str
 
 
-def _apply_metadata_overrides(
-    metadata_data: dict, registry_type: str, bucket_name: str, metadata_blob: storage.Blob, is_release_candidate: bool = False
-) -> dict:
+def _apply_metadata_overrides(metadata_data: dict, registry_type: str, bucket_name: str, metadata_blob: storage.Blob) -> dict:
     connector_type = metadata_data["connectorType"]
 
-    overridden_metadata_data = _apply_overrides_from_registry(metadata_data, registry_type, is_release_candidate=is_release_candidate)
+    overridden_metadata_data = _apply_overrides_from_registry(metadata_data, registry_type)
 
     # remove fields that are not needed in the registry
     del overridden_metadata_data["registryOverrides"]
@@ -110,13 +108,12 @@ def _apply_metadata_overrides(
 
 
 @deep_copy_params
-def _apply_overrides_from_registry(metadata_data: dict, override_registry_key: str, is_release_candidate: bool = False) -> dict:
+def _apply_overrides_from_registry(metadata_data: dict, override_registry_key: str) -> dict:
     """Apply the overrides from the registry to the metadata data.
 
     Args:
         metadata_data (dict): The metadata data field.
         override_registry_key (str): The key of the registry to override the metadata with.
-        is_release_candidate (bool): If True, skip applying dockerImageTag override to preserve the RC version.
 
     Returns:
         dict: The metadata data field with the overrides applied.
@@ -127,11 +124,11 @@ def _apply_overrides_from_registry(metadata_data: dict, override_registry_key: s
     # remove any None values from the override registry
     override_registry = {k: v for k, v in override_registry.items() if v is not None}
 
-    # For release candidate entries, we should NOT apply the dockerImageTag override.
-    # The RC registry entry should use the actual RC version (e.g., 0.1.0-rc.1), not the
-    # pinned production version (e.g., 0.0.45). This is critical for progressive rollouts
-    # to work correctly - the platform needs to see the RC version in the registry entry.
-    if is_release_candidate and "dockerImageTag" in override_registry:
+    # Never override dockerImageTag. The registry entry for any given version should
+    # always reflect the actual version being published, not a pinned version.
+    # The existence of a pinned version in registryOverrides is a separate concern
+    # from which version is being published.
+    if "dockerImageTag" in override_registry:
         del override_registry["dockerImageTag"]
 
     metadata_data.update(override_registry)
@@ -484,22 +481,6 @@ def generate_and_persist_registry_entry(
             send_slack_message(PUBLISH_UPDATE_CHANNEL, message)
             raise
 
-        # For RC versions, we also need metadata without the dockerImageTag override applied.
-        # This ensures the RC registry entry shows the actual RC version (e.g., 0.1.0-rc.1)
-        # instead of a pinned production version (e.g., 0.0.45).
-        is_rc_version = "-rc" in metadata_dict["data"]["dockerImageTag"]
-        rc_overridden_metadata_data = None
-        if is_rc_version:
-            try:
-                rc_overridden_metadata_data = _apply_metadata_overrides(
-                    metadata_data, registry_type, bucket_name, metadata_blob, is_release_candidate=True
-                )
-            except Exception as e:
-                logger.exception(f"Error applying RC metadata overrides")
-                message = f"*🤖 🔴 _Registry Entry Generation_ FAILED*:\nRegistry Entry: `{registry_type}.json`\nConnector: `{metadata_data['dockerRepository']}`\nGCS Bucket: `{bucket_name}`."
-                send_slack_message(PUBLISH_UPDATE_CHANNEL, message)
-                raise
-
         registry_entry_blob_paths = _get_registry_blob_information(metadata_dict, registry_type, overridden_metadata_data, is_prerelease)
 
         logger.info("Parsing spec file.")
@@ -511,47 +492,28 @@ def generate_and_persist_registry_entry(
         overridden_metadata_data["spec"] = spec_cache.download_spec(cached_spec)
         logger.info("Spec file parsed and added to metadata.")
 
-        # If we have RC metadata, fetch the spec using the RC version's dockerImageTag
-        if rc_overridden_metadata_data is not None:
-            rc_cached_spec = spec_cache.find_spec_cache_with_fallback(
-                rc_overridden_metadata_data["dockerRepository"], rc_overridden_metadata_data["dockerImageTag"], registry_type
-            )
-            rc_overridden_metadata_data["spec"] = spec_cache.download_spec(rc_cached_spec)
-
         logger.info("Parsing registry entry model.")
         _, RegistryEntryModel = _get_connector_type_from_registry_entry(overridden_metadata_data)
         registry_entry_model = RegistryEntryModel.parse_obj(overridden_metadata_data)
         logger.info("Registry entry model parsed.")
 
-        # Also parse the RC registry entry model if needed
-        rc_registry_entry_model = None
-        if rc_overridden_metadata_data is not None:
-            rc_registry_entry_model = RegistryEntryModel.parse_obj(rc_overridden_metadata_data)
-
         # Persist the registry entry to the GCS bucket.
         for registry_entry_info in registry_entry_blob_paths:
             registry_entry_blob_path = registry_entry_info.entry_blob_path
             metadata_blob_path = registry_entry_info.metadata_file_path
-
-            # Use the RC-specific registry entry model for release_candidate paths
-            is_rc_entry = "/release_candidate/" in registry_entry_blob_path
-            current_registry_entry_model = (
-                rc_registry_entry_model if (is_rc_entry and rc_registry_entry_model is not None) else registry_entry_model
-            )
-
             try:
                 logger.info(
                     f"Persisting `{metadata_data['dockerRepository']}` {registry_type} registry entry to `{registry_entry_blob_path}`"
                 )
 
                 # set the correct metadata blob path on the registry entry
-                current_registry_entry_model = copy.deepcopy(current_registry_entry_model)
-                generated_fields: Optional[GeneratedFields] = current_registry_entry_model.generated
+                registry_entry_model = copy.deepcopy(registry_entry_model)
+                generated_fields: Optional[GeneratedFields] = registry_entry_model.generated
                 if generated_fields is not None:
                     source_file_info: Optional[SourceFileInfo] = generated_fields.source_file_info
                     if source_file_info is not None:
                         source_file_info.metadata_file_path = metadata_blob_path
-                _persist_connector_registry_entry(bucket_name, current_registry_entry_model, registry_entry_blob_path)
+                _persist_connector_registry_entry(bucket_name, registry_entry_model, registry_entry_blob_path)
 
                 message = f"*🤖 🟢 _Registry Entry Generation_ SUCCESS*:\nRegistry Entry: `{registry_type}.json`\nConnector: `{metadata_data['dockerRepository']}`\nGCS Bucket: `{bucket_name}`\nPath: `{registry_entry_blob_path}`."
                 send_slack_message(PUBLISH_UPDATE_CHANNEL, message)

--- a/airbyte-ci/connectors/metadata_service/lib/tests/test_registry_entry.py
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/test_registry_entry.py
@@ -173,8 +173,15 @@ def test_generate_and_persist_registry_entry(
 
         # Verify GCS operations were called
         mock_gcs_client.assert_called()
-        mock_safe_read_gcs_file.assert_called_once()
-        mock_get_icon_blob.assert_called_once_with(bucket_name, scenario["metadata_dict"]["data"])
+        # For RC versions, safe_read_gcs_file and _get_icon_blob_from_gcs are called twice
+        # because we generate two sets of metadata: one with version pin for versioned entry,
+        # one without version pin for the release_candidate entry
+        if scenario["version_type"] == "rc":
+            assert mock_safe_read_gcs_file.call_count == 2
+            assert mock_get_icon_blob.call_count == 2
+        else:
+            mock_safe_read_gcs_file.assert_called_once()
+            mock_get_icon_blob.assert_called_once_with(bucket_name, scenario["metadata_dict"]["data"])
 
         # Verify registry entry was persisted
         mock_persist_entry.assert_called()

--- a/airbyte-ci/connectors/metadata_service/lib/tests/test_registry_entry.py
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/test_registry_entry.py
@@ -173,8 +173,15 @@ def test_generate_and_persist_registry_entry(
 
         # Verify GCS operations were called
         mock_gcs_client.assert_called()
-        mock_safe_read_gcs_file.assert_called_once()
-        mock_get_icon_blob.assert_called_once_with(bucket_name, scenario["metadata_dict"]["data"])
+        # For "latest" version type (normal publishes), safe_read_gcs_file and _get_icon_blob_from_gcs
+        # are called twice because we generate two sets of metadata: one for versioned entry (actual
+        # published version), one for latest entry (with version pinning applied).
+        if scenario["version_type"] == "latest":
+            assert mock_safe_read_gcs_file.call_count == 2
+            assert mock_get_icon_blob.call_count == 2
+        else:
+            mock_safe_read_gcs_file.assert_called_once()
+            mock_get_icon_blob.assert_called_once_with(bucket_name, scenario["metadata_dict"]["data"])
 
         # Verify registry entry was persisted
         mock_persist_entry.assert_called()

--- a/airbyte-ci/connectors/metadata_service/lib/tests/test_registry_entry.py
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/test_registry_entry.py
@@ -173,15 +173,8 @@ def test_generate_and_persist_registry_entry(
 
         # Verify GCS operations were called
         mock_gcs_client.assert_called()
-        # For RC versions, safe_read_gcs_file and _get_icon_blob_from_gcs are called twice
-        # because we generate two sets of metadata: one with version pin for versioned entry,
-        # one without version pin for the release_candidate entry
-        if scenario["version_type"] == "rc":
-            assert mock_safe_read_gcs_file.call_count == 2
-            assert mock_get_icon_blob.call_count == 2
-        else:
-            mock_safe_read_gcs_file.assert_called_once()
-            mock_get_icon_blob.assert_called_once_with(bucket_name, scenario["metadata_dict"]["data"])
+        mock_safe_read_gcs_file.assert_called_once()
+        mock_get_icon_blob.assert_called_once_with(bucket_name, scenario["metadata_dict"]["data"])
 
         # Verify registry entry was persisted
         mock_persist_entry.assert_called()


### PR DESCRIPTION
## What

Fixes a bug where registry entries would show a pinned production version instead of the actual version being published. For example, when publishing `1.0.0-rc.1` for a connector with `registryOverrides.cloud.dockerImageTag: "0.0.45"`, the `release_candidate/cloud.json` entry would incorrectly show `dockerImageTag: "0.0.45"` instead of `1.0.0-rc.1`.

The root cause was conflating two concepts:
1. **The version being published** — should determine versioned/RC entry paths and content
2. **The pinned version** — should only affect what `latest/cloud.json` shows

Fixes: https://github.com/airbytehq/airbyte-ops-mcp/issues/329

## How

Added a `skip_docker_image_tag` parameter to `_apply_overrides_from_registry` (default `True`) that controls whether the `dockerImageTag` override is applied:

- **Versioned entries** (e.g., `1.0.0/cloud.json`): Skip override → use actual published version
- **RC entries** (`release_candidate/cloud.json`): Skip override → use actual RC version  
- **Latest entries** (`latest/cloud.json`): Apply override → use pinned version for version pinning behavior

When writing to `latest/`, the code generates metadata with the version pin applied on-demand inside the persist loop.

## Review guide

1. `airbyte-ci/connectors/metadata_service/lib/metadata_service/registry_entry.py`:
   - Lines 110-141: `_apply_overrides_from_registry` now accepts `skip_docker_image_tag` parameter
   - Lines 512-521: Inside the persist loop, generates metadata with version pin for `/latest/` entries

2. `airbyte-ci/connectors/metadata_service/lib/tests/test_registry_entry.py`:
   - Lines 176-184: Updated test expectations for dual metadata generation on normal publishes

## Human Review Checklist

- [ ] Confirm the pinned version's spec will always be available in the spec cache for latest entries
- [ ] Verify other overrides (e.g., `dockerRepository` for strict-encrypt connectors) are unaffected
- [ ] Verify the `/latest/` string check correctly identifies latest entry paths

## User Impact

Registry entries now correctly reflect the actual version being published for versioned and RC entries, while preserving version pinning behavior for `latest/` entries. Previously, connectors with version pins would have all their registry entries (including versioned and release_candidate) incorrectly show the pinned version.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

### Updates since last revision

Simplified the implementation per Matt's feedback:
- Removed `is_normal_publish` check and pre-generation of latest metadata
- Now generates latest metadata on-demand inside the loop when writing to `/latest/`
- Logic is clearer: "when writing to latest/, apply the version pin override"

---

Requested by @aaronsteers (original), updated by Matt Bayley (matt.bayley@airbyte.io)

Link to Devin session (original): https://app.devin.ai/sessions/187c751f05d84009bfccb714f620d89a
Link to Devin session (update): https://app.devin.ai/sessions/67ef5ea26a884dafacdd559f573f0b9a