### PR TITLE
ci(auto-merge): handle draft PRs, fix label timing, and auto-promote on label

### DIFF
--- a/.github/workflows/promote-draft-on-auto-merge-label.yml
+++ b/.github/workflows/promote-draft-on-auto-merge-label.yml
@@ -1,0 +1,42 @@
+name: Promote Draft on Auto-Merge Label
+
+# This workflow automatically marks draft PRs as ready for review
+# when an auto-merge label is added. This complements the
+# enforce-draft-pr-status workflow: if a PR is converted to draft
+# before its auto-merge label is applied, this workflow will
+# promote it back to ready once the label arrives.
+
+on:
+  pull_request_target:
+    types:
+      - labeled
+
+jobs:
+  promote-draft:
+    name: Mark PR as Ready for Review
+    if: |
+      github.event.pull_request.draft == true &&
+      (
+        github.event.label.name == 'auto-merge' ||
+        github.event.label.name == 'auto-merge/bypass-ci-checks'
+      )
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Authenticate as GitHub App
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        id: get-app-token
+        with:
+          owner: "airbytehq"
+          repositories: "airbyte"
+          app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
+          private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
+
+      - name: Mark PR as ready for review
+        env:
+          GH_TOKEN: ${{ steps.get-app-token.outputs.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr ready "$PR_NUMBER" --repo "${{ github.repository }}"

--- a/airbyte-ci/connectors/auto_merge/src/auto_merge/main.py
+++ b/airbyte-ci/connectors/auto_merge/src/auto_merge/main.py
@@ -138,6 +138,7 @@ def merge_with_retries(pr: PullRequest, max_retries: int = 3, wait_time: int = 6
         logger.info(f"PR #{pr.number} is a draft, marking as ready for review before merging")
         mark_pr_as_ready(pr.node_id)
         pr.update()
+        logger.info(f"PR #{pr.number} draft status after marking ready: {pr.draft}")
     for i in range(max_retries):
         try:
             pr.merge(merge_method=MERGE_METHOD)

--- a/airbyte-ci/connectors/auto_merge/src/auto_merge/main.py
+++ b/airbyte-ci/connectors/auto_merge/src/auto_merge/main.py
@@ -104,6 +104,16 @@ def merge_with_retries(pr: PullRequest, max_retries: int = 3, wait_time: int = 6
         max_retries (int, optional): The maximum number of retries. Defaults to 3.
         wait_time (int, optional): The time to wait between retries in seconds. Defaults to 60.
     """
+    if pr.draft:
+        logger.info(f"PR #{pr.number} is a draft, marking as ready for review before merging")
+        requests.patch(
+            pr.url,
+            json={"draft": False},
+            headers={
+                "Authorization": f"token {GITHUB_TOKEN}",
+                "Accept": "application/vnd.github+json",
+            },
+        ).raise_for_status()
     for i in range(max_retries):
         try:
             pr.merge(merge_method=MERGE_METHOD)

--- a/airbyte-ci/connectors/auto_merge/src/auto_merge/main.py
+++ b/airbyte-ci/connectors/auto_merge/src/auto_merge/main.py
@@ -96,6 +96,36 @@ def get_pr_validators(pr: PullRequest) -> set[Callable]:
     return validators
 
 
+def mark_pr_as_ready(node_id: str) -> None:
+    """Mark a draft PR as ready for review using the GitHub GraphQL API.
+
+    The REST API PATCH endpoint does not support changing draft status.
+    The GraphQL markPullRequestReadyForReview mutation is required instead.
+
+    Args:
+        node_id (str): The GraphQL node ID of the pull request
+    """
+    query = """
+    mutation($prId: ID!) {
+      markPullRequestReadyForReview(input: {pullRequestId: $prId}) {
+        pullRequest { isDraft }
+      }
+    }
+    """
+    response = requests.post(
+        "https://api.github.com/graphql",
+        json={"query": query, "variables": {"prId": node_id}},
+        headers={
+            "Authorization": f"token {GITHUB_TOKEN}",
+            "Accept": "application/vnd.github+json",
+        },
+    )
+    response.raise_for_status()
+    data = response.json()
+    if "errors" in data:
+        raise RuntimeError(f"GraphQL error marking PR as ready: {data['errors']}")
+
+
 def merge_with_retries(pr: PullRequest, max_retries: int = 3, wait_time: int = 60) -> Optional[PullRequest]:
     """Merge a PR with retries
 
@@ -106,14 +136,8 @@ def merge_with_retries(pr: PullRequest, max_retries: int = 3, wait_time: int = 6
     """
     if pr.draft:
         logger.info(f"PR #{pr.number} is a draft, marking as ready for review before merging")
-        requests.patch(
-            pr.url,
-            json={"draft": False},
-            headers={
-                "Authorization": f"token {GITHUB_TOKEN}",
-                "Accept": "application/vnd.github+json",
-            },
-        ).raise_for_status()
+        mark_pr_as_ready(pr.node_id)
+        pr.update()
     for i in range(max_retries):
         try:
             pr.merge(merge_method=MERGE_METHOD)

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/up_to_date/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/up_to_date/pipeline.py
@@ -145,16 +145,16 @@ async def run_connector_up_to_date_pipeline(
                     step_results.append(dependency_updates_result)
                     dependency_updates = dependency_updates_result.output
 
-                    # We open a PR even if build is failing.
-                    # This might allow a developer to fix the build in the PR.
-                    initial_labels = DEFAULT_PR_LABELS + ([AUTO_MERGE_PR_LABEL] if auto_merge else [])
-                    initial_pr_creation = CreateOrUpdatePullRequest(
-                        context,
-                        labels=initial_labels,
-                        # Reduce pressure on rate limit, since we need to push a
-                        # a follow-on commit anyway once we have the PR number:
-                        skip_ci=True,
-                    )
+                # We open a PR even if build is failing.
+                # This might allow a developer to fix the build in the PR.
+                initial_labels = DEFAULT_PR_LABELS + ([AUTO_MERGE_PR_LABEL] if auto_merge else [])
+                initial_pr_creation = CreateOrUpdatePullRequest(
+                    context,
+                    labels=initial_labels,
+                    # Reduce pressure on rate limit, since we need to push a
+                    # a follow-on commit anyway once we have the PR number:
+                    skip_ci=True,
+                )
                 pr_creation_args, pr_creation_kwargs = get_pr_creation_arguments(
                     all_modified_files, context, step_results, dependency_updates
                 )

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/up_to_date/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/up_to_date/pipeline.py
@@ -145,15 +145,16 @@ async def run_connector_up_to_date_pipeline(
                     step_results.append(dependency_updates_result)
                     dependency_updates = dependency_updates_result.output
 
-                # We open a PR even if build is failing.
-                # This might allow a developer to fix the build in the PR.
-                initial_pr_creation = CreateOrUpdatePullRequest(
-                    context,
-                    labels=DEFAULT_PR_LABELS,
-                    # Reduce pressure on rate limit, since we need to push a
-                    # a follow-on commit anyway once we have the PR number:
-                    skip_ci=True,
-                )
+                    # We open a PR even if build is failing.
+                    # This might allow a developer to fix the build in the PR.
+                    initial_labels = DEFAULT_PR_LABELS + ([AUTO_MERGE_PR_LABEL] if auto_merge else [])
+                    initial_pr_creation = CreateOrUpdatePullRequest(
+                        context,
+                        labels=initial_labels,
+                        # Reduce pressure on rate limit, since we need to push a
+                        # a follow-on commit anyway once we have the PR number:
+                        skip_ci=True,
+                    )
                 pr_creation_args, pr_creation_kwargs = get_pr_creation_arguments(
                     all_modified_files, context, step_results, dependency_updates
                 )


### PR DESCRIPTION
## What

Three complementary fixes for the auto-merge cron job failing on draft PRs:

1. **405 "Pull Request is still a draft"** — The auto-merge script crashes when trying to merge draft PRs. This was previously masked by the [rulesets 404 error](https://github.com/airbytehq/airbyte/pull/72908) — the script crashed before reaching the merge step.

2. **Race condition with draft enforcement** — The up-to-date pipeline creates PRs without the `auto-merge` label, then the [`enforce-draft-pr-status`](.github/workflows/enforce-draft-pr-status.yml) workflow fires on the `opened` event, sees no exempt label, and converts the PR to draft. The `auto-merge` label is only added in a follow-up commit (too late).

3. **No recovery when label arrives late** — Even after the label is eventually added, there was no mechanism to promote the PR back out of draft status. A new workflow now handles this automatically.

## How

### Fix 1: `auto_merge/main.py` — Mark draft PRs as ready before merging

- New `mark_pr_as_ready()` function calls the GitHub **GraphQL** `markPullRequestReadyForReview` mutation
- `merge_with_retries()` calls it when `pr.draft` is `True`, then calls `pr.update()` to refresh PyGithub's local state

> **Why GraphQL?** The REST API `PATCH /pulls/{number}` with `{"draft": false}` silently ignores the `draft` field — GitHub requires the GraphQL mutation to change draft status. PyGithub 2.3.0's `PullRequest.edit()` also does not support the `draft` parameter.

### Fix 2: `up_to_date/pipeline.py` — Include `auto-merge` label at initial PR creation

- The `auto-merge` label is now included in `initial_labels` when `auto_merge=True`, so the enforce-draft workflow sees it and skips the PR.

### Fix 3: `promote-draft-on-auto-merge-label.yml` — Auto-promote draft PRs when labeled

- New workflow triggers on `pull_request_target: labeled` events
- If the PR is in draft and the added label is `auto-merge` or `auto-merge/bypass-ci-checks`, the workflow marks the PR as ready for review
- Uses the same Octavia Bot App authentication as the enforce-draft workflow
- This is the inverse complement to `enforce-draft-pr-status.yml`: that workflow drafts PRs without the label, this one un-drafts PRs when the label arrives

## Review guide

1. `airbyte-ci/connectors/auto_merge/src/auto_merge/main.py`
   - New function `mark_pr_as_ready()` (GraphQL mutation wrapper)
   - Updated `merge_with_retries()` to call it when `pr.draft` is `True`

2. `airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/up_to_date/pipeline.py`
   - Added `initial_labels` variable that includes `AUTO_MERGE_PR_LABEL` when `auto_merge=True`
   - This is a 2-line change at the existing indentation level (no control flow change)

3. `.github/workflows/promote-draft-on-auto-merge-label.yml` *(new file)*
   - Triggers on `pull_request_target: labeled`
   - Runs `gh pr ready` when an auto-merge label is added to a draft PR

**Suggested review checklist:**


- [ ] **Token permissions:** Verify that the `GH_PAT_MAINTENANCE_OSS` PAT used by the cron job has GraphQL API access and permission to call `markPullRequestReadyForReview`. This was tested with Devin's token but not the production token.
- [ ] **Side effect on failed merges:** The draft→ready transition happens *before* the merge attempt. If the merge subsequently fails (e.g., CI not passing), the PR remains marked as ready for review permanently. Is this acceptable for up-to-date pipeline PRs?
- [ ] **Workflow trigger:** The new workflow uses `pull_request_target` (required for secret access). Verify this is the correct pattern for label-triggered workflows.

## User Impact

Draft PRs with auto-merge labels (from the up-to-date pipeline) will be automatically marked as ready for review and merged, restoring the expected auto-merge behavior. Additionally, if a PR is converted to draft before its label is applied, it will be automatically promoted back to ready once the label arrives.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Reverting returns to the current state where draft PRs fail to merge with 405 errors.

---

Link to Devin run: https://app.devin.ai/sessions/985a63252d134d79b93c7335a5668d5b
Requested by: @brianjlai