### PR TITLE
#67619 fix wrong datetime format in paypal connector

### DIFF
--- a/airbyte-integrations/connectors/source-paypal-transaction/manifest.yaml
+++ b/airbyte-integrations/connectors/source-paypal-transaction/manifest.yaml
@@ -290,12 +290,12 @@ definitions:
         type: DatetimeBasedCursor
         cursor_field: updated_time_cut
         cursor_datetime_formats:
-          - "%Y-%m-%dT%H:%M:%S.%fZ"
-        datetime_format: "%Y-%m-%dT%H:%M:%S.%fZ"
+          - "%Y-%m-%dT%H:%M:%SZ"
+        datetime_format: "%Y-%m-%dT%H:%M:%SZ"
         start_datetime:
           type: MinMaxDatetime
-          datetime: "{{ format_datetime(config.get('dispute_start_date') if config.get('dispute_start_date') and day_delta(-180) <= config.get('dispute_start_date') else day_delta(-180), '%Y-%m-%dT%H:%M:%S.%fZ')[:23] + 'Z' }}"
-          datetime_format: "%Y-%m-%dT%H:%M:%S.%fZ"
+          datetime: "{{ format_datetime(config.get('dispute_start_date') if config.get('dispute_start_date') and day_delta(-180) <= config.get('dispute_start_date') else day_delta(-180), '%Y-%m-%dT%H:%M:%SZ') }}"
+          datetime_format: "%Y-%m-%dT%H:%M:%SZ"
         start_time_option:
           type: RequestOption
           field_name: update_time_after
@@ -306,8 +306,8 @@ definitions:
           inject_into: request_parameter
         end_datetime:
           type: MinMaxDatetime
-          datetime: "{{ format_datetime(config.get('dispute_end_date') if config.get('dispute_end_date') and day_delta(-180) <= config.get('dispute_end_date') else (now_utc() - duration('PT30M')), '%Y-%m-%dT%H:%M:%S.%fZ')[:23] + 'Z' }}"
-          datetime_format: "%Y-%m-%dT%H:%M:%S.%fZ"
+          datetime: "{{ format_datetime(config.get('dispute_end_date') if config.get('dispute_end_date') and day_delta(-180) <= config.get('dispute_end_date') else (now_utc() - duration('PT30M')), '%Y-%m-%dT%H:%M:%SZ') }}"
+          datetime_format: "%Y-%m-%dT%H:%M:%SZ"
         step: P{{ config.get('time_window', 7) }}D
         cursor_granularity: PT1S
       transformations:


### PR DESCRIPTION
Fixes airbytehq/airbyte#67619

## What
Syncing disputes from PayPal results in a 400 Bad Request, as reported in https://github.com/airbytehq/airbyte/issues/67619.
The error logs already show that the issue is due to a wrong datetime format send for the field `update_time_after`.

PayPal expects the datetime to be send in the format `yyyy-MM-ddTHH:mm:ss.SSSZ`, with 3 digits for the milliseconds, but `%fZ` in python results in 6 digits (`yyyy-MM-ddTHH:mm:ss.SSSSSSZ`).
While this is properly handled for the initial `start_datetime` and `end_datetime`, all consecutive requests aren't.


Log:
```
'GET' request to 'https://api-m.paypal.com/v1/customer/disputes?page_size=50&update_time_after=2025-04-13T21%3A28%3A20.828000Z&update_time_before=2025-04-20T21%3A28%3A19.828000Z' failed with status code '400' and error message: 'Request is not well-formed, syntactically incorrect, or violates schema.'. Request (body): 'None'. Response (body): '{'name': 'INVALID_REQUEST', 'message': 'Request is not well-formed, syntactically incorrect, or violates schema.', 'debug_id': '9e61746f584dc', 'information_link': 'https://developer.paypal.com/docs/api/customer-disputes/v1/#errors', 'details': [{'field': 'update_time_before', 'value': '2025-04-20T21:28:19.828000.000Z', 'location': 'query', 'issue': 'INVALID_DATE_TIME_FORMAT'}, {'field': 'update_time_after', 'value': '2025-04-13T21:28:20.828000.000Z', 'location': 'query', 'issue': 'INVALID_DATE_TIME_FORMAT'}], 'links': []}'. Response (headers): '{'Connection': 'keep-alive', 'Content-Length': '502', 'access-control-expose-headers': 'Server-Timing', 'set-cookie': 'l7_az=ccg13.slc; Path=/; Domain=paypal.com; Expires=Fri, 10 Oct 2025 21:58:21 GMT; HttpOnly; Secure', 'server-timing': 'traceparent;desc="00-00000000000000000009e61746f584dc-ebfb8379df7a250e-01"', 'content-type': 'application/json', 'cache-control': 'max-age=0, no-cache, no-store, must-revalidate', 'paypal-debug-id': '9e61746f584dc', 'Edge-Control': 'max-age=0', 'Accept-Ranges': 'bytes', 'Date': 'Fri, 10 Oct 2025 21:28:21 GMT', 'Via': '1.1 varnish', 'Strict-Transport-Security': 'max-age=63072000; includeSubDomains; preload', 'X-Served-By': 'cache-iad-kcgs7200040-IAD, cache-iad-kcgs7200104-IAD', 'X-Cache': 'MISS, MISS', 'X-Cache-Hits': '0, 0', 'X-Timer': 'S1760131702.534205,VS0,VE139', 'Vary': 'Accept-Encoding'}'.
```

## How
Removing the milliseconds part should resolve the wrong datetime format and is consistent with all other requests within the PayPal connector.

## User Impact

PayPal disputes can be synced again.

A tradeoff might be that duplications are ingested, due to the cutoff of the milliseconds part, which are handled either by choosing one of the Airbyte deduplication strategies or in a follow-up processing step (e.g., clean layer in a data pipeline).

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

⚠️ It wasn't possible for me to test the changes due to the PayPal connector relying on custom code that can't be executed in my cloud instance.