### PR TITLE
release(source-clickhouse): yaml fix for cloud 0.3.0-rc.1

### DIFF
--- a/airbyte-integrations/connectors/source-clickhouse-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/source-clickhouse-strict-encrypt/metadata.yaml
@@ -23,6 +23,9 @@ data:
       enabled: false
     oss:
       enabled: false
+  releases:
+    rolloutConfiguration:
+      enableProgressiveRollout: true
   releaseStage: alpha
   tags:
     - language:java


### PR DESCRIPTION
Publishing of 0.3.0-rc.1 for cloud failed with the folllowing error:
```
Running validator: validate_rc_suffix_and_rollout_configuration
airbyte-integrations/connectors/source-clickhouse-strict-encrypt/metadata.yaml is not a valid ConnectorMetadataDefinitionV0 YAML file.
Validation error: The dockerImageTag field has an -rc.<RC #> suffix but the connector is not set to use progressive rollout (releases.rolloutConfiguration.enableProgressiveRollout).
Error: Process completed with exit code 1.
```
Here we enable progressive rollout to pass this validation. It shouldn't have any impact, since cloud customer jobs select the "vanilla" connector, then are redirected to the docker hub registry for the "strict-encrypt" version of the connector when we pull the image.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌
