### PR TITLE
fix(docs): add Definition ID to enterprise connector docs header

### DIFF
--- a/docusaurus/src/remark/enterpriseDocsHeaderInformation.js
+++ b/docusaurus/src/remark/enterpriseDocsHeaderInformation.js
@@ -3,9 +3,12 @@ const { toAttributes } = require("../helpers/objects");
 const visit = require("unist-util-visit").visit;
 const { fetchRegistry } = require("../scripts/fetch-registry");
 
-const getEnterpriseConnectorVersion = async (dockerRepository) => {
+const getEnterpriseConnectorRegistryInfo = async (dockerRepository) => {
   if (!dockerRepository) {
-    return "No version information available";
+    return {
+      version: "No version information available",
+      definitionId: undefined,
+    };
   }
   try {
     const registry = await fetchRegistry();
@@ -16,16 +19,24 @@ const getEnterpriseConnectorVersion = async (dockerRepository) => {
         r.dockerRepository_cloud === dockerRepository,
     );
     if (!registryEntry) {
-      return "No version information available";
+      return {
+        version: "No version information available",
+        definitionId: undefined,
+      };
     }
-    return (
-      registryEntry.dockerImageTag_oss || registryEntry.dockerImageTag_cloud
-    );
+    return {
+      version:
+        registryEntry.dockerImageTag_oss || registryEntry.dockerImageTag_cloud,
+      definitionId: registryEntry.definitionId || undefined,
+    };
   } catch (error) {
     console.warn(`[Enterprise Connector Debug] Error fetching version:`, error);
   }
 
-  return "No version information available";
+  return {
+    version: "No version information available",
+    definitionId: undefined,
+  };
 };
 
 const plugin = () => {
@@ -33,7 +44,7 @@ const plugin = () => {
     const isDocsPage = isEnterpriseConnectorDocsPage(vfile);
     if (!isDocsPage) return;
 
-    const version = await getEnterpriseConnectorVersion(
+    const { version, definitionId } = await getEnterpriseConnectorRegistryInfo(
       vfile.data.frontMatter.dockerRepository,
     );
 
@@ -52,7 +63,9 @@ const plugin = () => {
           dockerImageTag: version,
           github_url: undefined,
           originalTitle,
-          "enterprise-connector": vfile.data.frontMatter["enterprise-connector"] || true,
+          "enterprise-connector":
+            vfile.data.frontMatter["enterprise-connector"] || true,
+          definitionId,
         };
 
         firstHeading = false;

--- a/docusaurus/src/remark/enterpriseDocsHeaderInformation.js
+++ b/docusaurus/src/remark/enterpriseDocsHeaderInformation.js
@@ -3,12 +3,13 @@ const { toAttributes } = require("../helpers/objects");
 const visit = require("unist-util-visit").visit;
 const { fetchRegistry } = require("../scripts/fetch-registry");
 
+const FALLBACK_VERSION = "No version information available";
 const FALLBACK_DEFINITION_ID = "No definition ID available.";
 
 const getEnterpriseConnectorRegistryInfo = async (dockerRepository) => {
   if (!dockerRepository) {
     return {
-      version: "No version information available",
+      version: FALLBACK_VERSION,
       definitionId: FALLBACK_DEFINITION_ID,
     };
   }
@@ -22,7 +23,7 @@ const getEnterpriseConnectorRegistryInfo = async (dockerRepository) => {
     );
     if (!registryEntry) {
       return {
-        version: "No version information available",
+        version: FALLBACK_VERSION,
         definitionId: FALLBACK_DEFINITION_ID,
       };
     }
@@ -36,7 +37,7 @@ const getEnterpriseConnectorRegistryInfo = async (dockerRepository) => {
   }
 
   return {
-    version: "No version information available",
+    version: FALLBACK_VERSION,
     definitionId: FALLBACK_DEFINITION_ID,
   };
 };

--- a/docusaurus/src/remark/enterpriseDocsHeaderInformation.js
+++ b/docusaurus/src/remark/enterpriseDocsHeaderInformation.js
@@ -3,11 +3,13 @@ const { toAttributes } = require("../helpers/objects");
 const visit = require("unist-util-visit").visit;
 const { fetchRegistry } = require("../scripts/fetch-registry");
 
+const FALLBACK_DEFINITION_ID = "No definition ID available.";
+
 const getEnterpriseConnectorRegistryInfo = async (dockerRepository) => {
   if (!dockerRepository) {
     return {
       version: "No version information available",
-      definitionId: undefined,
+      definitionId: FALLBACK_DEFINITION_ID,
     };
   }
   try {
@@ -21,13 +23,13 @@ const getEnterpriseConnectorRegistryInfo = async (dockerRepository) => {
     if (!registryEntry) {
       return {
         version: "No version information available",
-        definitionId: undefined,
+        definitionId: FALLBACK_DEFINITION_ID,
       };
     }
     return {
       version:
         registryEntry.dockerImageTag_oss || registryEntry.dockerImageTag_cloud,
-      definitionId: registryEntry.definitionId || undefined,
+      definitionId: registryEntry.definitionId || FALLBACK_DEFINITION_ID,
     };
   } catch (error) {
     console.warn(`[Enterprise Connector Debug] Error fetching version:`, error);
@@ -35,7 +37,7 @@ const getEnterpriseConnectorRegistryInfo = async (dockerRepository) => {
 
   return {
     version: "No version information available",
-    definitionId: undefined,
+    definitionId: FALLBACK_DEFINITION_ID,
   };
 };
 


### PR DESCRIPTION
## What

Enterprise connector documentation pages were missing the **Definition ID** in their header metadata, even though the `HeaderDecoration` component already supports rendering it. Non-enterprise connectors display this field via `docsHeaderDecoration.js`, but the enterprise-specific remark plugin (`enterpriseDocsHeaderInformation.js`) never extracted or passed it through.

Requested by @rwask. [Link to Devin run](https://app.devin.ai/sessions/df075cbd6fa24d3ba2a159e294a2dfbf).

## How

Refactored `getEnterpriseConnectorVersion` → `getEnterpriseConnectorRegistryInfo` to return both `version` and `definitionId` from the registry entry (instead of only the version string). The `definitionId` is then included in the attribute dictionary passed to the `HeaderDecoration` component, which already conditionally renders it when present.

When `definitionId` is not available (no registry entry, missing `dockerRepository` frontmatter, or fetch error), the fallback string `"No definition ID available."` is passed instead of `undefined`, ensuring the field always renders with a useful message.

No changes to `HeaderDecoration.jsx` were needed — it already supports the `definitionId` prop (used by non-enterprise connectors).

## Review guide

1. `docusaurus/src/remark/enterpriseDocsHeaderInformation.js` — the only file changed

Key things to verify:
- The registry lookup in `fetch-registry.js:74` already extracts `definitionId` for all connectors, so the data is available.
- `HeaderDecoration.jsx:344-348` already renders `definitionId` conditionally — no component changes needed.
- All fallback paths (no `dockerRepository`, no registry entry, fetch error) now return the `FALLBACK_DEFINITION_ID` string so the Definition ID row always appears.
- The `"enterprise-connector"` line diff is purely a Prettier reformatting, not a logic change.

⚠️ **Note**: The fallback string `"No definition ID available."` will be rendered inside a `<code>` tag by `HeaderDecoration.jsx:346`. This matches how the field renders real UUIDs but may look slightly odd for a plain-text message. Reviewer should confirm this is acceptable.

⚠️ **Not tested with a local Docusaurus build** — this is a build-time remark plugin. The Vercel preview deployment can be used to verify enterprise connector pages.

## User Impact

Enterprise connector documentation pages will now display their **Definition ID** in the header metadata callout, matching the behavior of non-enterprise connectors. If a Definition ID cannot be resolved from the registry, the field displays "No definition ID available." instead of being hidden. This helps users who need the Definition ID when adding connectors via the Airbyte UI or programmatic APIs.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚