### PR TITLE
chore(destination-gcs-data-lake): update to latest CDK

### DIFF
--- a/airbyte-integrations/connectors/destination-gcs-data-lake/gradle.properties
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/gradle.properties
@@ -1,3 +1,3 @@
 testExecutionConcurrency=1
-cdkVersion=local
+cdkVersion=0.2.8
 JunitMethodExecutionTimeout=10m

--- a/airbyte-integrations/connectors/destination-gcs-data-lake/gradle.properties
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/gradle.properties
@@ -1,3 +1,3 @@
 testExecutionConcurrency=1
-cdkVersion=0.2.0
+cdkVersion=local
 JunitMethodExecutionTimeout=10m

--- a/airbyte-integrations/connectors/destination-gcs-data-lake/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/metadata.yaml
@@ -21,7 +21,7 @@ data:
             alias: airbyte-connector-testing-secret-store
   connectorType: destination
   definitionId: 8c8a2d3e-1b4f-4a9c-9e7d-6f5a4b3c2d1e
-  dockerImageTag: 1.0.6
+  dockerImageTag: 1.0.7
   dockerRepository: airbyte/destination-gcs-data-lake
   documentationUrl: https://docs.airbyte.com/integrations/destinations/gcs-data-lake
   githubIssueLabel: destination-gcs-data-lake

--- a/airbyte-integrations/connectors/destination-gcs-data-lake/src/main/kotlin/io/airbyte/integrations/destination/gcs_data_lake/GcsDataLakeBeanFactory.kt
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/src/main/kotlin/io/airbyte/integrations/destination/gcs_data_lake/GcsDataLakeBeanFactory.kt
@@ -6,8 +6,8 @@ package io.airbyte.integrations.destination.gcs_data_lake
 
 import io.airbyte.cdk.load.command.Dedupe
 import io.airbyte.cdk.load.command.DestinationCatalog
-import io.airbyte.cdk.load.dataflow.config.AggregatePublishingConfig
-import io.airbyte.cdk.load.dataflow.config.DataFlowSocketConfig
+import io.airbyte.cdk.load.dataflow.config.model.AggregatePublishingConfig
+import io.airbyte.cdk.load.dataflow.config.model.DataFlowSocketConfig
 import io.airbyte.cdk.load.table.DefaultTempTableNameGenerator
 import io.airbyte.cdk.load.table.TempTableNameGenerator
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -47,7 +47,7 @@ class GcsDataLakeBeanFactory {
     @Singleton
     @Requires(notEnv = [Environment.TEST])
     fun dataFlowSocketConfig(catalog: DestinationCatalog): DataFlowSocketConfig {
-        val hasDedupStreams = catalog.streams.any { it.importType is Dedupe }
+        val hasDedupStreams = catalog.streams.any { it.tableSchema.importType is Dedupe }
         return if (hasDedupStreams) {
             log.info { "Dedup streams detected, limiting to 1 socket for data consistency" }
             object : DataFlowSocketConfig {

--- a/airbyte-integrations/connectors/destination-gcs-data-lake/src/main/kotlin/io/airbyte/integrations/destination/gcs_data_lake/GcsDataLakeBeanFactory.kt
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/src/main/kotlin/io/airbyte/integrations/destination/gcs_data_lake/GcsDataLakeBeanFactory.kt
@@ -8,6 +8,7 @@ import io.airbyte.cdk.load.command.Dedupe
 import io.airbyte.cdk.load.command.DestinationCatalog
 import io.airbyte.cdk.load.dataflow.config.model.AggregatePublishingConfig
 import io.airbyte.cdk.load.dataflow.config.model.DataFlowSocketConfig
+import io.airbyte.cdk.load.dataflow.config.model.MediumConverterConfig
 import io.airbyte.cdk.load.table.DefaultTempTableNameGenerator
 import io.airbyte.cdk.load.table.TempTableNameGenerator
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -37,6 +38,13 @@ class GcsDataLakeBeanFactory {
     // from being loaded. So this is necessary for now.
     @Singleton
     fun tempTableNameGenerator(): TempTableNameGenerator = DefaultTempTableNameGenerator()
+
+    /** Iceberg has specific timestamp requirements */
+    @Singleton
+    fun mediumConverterConfig() =
+        MediumConverterConfig(
+            extractedAtAsTimestampWithTimezone = false,
+        )
 
     /**
      * Socket configuration for GCS Data Lake destination.

--- a/airbyte-integrations/connectors/destination-gcs-data-lake/src/main/kotlin/io/airbyte/integrations/destination/gcs_data_lake/dataflow/GcsDataLakeAggregate.kt
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/src/main/kotlin/io/airbyte/integrations/destination/gcs_data_lake/dataflow/GcsDataLakeAggregate.kt
@@ -44,7 +44,7 @@ class GcsDataLakeAggregate(
     }
 
     private val operationType =
-        if (stream.importType is Dedupe) {
+        if (stream.tableSchema.importType is Dedupe) {
             Operation.UPDATE
         } else {
             Operation.INSERT

--- a/airbyte-integrations/connectors/destination-gcs-data-lake/src/main/kotlin/io/airbyte/integrations/destination/gcs_data_lake/dataflow/GcsDataLakeAggregate.kt
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/src/main/kotlin/io/airbyte/integrations/destination/gcs_data_lake/dataflow/GcsDataLakeAggregate.kt
@@ -8,11 +8,8 @@ import io.airbyte.cdk.load.command.Dedupe
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.data.AirbyteValue
 import io.airbyte.cdk.load.data.ArrayValue
-import io.airbyte.cdk.load.data.IntegerValue
 import io.airbyte.cdk.load.data.ObjectValue
 import io.airbyte.cdk.load.data.StringValue
-import io.airbyte.cdk.load.data.TimestampWithTimezoneValue
-import io.airbyte.cdk.load.data.TimestampWithoutTimezoneValue
 import io.airbyte.cdk.load.data.iceberg.parquet.AirbyteValueToIcebergRecord
 import io.airbyte.cdk.load.dataflow.aggregate.Aggregate
 import io.airbyte.cdk.load.dataflow.transform.RecordDTO
@@ -20,8 +17,6 @@ import io.airbyte.cdk.load.toolkits.iceberg.parquet.io.Operation
 import io.airbyte.cdk.load.toolkits.iceberg.parquet.io.RecordWrapper
 import io.airbyte.cdk.load.util.serializeToString
 import io.github.oshai.kotlinlogging.KotlinLogging
-import java.math.BigInteger
-import java.time.ZoneOffset
 import org.apache.iceberg.Schema
 import org.apache.iceberg.Table
 import org.apache.iceberg.data.GenericRecord
@@ -55,8 +50,6 @@ class GcsDataLakeAggregate(
     private val schemaFields = schema.asStruct().fields()
 
     // Pre-compute which fields need special transformations to avoid repeated type checks
-    private val longFields =
-        schemaFields.filter { it.type().typeId() == Type.TypeID.LONG }.map { it.name() }.toSet()
     private val stringFields =
         schemaFields.filter { it.type().typeId() == Type.TypeID.STRING }.map { it.name() }.toSet()
 
@@ -98,19 +91,6 @@ class GcsDataLakeAggregate(
         val fieldName = field.name()
 
         return when {
-            // Timestamp → Integer for LONG fields (_airbyte_extracted_at)
-            // Use cached set lookup instead of repeated typeId() calls
-            fieldName in longFields &&
-                (value is TimestampWithTimezoneValue || value is TimestampWithoutTimezoneValue) -> {
-                val millis =
-                    when (value) {
-                        is TimestampWithTimezoneValue -> value.value.toInstant().toEpochMilli()
-                        is TimestampWithoutTimezoneValue ->
-                            value.value.atOffset(ZoneOffset.UTC).toInstant().toEpochMilli()
-                        else -> 0L
-                    }
-                IntegerValue(BigInteger.valueOf(millis))
-            }
             // Object/Array → String for STRING fields (for stringifySchemalessObjects behavior)
             // Note: Union values are already stringified by ValueCoercer
             // Use cached set lookup instead of repeated typeId() calls

--- a/airbyte-integrations/connectors/destination-gcs-data-lake/src/main/kotlin/io/airbyte/integrations/destination/gcs_data_lake/dataflow/GcsDataLakeAggregateFactory.kt
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/src/main/kotlin/io/airbyte/integrations/destination/gcs_data_lake/dataflow/GcsDataLakeAggregateFactory.kt
@@ -32,7 +32,7 @@ class GcsDataLakeAggregateFactory(
             icebergTableWriterFactory.create(
                 table = state.table,
                 generationId = icebergUtil.constructGenerationIdSuffix(stream),
-                importType = stream.importType,
+                importType = stream.tableSchema.importType,
                 schema = state.schema
             )
 

--- a/airbyte-integrations/connectors/destination-gcs-data-lake/src/main/kotlin/io/airbyte/integrations/destination/gcs_data_lake/write/GcsDataLakeStreamLoader.kt
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/src/main/kotlin/io/airbyte/integrations/destination/gcs_data_lake/write/GcsDataLakeStreamLoader.kt
@@ -124,7 +124,7 @@ class GcsDataLakeStreamLoader(
         // Reconcile identifier fields after BigLake creates the table
         // BigLake reassigns field IDs, so we need to update the schema with the correct field names
         val primaryKeyNames =
-            when (val importType = stream.importType) {
+            when (val importType = stream.tableSchema.importType) {
                 is Dedupe -> {
                     importType.primaryKey.flatten().map { originalName ->
                         if (Meta.COLUMN_NAMES.contains(originalName)) {

--- a/airbyte-integrations/connectors/destination-gcs-data-lake/src/test-integration/kotlin/io/airbyte/integrations/destination/gcs_data_lake/BigLakeDataDumper.kt
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/src/test-integration/kotlin/io/airbyte/integrations/destination/gcs_data_lake/BigLakeDataDumper.kt
@@ -6,7 +6,6 @@ package io.airbyte.integrations.destination.gcs_data_lake
 
 import io.airbyte.cdk.command.ConfigurationSpecification
 import io.airbyte.cdk.load.command.DestinationStream
-import io.airbyte.cdk.load.data.ObjectType
 import io.airbyte.cdk.load.data.ObjectValue
 import io.airbyte.cdk.load.data.Transformations
 import io.airbyte.cdk.load.test.util.DestinationDataDumper
@@ -55,9 +54,9 @@ class BigLakeDataDumper(
     private fun buildReverseMapping(stream: DestinationStream): Map<String, String> {
         val mapping = mutableMapOf<String, String>()
 
-        val schema = stream.schema as? ObjectType ?: return mapping
+        val inputSchema = stream.tableSchema.columnSchema.inputSchema
 
-        schema.properties.keys.forEach { originalName ->
+        inputSchema.keys.forEach { originalName ->
             val sanitized = Transformations.toAlphanumericAndUnderscore(originalName)
             mapping[sanitized] = originalName
         }

--- a/airbyte-integrations/connectors/destination-gcs-data-lake/src/test-integration/kotlin/io/airbyte/integrations/destination/gcs_data_lake/GcsDataLakeWriteTest.kt
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/src/test-integration/kotlin/io/airbyte/integrations/destination/gcs_data_lake/GcsDataLakeWriteTest.kt
@@ -97,13 +97,11 @@ class BigLakeWriteTest :
             DestinationStream(
                 unmappedNamespace = randomizedNamespace + namespaceSuffix,
                 unmappedName = name,
-                Append,
-                ObjectType(linkedMapOf("id" to intType)),
                 generationId = 0,
                 minimumGenerationId = 0,
                 syncId = 42,
                 namespaceMapper = NamespaceMapper(),
-                tableSchema = emptyTableSchema
+                tableSchema = makeTableSchema(ObjectType(linkedMapOf("id" to intType)), Append),
             )
         // Glue downcases stream IDs, and also coerces to alphanumeric+underscore.
         // So these two streams will collide.
@@ -141,13 +139,11 @@ class BigLakeWriteTest :
             DestinationStream(
                 unmappedNamespace = randomizedNamespace,
                 unmappedName = "test_stream",
-                Append,
-                ObjectType(schema),
                 generationId = 0,
                 minimumGenerationId = 0,
-                syncId,
+                syncId = syncId,
                 namespaceMapper = NamespaceMapper(),
-                tableSchema = emptyTableSchema
+                tableSchema = makeTableSchema(ObjectType(schema), Append),
             )
         val firstStream =
             makeStream(

--- a/airbyte-integrations/connectors/destination-gcs-data-lake/src/test-integration/kotlin/io/airbyte/integrations/destination/gcs_data_lake/GcsPolarisWriteTest.kt
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/src/test-integration/kotlin/io/airbyte/integrations/destination/gcs_data_lake/GcsPolarisWriteTest.kt
@@ -70,13 +70,11 @@ class GcsPolarisWriteTest :
             DestinationStream(
                 unmappedNamespace = randomizedNamespace,
                 unmappedName = "test_stream",
-                Append,
-                ObjectType(schema),
                 generationId = 0,
                 minimumGenerationId = 0,
-                syncId,
+                syncId = syncId,
                 namespaceMapper = NamespaceMapper(),
-                tableSchema = emptyTableSchema
+                tableSchema = makeTableSchema(ObjectType(schema), Append),
             )
         val firstStream =
             makeStream(

--- a/docs/integrations/destinations/gcs-data-lake.md
+++ b/docs/integrations/destinations/gcs-data-lake.md
@@ -204,7 +204,7 @@ If compaction runs simultaneously with the sync, it would delete files from the 
 
 | Version | Date       | Pull Request                                                 | Subject                                                                               |
 |:--------|:-----------|:-------------------------------------------------------------|:--------------------------------------------------------------------------------------|
-| 1.0.6   | 2026-02-04 | [72855](https://github.com/airbytehq/airbyte/pull/72855)     | Upgrade CDK to 0.2.8                                                                  |
+| 1.0.7   | 2026-02-04 | [72855](https://github.com/airbytehq/airbyte/pull/72855)     | Upgrade CDK to 0.2.8                                                                  |
 | 1.0.6   | 2026-01-23 | [72300](https://github.com/airbytehq/airbyte/pull/72300)     | Upgrade CDK to 0.2.0                                                                  |
 | 1.0.5   | 2026-01-14 | [71760](https://github.com/airbytehq/airbyte/pull/71760)     | Restore integration tests in CI. Workaround DI error.                                 |
 | 1.0.4   | 2026-01-12 | [71227](https://github.com/airbytehq/airbyte/pull/71227)     | Add speed mode support with PROTOBUF serialization                                    |

--- a/docs/integrations/destinations/gcs-data-lake.md
+++ b/docs/integrations/destinations/gcs-data-lake.md
@@ -204,7 +204,7 @@ If compaction runs simultaneously with the sync, it would delete files from the 
 
 | Version | Date       | Pull Request                                                 | Subject                                                                               |
 |:--------|:-----------|:-------------------------------------------------------------|:--------------------------------------------------------------------------------------|
-| 1.0.6   | 2026-02-04 | [72300](https://github.com/airbytehq/airbyte/pull/72300)     | Upgrade CDK to 0.2.8                                                                  |
+| 1.0.6   | 2026-02-04 | [72855](https://github.com/airbytehq/airbyte/pull/72855)     | Upgrade CDK to 0.2.8                                                                  |
 | 1.0.6   | 2026-01-23 | [72300](https://github.com/airbytehq/airbyte/pull/72300)     | Upgrade CDK to 0.2.0                                                                  |
 | 1.0.5   | 2026-01-14 | [71760](https://github.com/airbytehq/airbyte/pull/71760)     | Restore integration tests in CI. Workaround DI error.                                 |
 | 1.0.4   | 2026-01-12 | [71227](https://github.com/airbytehq/airbyte/pull/71227)     | Add speed mode support with PROTOBUF serialization                                    |

--- a/docs/integrations/destinations/gcs-data-lake.md
+++ b/docs/integrations/destinations/gcs-data-lake.md
@@ -204,6 +204,7 @@ If compaction runs simultaneously with the sync, it would delete files from the 
 
 | Version | Date       | Pull Request                                                 | Subject                                                                               |
 |:--------|:-----------|:-------------------------------------------------------------|:--------------------------------------------------------------------------------------|
+| 1.0.6   | 2026-02-04 | [72300](https://github.com/airbytehq/airbyte/pull/72300)     | Upgrade CDK to 0.2.8                                                                  |
 | 1.0.6   | 2026-01-23 | [72300](https://github.com/airbytehq/airbyte/pull/72300)     | Upgrade CDK to 0.2.0                                                                  |
 | 1.0.5   | 2026-01-14 | [71760](https://github.com/airbytehq/airbyte/pull/71760)     | Restore integration tests in CI. Workaround DI error.                                 |
 | 1.0.4   | 2026-01-12 | [71227](https://github.com/airbytehq/airbyte/pull/71227)     | Add speed mode support with PROTOBUF serialization                                    |


### PR DESCRIPTION
## What
Update gcs data lake to latest CDK

## How
 - Add MediumConverterConfig bean with extractedAtAsTimestampWithTimezone=false                                                                                                          
  - Remove timestamp→integer workaround from GcsDataLakeAggregate                                                                                                                         
  - Remove unused imports (IntegerValue, TimestampWithTimezoneValue, etc.)  