### PR TITLE
release(source-clickhouse): publish 0.3.0-rc.1 for cloud

### DIFF
--- a/airbyte-integrations/connectors/source-clickhouse-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/source-clickhouse-strict-encrypt/metadata.yaml
@@ -11,7 +11,7 @@ data:
     - suite: acceptanceTests
   connectorType: source
   definitionId: bad83517-5e54-4a3d-9b53-63e85fbd4d7c
-  dockerImageTag: 0.2.6
+  dockerImageTag: 0.3.0-rc.1
   dockerRepository: airbyte/source-clickhouse-strict-encrypt
   documentationUrl: https://docs.airbyte.com/integrations/sources/clickhouse
   githubIssueLabel: source-clickhouse


### PR DESCRIPTION
The original PR for 0.3.0-rc.1 neglected to update the version in the scrict-encrypt connector, which meant the image was not published for cloud users. This yaml update will publish the RC for cloud.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._