### PR TITLE
docs(mcp-servers): Add Connector Builder MCP documentation page

### DIFF
--- a/docs/ai-agents/README.md
+++ b/docs/ai-agents/README.md
@@ -12,7 +12,7 @@ Airbyte provides a set of tools to help you automate, understand, move, and work
 
 - **Connector Builder MCP**: Let AI agents autonomously build new Airbyte source connectors using the [Connector Builder MCP server](/developers/mcp-servers/connector-builder-mcp). Install via `uvx airbyte-connector-builder-mcp` or [view the GitHub repo](https://github.com/airbytehq/connector-builder-mcp).
 
-<!-- import Taxonomyfrom "@site/static/_taxonomy_of_data_movement.md";
+<!-- import Taxonomy from "@site/static/_taxonomy_of_data_movement.md";
 
 Airbyte's Agent engine is a set of tools to help you automate, understand, move, and work with your data in coordination with AI agents. Some of these tools are standalone open source solutions, and others are pay solutions built on top of Airbyte Cloud.
 

--- a/docs/ai-agents/README.md
+++ b/docs/ai-agents/README.md
@@ -10,7 +10,9 @@ Airbyte provides a set of tools to help you automate, understand, move, and work
 
 - **Airbyte Embedded**: Add hundreds of integrations into your product instantly. Your end-users can authenticate into their data sources and begin syncing data to your product. You no longer need to spend engineering cycles on data movement. Focus on what makes your product great, rather than maintaining data integrations.
 
-<!-- import Taxonomy from "@site/static/_taxonomy_of_data_movement.md";
+- **Connector Builder MCP**: Let AI agents autonomously build new Airbyte source connectors using the [Connector Builder MCP server](/developers/mcp-servers/connector-builder-mcp). Install via `uvx airbyte-connector-builder-mcp` or [view the GitHub repo](https://github.com/airbytehq/connector-builder-mcp).
+
+<!-- import Taxonomyfrom "@site/static/_taxonomy_of_data_movement.md";
 
 Airbyte's Agent engine is a set of tools to help you automate, understand, move, and work with your data in coordination with AI agents. Some of these tools are standalone open source solutions, and others are pay solutions built on top of Airbyte Cloud.
 

--- a/docs/developers/mcp-servers/connector-builder-mcp.md
+++ b/docs/developers/mcp-servers/connector-builder-mcp.md
@@ -1,19 +1,90 @@
----
-draft: true
----
-
 # Connector Builder MCP Server
 
-:::note
-The Connector Builder MCP server is currently in development. This documentation will be updated as the server becomes available.
-:::
+The Connector Builder MCP (Model Context Protocol) server enables AI agents to autonomously build Airbyte source connectors. Rather than assisting a human developer, this MCP server gives AI agents full ownership of the connector development lifecycle, from manifest creation and validation to stream testing and PR creation.
 
-The Connector Builder MCP server provides AI-driven connector building experience for building and testing Airbyte connectors using the [Model Context Protocol](https://modelcontextprotocol.io/). This enables AI assistants to help developers create, configure, and validate custom connectors through a standardized interface.
+## Documentation
 
-## Coming Soon
+For the complete API reference, refer to the auto-generated Connector Builder MCP documentation:
 
-This MCP server is under active development. Check back for updates.
+**[Connector Builder MCP API Reference](https://airbytehq.github.io/connector-builder-mcp/)**
 
-## Early Access Preview
+## When to use
 
-If you are an active Airbyte customer interested in early access to the **Connector Builder MCP** server, please reach out to your sales representative to request early access.
+Use the Connector Builder MCP when you want an AI agent to build a new Airbyte source connector for an API that isn't already in the [connector catalog](/integrations/sources). The MCP server provides tools that let AI agents:
+
+- Create and edit declarative YAML connector manifests
+- Validate manifests against the Airbyte CDK schema
+- Test stream reads against live APIs
+- Run connector readiness reports
+- Manage secrets for API authentication
+- Access connector-building documentation and guidance
+
+## Quick start
+
+### Prerequisites
+
+- [uv](https://docs.astral.sh/uv/) for package management (`brew install uv`)
+- Python 3.10+
+
+### Install and run
+
+The Connector Builder MCP server is available on PyPI and can be run directly with `uvx`:
+
+```bash
+uvx airbyte-connector-builder-mcp
+```
+
+### Configure your MCP client
+
+Add the following configuration to your MCP client. The example below works with Claude Desktop, Claude Code, and other MCP-compatible clients.
+
+```json
+{
+  "mcpServers": {
+    "airbyte-connector-builder-mcp": {
+      "command": "uvx",
+      "args": [
+        "airbyte-connector-builder-mcp"
+      ]
+    }
+  }
+}
+```
+
+For a more complete setup that includes the [PyAirbyte MCP](pyairbyte-mcp.md) server for publishing connectors to Airbyte Cloud, see the [suggested configuration](https://github.com/airbytehq/connector-builder-mcp#suggested-mcp-server-config) in the GitHub repository.
+
+## Sample prompts
+
+Here are some prompts to get started:
+
+1. "Create an Airbyte source connector for the Sentry API from scratch using your connector-builder-mcp tools."
+2. "Validate the current connector manifest and fix any issues."
+3. "Test the `events` stream and show me the results."
+4. "Run a full readiness test report for all streams."
+5. "List the secrets available in my `.env` file."
+
+When prompting the agent, provide the path to a `.env` file containing the API credentials for the source you're building. For example:
+
+> I have a `.env` file at `/path/to/secrets/.env` with my API credentials. Use the connector-builder-mcp tools to build a source connector for the Sentry API.
+
+## Complementary MCP servers
+
+The Connector Builder MCP works well alongside other MCP servers:
+
+- **[PyAirbyte MCP](pyairbyte-mcp.md)**: Publish built connectors to your Airbyte Cloud workspace, run local syncs, and validate data.
+- **Playwright MCP**: Give the agent web browsing capabilities for researching API documentation.
+
+## Contributing
+
+- [Connector Builder MCP Contributing Guide](https://github.com/airbytehq/connector-builder-mcp/blob/main/CONTRIBUTING.md)
+
+### Additional resources
+
+- [Connector Builder MCP on GitHub](https://github.com/airbytehq/connector-builder-mcp)
+- [Connector Builder MCP on PyPI](https://pypi.org/project/airbyte-connector-builder-mcp/)
+- [Model Context Protocol Documentation](https://modelcontextprotocol.io/)
+
+For issues and questions:
+
+- [GitHub Issues](https://github.com/airbytehq/connector-builder-mcp/issues)
+- [Airbyte Community Slack](https://airbyte.com/community)

--- a/docs/developers/mcp-servers/readme.md
+++ b/docs/developers/mcp-servers/readme.md
@@ -6,6 +6,6 @@ Airbyte provides MCP (Model Context Protocol) servers to enable AI-assisted data
 
 - The Airbyte knowledge MCP is a hosted server that connects AI agents to Airbyte's documentation, website, OpenAPI specs, YouTube content, and GitHub issues, discussions, and pull requests.
 - The PyAirbyte MCP is a local MCP server for managing Airbyte connectors through AI assistants.
-- The Connector Builder MCP (coming soon) is an AI-assisted connector development.
+- The [Connector Builder MCP](connector-builder-mcp.md) server enables AI agents to autonomously build new Airbyte source connectors.
 
 <DocCardList />

--- a/docusaurus/sidebar-developers.js
+++ b/docusaurus/sidebar-developers.js
@@ -45,7 +45,7 @@ module.exports = {
           items: [
             'mcp-servers/airbyte-knowledge-mcp',
             'mcp-servers/pyairbyte-mcp',
-            // 'mcp-servers/connector-builder-mcp',
+            'mcp-servers/connector-builder-mcp',
           ],
         },
       ],


### PR DESCRIPTION
## What

Replaces the "coming soon" placeholder for the Connector Builder MCP server with a full documentation page and makes it discoverable from the AI Agents landing page and MCP Servers index.

Requested by @aaronsteers. [Link to Devin run](https://app.devin.ai/sessions/64d0d59b10f745bf8859e1840afb6437).

## How

1. **`docs/developers/mcp-servers/connector-builder-mcp.md`** — Replaced the draft placeholder with full documentation: overview, quick start, MCP client config JSON, sample prompts, complementary servers, and contributing/resource links.
2. **`docusaurus/sidebar-developers.js`** — Uncommented the sidebar entry so the page appears in navigation.
3. **`docs/developers/mcp-servers/readme.md`** — Updated the Connector Builder MCP bullet from "(coming soon)" to a live link with updated description.
4. **`docs/ai-agents/README.md`** — Added a Connector Builder MCP bullet point to the AI Agents landing page for discoverability.

## Review guide

1. `docs/developers/mcp-servers/connector-builder-mcp.md` — Main new content. Please verify accuracy of quick start instructions, MCP client config JSON, and sample prompts against the [connector-builder-mcp repo](https://github.com/airbytehq/connector-builder-mcp). Content was derived from the repo README but may drift.
2. `docs/ai-agents/README.md` — One new bullet point added. The cross-link `/developers/mcp-servers/connector-builder-mcp` should be verified in the Vercel preview to ensure it resolves correctly across Docusaurus doc instances.
3. `docusaurus/sidebar-developers.js` — One-line uncomment.
4. `docs/developers/mcp-servers/readme.md` — One-line update.

## User Impact

The Connector Builder MCP server documentation becomes publicly discoverable from:
- The Developers > MCP Servers sidebar
- The AI Agents landing page

Previously, this was a hidden draft page with a "coming soon" message.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚