### PR TITLE
chore(source-google-ads): Add deprecation and sunset schedule URL to external docs

### DIFF
--- a/airbyte-integrations/connectors/source-google-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-ads/metadata.yaml
@@ -18,6 +18,9 @@ data:
     - title: Release notes
       url: https://developers.google.com/google-ads/api/docs/release-notes
       type: api_release_history
+    - title: Deprecation and sunset schedule
+      url: https://developers.google.com/google-ads/api/docs/sunset-dates
+      type: api_deprecations
     - title: Developer blog
       url: https://ads-developers.googleblog.com/
   githubIssueLabel: source-google-ads


### PR DESCRIPTION
## What

Adds Google's [Deprecation and Sunset Schedule](https://developers.google.com/google-ads/api/docs/sunset-dates) page to the connector's `externalDocumentationUrls` in `metadata.yaml`. This page tracks API version sunset dates and is the primary source of truth for version lifecycle information.

This was identified during routine API deprecation monitoring for `source-google-ads` (tracked in [airbytehq/oncall#10436](https://github.com/airbytehq/oncall/issues/10436)). The existing external docs listed the release notes and developer blog but were missing the dedicated deprecation/sunset schedule page.

Related issue: https://github.com/airbytehq/oncall/issues/10436

## How

Added a single new entry to `externalDocumentationUrls` with `type: api_deprecations`, placed between the existing `api_release_history` entry and the developer blog entry.

## Review guide

1. `airbyte-integrations/connectors/source-google-ads/metadata.yaml` — Only file changed. Single new URL entry added to `externalDocumentationUrls`.

## User Impact

None. This is a metadata-only change with no version bump. It improves future deprecation monitoring tooling by ensuring the sunset schedule URL is available for automated checks.

## Can this PR be safely reverted and rolled back?

- [x] YES

---

Link to Devin run: https://app.devin.ai/sessions/3e7a27fda14749d0b1b2385e04b6cc1b
Requested by: Danylo Jablonski (@DanyloGL)