### PR TITLE
chore(source-monday): Update external documentation URLs

### DIFF
--- a/airbyte-integrations/connectors/source-monday/metadata.yaml
+++ b/airbyte-integrations/connectors/source-monday/metadata.yaml
@@ -86,6 +86,12 @@ data:
     - title: monday.com API reference
       url: https://developer.monday.com/api-reference/docs
       type: api_reference
+    - title: monday.com API changelog
+      url: https://developer.monday.com/api-reference/changelog
+      type: api_release_history
+    - title: monday.com API versioning and deprecation schedule
+      url: https://developer.monday.com/api-reference/docs/api-versioning
+      type: api_deprecations
     - title: monday.com authentication
       url: https://developer.monday.com/api-reference/docs/authentication
       type: authentication_guide


### PR DESCRIPTION
## What

Adds missing external documentation URLs to `source-monday` metadata for API deprecation monitoring. Discovered during a routine API deprecation audit ([oncall#11263](https://github.com/airbytehq/oncall/issues/11263)) — the connector had no changelog or deprecation-related URLs, making automated deprecation checks less effective.

Resolves https://github.com/airbytehq/oncall/issues/11263

- https://github.com/airbytehq/oncall/issues/11263

## How

Added two entries to `externalDocumentationUrls` in `metadata.yaml`:
- **monday.com API changelog** (`api_release_history`): https://developer.monday.com/api-reference/changelog
- **monday.com API versioning and deprecation schedule** (`api_deprecations`): https://developer.monday.com/api-reference/docs/api-versioning

## Review guide

1. `airbyte-integrations/connectors/source-monday/metadata.yaml` — only file changed. Verify the two new URLs are accessible and the `type` values (`api_release_history`, `api_deprecations`) are valid.

## User Impact

No user-facing impact. This is a metadata-only change that improves internal deprecation monitoring coverage.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Link to Devin run: https://app.devin.ai/sessions/4e77cacb2c274f3e9ee7da4fcd272d58
Requested by: @DanyloGL