### PR TITLE
chore(source-postgres): configure heartbeat timeout

### DIFF
--- a/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/DebeziumPropertiesBuilder.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/DebeziumPropertiesBuilder.kt
@@ -159,6 +159,9 @@ class DebeziumPropertiesBuilder(private val props: Properties = Properties()) {
         }
     }
 
+    fun withHeartbeatTimeout(timeout: Duration): DebeziumPropertiesBuilder =
+        with(AIRBYTE_HEARTBEAT_TIMEOUT_SECONDS, timeout.seconds.toString())
+
     companion object {
         private const val BYTE_VALUE_256_MB = (256 * 1024 * 1024).toString()
 

--- a/airbyte-integrations/connectors/source-postgres/src/main/kotlin/io/airbyte/integrations/source/postgres/cdc/PostgresSourceDebeziumOperations.kt
+++ b/airbyte-integrations/connectors/source-postgres/src/main/kotlin/io/airbyte/integrations/source/postgres/cdc/PostgresSourceDebeziumOperations.kt
@@ -123,7 +123,7 @@ class PostgresSourceDebeziumOperations(
                     this.with("heartbeat.action.query", cdcConfig.heartbeatActionQuery)
                 }
             }
-    // TODO: airbyte.heartbeat.timeout.seconds
+            .withHeartbeatTimeout(cdcConfig.airbyteHeartbeatTimeout)
     // TODO: SSL support
         }
 

--- a/airbyte-integrations/connectors/source-postgres/src/main/kotlin/io/airbyte/integrations/source/postgres/config/PostgresSourceConfiguration.kt
+++ b/airbyte-integrations/connectors/source-postgres/src/main/kotlin/io/airbyte/integrations/source/postgres/config/PostgresSourceConfiguration.kt
@@ -101,7 +101,7 @@ data class CdcIncrementalConfiguration(
     val publication: String,
     val debeziumCommitsLsn: Boolean,
     val heartbeatActionQuery: String,
-    val airbyteHeartbeatTimeout: Duration = Duration.ofSeconds(60),
+    val airbyteHeartbeatTimeout: Duration,
 // TODO: Support this configuration:
 //  initial waiting time in seconds
 //  size of the queue
@@ -253,6 +253,8 @@ constructor(
                     } else {
                         InvalidCdcCursorPositionBehavior.RESET_SYNC
                     }
+                val initialWaitingDuration =
+                    Duration.ofSeconds(incrementalSpec.initialWaitingSeconds.toLong())
                 val shutdownTimeout: Duration =
                     Duration.ofSeconds(incrementalSpec.debeziumShutdownTimeoutSeconds!!.toLong())
                 CdcIncrementalConfiguration(
@@ -263,6 +265,7 @@ constructor(
                     publication = incrementalSpec.publication,
                     debeziumCommitsLsn = incrementalSpec.lsnCommitBehavior == "While reading Data",
                     heartbeatActionQuery = incrementalSpec.heartbeatActionQuery,
+                    airbyteHeartbeatTimeout = initialWaitingDuration,
                 )
             }
         }

--- a/airbyte-integrations/connectors/source-postgres/src/main/kotlin/io/airbyte/integrations/source/postgres/config/PostgresSourceConfiguration.kt
+++ b/airbyte-integrations/connectors/source-postgres/src/main/kotlin/io/airbyte/integrations/source/postgres/config/PostgresSourceConfiguration.kt
@@ -37,7 +37,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.time.Duration
-import java.util.*
+import java.util.UUID
 import org.postgresql.PGProperty.CONNECT_TIMEOUT
 import org.postgresql.PGProperty.PREPARE_THRESHOLD
 import org.postgresql.PGProperty.TCP_KEEP_ALIVE
@@ -101,6 +101,7 @@ data class CdcIncrementalConfiguration(
     val publication: String,
     val debeziumCommitsLsn: Boolean,
     val heartbeatActionQuery: String,
+    val airbyteHeartbeatTimeout: Duration = Duration.ofSeconds(60),
 // TODO: Support this configuration:
 //  initial waiting time in seconds
 //  size of the queue

--- a/airbyte-integrations/connectors/source-postgres/src/main/kotlin/io/airbyte/integrations/source/postgres/config/PostgresSourceConfigurationSpecification.kt
+++ b/airbyte-integrations/connectors/source-postgres/src/main/kotlin/io/airbyte/integrations/source/postgres/config/PostgresSourceConfigurationSpecification.kt
@@ -457,6 +457,15 @@ class CdcReplicationMethodConfigurationSpecification : IncrementalConfigurationS
     @JsonSchemaInject(json = """{"order":5,"always_show":true, "minLength":1}""")
     lateinit var publication: String
 
+    @JsonProperty("initial_waiting_seconds")
+    @JsonSchemaTitle("Initial Waiting Time in Seconds (Advanced)")
+    @JsonPropertyDescription(
+        "The amount of time the connector will wait when it launches to determine if there is new data to sync or not. Defaults to 1200 seconds. Valid range: 120 seconds to 2400 seconds. Read about <a href=\"https://docs.airbyte.com/integrations/sources/postgres/postgres-troubleshooting#advanced-setting-up-initial-cdc-waiting-time\">initial waiting time</a>."
+    )
+    @JsonSchemaDefault("1200")
+    @JsonSchemaInject(json = """{"order":6,"min":120,"max":2400,"always_show":true}""")
+    var initialWaitingSeconds: Int = 1200
+
     @JsonProperty("lsn_commit_behavior")
     @JsonSchemaTitle("LSN commit behavior")
     @JsonPropertyDescription(


### PR DESCRIPTION
Set heartbeat timeout for CDC based on `initial_waiting_seconds`.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌
