### PR TITLE
feat(source-slack): add files stream using Slack files.list API

### DIFF
--- a/airbyte-integrations/connectors/source-slack/manifest.yaml
+++ b/airbyte-integrations/connectors/source-slack/manifest.yaml
@@ -369,12 +369,68 @@ definitions:
       schema:
         $ref: "#/schemas/threads"
 
+  files_stream:
+    primary_key: "id"
+    $parameters:
+      name: files
+      path: files.list
+      extractor_field_path: files
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        $ref: "#/schemas/files"
+    retriever:
+      type: SimpleRetriever
+      requester:
+        $ref: "#/definitions/requester"
+      record_selector:
+        $ref: "#/definitions/selector"
+      paginator:
+        type: DefaultPaginator
+        page_token_option:
+          type: RequestOption
+          inject_into: request_parameter
+          field_name: page
+        page_size_option:
+          type: RequestOption
+          field_name: count
+          inject_into: request_parameter
+        pagination_strategy:
+          type: PageIncrement
+          page_size: 100
+          start_from_page: 1
+    incremental_sync:
+      type: DatetimeBasedCursor
+      cursor_field: created
+      cursor_datetime_formats:
+        - "%s"
+      datetime_format: "%s"
+      start_datetime:
+        type: MinMaxDatetime
+        datetime: "{{ config['start_date'] }}"
+        datetime_format: "%Y-%m-%dT%H:%M:%SZ"
+      start_time_option:
+        inject_into: request_parameter
+        field_name: ts_from
+        type: RequestOption
+      end_time_option:
+        inject_into: request_parameter
+        field_name: ts_to
+        type: RequestOption
+      end_datetime:
+        type: MinMaxDatetime
+        datetime: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"
+        datetime_format: "%Y-%m-%dT%H:%M:%SZ"
+      step: P30D
+      cursor_granularity: PT1S
+
 streams:
   - "#/definitions/users_stream"
   - "#/definitions/channels_stream"
   - "#/definitions/channel_members_stream"
   - "#/definitions/channel_messages_stream"
   - "#/definitions/threads_stream"
+  - "#/definitions/files_stream"
 
 check:
   type: CheckStream
@@ -1431,3 +1487,175 @@ schemas:
         type:
           - "null"
           - boolean
+
+  files:
+    $schema: http://json-schema.org/draft-07/schema#
+    additionalProperties: true
+    type: object
+    properties:
+      id:
+        description: The unique identifier of the file.
+        type: string
+      created:
+        description: Unix timestamp representing when the file was created.
+        type:
+          - "null"
+          - integer
+      timestamp:
+        description: A deprecated property provided for backwards compatibility.
+        type:
+          - "null"
+          - integer
+      name:
+        description: Name of the file.
+        type:
+          - "null"
+          - string
+      title:
+        description: Title of the file.
+        type:
+          - "null"
+          - string
+      mimetype:
+        description: The MIME type of the file.
+        type:
+          - "null"
+          - string
+      filetype:
+        description: The type identifier of the file.
+        type:
+          - "null"
+          - string
+      pretty_type:
+        description: A human-readable version of the file type.
+        type:
+          - "null"
+          - string
+      user:
+        description: The ID of the user who created the file.
+        type:
+          - "null"
+          - string
+      user_team:
+        description: The team ID of the user who created the file.
+        type:
+          - "null"
+          - string
+      editable:
+        description: Indicates whether the file is stored in editable mode.
+        type:
+          - "null"
+          - boolean
+      size:
+        description: The filesize in bytes.
+        type:
+          - "null"
+          - integer
+      mode:
+        description: One of hosted, external, snippet, or post.
+        type:
+          - "null"
+          - string
+      is_external:
+        description: Indicates whether the master copy is stored externally.
+        type:
+          - "null"
+          - boolean
+      external_type:
+        description: The kind of external file (e.g., dropbox, gdoc).
+        type:
+          - "null"
+          - string
+      is_public:
+        description: Whether the file is public.
+        type:
+          - "null"
+          - boolean
+      public_url_shared:
+        description: Whether the public URL of the file has been shared.
+        type:
+          - "null"
+          - boolean
+      display_as_bot:
+        description: Whether the file is displayed as coming from a bot.
+        type:
+          - "null"
+          - boolean
+      username:
+        description: Username of the file creator.
+        type:
+          - "null"
+          - string
+      url_private:
+        description: URL to the file contents (requires authentication).
+        type:
+          - "null"
+          - string
+      url_private_download:
+        description: URL to force browser download of the file (requires authentication).
+        type:
+          - "null"
+          - string
+      permalink:
+        description: Permanent link to the file.
+        type:
+          - "null"
+          - string
+      permalink_public:
+        description: Public permanent link to the file.
+        type:
+          - "null"
+          - string
+      comments_count:
+        description: Number of comments on the file.
+        type:
+          - "null"
+          - integer
+      is_starred:
+        description: Whether the calling user has starred the file.
+        type:
+          - "null"
+          - boolean
+      shares:
+        description: Information about channels and conversations where the file is shared.
+        type:
+          - "null"
+          - object
+        additionalProperties: true
+      channels:
+        description: IDs of channels where the file is currently shared.
+        type:
+          - "null"
+          - array
+        items:
+          type:
+            - "null"
+            - string
+      groups:
+        description: IDs of private groups where the file is currently shared.
+        type:
+          - "null"
+          - array
+        items:
+          type:
+            - "null"
+            - string
+      ims:
+        description: IDs of direct message channels where the file is currently shared.
+        type:
+          - "null"
+          - array
+        items:
+          type:
+            - "null"
+            - string
+      has_rich_preview:
+        description: Whether the file has a rich preview.
+        type:
+          - "null"
+          - boolean
+      updated:
+        description: Unix timestamp of when the file was last updated.
+        type:
+          - "null"
+          - integer

--- a/airbyte-integrations/connectors/source-slack/metadata.yaml
+++ b/airbyte-integrations/connectors/source-slack/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: c2281cee-86f9-4a86-bb48-d23286b4c7bd
-  dockerImageTag: 3.1.7
+  dockerImageTag: 3.2.0
   dockerRepository: airbyte/source-slack
   documentationUrl: https://docs.airbyte.com/integrations/sources/slack
   externalDocumentationUrls:

--- a/airbyte-integrations/connectors/source-slack/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-slack/unit_tests/test_source.py
@@ -24,7 +24,7 @@ def test_streams(conversations_list, config, is_valid):
     source = get_source(config)
     if is_valid:
         streams = source.streams(config)
-        assert len(streams) == 5
+        assert len(streams) == 6
     else:
         with pytest.raises(Exception) as exc_info:
             _ = source.streams(config)

--- a/docs/integrations/sources/slack.md
+++ b/docs/integrations/sources/slack.md
@@ -183,6 +183,7 @@ These two streams are effectively limited to **one request per minute**. Conside
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:-----------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 3.2.0 | 2026-02-05 | [72894](https://github.com/airbytehq/airbyte/pull/72894) | Add new `files` stream using Slack `files.list` API |
 | 3.1.7 | 2025-10-29 | [68772](https://github.com/airbytehq/airbyte/pull/68772) | Update dependencies |
 | 3.1.6 | 2025-10-21 | [68282](https://github.com/airbytehq/airbyte/pull/68282) | Update dependencies |
 | 3.1.5 | 2025-10-14 | [67767](https://github.com/airbytehq/airbyte/pull/67767) | Update dependencies |


### PR DESCRIPTION
## What
Adds a new `files` stream to the Slack source connector, backed by the [`files.list`](https://api.slack.com/methods/files.list) Slack API endpoint. This stream was not previously available in the connector.

## How
- Added `files_stream` definition in `manifest.yaml` using declarative low-code CDK
- Uses `PageIncrement` pagination (page/count parameters) since `files.list` uses traditional page-based pagination, unlike the other streams which use cursor-based pagination
- Supports incremental sync via `DatetimeBasedCursor` on the `created` field, using Slack's `ts_from`/`ts_to` request parameters
- Uses 30-day date windowing (`step: P30D`) to work around Slack's hard 100-page limit on `files.list` (max 10,000 files per window at page_size=100)
- Added inline schema covering the core [Slack file object](https://docs.slack.dev/reference/objects/file-object) properties with `additionalProperties: true` for extensibility
- Bumped connector version 3.1.7 → 3.2.0
- Updated unit test stream count assertion (5 → 6)
- Added changelog entry in connector docs

## Review guide
1. `manifest.yaml` — `files_stream` definition (pagination, incremental sync config) and `files` schema
2. `metadata.yaml` — version bump
3. `unit_tests/test_source.py` — stream count update
4. `docs/integrations/sources/slack.md` — changelog entry for 3.2.0

**Key areas to scrutinize:**
- **Pagination**: `files.list` uses traditional paging (not cursor-based). Verify `PageIncrement` with `start_from_page: 1` is correct for this endpoint.
- **30-day window sufficiency**: Workspaces uploading >10,000 files in a 30-day period could exceed the 100-page limit within a single window. Consider whether a smaller step (e.g., `P7D`) would be safer.
- **OAuth scopes**: The `files:read` scope is required for `files.list`. Confirm this scope is already included in the connector's Slack app configuration, or note it in docs.
- **No live/integration testing was performed** — only unit tests were run locally (all 34 pass).

## User Impact
Users can now sync file metadata (name, type, size, creator, URLs, sharing info, etc.) from their Slack workspace. This is a new optional stream — no impact on existing streams.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚

---

Link to Devin run: https://app.devin.ai/sessions/e2f36cf446db4297a14ba8e4a9d50a19
Requested by: @tgonzalezc5