### PR TITLE
deps(bulk-cdk): set debezium API version to latest 3.4.1

### DIFF
--- a/airbyte-integrations/connectors/source-postgres/build.gradle
+++ b/airbyte-integrations/connectors/source-postgres/build.gradle
@@ -15,6 +15,8 @@ airbyteBulkConnector {
 
 dependencies {
     implementation 'com.azure:azure-identity:1.17.0'
+
+    api platform('io.debezium:debezium-bom:3.4.1.Final')
     // version specified by the debezium bom dependency in the cdc toolkit
     implementation 'io.debezium:debezium-connector-postgres'
     // Use Postgres JDBC driver version specified by Debezium

--- a/airbyte-integrations/connectors/source-postgres/build.gradle
+++ b/airbyte-integrations/connectors/source-postgres/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     implementation 'com.azure:azure-identity:1.17.0'
 
     api platform('io.debezium:debezium-bom:3.4.1.Final')
-    // version specified by the debezium bom dependency in the cdc toolkit
+
     implementation 'io.debezium:debezium-connector-postgres'
     // Use Postgres JDBC driver version specified by Debezium
     implementation 'org.postgresql:postgresql'

--- a/airbyte-integrations/connectors/source-postgres/src/main/kotlin/io/airbyte/integrations/source/postgres/PostgresSourceMetadataQuerier.kt
+++ b/airbyte-integrations/connectors/source-postgres/src/main/kotlin/io/airbyte/integrations/source/postgres/PostgresSourceMetadataQuerier.kt
@@ -27,7 +27,7 @@ class PostgresSourceMetadataQuerier(
     override fun extraChecks() {
         base.extraChecks()
         if (postgresSourceConfig.incrementalConfiguration is XminIncrementalConfiguration) {
-            base.conn.use { conn ->
+            base.conn.use {
                 if (dbNumWraparound(base.conn) > 0) {
                     throw ConfigErrorException(xminWraparoundError)
                 }

--- a/airbyte-integrations/connectors/source-postgres/src/main/kotlin/io/airbyte/integrations/source/postgres/PostgresSourceMetadataQuerier.kt
+++ b/airbyte-integrations/connectors/source-postgres/src/main/kotlin/io/airbyte/integrations/source/postgres/PostgresSourceMetadataQuerier.kt
@@ -27,8 +27,8 @@ class PostgresSourceMetadataQuerier(
     override fun extraChecks() {
         base.extraChecks()
         if (postgresSourceConfig.incrementalConfiguration is XminIncrementalConfiguration) {
-            base.conn.use {
-                if (dbNumWraparound(base.conn) > 0) {
+            base.conn.use { conn ->
+                if (dbNumWraparound(conn) > 0) {
                     throw ConfigErrorException(xminWraparoundError)
                 }
             }

--- a/airbyte-integrations/connectors/source-postgres/src/main/kotlin/io/airbyte/integrations/source/postgres/cdc/PostgresSourceDebeziumOperations.kt
+++ b/airbyte-integrations/connectors/source-postgres/src/main/kotlin/io/airbyte/integrations/source/postgres/cdc/PostgresSourceDebeziumOperations.kt
@@ -77,7 +77,7 @@ class PostgresSourceDebeziumOperations(
             check(stateNode.size() == 1) { "State value has unexpected format: $opaqueStateValue" }
             val offsetMap: Map<JsonNode, JsonNode> =
                 stateNode
-                    .fields()
+                    .properties()
                     .asSequence()
                     .map { (k, v) -> Jsons.readTree(k) to Jsons.readTree(v.textValue()) }
                     .toMap()


### PR DESCRIPTION
Override the API version of debezium in postgres only - set to the latest 3.4.1.Final

This pulls in debezium-connector-postgres ver 3.4.1.Final as well
and org.postgresql:postgresql:42.7.7 
That's the version debezium natively pulled so we don't have a mismatch between pg jdbc driver and debezium libraries.