### PR TITLE
Support redshift auto sort keys

### DIFF
--- a/airbyte-integrations/connectors/destination-redshift/src/main/kotlin/io/airbyte/integrations/destination/redshift/operation/RedshiftStagingStorageOperation.kt
+++ b/airbyte-integrations/connectors/destination-redshift/src/main/kotlin/io/airbyte/integrations/destination/redshift/operation/RedshiftStagingStorageOperation.kt
@@ -266,7 +266,7 @@ class RedshiftStagingStorageOperation(
         private fun createRawTableQuery(streamId: StreamId, suffix: String): String {
             return """
                 CREATE TABLE IF NOT EXISTS "${streamId.rawNamespace}"."${streamId.rawName}$suffix" (
-                    ${JavaBaseConstants.COLUMN_NAME_AB_RAW_ID} VARCHAR(36),
+                    ${JavaBaseConstants.COLUMN_NAME_AB_RAW_ID} VARCHAR(36) distkey,
                     ${JavaBaseConstants.COLUMN_NAME_AB_EXTRACTED_AT} TIMESTAMPTZ DEFAULT GETDATE(),
                     ${JavaBaseConstants.COLUMN_NAME_AB_LOADED_AT} TIMESTAMPTZ,
                     ${JavaBaseConstants.COLUMN_NAME_DATA} SUPER NOT NULL,


### PR DESCRIPTION
## What
With auto distribution keys redshift can now randomly change the distribution key of one staging table but not the other, for example:

facebook_marketing_raw__stream_ads	AUTO(KEY(_airbyte_raw_id)) facebook_marketing_raw__stream_ads_airbyte_tmp	AUTO(EVEN)

This causes the following error on alter table append

The source table and the target table have different distribution styles. Make sure both tables use the same distribution style: EVEN, ALL, or DISTKEY.

## How
This change sets the distribution key explicitly to the raw id column to avoid this.