### PR TITLE
fix: migrate sentry client to SDK 2.x API

### DIFF
--- a/airbyte-ci/connectors/pipelines/pipelines/helpers/sentry_utils.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/helpers/sentry_utils.py
@@ -38,55 +38,59 @@ def before_send(event: Dict[str, Any], hint: Dict[str, Any]) -> Optional[Dict[st
 
 def with_step_context(func: Callable) -> Callable:
     def wrapper(self: Step, *args: Any, **kwargs: Any) -> Step:
-        with sentry_sdk.configure_scope() as scope:
-            step_name = self.__class__.__name__
-            scope.set_tag("pipeline_step", step_name)
+        # Use get_current_scope() for Sentry SDK 2.x compatibility
+        # instead of the deprecated configure_scope()
+        scope = sentry_sdk.get_current_scope()
+        step_name = self.__class__.__name__
+        scope.set_tag("pipeline_step", step_name)
+        scope.set_context(
+            "Pipeline Step",
+            {
+                "name": step_name,
+                "step_title": self.title,
+                "max_retries": self.max_retries,
+                "max_duration": self.max_duration,
+                "retry_count": self.retry_count,
+            },
+        )
+
+        if hasattr(self.context, "connector"):
+            connector: Connector = self.context.connector
+            scope.set_tag("connector", connector.technical_name)
             scope.set_context(
-                "Pipeline Step",
+                "Connector",
                 {
-                    "name": step_name,
-                    "step_title": self.title,
-                    "max_retries": self.max_retries,
-                    "max_duration": self.max_duration,
-                    "retry_count": self.retry_count,
+                    "name": connector.name,
+                    "technical_name": connector.technical_name,
+                    "language": connector.language,
+                    "version": connector.version,
+                    "support_level": connector.support_level,
                 },
             )
 
-            if hasattr(self.context, "connector"):
-                connector: Connector = self.context.connector
-                scope.set_tag("connector", connector.technical_name)
-                scope.set_context(
-                    "Connector",
-                    {
-                        "name": connector.name,
-                        "technical_name": connector.technical_name,
-                        "language": connector.language,
-                        "version": connector.version,
-                        "support_level": connector.support_level,
-                    },
-                )
-
-            return func(self, *args, **kwargs)
+        return func(self, *args, **kwargs)
 
     return wrapper
 
 
 def with_command_context(func: Callable) -> Callable:
     def wrapper(self: Command, ctx: Context, *args: Any, **kwargs: Any) -> Command:
-        with sentry_sdk.configure_scope() as scope:
-            scope.set_tag("pipeline_command", self.name)
-            scope.set_context(
-                "Pipeline Command",
-                {
-                    "name": self.name,
-                    "params": self.params,
-                },
-            )
+        # Use get_current_scope() for Sentry SDK 2.x compatibility
+        # instead of the deprecated configure_scope()
+        scope = sentry_sdk.get_current_scope()
+        scope.set_tag("pipeline_command", self.name)
+        scope.set_context(
+            "Pipeline Command",
+            {
+                "name": self.name,
+                "params": self.params,
+            },
+        )
 
-            scope.set_context("Click Context", ctx.obj)
-            scope.set_tag("git_branch", ctx.obj.get("git_branch", "unknown"))
-            scope.set_tag("git_revision", ctx.obj.get("git_revision", "unknown"))
+        scope.set_context("Click Context", ctx.obj)
+        scope.set_tag("git_branch", ctx.obj.get("git_branch", "unknown"))
+        scope.set_tag("git_revision", ctx.obj.get("git_revision", "unknown"))
 
-            return func(self, ctx, *args, **kwargs)
+        return func(self, ctx, *args, **kwargs)
 
     return wrapper


### PR DESCRIPTION
Fixes #52676

Updates sentry_utils.py to use the new Sentry SDK 2.x API, replacing the deprecated configure_scope() context manager with get_current_scope().

This eliminates the DeprecationWarning that appears in build logs and ensures compatibility with Sentry SDK 2.x.

Changes:
- Replace sentry_sdk.configure_scope() with sentry_sdk.get_current_scope()
- Update with_step_context and with_command_context decorators