### PR TITLE
[DO NOT MERGE] Source-MySQL (CDK): Default to 300s heartbeat timeout when not configured 

### DIFF
--- a/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/CdcPartitionReader.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/CdcPartitionReader.kt
@@ -173,6 +173,12 @@ class CdcPartitionReader<T : Comparable<T>>(
                     duration.seconds > 0
                 }
             }
+                ?: run {
+                    log.info {
+                        "$AIRBYTE_HEARTBEAT_TIMEOUT_SECONDS not configured for watchdog, defaulting to 300 seconds"
+                    }
+                    Duration.ofSeconds(300)
+                }
         if (timeoutDuration != null) {
             watchdogShouldStop = false
             lastEventTime.set(LocalDateTime.now())

--- a/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/CdcPartitionReader.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/CdcPartitionReader.kt
@@ -282,6 +282,12 @@ class CdcPartitionReader<T : Comparable<T>>(
                     duration.seconds > 0
                 }
             }
+                ?: run {
+                    log.info {
+                        "$AIRBYTE_HEARTBEAT_TIMEOUT_SECONDS not configured, defaulting to 300 seconds"
+                    }
+                    Duration.ofSeconds(300)
+                }
 
         override fun accept(changeEvent: ChangeEvent<String?, String?>) {
             // Stop watchdog once we receive any event - connection is working
@@ -419,6 +425,10 @@ class CdcPartitionReader<T : Comparable<T>>(
                     lastHeartbeatTime = now
                     log.info { "Heartbeat progressing to position: $currentPosition" }
                 } else {
+                    // testing
+                    log.info {
+                        "No progress since last heartbeat position found for $currentPosition"
+                    }
                     val timeSinceLastProgress = Duration.between(lastHeartbeatTime!!, now)
                     if (timeSinceLastProgress > heartbeatTimeoutDuration) {
                         log.info {
@@ -428,7 +438,8 @@ class CdcPartitionReader<T : Comparable<T>>(
                         return CloseReason.HEARTBEAT_NOT_PROGRESSING
                     }
                     log.info {
-                        "Heartbeat not progressing, time since last progress: ${timeSinceLastProgress.toSeconds()}s"
+                        "Heartbeat not progressing, time since last progress: ${timeSinceLastProgress.toSeconds()}s, " +
+                            "timeout in: ${(heartbeatTimeoutDuration.seconds - timeSinceLastProgress.toSeconds())}s"
                     }
                 }
             }

--- a/airbyte-integrations/connectors/source-mysql/gradle.properties
+++ b/airbyte-integrations/connectors/source-mysql/gradle.properties
@@ -1,3 +1,3 @@
 testExecutionConcurrency=1
 JunitMethodExecutionTimeout=5m
-cdkVersion=0.1.77
+cdkVersion=local


### PR DESCRIPTION
## What
Fixes [11155](https://github.com/airbytehq/oncall/issues/11155)

MySQL source connector doesn't have `AIRBYTE_HEARTBEAT_TIMEOUT_SECONDS` configured in its source spec (unlike MSSQL and Postgres). The `CdcPartitionReader` implementation didn't handle this case, causing `heartbeatTimeoutDuration` to be null. This caused the timeout check to be skipped entirely, allowing Debezium to hang indefinitely when the LSN position doesn't advance (e.g., when data is written in a single large transaction).

## How
- `CdcPartitionReader.kt`: Added a fallback to 300 seconds when `AIRBYTE_HEARTBEAT_TIMEOUT_SECONDS` is not configured
- This is an MVP fix to unblock customers while we work on adding the `Initial Waiting Time` configuration to the MySQL source spec (matching MSSQL/Postgres behavior)

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
