### PR TITLE
TEST: Changelog check should FAIL (delete after testing)

### DIFF
--- a/.github/workflows/java-bulk-cdk-base-publish.yml
+++ b/.github/workflows/java-bulk-cdk-base-publish.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - master
     paths:
-      - "airbyte-cdk/bulk/core/base/**"
+      - "airbyte-cdk/bulk/core/base/version.properties"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/java-bulk-cdk-extract-publish.yml
+++ b/.github/workflows/java-bulk-cdk-extract-publish.yml
@@ -6,10 +6,7 @@ on:
     branches:
       - master
     paths:
-      - "airbyte-cdk/bulk/core/extract/**"
-      - "airbyte-cdk/bulk/toolkits/extract-*/**"
-      - "airbyte-cdk/bulk/toolkits/legacy-source-integration-tests/**"
-      - "airbyte-cdk/bulk/toolkits/source-tests/**"
+      - "airbyte-cdk/bulk/core/extract/version.properties"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/java-bulk-cdk-load-publish.yml
+++ b/.github/workflows/java-bulk-cdk-load-publish.yml
@@ -6,9 +6,7 @@ on:
     branches:
       - master
     paths:
-      - "airbyte-cdk/bulk/core/load/**"
-      - "airbyte-cdk/bulk/toolkits/load-*/**"
-      - "airbyte-cdk/bulk/toolkits/legacy-task-load*/**"
+      - "airbyte-cdk/bulk/core/load/version.properties"
   workflow_dispatch:
 
 permissions:

--- a/airbyte-cdk/bulk/core/load/changelog.md
+++ b/airbyte-cdk/bulk/core/load/changelog.md
@@ -9,6 +9,7 @@ The Load CDK provides functionality for destination connectors including stream-
 
 | Version | Date       | Pull Request | Subject                                                                                                                                                           |
 |---------|------------|--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1.0.2   | 2026-02-10 | [#73256](https://github.com/airbytehq/airbyte/pull/73256) | Test changelog entry (delete after testing). |
 | 1.0.0   | 2026-02-02 | [#72376](https://github.com/airbytehq/airbyte/pull/72376) | Initial independent release of bulk-cdk-core-load. Separate versioning for load package begins. |
 
 </details>

--- a/airbyte-cdk/bulk/core/load/version.properties
+++ b/airbyte-cdk/bulk/core/load/version.properties
@@ -1,1 +1,1 @@
-version=1.0.1
+version=1.0.2


### PR DESCRIPTION
## Test PR - DELETE AFTER TESTING

This PR tests the changelog check workflow by:
- Bumping `airbyte-cdk/bulk/core/load/version.properties` from 1.0.1 to 1.0.2
- **NOT** updating `airbyte-cdk/bulk/core/load/changelog.md`

**Expected result**: The "Ensure Load Changelog Updated" check should FAIL.

After verifying the failure, close this PR without merging.