### PR TITLE
Refactor: Migrate source-postgres to bulk CDK and update workflows

### DIFF
--- a/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/output/NativeRecord.kt
+++ b/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/output/NativeRecord.kt
@@ -21,7 +21,9 @@ import io.airbyte.protocol.protobuf.AirbyteRecordMessage
 import io.airbyte.protocol.protobuf.AirbyteRecordMessage.AirbyteRecordMessageProtobuf
 import java.math.BigDecimal
 import java.net.URL
+import java.nio.ByteBuffer
 import java.time.OffsetDateTime
+import java.time.temporal.TemporalAccessor
 
 // A value of a field along with its encoder
 class FieldValueEncoder<R>(val fieldValue: R?, val jsonEncoder: JsonEncoder<in R>) {
@@ -96,7 +98,23 @@ fun <R> valueForProtobufEncoding(fve: FieldValueEncoder<R>): Any? {
             is CdcOffsetDateTimeCodec ->
                 (value as OffsetDateTime).format(OffsetDateTimeCodec.formatter)
             is ArrayEncoder<*> -> fve.encode().toString()
-            else -> value
+            else ->
+                if (
+                    value is String ||
+                        value is Number ||
+                        value is Boolean ||
+                        value is TemporalAccessor ||
+                        value is java.util.Date ||
+                        value is ByteArray ||
+                        value is ByteBuffer
+                ) {
+                    value
+                } else {
+                    // The native value type is not directly compatible with protobuf encoding.
+                    // Fall back to the JSON encoder to produce a protobuf-compatible value.
+                    // This handles cases like hstore (Map<String, String?> -> STRING).
+                    fve.encode().asText()
+                }
         }
     }
 }

--- a/airbyte-cdk/bulk/core/extract/src/test/kotlin/io/airbyte/cdk/output/sockets/NativeRecordProtobufEncoderTest.kt
+++ b/airbyte-cdk/bulk/core/extract/src/test/kotlin/io/airbyte/cdk/output/sockets/NativeRecordProtobufEncoderTest.kt
@@ -4,6 +4,8 @@
 
 package io.airbyte.cdk.output.sockets
 
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.node.TextNode
 import io.airbyte.cdk.data.AirbyteSchemaType
 import io.airbyte.cdk.data.BigDecimalCodec
 import io.airbyte.cdk.data.BigDecimalIntegerCodec
@@ -45,6 +47,17 @@ import org.junit.jupiter.api.DynamicNode
 import org.junit.jupiter.api.DynamicTest
 import org.junit.jupiter.api.TestFactory
 
+/** Test encoder that mimics hstore: encodes a Map as a JSON string in a TextNode. */
+object MapAsJsonStringEncoder : JsonEncoder<Map<String, String?>> {
+    override fun encode(decoded: Map<String, String?>): JsonNode {
+        val json =
+            decoded.entries.joinToString(",", "{", "}") { (k, v) ->
+                if (v == null) "\"$k\":null" else "\"$k\":\"$v\""
+            }
+        return TextNode(json)
+    }
+}
+
 class NativeRecordProtobufEncoderTest {
     private val protoDecoder = AirbyteValueProtobufDecoder()
 
@@ -69,6 +82,11 @@ class NativeRecordProtobufEncoderTest {
                         }
                     is Byte -> value.toLong().toBigInteger()
                     is Double -> value.toBigDecimal()
+                    is Map<*, *> ->
+                        MapAsJsonStringEncoder.encode(
+                                @Suppress("UNCHECKED_CAST") (value as Map<String, String?>)
+                            )
+                            .asText()
                     else -> value!!
                 }
     }
@@ -186,6 +204,12 @@ class NativeRecordProtobufEncoderTest {
                 value = OffsetTime.parse(OffsetTime.now().format(OffsetTimeCodec.formatter)),
                 jsonEncoder = OffsetTimeCodec,
                 airbyteSchemaType = LeafAirbyteSchemaType.TIME_WITH_TIMEZONE
+            ),
+            // Simulates hstore: native value is Map but schema type is STRING.
+            TestCase(
+                value = mapOf("color" to "red", "size" to null),
+                jsonEncoder = MapAsJsonStringEncoder,
+                airbyteSchemaType = LeafAirbyteSchemaType.STRING
             ),
         )
 


### PR DESCRIPTION
## Summary

This is a comprehensive migration of the source-postgres connector from the legacy framework to the Airbyte Bulk CDK, along with significant workflow and infrastructure updates.

## Major Changes

### Source Postgres Migration
- **Complete rewrite** from Java to Kotlin using Bulk CDK framework
- Implements JDBC-based partitioning and CDC (Change Data Capture) support
- Adds support for:
  - HSTORE field types with custom parsing
  - Multiple state management strategies (cursor-based, xmin, ctid)
  - Debezium-based CDC with heartbeat configuration
  - Azure Entra authentication
  - SSH tunnel support
  - SSL/TLS certificate authentication
- Removes 1000+ lines of legacy Java code
- Adds comprehensive Kotlin test suite with integration tests

### CI/CD Workflow Updates
- **Renamed parameters** for consistency: `release-type` → `with-semver-suffix`
- **New suffix modes**: `none` (production), `preview` (development), `rc` (release candidates)
- **New force-merge workflow**: Added `/force-merge` admin command (requires reason)
- **Removed approval checks** from force-merge (replaced with admin auth)
- **Dry-run support**: New `--dry-run` flag to test publishing without uploads
- **RC build support**: Auto-enables progressive rollout for RC releases
- **Bulk CDK base versioning**: Independent versioning for `core/base` package

### Documentation & Config
- Updated CODEOWNERS to remove review requirements for connector markdown files
- Added new TK-TODO check workflow to prevent temporary markers
- Updated PR welcome messages with new slash commands
- Added Okta SSO IdP-Initiated Login configuration docs
- Synced AI agent connector documentation

### New Connectors & Features
- **source-grafana**: New connector contributed by community
- **source-nexus-datasets**: New connector for Nexus data access
- **source-shopify**: Added CollectionProducts stream
- **destination-motherduck**: Fixed empty STRUCT handling
- Various connector updates and version bumps

### Infrastructure
- Java connector image build/push action refactored for new semver suffix modes
- New `java-bulk-cdk-base-publish` workflow for independent base package releases
- Enhanced gradle configuration for Bulk CDK with separate base versioning

## Testing
- Comprehensive integration and unit tests added for Postgres source
- Legacy test suite preserved and ported to Kotlin
- Support for various database configurations (CDC, JDBC, SSL, SSH)
