### PR TITLE
fix: replace deprecated sentry_sdk.configure_scope with isolation_scope

### DIFF
--- a/airbyte-ci/connectors/pipelines/pipelines/helpers/sentry_utils.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/helpers/sentry_utils.py
@@ -38,7 +38,7 @@ def before_send(event: Dict[str, Any], hint: Dict[str, Any]) -> Optional[Dict[st
 
 def with_step_context(func: Callable) -> Callable:
     def wrapper(self: Step, *args: Any, **kwargs: Any) -> Step:
-        with sentry_sdk.configure_scope() as scope:
+        with sentry_sdk.isolation_scope() as scope:
             step_name = self.__class__.__name__
             scope.set_tag("pipeline_step", step_name)
             scope.set_context(
@@ -73,7 +73,7 @@ def with_step_context(func: Callable) -> Callable:
 
 def with_command_context(func: Callable) -> Callable:
     def wrapper(self: Command, ctx: Context, *args: Any, **kwargs: Any) -> Command:
-        with sentry_sdk.configure_scope() as scope:
+        with sentry_sdk.isolation_scope() as scope:
             scope.set_tag("pipeline_command", self.name)
             scope.set_context(
                 "Pipeline Command",


### PR DESCRIPTION
## Problem
The Sentry SDK was showing a DeprecationWarning about the deprecated `sentry_sdk.configure_scope` API.

## Solution
Replace `sentry_sdk.configure_scope()` with `sentry_sdk.isolation_scope()` as recommended in the Sentry Python SDK 2.x migration guide.

### Changes
- Updated `with_step_context` decorator to use `isolation_scope()`
- Updated `with_command_context` decorator to use `isolation_scope()`

This eliminates the deprecation warning while maintaining the same functionality.

Fixes #52676