### PR TITLE
feat(source-ashby): add interviews, interview_stages, and application_criteria_evaluations streams

### DIFF
--- a/airbyte-integrations/connectors/source-ashby/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-ashby/acceptance-test-config.yml
@@ -1,7 +1,7 @@
 # See [Connector Acceptance Tests](https://docs.airbyte.com/connector-development/testing-connectors/connector-acceptance-tests-reference)
 # for more information about how to configure these tests
 connector_image: airbyte/source-ashby:dev
-tests:
+acceptance_tests:
   spec:
     - spec_path: "manifest.yaml"
   connection:

--- a/airbyte-integrations/connectors/source-ashby/manifest.yaml
+++ b/airbyte-integrations/connectors/source-ashby/manifest.yaml
@@ -1,4 +1,4 @@
-version: 4.3.0
+version: 6.48.10
 type: DeclarativeSource
 check:
   type: CheckStream
@@ -1019,6 +1019,11 @@ streams:
           type: DpathExtractor
           field_path:
             - results
+        record_filter:
+          type: RecordFilter
+          condition: >-
+            {{ not config.get('current_applications_only', false) or
+            record.get('status') not in ['Archived', 'Hired'] }}
       paginator:
         type: DefaultPaginator
         page_token_option:
@@ -1547,6 +1552,175 @@ streams:
               - "null"
               - string
   - type: DeclarativeStream
+    name: interviews
+    primary_key:
+      - id
+    retriever:
+      type: SimpleRetriever
+      requester:
+        type: HttpRequester
+        url_base: https://api.ashbyhq.com
+        authenticator:
+          type: BasicHttpAuthenticator
+          username: "{{ config['api_key'] }}"
+          password: "{{ config['api_key'] }}"
+        path: /interview.list
+        http_method: POST
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path:
+            - results
+      paginator:
+        type: DefaultPaginator
+        page_token_option:
+          type: RequestOption
+          inject_into: body_json
+          field_name: cursor
+        page_size_option:
+          type: RequestOption
+          inject_into: body_json
+          field_name: per_page
+        pagination_strategy:
+          type: CursorPagination
+          page_size: 100
+          cursor_value: "{{ response.nextCursor }}"
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/draft-07/schema#
+        additionalProperties: true
+        properties:
+          id:
+            type:
+              - "null"
+              - string
+          applicationId:
+            type:
+              - "null"
+              - string
+          interviewScheduleId:
+            type:
+              - "null"
+              - string
+          interviewStageId:
+            type:
+              - "null"
+              - string
+          status:
+            type:
+              - "null"
+              - string
+          createdAt:
+            type:
+              - "null"
+              - string
+            format: date-time
+          updatedAt:
+            type:
+              - "null"
+              - string
+            format: date-time
+          cancelledAt:
+            type:
+              - "null"
+              - string
+            format: date-time
+          startTime:
+            type:
+              - "null"
+              - string
+            format: date-time
+          endTime:
+            type:
+              - "null"
+              - string
+            format: date-time
+          feedbackLink:
+            type:
+              - "null"
+              - string
+          interviewerUserIds:
+            type:
+              - "null"
+              - array
+            items:
+              type:
+                - "null"
+                - string
+          meetingLink:
+            type:
+              - "null"
+              - string
+  - type: DeclarativeStream
+    name: interview_stages
+    primary_key:
+      - id
+    retriever:
+      type: SimpleRetriever
+      requester:
+        type: HttpRequester
+        url_base: https://api.ashbyhq.com
+        authenticator:
+          type: BasicHttpAuthenticator
+          username: "{{ config['api_key'] }}"
+          password: "{{ config['api_key'] }}"
+        path: /interviewStage.list
+        http_method: POST
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path:
+            - results
+      paginator:
+        type: DefaultPaginator
+        page_token_option:
+          type: RequestOption
+          inject_into: body_json
+          field_name: cursor
+        page_size_option:
+          type: RequestOption
+          inject_into: body_json
+          field_name: per_page
+        pagination_strategy:
+          type: CursorPagination
+          page_size: 100
+          cursor_value: "{{ response.nextCursor }}"
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/draft-07/schema#
+        additionalProperties: true
+        properties:
+          id:
+            type:
+              - "null"
+              - string
+          title:
+            type:
+              - "null"
+              - string
+          type:
+            type:
+              - "null"
+              - string
+          orderInInterviewPlan:
+            type:
+              - "null"
+              - integer
+          interviewPlanId:
+            type:
+              - "null"
+              - string
+          isArchived:
+            type:
+              - "null"
+              - boolean
+  - type: DeclarativeStream
     name: job_postings
     primary_key:
       - id
@@ -1964,6 +2138,126 @@ streams:
             type:
               - "null"
               - string
+  - type: DeclarativeStream
+    name: application_criteria_evaluations
+    primary_key: []
+    retriever:
+      type: SimpleRetriever
+      requester:
+        type: HttpRequester
+        url_base: https://api.ashbyhq.com
+        authenticator:
+          type: BasicHttpAuthenticator
+          username: "{{ config['api_key'] }}"
+          password: "{{ config['api_key'] }}"
+        path: /application.listCriteriaEvaluations
+        http_method: POST
+        request_body_json:
+          applicationId: "{{ stream_partition.application_id }}"
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path:
+            - results
+      paginator:
+        type: NoPagination
+      partition_router:
+        type: SubstreamPartitionRouter
+        parent_stream_configs:
+          - type: ParentStreamConfig
+            stream:
+              type: DeclarativeStream
+              name: applications_for_criteria
+              primary_key:
+                - id
+              retriever:
+                type: SimpleRetriever
+                requester:
+                  type: HttpRequester
+                  url_base: https://api.ashbyhq.com
+                  authenticator:
+                    type: BasicHttpAuthenticator
+                    username: "{{ config['api_key'] }}"
+                    password: "{{ config['api_key'] }}"
+                  path: /application.list
+                  http_method: POST
+                  request_body_json:
+                    createdAfter: "{{ timestamp(config['start_date']) * 1000 }}"
+                record_selector:
+                  type: RecordSelector
+                  extractor:
+                    type: DpathExtractor
+                    field_path:
+                      - results
+                  record_filter:
+                    type: RecordFilter
+                    condition: >-
+                      {{ record.get('currentInterviewStage', {}).get('type') == 'PreInterviewScreen'
+                      and record.get('status') != 'Archived'
+                      and record.get('status') != 'Hired' }}
+                paginator:
+                  type: DefaultPaginator
+                  page_token_option:
+                    type: RequestOption
+                    inject_into: body_json
+                    field_name: cursor
+                  page_size_option:
+                    type: RequestOption
+                    inject_into: body_json
+                    field_name: per_page
+                  pagination_strategy:
+                    type: CursorPagination
+                    page_size: 100
+                    cursor_value: "{{ response.nextCursor }}"
+              schema_loader:
+                type: InlineSchemaLoader
+                schema:
+                  type: object
+                  $schema: http://json-schema.org/draft-07/schema#
+                  additionalProperties: true
+                  properties:
+                    id:
+                      type: string
+            parent_key: id
+            partition_field: application_id
+    transformations:
+      - type: AddFields
+        fields:
+          - path:
+              - application_id
+            value: "{{ stream_partition.application_id }}"
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/draft-07/schema#
+        additionalProperties: true
+        properties:
+          application_id:
+            type:
+              - "null"
+              - string
+          criterionName:
+            type:
+              - "null"
+              - string
+          outcome:
+            type:
+              - "null"
+              - string
+          reasoning:
+            type:
+              - "null"
+              - string
+          assessmentType:
+            type:
+              - "null"
+              - string
+          jobId:
+            type:
+              - "null"
+              - string
 spec:
   type: Spec
   connection_specification:
@@ -1992,6 +2286,15 @@ spec:
         examples:
           - "2017-01-25T00:00:00Z"
         order: 1
+      current_applications_only:
+        type: boolean
+        title: Current Applications Only
+        description: >-
+          When enabled, excludes hired and archived applications from the
+          applications stream. Only active/in-progress applications will be
+          synced.
+        default: false
+        order: 2
     additionalProperties: true
 metadata:
   autoImportSchema:
@@ -2009,6 +2312,9 @@ metadata:
     offers: false
     sources: false
     users: false
+    interviews: false
+    interview_stages: false
+    application_criteria_evaluations: false
 schemas:
   applications:
     type: object

--- a/airbyte-integrations/connectors/source-ashby/manifest.yaml
+++ b/airbyte-integrations/connectors/source-ashby/manifest.yaml
@@ -1019,9 +1019,6 @@ streams:
           type: DpathExtractor
           field_path:
             - results
-        record_filter:
-          type: RecordFilter
-          condition: "{{ not config.get('current_applications_only', false) or record.get('status') not in ['Archived', 'Hired'] }}"
       paginator:
         type: DefaultPaginator
         page_token_option:
@@ -2281,15 +2278,6 @@ spec:
         examples:
           - "2017-01-25T00:00:00Z"
         order: 1
-      current_applications_only:
-        type: boolean
-        title: Current Applications Only
-        description: >-
-          When enabled, excludes hired and archived applications from the
-          applications stream. Only active/in-progress applications will be
-          synced.
-        default: false
-        order: 2
     additionalProperties: true
 metadata:
   autoImportSchema:

--- a/airbyte-integrations/connectors/source-ashby/manifest.yaml
+++ b/airbyte-integrations/connectors/source-ashby/manifest.yaml
@@ -1,4 +1,4 @@
-version: 6.48.10
+version: 4.3.0
 type: DeclarativeSource
 check:
   type: CheckStream
@@ -1021,9 +1021,7 @@ streams:
             - results
         record_filter:
           type: RecordFilter
-          condition: >-
-            {{ not config.get('current_applications_only', false) or
-            record.get('status') not in ['Archived', 'Hired'] }}
+          condition: "{{ not config.get('current_applications_only', false) or record.get('status') not in ['Archived', 'Hired'] }}"
       paginator:
         type: DefaultPaginator
         page_token_option:
@@ -2192,10 +2190,7 @@ streams:
                       - results
                   record_filter:
                     type: RecordFilter
-                    condition: >-
-                      {{ record.get('currentInterviewStage', {}).get('type') == 'PreInterviewScreen'
-                      and record.get('status') != 'Archived'
-                      and record.get('status') != 'Hired' }}
+                    condition: "{{ (record.get('currentInterviewStage') or {}).get('type') == 'PreInterviewScreen' and record.get('status') not in ['Archived', 'Hired'] }}"
                 paginator:
                   type: DefaultPaginator
                   page_token_option:

--- a/airbyte-integrations/connectors/source-ashby/metadata.yaml
+++ b/airbyte-integrations/connectors/source-ashby/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 4e8c9fa0-3634-499b-b948-11581b5c3efa
-  dockerImageTag: 0.2.23
+  dockerImageTag: 0.3.0
   dockerRepository: airbyte/source-ashby
   githubIssueLabel: source-ashby
   icon: ashby.svg

--- a/airbyte-integrations/connectors/source-ashby/metadata.yaml
+++ b/airbyte-integrations/connectors/source-ashby/metadata.yaml
@@ -25,6 +25,14 @@ data:
   ab_internal:
     sl: 100
     ql: 100
+  suggestedStreams:
+    streams:
+      - applications
+      - candidates
+      - jobs
+      - job_postings
+      - users
+      - interview_schedules
   supportLevel: community
   connectorTestSuitesOptions:
     - suite: unitTests

--- a/docs/integrations/sources/ashby.md
+++ b/docs/integrations/sources/ashby.md
@@ -51,7 +51,7 @@ The Ashby connector should not run into Ashby API limitations under normal usage
 
 | Version | Date       | Pull Request                                             | Subject                                     |
 |:--------| :--------- | :------------------------------------------------------- |:--------------------------------------------|
-| 0.3.0 | 2026-02-11 | [73244](https://github.com/airbytehq/airbyte/pull/73244) | Add interviews, interview_stages, and application_criteria_evaluations streams; add current_applications_only config option |
+| 0.3.0 | 2026-02-11 | [73244](https://github.com/airbytehq/airbyte/pull/73244) | Add interviews, interview_stages, and application_criteria_evaluations streams |
 | 0.2.23 | 2025-05-10 | [59853](https://github.com/airbytehq/airbyte/pull/59853) | Update dependencies |
 | 0.2.22 | 2025-05-03 | [59322](https://github.com/airbytehq/airbyte/pull/59322) | Update dependencies |
 | 0.2.21 | 2025-04-26 | [58746](https://github.com/airbytehq/airbyte/pull/58746) | Update dependencies |

--- a/docs/integrations/sources/ashby.md
+++ b/docs/integrations/sources/ashby.md
@@ -11,6 +11,7 @@ This source can sync data for the [Ashby API](https://developers.ashbyhq.com/ref
 This Source is capable of syncing the following core Streams:
 
 - [applications](https://developers.ashbyhq.com/reference/applicationlist)
+- [application_criteria_evaluations](https://developers.ashbyhq.com/reference/applicationlistcriteriaevaluations) (substream of applications)
 - [archive_reasons](https://developers.ashbyhq.com/reference/archivereasonlist)
 - [candidate_tags](https://developers.ashbyhq.com/reference/candidatetaglist)
 - [candidates](https://developers.ashbyhq.com/reference/candidatelist)
@@ -18,6 +19,8 @@ This Source is capable of syncing the following core Streams:
 - [departments](https://developers.ashbyhq.com/reference/departmentlist)
 - [feedback_form_definitions](https://developers.ashbyhq.com/reference/feedbackformdefinitionlist)
 - [interview_schedules](https://developers.ashbyhq.com/reference/interviewschedulelist)
+- [interviews](https://developers.ashbyhq.com/reference/interviewlist)
+- [interview_stages](https://developers.ashbyhq.com/reference/interviewstagelist)
 - [job_postings](https://developers.ashbyhq.com/reference/jobpostinglist)
 - [jobs](https://developers.ashbyhq.com/reference/joblist)
 - [locations](https://developers.ashbyhq.com/reference/locationlist)
@@ -48,6 +51,7 @@ The Ashby connector should not run into Ashby API limitations under normal usage
 
 | Version | Date       | Pull Request                                             | Subject                                     |
 |:--------| :--------- | :------------------------------------------------------- |:--------------------------------------------|
+| 0.3.0 | 2026-02-11 | [73244](https://github.com/airbytehq/airbyte/pull/73244) | Add interviews, interview_stages, and application_criteria_evaluations streams; add current_applications_only config option |
 | 0.2.23 | 2025-05-10 | [59853](https://github.com/airbytehq/airbyte/pull/59853) | Update dependencies |
 | 0.2.22 | 2025-05-03 | [59322](https://github.com/airbytehq/airbyte/pull/59322) | Update dependencies |
 | 0.2.21 | 2025-04-26 | [58746](https://github.com/airbytehq/airbyte/pull/58746) | Update dependencies |


### PR DESCRIPTION
## What

Adds 3 new streams to the existing `source-ashby` manifest-only connector (v0.2.23 → v0.3.0).

New streams:
- `interviews` — `/interview.list`
- `interview_stages` — `/interviewStage.list`
- `application_criteria_evaluations` — `/application.listCriteriaEvaluations` (substream of applications, for AI-generated criteria evaluations)

Requested by @aaronsteers.
[Link to Devin run](https://app.devin.ai/sessions/efd3a7b8461c45d0b395564b500b5f37)

## How

All connector logic changes are in `manifest.yaml` (declarative YAML connector, no Python code):

1. **`interviews` / `interview_stages`**: Standard stream definitions following the same pattern as existing streams (POST requester, cursor pagination, inline schema).
2. **`application_criteria_evaluations`**: Uses `SubstreamPartitionRouter` with an **inline parent stream** (`applications_for_criteria`) that fetches all applications and filters to only those in the "Application Review" stage (`currentInterviewStage.type == 'PreInterviewScreen'`) and excludes Archived/Hired. For each matching application, it calls `/application.listCriteriaEvaluations` with the `applicationId`. An `AddFields` transformation injects `application_id` from the partition into each record.

Supporting changes:
- **`metadata.yaml`**: Version bump `0.2.23` → `0.3.0`, added `suggestedStreams` list, added `autoImportSchema` entries for new streams.
- **`acceptance-test-config.yml`**: Fixed top-level key from `tests:` to `acceptance_tests:` (required by current CDK).
- **`docs/integrations/sources/ashby.md`**: Added changelog entry for v0.3.0, documented new streams in output schema.

## Review guide

1. **`manifest.yaml`** — focus review on:
   - **`application_criteria_evaluations` substream** (~lines 2133–2255): The `SubstreamPartitionRouter` with an inline `DeclarativeStream` parent is the most complex part. Verify the CDK supports this nesting pattern. `primary_key: []` and `NoPagination` are intentional (evaluations are per-application, no cursor).
   - **Inline parent stream filter** (`record_filter` on `applications_for_criteria`): Uses `(record.get('currentInterviewStage') or {}).get('type') == 'PreInterviewScreen'` with a null guard — verify this Jinja2 expression works in the CDK sandbox.
2. **`metadata.yaml`** — version bump and `suggestedStreams` addition.
3. **`acceptance-test-config.yml`** — trivial fix (`tests:` → `acceptance_tests:`).
4. **`docs/integrations/sources/ashby.md`** — changelog and stream list updates.

### 🔍 Reviewer checklist (risky areas)
- [ ] **Schemas for untested streams**: `interviews`, `interview_stages`, and `application_criteria_evaluations` schemas are based on API documentation only — the test API key lacked permissions or data to validate them against live responses. Verify field names/types match what the API actually returns.
- [ ] **Inline parent stream nesting**: The `SubstreamPartitionRouter` uses an inline `DeclarativeStream` as the parent rather than referencing a top-level stream. Confirm the CDK handles this correctly (especially pagination within the inline parent).
- [ ] **Jinja2 null guard**: `(record.get('currentInterviewStage') or {}).get('type')` — confirm this pattern is safe in the CDK's Jinja2 sandbox (handles both missing key and explicit `null` value).

## ⚠️ Testing notes

- **CI passes**: All required checks green, connector acceptance tests pass.
- **DuckDB sync verified**: 213k+ records synced across 12 streams via Coral MCP (PyAirbyte).
- **Limitations**: The `interviews` and `interview_stages` endpoints returned `missing_endpoint_permission` with the test API key. The `application.listCriteriaEvaluations` endpoint returned empty results (AI Application Review feature may not be enabled in the test account). These streams' schemas are based on API documentation.

## User Impact

Users can now sync:
- Interview data (`interviews`, `interview_stages`)
- AI-generated application criteria evaluations (`application_criteria_evaluations`)

No breaking changes to existing streams.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚