### PR TITLE
ci: add Sonar replication compatibility check to connector pre-release checks

### DIFF
--- a/.github/workflows/connector-ci-checks.yml
+++ b/.github/workflows/connector-ci-checks.yml
@@ -449,6 +449,15 @@ jobs:
           connector_name=${{ matrix.connector }}
           airbyte-ops local connector qa --name ${connector_name%-strict-encrypt}
 
+      - name: Sonar Replication Compatibility Check
+        if: matrix.connector && startsWith(matrix.connector, 'source-')
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          connector_name=${{ matrix.connector }}
+          airbyte-ops local connector sonar-compat-check --name ${connector_name%-strict-encrypt}
+        continue-on-error: true
+
       - name: Detect Python CDK Prerelease Versions
         if: matrix.connector
         working-directory: airbyte-integrations/connectors/${{ matrix.connector }}


### PR DESCRIPTION
## What

Adds a Sonar replication compatibility check step to the connector CI pre-release checks workflow. This step validates that Sonar connector.yaml replication mappings remain compatible with modified Airbyte source connectors, helping catch divergence issues before they reach production.

Companion PR: https://github.com/airbytehq/airbyte-ops-mcp/pull/342 (adds the `sonar-compat-check` CLI command to `airbyte-internal-ops`)

## How

Adds a single step to the `pre-release-checks` job in `connector-ci-checks.yml` that:
- Runs only for source connectors (`startsWith(matrix.connector, 'source-')`)
- Calls `airbyte-ops local connector sonar-compat-check --name <connector>`
- Uses `continue-on-error: true` — this is informational only and will not block PRs
- Passes `GITHUB_TOKEN` for authenticating to the private `airbytehq/sonar` repo

The `airbyte-internal-ops` package (which provides `airbyte-ops`) is already installed in a prior step.

## Review guide

1. `.github/workflows/connector-ci-checks.yml` — the only file changed

**⚠️ Known blockers before this is functional:**
- The `sonar-compat-check` command does not exist in the currently published `airbyte-internal-ops` on PyPI. It is in draft at https://github.com/airbytehq/airbyte-ops-mcp/pull/342 and must be merged + published first.
- The default `GITHUB_TOKEN` is scoped to `airbytehq/airbyte` and almost certainly **cannot** read from the private `airbytehq/sonar` repo. A cross-repo PAT or GitHub App token with `airbytehq/sonar` read access will likely be needed. Until then, the check will silently skip every connector (no Sonar connector found → exit 0).

## User Impact

No user-facing impact. This is a CI-only change that runs with `continue-on-error: true`, so it cannot block any PRs. Once fully wired up (ops-mcp published + proper auth), it will surface Sonar compatibility warnings in CI logs for source connector PRs.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

- Requested by: AJ Steers (@aaronsteers)
- [Link to Devin run](https://app.devin.ai/sessions/85f508fa18e04e03a779d4670222ddd1)