### PR TITLE
fix(source-facebook-pages): show actual error message on 400 status code

### DIFF
--- a/airbyte-integrations/connectors/source-facebook-pages/source_facebook_pages/manifest.yaml
+++ b/airbyte-integrations/connectors/source-facebook-pages/source_facebook_pages/manifest.yaml
@@ -20,7 +20,8 @@ definitions:
           error_message_contains: Tried accessing nonexisting field
           error_message: Request contains invalid/deprecated field.
         - http_codes: [400]
-          action: RETRY
+          action: FAIL
+          error_message: "Bad request: {{ response.get('error', {}).get('message', response) }}"
     authenticator:
       type: CustomAuthenticator
       class_name: source_facebook_pages.components.AuthenticatorFacebookPageAccessToken

--- a/airbyte-integrations/connectors/source-facebook-pages/unit_tests/test_streams.py
+++ b/airbyte-integrations/connectors/source-facebook-pages/unit_tests/test_streams.py
@@ -8,7 +8,7 @@ from source_facebook_pages.source import SourceFacebookPages
 from airbyte_cdk.sources.streams.http.http_client import MessageRepresentationAirbyteTracedErrors
 
 
-@pytest.mark.parametrize("error_code", (400, 429, 500))
+@pytest.mark.parametrize("error_code", (429, 500))
 def test_retries(mocker, requests_mock, error_code):
     mocker.patch("time.sleep")
     requests_mock.get("https://graph.facebook.com/1?fields=access_token&access_token=token", json={"access_token": "access"})
@@ -18,6 +18,19 @@ def test_retries(mocker, requests_mock, error_code):
     for slice_ in stream.stream_slices(sync_mode="full_refresh"):
         list(stream.read_records(sync_mode="full_refresh", stream_slice=slice_))
     assert requests_mock.call_count >= 3
+
+
+def test_400_fails_with_error_message(requests_mock):
+    """Test that 400 errors fail immediately with the actual error message from the response."""
+    requests_mock.get("https://graph.facebook.com/1?fields=access_token&access_token=token", json={"access_token": "access"})
+    requests_mock.get("https://graph.facebook.com/v24.0/1", status_code=400, json={"error": {"message": "Some API error"}})
+    source = SourceFacebookPages()
+    stream = source.streams({"page_id": 1, "access_token": "token"})[0]
+    with pytest.raises(MessageRepresentationAirbyteTracedErrors) as err:
+        for slice_ in stream.stream_slices(sync_mode="full_refresh"):
+            list(stream.read_records(sync_mode="full_refresh", stream_slice=slice_))
+
+    assert "Bad request: Some API error" in str(err.value)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What
Previously, when the Facebook Pages connector received a 400 status code, it would retry the request and eventually show a generic error message: "Bad request. Please check your request parameters." This made debugging difficult as users couldn't see the actual error from the Facebook API.

## How
Changed the error handler for 400 status codes in the manifest from `RETRY` to `FAIL`, and added an interpolated error message that extracts the actual error from the Facebook API response.

The error message uses Jinja2 interpolation to access `response.get('error', {}).get('message', response)`, which:
- Extracts the `message` field from Facebook's standard error response structure
- Falls back to showing the entire response if the expected structure isn't present

## Review guide
1. `airbyte-integrations/connectors/source-facebook-pages/source_facebook_pages/manifest.yaml` - Changed error handler for 400 from RETRY to FAIL with interpolated error message
2. `airbyte-integrations/connectors/source-facebook-pages/unit_tests/test_streams.py` - Updated tests: removed 400 from retry test (since it now fails immediately) and added new test to verify the error message extraction

Key things to verify:
- The Jinja2 interpolation syntax is correct for the CDK's `error_message` field
- Changing from RETRY to FAIL is appropriate for 400 errors (client errors typically don't resolve with retries)
- The new test `test_400_fails_with_error_message` correctly validates the expected behavior

## User Impact
Users will now see the actual Facebook API error message when a 400 error occurs, making it easier to diagnose and fix configuration or request issues.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚

---
Requested by: Daryna Ishchenko (@darynaishchenko)
Link to Devin run: https://app.devin.ai/sessions/db1d7f0c50c64b058b62ebd3a7f51e98