### PR TITLE
ci: disable flaky UUID performance tests

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/util/UUIDGeneratorTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/util/UUIDGeneratorTest.kt
@@ -9,6 +9,7 @@ import kotlin.time.measureTime
 import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 
 internal class UUIDGeneratorTest {
@@ -34,6 +35,7 @@ internal class UUIDGeneratorTest {
     }
 
     @Test
+    @Disabled("Flaky in CI due to timing variability. Useful for manual performance testing.")
     fun testV4Performance() {
         val generator = UUIDGenerator()
 
@@ -55,6 +57,7 @@ internal class UUIDGeneratorTest {
     }
 
     @Test
+    @Disabled("Flaky in CI due to timing variability. Useful for manual performance testing.")
     fun testV7Performance() {
         val generator = UUIDGenerator()
 


### PR DESCRIPTION
## Summary

Disables two flaky performance tests in  that cause intermittent CI failures.

## Problem

The performance tests `testV4Performance()` and `testV7Performance()` assert that custom UUID generators are faster than Java's built-in `UUID.randomUUID()`. These timing-based assertions are inherently flaky in CI:

**Evidence of flakiness:**
- ✅ **Passed**: Unified workflow run on Feb 4, 2026 (run #21692059937)
- ❌ **Failed**: Load workflow run on Feb 9, 2026 (run #21838972046)
- Same code, same runner type (`linux-24.04-large`), different results

**Error:**
```
UUIDGeneratorTest > testV7Performance() FAILED
    org.opentest4j.AssertionFailedError: expected: <true> but was: <false>
```

## Solution

Disable performance tests with `@Disabled` annotation while keeping them in the codebase.

**Tests disabled:**
- `testV4Performance()` - Timing comparison for v4 UUID generation
- `testV7Performance()` - Timing comparison for v7 UUID generation

**Tests still running:**
- `testV4UuidGeneration()` - Functional correctness for v4 UUIDs ✅
- `testV7Generation()` - Functional correctness for v7 UUIDs ✅

## Benefits

✅ **Removes flakiness** from CI builds and publish workflows  
✅ **Keeps tests available** for manual local performance testing  
✅ **Preserves functional tests** that verify correctness  
✅ **Small, focused change** - Only adds 2 annotations  

## Why Keep Them?

Performance tests are still valuable for:
- Local development when optimizing UUID generation
- Manual benchmarking during refactoring
- Documentation of performance expectations

Developers can manually run them locally by removing the `@Disabled` annotation temporarily.

## Testing

Verified that:
- ✅ Disabled tests are skipped: `testV4Performance() SKIPPED`, `testV7Performance() SKIPPED`
- ✅ Functional tests still pass: `testV4UuidGeneration() PASSED`, `testV7Generation() PASSED`
- ✅ Build succeeds without flaky failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._