### PR TITLE
ci(auto-merge): use Octavia-Bot-Hoard app token instead of GH_PAT_MAINTENANCE_OSS

### DIFF
--- a/.github/workflows/auto_merge.yml
+++ b/.github/workflows/auto_merge.yml
@@ -16,8 +16,8 @@ jobs:
         with:
           owner: "airbytehq"
           repositories: "airbyte"
-          app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
-          private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
+          app-id: ${{ secrets.OCTAVIA_BOT_HOARD_APP_ID }}
+          private-key: ${{ secrets.OCTAVIA_BOT_HOARD_PRIVATE_KEY }}
       - name: Checkout
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       - name: Set up Python

--- a/.github/workflows/auto_merge.yml
+++ b/.github/workflows/auto_merge.yml
@@ -10,6 +10,14 @@ jobs:
     name: Run auto-merge
     runs-on: ubuntu-24.04
     steps:
+      - name: Authenticate as GitHub App
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        id: get-app-token
+        with:
+          owner: "airbytehq"
+          repositories: "airbyte"
+          app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
+          private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
       - name: Checkout
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       - name: Set up Python
@@ -26,10 +34,7 @@ jobs:
         shell: bash
         working-directory: airbyte-ci/connectors/auto_merge
         env:
-          # We need a custom Github Token as some API endpoints
-          # are not available from GHA auto generated tokens
-          # like the one to list branch protection rules...
-          GITHUB_TOKEN: ${{ secrets.GH_PAT_MAINTENANCE_OSS }}
+          GITHUB_TOKEN: ${{ steps.get-app-token.outputs.token }}
           AUTO_MERGE_PRODUCTION: ${{ vars.ENABLE_CONNECTOR_AUTO_MERGE }}
         run: |
           poetry install


### PR DESCRIPTION
## What

The auto-merge cron job fails with 405 "repository rule violated — requires at least one approving review" because the bot behind `GH_PAT_MAINTENANCE_OSS` is not a bypass actor on the "protect default branch" ruleset.

This switches the workflow to authenticate as the Octavia-Bot-Hoard GitHub App, which can be configured as a bypass actor on the ruleset.

## How

- Adds an `actions/create-github-app-token` step (same pattern used by `enforce-draft-pr-status.yml` and `promote-draft-on-auto-merge-label.yml`)
- Uses `OCTAVIA_BOT_HOARD_APP_ID` and `OCTAVIA_BOT_HOARD_PRIVATE_KEY` secrets (not the regular Octavia Bot secrets)
- Replaces `secrets.GH_PAT_MAINTENANCE_OSS` with the generated app token
- Removes the now-stale comment about needing a custom token for branch protection rules
- No changes to the Python auto-merge script — it reads `GITHUB_TOKEN` from env unchanged

## Review guide

1. `.github/workflows/auto_merge.yml` — only file changed

### Human review checklist
- [ ] **Octavia-Bot-Hoard must be added as a bypass actor** on the "protect default branch" ruleset (repo admin settings) for this to actually resolve the 405. This PR alone is not sufficient.
- [ ] Confirm the Octavia-Bot-Hoard app token has sufficient permissions for: listing rulesets, reading PR data, merging PRs, and calling the GraphQL `markPullRequestReadyForReview` mutation
- [ ] Verify that `OCTAVIA_BOT_HOARD_APP_ID` and `OCTAVIA_BOT_HOARD_PRIVATE_KEY` are the correct secret names (not the regular `OCTAVIA_BOT_APP_ID` / `OCTAVIA_BOT_PRIVATE_KEY`)

> **Note:** This change cannot be tested locally — it depends on repo secrets and will only be verifiable when the workflow runs in production.

## User Impact

Auto-merge for connector PRs will work once the Octavia-Bot-Hoard app is also added as a bypass actor on the ruleset. No user-facing changes otherwise.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Link to Devin run: https://app.devin.ai/sessions/985a63252d134d79b93c7335a5668d5b
Requested by: @brianjlai