### PR TITLE
fix(pipelines): migrate from deprecated sentry_sdk.configure_scope to get_current_scope

### DIFF
--- a/airbyte-ci/connectors/pipelines/pipelines/helpers/sentry_utils.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/helpers/sentry_utils.py
@@ -38,55 +38,55 @@ def before_send(event: Dict[str, Any], hint: Dict[str, Any]) -> Optional[Dict[st
 
 def with_step_context(func: Callable) -> Callable:
     def wrapper(self: Step, *args: Any, **kwargs: Any) -> Step:
-        with sentry_sdk.configure_scope() as scope:
-            step_name = self.__class__.__name__
-            scope.set_tag("pipeline_step", step_name)
+        scope = sentry_sdk.get_current_scope()
+        step_name = self.__class__.__name__
+        scope.set_tag("pipeline_step", step_name)
+        scope.set_context(
+            "Pipeline Step",
+            {
+                "name": step_name,
+                "step_title": self.title,
+                "max_retries": self.max_retries,
+                "max_duration": self.max_duration,
+                "retry_count": self.retry_count,
+            },
+        )
+
+        if hasattr(self.context, "connector"):
+            connector: Connector = self.context.connector
+            scope.set_tag("connector", connector.technical_name)
             scope.set_context(
-                "Pipeline Step",
+                "Connector",
                 {
-                    "name": step_name,
-                    "step_title": self.title,
-                    "max_retries": self.max_retries,
-                    "max_duration": self.max_duration,
-                    "retry_count": self.retry_count,
+                    "name": connector.name,
+                    "technical_name": connector.technical_name,
+                    "language": connector.language,
+                    "version": connector.version,
+                    "support_level": connector.support_level,
                 },
             )
 
-            if hasattr(self.context, "connector"):
-                connector: Connector = self.context.connector
-                scope.set_tag("connector", connector.technical_name)
-                scope.set_context(
-                    "Connector",
-                    {
-                        "name": connector.name,
-                        "technical_name": connector.technical_name,
-                        "language": connector.language,
-                        "version": connector.version,
-                        "support_level": connector.support_level,
-                    },
-                )
-
-            return func(self, *args, **kwargs)
+        return func(self, *args, **kwargs)
 
     return wrapper
 
 
 def with_command_context(func: Callable) -> Callable:
     def wrapper(self: Command, ctx: Context, *args: Any, **kwargs: Any) -> Command:
-        with sentry_sdk.configure_scope() as scope:
-            scope.set_tag("pipeline_command", self.name)
-            scope.set_context(
-                "Pipeline Command",
-                {
-                    "name": self.name,
-                    "params": self.params,
-                },
-            )
+        scope = sentry_sdk.get_current_scope()
+        scope.set_tag("pipeline_command", self.name)
+        scope.set_context(
+            "Pipeline Command",
+            {
+                "name": self.name,
+                "params": self.params,
+            },
+        )
 
-            scope.set_context("Click Context", ctx.obj)
-            scope.set_tag("git_branch", ctx.obj.get("git_branch", "unknown"))
-            scope.set_tag("git_revision", ctx.obj.get("git_revision", "unknown"))
+        scope.set_context("Click Context", ctx.obj)
+        scope.set_tag("git_branch", ctx.obj.get("git_branch", "unknown"))
+        scope.set_tag("git_revision", ctx.obj.get("git_revision", "unknown"))
 
-            return func(self, ctx, *args, **kwargs)
+        return func(self, ctx, *args, **kwargs)
 
     return wrapper


### PR DESCRIPTION
## Problem
The airbyte-ci pipelines show a DeprecationWarning in build logs:
```
/airbyte/airbyte-ci/connectors/pipelines/pipelines/helpers/sentry_utils.py:41: DeprecationWarning: sentry_sdk.configure_scope is deprecated and will be removed in the next major version.
```

## Solution
Replace deprecated `sentry_sdk.configure_scope()` context manager with `sentry_sdk.get_current_scope()` to eliminate the deprecation warning.

The `configure_scope()` API is deprecated in Sentry SDK 2.x and will be removed in the next major version. The new `get_current_scope()` API provides direct access to the current scope without needing a context manager.

## Changes
- Updated `with_step_context` decorator to use `get_current_scope()` instead of `configure_scope()`
- Updated `with_command_context` decorator to use `get_current_scope()` instead of `configure_scope()`

Fixes #52676