### PR TITLE
docs(source-sharepoint-enterprise): add changelog entry for v0.3.1 CDK bump

### DIFF
--- a/docs/integrations/enterprise-connectors/source-sharepoint-enterprise.md
+++ b/docs/integrations/enterprise-connectors/source-sharepoint-enterprise.md
@@ -317,6 +317,7 @@ The connector is restricted by normal Microsoft Graph [requests limitation](http
 
 | Version | Date       | Pull Request                                           | Subject                                                                   |
 |:--------|:-----------|:-------------------------------------------------------|:--------------------------------------------------------------------------|
+| 0.3.1 | 2026-02-11 | [381](https://github.com/airbytehq/airbyte-enterprise/pull/381) | Bump CDK to 7.9.3 to fix permissions stream primary key |
 | 0.3.0 | 2025-05-21 | [161](https://github.com/airbytehq/airbyte-enterprise/pull/161) | Add permissions sync support |
 | 0.2.0 | 2025-04-30 | [144](https://github.com/airbytehq/airbyte-enterprise/pull/144) | Adapt file-transfer records to latest protocol, requires platform >= 1.7.0, destination-s3 >= 1.8.0 |
 | 0.1.0 | 2025-04-10 | [134](https://github.com/airbytehq/airbyte-enterprise/pull/134) | New source |


### PR DESCRIPTION
## What

Adds a changelog entry for `source-sharepoint-enterprise` v0.3.1, which bumps the CDK to 7.9.3 to fix the permissions stream primary key bug.

This accompanies the connector change in [airbytehq/airbyte-enterprise#381](https://github.com/airbytehq/airbyte-enterprise/pull/381).

## How

Single-line addition to the changelog table in the connector's documentation.

## Review guide

1. `docs/integrations/enterprise-connectors/source-sharepoint-enterprise.md` — verify the new row matches the table format and links to the correct enterprise PR.

## User Impact

Documentation only — no runtime impact.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---
[Link to Devin run](https://app.devin.ai/sessions/c1ea454c5dca430e8359965bd004d023)
Requested by: @rwask