### PR TITLE
feat: add source-salesforce-commerce-cloud manifest-only connector

### DIFF
--- a/airbyte-integrations/connectors/source-salesforce-commerce-cloud/icon.svg
+++ b/airbyte-integrations/connectors/source-salesforce-commerce-cloud/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100">
+  <circle cx="50" cy="50" r="45" fill="#00A1E0"/>
+  <path d="M30 55 C30 40, 45 30, 55 35 C58 25, 75 25, 78 35 C88 35, 90 50, 80 55 C85 65, 70 72, 60 65 C55 75, 35 75, 30 65 C20 65, 18 50, 30 55Z" fill="white"/>
+</svg>

--- a/airbyte-integrations/connectors/source-salesforce-commerce-cloud/manifest.yaml
+++ b/airbyte-integrations/connectors/source-salesforce-commerce-cloud/manifest.yaml
@@ -196,6 +196,103 @@ definitions:
         schema:
           $ref: "#/schemas/campaigns"
 
+    categories:
+      type: DeclarativeStream
+      name: categories
+      retriever:
+        type: SimpleRetriever
+        requester:
+          $ref: "#/definitions/base_requester"
+          path: /product/catalogs/v1/organizations/{{ config['organization_id'] }}/catalogs/{{ stream_partition.catalog_id }}/categories
+          http_method: GET
+          request_parameters:
+            siteId: "{{ config['site_id'] }}"
+        record_selector:
+          type: RecordSelector
+          extractor:
+            type: DpathExtractor
+            field_path:
+              - data
+        paginator:
+          type: DefaultPaginator
+          page_token_option:
+            type: RequestOption
+            inject_into: request_parameter
+            field_name: offset
+          page_size_option:
+            type: RequestOption
+            inject_into: request_parameter
+            field_name: limit
+          pagination_strategy:
+            type: OffsetIncrement
+            page_size: 200
+        partition_router:
+          - type: SubstreamPartitionRouter
+            parent_stream_configs:
+              - type: ParentStreamConfig
+                parent_key: id
+                partition_field: catalog_id
+                stream:
+                  $ref: "#/definitions/streams/catalogs"
+      primary_key:
+        - id
+      schema_loader:
+        type: InlineSchemaLoader
+        schema:
+          $ref: "#/schemas/categories"
+
+    products:
+      type: DeclarativeStream
+      name: products
+      retriever:
+        type: SimpleRetriever
+        requester:
+          $ref: "#/definitions/base_requester"
+          path: /product/catalogs/v1/organizations/{{ config['organization_id'] }}/catalogs/{{ stream_partition.parent_slice.catalog_id }}/categories/{{ stream_partition.category_id }}/products
+          http_method: POST
+          request_parameters:
+            siteId: "{{ config['site_id'] }}"
+          request_body_json:
+            query:
+              textQuery:
+                fields:
+                  - "productId"
+                searchPhrase: "*"
+            select: "(**)"
+        record_selector:
+          type: RecordSelector
+          extractor:
+            type: DpathExtractor
+            field_path:
+              - data
+        paginator:
+          type: DefaultPaginator
+          page_token_option:
+            type: RequestOption
+            inject_into: body_json
+            field_name: start
+          page_size_option:
+            type: RequestOption
+            inject_into: body_json
+            field_name: count
+          pagination_strategy:
+            type: OffsetIncrement
+            page_size: 200
+        partition_router:
+          - type: SubstreamPartitionRouter
+            parent_stream_configs:
+              - type: ParentStreamConfig
+                parent_key: id
+                partition_field: category_id
+                stream:
+                  $ref: "#/definitions/streams/categories"
+      primary_key:
+        - id
+      schema_loader:
+        type: InlineSchemaLoader
+        schema:
+          $ref: "#/schemas/products"
+
   base_requester:
     type: HttpRequester
     url_base: >-
@@ -215,6 +312,8 @@ definitions:
 streams:
   - $ref: "#/definitions/streams/orders"
   - $ref: "#/definitions/streams/catalogs"
+  - $ref: "#/definitions/streams/categories"
+  - $ref: "#/definitions/streams/products"
   - $ref: "#/definitions/streams/promotions"
   - $ref: "#/definitions/streams/campaigns"
 
@@ -476,6 +575,88 @@ schemas:
         type:
           - "null"
           - boolean
+
+  categories:
+    type: object
+    $schema: http://json-schema.org/draft-07/schema#
+    additionalProperties: true
+    properties:
+      id:
+        type:
+          - "null"
+          - string
+      name:
+        type:
+          - "null"
+          - object
+        additionalProperties: true
+      parentCategoryId:
+        type:
+          - "null"
+          - string
+      position:
+        type:
+          - "null"
+          - number
+      online:
+        type:
+          - "null"
+          - boolean
+      creationDate:
+        type:
+          - "null"
+          - string
+        format: date-time
+      lastModified:
+        type:
+          - "null"
+          - string
+        format: date-time
+
+  products:
+    type: object
+    $schema: http://json-schema.org/draft-07/schema#
+    additionalProperties: true
+    properties:
+      id:
+        type:
+          - "null"
+          - string
+      name:
+        type:
+          - "null"
+          - object
+        additionalProperties: true
+      brand:
+        type:
+          - "null"
+          - string
+      online:
+        type:
+          - "null"
+          - boolean
+      searchable:
+        type:
+          - "null"
+          - boolean
+      primaryCategoryId:
+        type:
+          - "null"
+          - string
+      price:
+        type:
+          - "null"
+          - number
+      creationDate:
+        type:
+          - "null"
+          - string
+        format: date-time
+      lastModified:
+        type:
+          - "null"
+          - string
+        format: date-time
 
   campaigns:
     type: object

--- a/airbyte-integrations/connectors/source-salesforce-commerce-cloud/manifest.yaml
+++ b/airbyte-integrations/connectors/source-salesforce-commerce-cloud/manifest.yaml
@@ -1,0 +1,522 @@
+version: 6.8.0
+
+type: DeclarativeSource
+
+check:
+  type: CheckStream
+  stream_names:
+    - orders
+
+definitions:
+  streams:
+    orders:
+      type: DeclarativeStream
+      name: orders
+      retriever:
+        type: SimpleRetriever
+        requester:
+          $ref: "#/definitions/base_requester"
+          path: /checkout/orders/v1/organizations/{{ config['organization_id'] }}/orders
+          http_method: GET
+          request_parameters:
+            siteId: "{{ config['site_id'] }}"
+            sortBy: last_modified_date
+            sortOrder: asc
+        record_selector:
+          type: RecordSelector
+          extractor:
+            type: DpathExtractor
+            field_path:
+              - data
+        paginator:
+          type: DefaultPaginator
+          page_token_option:
+            type: RequestOption
+            inject_into: request_parameter
+            field_name: offset
+          page_size_option:
+            type: RequestOption
+            inject_into: request_parameter
+            field_name: limit
+          pagination_strategy:
+            type: OffsetIncrement
+            page_size: 200
+      primary_key:
+        - orderNo
+      schema_loader:
+        type: InlineSchemaLoader
+        schema:
+          $ref: "#/schemas/orders"
+      incremental_sync:
+        type: DatetimeBasedCursor
+        cursor_field: lastModified
+        cursor_datetime_formats:
+          - "%Y-%m-%dT%H:%M:%S.%fZ"
+          - "%Y-%m-%dT%H:%M:%SZ"
+        datetime_format: "%Y-%m-%dT%H:%M:%SZ"
+        start_datetime:
+          type: MinMaxDatetime
+          datetime: "{{ config.get('start_date', '2020-01-01T00:00:00Z') }}"
+          datetime_format: "%Y-%m-%dT%H:%M:%SZ"
+        end_datetime:
+          type: MinMaxDatetime
+          datetime: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"
+          datetime_format: "%Y-%m-%dT%H:%M:%SZ"
+        start_time_option:
+          type: RequestOption
+          inject_into: request_parameter
+          field_name: lastModifiedDateFrom
+        end_time_option:
+          type: RequestOption
+          inject_into: request_parameter
+          field_name: lastModifiedDateTo
+
+    catalogs:
+      type: DeclarativeStream
+      name: catalogs
+      retriever:
+        type: SimpleRetriever
+        requester:
+          $ref: "#/definitions/base_requester"
+          path: /product/catalogs/v1/organizations/{{ config['organization_id'] }}/catalogs
+          http_method: GET
+          request_parameters:
+            siteId: "{{ config['site_id'] }}"
+        record_selector:
+          type: RecordSelector
+          extractor:
+            type: DpathExtractor
+            field_path:
+              - data
+        paginator:
+          type: DefaultPaginator
+          page_token_option:
+            type: RequestOption
+            inject_into: request_parameter
+            field_name: offset
+          page_size_option:
+            type: RequestOption
+            inject_into: request_parameter
+            field_name: limit
+          pagination_strategy:
+            type: OffsetIncrement
+            page_size: 200
+      primary_key:
+        - id
+      schema_loader:
+        type: InlineSchemaLoader
+        schema:
+          $ref: "#/schemas/catalogs"
+
+    promotions:
+      type: DeclarativeStream
+      name: promotions
+      retriever:
+        type: SimpleRetriever
+        requester:
+          $ref: "#/definitions/base_requester"
+          path: /pricing/promotions/v1/organizations/{{ config['organization_id'] }}/promotions
+          http_method: POST
+          request_parameters:
+            siteId: "{{ config['site_id'] }}"
+          request_body_json:
+            query:
+              textQuery:
+                fields:
+                  - promotionId
+                searchPhrase: "*"
+            select: "(**)"
+        record_selector:
+          type: RecordSelector
+          extractor:
+            type: DpathExtractor
+            field_path:
+              - data
+        paginator:
+          type: DefaultPaginator
+          page_token_option:
+            type: RequestOption
+            inject_into: body_json
+            field_name: start
+          page_size_option:
+            type: RequestOption
+            inject_into: body_json
+            field_name: count
+          pagination_strategy:
+            type: OffsetIncrement
+            page_size: 200
+      primary_key:
+        - id
+      schema_loader:
+        type: InlineSchemaLoader
+        schema:
+          $ref: "#/schemas/promotions"
+
+    campaigns:
+      type: DeclarativeStream
+      name: campaigns
+      retriever:
+        type: SimpleRetriever
+        requester:
+          $ref: "#/definitions/base_requester"
+          path: /pricing/campaigns/v1/organizations/{{ config['organization_id'] }}/campaigns
+          http_method: POST
+          request_parameters:
+            siteId: "{{ config['site_id'] }}"
+          request_body_json:
+            query:
+              textQuery:
+                fields:
+                  - campaignId
+                searchPhrase: "*"
+            select: "(**)"
+        record_selector:
+          type: RecordSelector
+          extractor:
+            type: DpathExtractor
+            field_path:
+              - data
+        paginator:
+          type: DefaultPaginator
+          page_token_option:
+            type: RequestOption
+            inject_into: body_json
+            field_name: start
+          page_size_option:
+            type: RequestOption
+            inject_into: body_json
+            field_name: count
+          pagination_strategy:
+            type: OffsetIncrement
+            page_size: 200
+      primary_key:
+        - id
+      schema_loader:
+        type: InlineSchemaLoader
+        schema:
+          $ref: "#/schemas/campaigns"
+
+  base_requester:
+    type: HttpRequester
+    url_base: >-
+      https://{{ config['short_code'] }}.api.commercecloud.salesforce.com
+    authenticator:
+      type: OAuthAuthenticator
+      client_id: "{{ config['client_id'] }}"
+      client_secret: "{{ config['client_secret'] }}"
+      grant_type: client_credentials
+      token_refresh_endpoint: https://account.demandware.com/dwsso/oauth2/access_token
+      refresh_request_body:
+        scope: >-
+          SALESFORCE_COMMERCE_API:{{ config['organization_id'] | replace('f_ecom_', '') }}
+          sfcc.orders sfcc.products sfcc.catalogs
+          sfcc.pricing.promotions sfcc.pricing.coupons sfcc.pricing.campaigns
+
+streams:
+  - $ref: "#/definitions/streams/orders"
+  - $ref: "#/definitions/streams/catalogs"
+  - $ref: "#/definitions/streams/promotions"
+  - $ref: "#/definitions/streams/campaigns"
+
+spec:
+  type: Spec
+  documentation_url: https://docs.airbyte.com/integrations/sources/salesforce-commerce-cloud
+  connection_specification:
+    type: object
+    $schema: http://json-schema.org/draft-07/schema#
+    required:
+      - client_id
+      - client_secret
+      - organization_id
+      - short_code
+      - site_id
+    properties:
+      client_id:
+        type: string
+        order: 0
+        title: Client ID
+        description: >-
+          The client ID from your Salesforce Commerce Cloud Account Manager API client.
+        airbyte_secret: true
+      client_secret:
+        type: string
+        order: 1
+        title: Client Secret
+        description: >-
+          The client secret from your Salesforce Commerce Cloud Account Manager API client.
+        airbyte_secret: true
+      organization_id:
+        type: string
+        order: 2
+        title: Organization ID
+        description: >-
+          The organization ID for your Commerce Cloud instance (e.g., f_ecom_zzxy_prd).
+        examples:
+          - f_ecom_zzxy_prd
+      short_code:
+        type: string
+        order: 3
+        title: Short Code
+        description: >-
+          The short code for your Commerce Cloud instance, used in the API base URL.
+        examples:
+          - kv7kzm78
+      site_id:
+        type: string
+        order: 4
+        title: Site ID
+        description: >-
+          The site ID for your Commerce Cloud storefront (e.g., SiteGenesis, RefArch).
+        examples:
+          - SiteGenesis
+          - RefArch
+      start_date:
+        type: string
+        order: 5
+        title: Start Date
+        description: >-
+          The date from which to start syncing data for incremental streams, in ISO 8601 format.
+          If not provided, defaults to 2020-01-01T00:00:00Z.
+        pattern: "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$"
+        examples:
+          - "2024-01-01T00:00:00Z"
+        format: date-time
+    additionalProperties: true
+
+schemas:
+  orders:
+    type: object
+    $schema: http://json-schema.org/draft-07/schema#
+    additionalProperties: true
+    properties:
+      orderNo:
+        type:
+          - "null"
+          - string
+      orderToken:
+        type:
+          - "null"
+          - string
+      status:
+        type:
+          - "null"
+          - string
+      confirmationStatus:
+        type:
+          - "null"
+          - string
+      exportStatus:
+        type:
+          - "null"
+          - string
+      paymentStatus:
+        type:
+          - "null"
+          - string
+      shippingStatus:
+        type:
+          - "null"
+          - string
+      siteId:
+        type:
+          - "null"
+          - string
+      creationDate:
+        type:
+          - "null"
+          - string
+        format: date-time
+      lastModified:
+        type:
+          - "null"
+          - string
+        format: date-time
+      currency:
+        type:
+          - "null"
+          - string
+      orderTotal:
+        type:
+          - "null"
+          - number
+      taxTotal:
+        type:
+          - "null"
+          - number
+      shippingTotal:
+        type:
+          - "null"
+          - number
+      productSubTotal:
+        type:
+          - "null"
+          - number
+      productTotal:
+        type:
+          - "null"
+          - number
+      customerInfo:
+        type:
+          - "null"
+          - object
+        additionalProperties: true
+      billingAddress:
+        type:
+          - "null"
+          - object
+        additionalProperties: true
+      shipments:
+        type:
+          - "null"
+          - array
+        items:
+          type: object
+          additionalProperties: true
+      productItems:
+        type:
+          - "null"
+          - array
+        items:
+          type: object
+          additionalProperties: true
+      paymentInstruments:
+        type:
+          - "null"
+          - array
+        items:
+          type: object
+          additionalProperties: true
+      notes:
+        type:
+          - "null"
+          - object
+        additionalProperties: true
+
+  catalogs:
+    type: object
+    $schema: http://json-schema.org/draft-07/schema#
+    additionalProperties: true
+    properties:
+      id:
+        type:
+          - "null"
+          - string
+      name:
+        type:
+          - "null"
+          - object
+        additionalProperties: true
+      description:
+        type:
+          - "null"
+          - object
+        additionalProperties: true
+      online:
+        type:
+          - "null"
+          - boolean
+      creationDate:
+        type:
+          - "null"
+          - string
+        format: date-time
+      lastModified:
+        type:
+          - "null"
+          - string
+        format: date-time
+
+  promotions:
+    type: object
+    $schema: http://json-schema.org/draft-07/schema#
+    additionalProperties: true
+    properties:
+      id:
+        type:
+          - "null"
+          - string
+      name:
+        type:
+          - "null"
+          - object
+        additionalProperties: true
+      enabled:
+        type:
+          - "null"
+          - boolean
+      promotionClass:
+        type:
+          - "null"
+          - string
+      startDate:
+        type:
+          - "null"
+          - string
+        format: date-time
+      endDate:
+        type:
+          - "null"
+          - string
+        format: date-time
+      creationDate:
+        type:
+          - "null"
+          - string
+        format: date-time
+      lastModified:
+        type:
+          - "null"
+          - string
+        format: date-time
+      currency:
+        type:
+          - "null"
+          - string
+      exclusive:
+        type:
+          - "null"
+          - boolean
+
+  campaigns:
+    type: object
+    $schema: http://json-schema.org/draft-07/schema#
+    additionalProperties: true
+    properties:
+      id:
+        type:
+          - "null"
+          - string
+      name:
+        type:
+          - "null"
+          - object
+        additionalProperties: true
+      description:
+        type:
+          - "null"
+          - object
+        additionalProperties: true
+      enabled:
+        type:
+          - "null"
+          - boolean
+      startDate:
+        type:
+          - "null"
+          - string
+        format: date-time
+      endDate:
+        type:
+          - "null"
+          - string
+        format: date-time
+      creationDate:
+        type:
+          - "null"
+          - string
+        format: date-time
+      lastModified:
+        type:
+          - "null"
+          - string
+        format: date-time

--- a/airbyte-integrations/connectors/source-salesforce-commerce-cloud/metadata.yaml
+++ b/airbyte-integrations/connectors/source-salesforce-commerce-cloud/metadata.yaml
@@ -1,0 +1,40 @@
+data:
+  allowedHosts:
+    hosts:
+      - "*.api.commercecloud.salesforce.com"
+      - account.demandware.com
+  registryOverrides:
+    oss:
+      enabled: true
+    cloud:
+      enabled: false
+  remoteRegistries:
+    pypi:
+      enabled: false
+      packageName: airbyte-source-salesforce-commerce-cloud
+  connectorBuildOptions:
+    baseImage: docker.io/airbyte/source-declarative-manifest:7.9.2@sha256:94ddf0cfd5acf1179e7830e9b5da7affc7f697c3a1581a55895b16384b39cc8a
+  connectorSubtype: api
+  connectorType: source
+  definitionId: 47806656-ba42-4c50-9c72-e1370f301952
+  dockerImageTag: 0.1.0
+  dockerRepository: airbyte/source-salesforce-commerce-cloud
+  githubIssueLabel: source-salesforce-commerce-cloud
+  icon: salesforce-commerce-cloud.svg
+  license: ELv2
+  name: Salesforce Commerce Cloud
+  releaseDate: "2026-02-13"
+  releaseStage: alpha
+  supportLevel: community
+  documentationUrl: https://docs.airbyte.com/integrations/sources/salesforce-commerce-cloud
+  tags:
+    - cdk:low-code
+    - language:manifest-only
+  externalDocumentationUrls:
+    - title: Salesforce Commerce Cloud SCAPI reference
+      url: https://developer.salesforce.com/docs/commerce/commerce-api/references/about-commerce-api
+      type: api_reference
+    - title: SCAPI authentication guide
+      url: https://developer.salesforce.com/docs/commerce/commerce-api/guide/authorization-for-admin-apis.html
+      type: authentication_guide
+metadataSpecVersion: "1.0"

--- a/docs/integrations/sources/salesforce-commerce-cloud.md
+++ b/docs/integrations/sources/salesforce-commerce-cloud.md
@@ -1,0 +1,111 @@
+# Salesforce Commerce Cloud
+
+<HideInUI>
+
+This page contains the setup guide and reference information for the [Salesforce Commerce Cloud](https://developer.salesforce.com/docs/commerce/commerce-api/overview) source connector.
+
+</HideInUI>
+
+## Prerequisites
+
+- A Salesforce Commerce Cloud B2C instance
+- An API client configured in [Account Manager](https://account.demandware.com) with appropriate scopes
+- Your instance's Organization ID, Short Code, and Site ID
+
+## Setup guide
+
+### Step 1: Obtain API credentials
+
+1. Log in to [Salesforce Commerce Cloud Account Manager](https://account.demandware.com).
+2. Navigate to **API Client** and create a new API client or use an existing one.
+3. Ensure the client has the following scopes enabled:
+   - `sfcc.orders` (for Orders stream)
+   - `sfcc.products` (for future Products stream)
+   - `sfcc.catalogs` (for Catalogs stream)
+   - `sfcc.pricing.promotions` (for Promotions stream)
+   - `sfcc.pricing.campaigns` (for Campaigns stream)
+4. Note the **Client ID** and **Client Secret**.
+
+### Step 2: Find your instance details
+
+- **Organization ID**: Found in Business Manager under **Administration > Site Development > Salesforce Commerce API Settings**. Format: `f_ecom_xxxx_prd`.
+- **Short Code**: Found in the same location. Used in the API base URL.
+- **Site ID**: The identifier for your storefront site (for example, `SiteGenesis` or `RefArch`).
+
+### Step 3: Set up the connector in Airbyte
+
+<!-- env:oss -->
+
+**For Airbyte Open Source:**
+
+1. Navigate to the Airbyte Open Source dashboard.
+2. In the left navigation bar, click **Sources**. In the top-right corner, click **+ New source**.
+3. On the Set up the source page, select **Salesforce Commerce Cloud** from the Source type dropdown.
+4. Enter your **Client ID** and **Client Secret**.
+5. Enter your **Organization ID**, **Short Code**, and **Site ID**.
+6. Optionally set a **Start Date** for incremental sync (defaults to 2020-01-01).
+7. Click **Set up source**.
+
+<!-- /env:oss -->
+
+<HideInUI>
+
+## Supported sync modes
+
+The Salesforce Commerce Cloud source connector supports the following [sync modes](https://docs.airbyte.com/using-airbyte/core-concepts/sync-modes/):
+
+| Feature                        | Supported? |
+| :----------------------------- | :--------- |
+| Full Refresh Overwrite         | Yes        |
+| Full Refresh Append            | Yes        |
+| Incremental Append             | Yes        |
+| Incremental Append + Deduped   | Yes        |
+
+## Supported streams
+
+| Stream | API Endpoint | Sync Mode | Primary Key |
+| :--- | :--- | :--- | :--- |
+| [Orders](https://developer.salesforce.com/docs/commerce/commerce-api/references/orders?meta=getOrders) | GET /checkout/orders/v1/.../orders | Incremental | orderNo |
+| Catalogs | GET /product/catalogs/v1/.../catalogs | Full Refresh | id |
+| Promotions | POST /pricing/promotions/v1/.../promotions | Full Refresh | id |
+| Campaigns | POST /pricing/campaigns/v1/.../campaigns | Full Refresh | id |
+
+## Limitations & Troubleshooting
+
+<details>
+<summary>
+Expand to see details about Salesforce Commerce Cloud connector limitations and troubleshooting.
+</summary>
+
+### Connector limitations
+
+#### Rate limiting
+
+Salesforce Commerce Cloud APIs use throttle windows of 5-60 seconds. The connector does not currently implement automatic retry on rate limit responses. If you encounter rate limiting, consider reducing sync frequency.
+
+#### Products stream
+
+The SCAPI Admin Products API only exposes single-product endpoints (by product ID). A list/search endpoint is not available, so the Products stream is not yet implemented. Future versions may add this using a SubstreamPartitionRouter from Catalogs.
+
+#### Offset pagination limit
+
+The Orders API caps offset + limit at 10,000. For large datasets, incremental sync with date windowing mitigates this limitation.
+
+### Troubleshooting
+
+- Check out common troubleshooting issues for the Salesforce Commerce Cloud source connector on our [Airbyte Forum](https://github.com/airbytehq/airbyte/discussions).
+
+</details>
+
+## Changelog
+
+<details>
+  <summary>Expand to review</summary>
+
+| Version | Date       | Pull Request                                              | Subject                        |
+| :------ | :--------- | :-------------------------------------------------------- | :----------------------------- |
+| 0.1.0   | 2026-02-13 | [73343](https://github.com/airbytehq/airbyte/pull/73343)  | Initial release with Orders, Catalogs, Promotions, and Campaigns streams |
+
+</details>
+
+</HideInUI>

--- a/docs/integrations/sources/salesforce-commerce-cloud.md
+++ b/docs/integrations/sources/salesforce-commerce-cloud.md
@@ -20,7 +20,7 @@ This page contains the setup guide and reference information for the [Salesforce
 2. Navigate to **API Client** and create a new API client or use an existing one.
 3. Ensure the client has the following scopes enabled:
    - `sfcc.orders` (for Orders stream)
-   - `sfcc.products` (for future Products stream)
+   - `sfcc.products` (for Products stream)
    - `sfcc.catalogs` (for Catalogs stream)
    - `sfcc.pricing.promotions` (for Promotions stream)
    - `sfcc.pricing.campaigns` (for Campaigns stream)
@@ -67,6 +67,8 @@ The Salesforce Commerce Cloud source connector supports the following [sync mode
 | :--- | :--- | :--- | :--- |
 | [Orders](https://developer.salesforce.com/docs/commerce/commerce-api/references/orders?meta=getOrders) | GET /checkout/orders/v1/.../orders | Incremental | orderNo |
 | Catalogs | GET /product/catalogs/v1/.../catalogs | Full Refresh | id |
+| Categories | GET /product/catalogs/v1/.../catalogs/{catalogId}/categories | Full Refresh | id |
+| Products | POST /product/catalogs/v1/.../categories/{categoryId}/products | Full Refresh | id |
 | Promotions | POST /pricing/promotions/v1/.../promotions | Full Refresh | id |
 | Campaigns | POST /pricing/campaigns/v1/.../campaigns | Full Refresh | id |
 
@@ -85,7 +87,7 @@ Salesforce Commerce Cloud APIs use throttle windows of 5-60 seconds. The connect
 
 #### Products stream
 
-The SCAPI Admin Products API only exposes single-product endpoints (by product ID). A list/search endpoint is not available, so the Products stream is not yet implemented. Future versions may add this using a SubstreamPartitionRouter from Catalogs.
+The SCAPI Admin Products API only exposes single-product endpoints (by product ID). The connector works around this by using a SubstreamPartitionRouter chain: Catalogs → Categories → Products. This means products are discovered by iterating through each catalog's categories and searching for products assigned to each category.
 
 #### Offset pagination limit
 
@@ -104,7 +106,7 @@ The Orders API caps offset + limit at 10,000. For large datasets, incremental sy
 
 | Version | Date       | Pull Request                                              | Subject                        |
 | :------ | :--------- | :-------------------------------------------------------- | :----------------------------- |
-| 0.1.0   | 2026-02-13 | [73343](https://github.com/airbytehq/airbyte/pull/73343)  | Initial release with Orders, Catalogs, Promotions, and Campaigns streams |
+| 0.1.0   | 2026-02-13 | [73343](https://github.com/airbytehq/airbyte/pull/73343)  | Initial release with Orders, Catalogs, Categories, Products, Promotions, and Campaigns streams |
 
 </details>
 

--- a/docs/integrations/sources/salesforce-commerce-cloud.md
+++ b/docs/integrations/sources/salesforce-commerce-cloud.md
@@ -67,8 +67,8 @@ The Salesforce Commerce Cloud source connector supports the following [sync mode
 | :--- | :--- | :--- | :--- |
 | [Orders](https://developer.salesforce.com/docs/commerce/commerce-api/references/orders?meta=getOrders) | GET /checkout/orders/v1/.../orders | Incremental | orderNo |
 | Catalogs | GET /product/catalogs/v1/.../catalogs | Full Refresh | id |
-| Categories | GET /product/catalogs/v1/.../catalogs/{catalogId}/categories | Full Refresh | id |
-| Products | POST /product/catalogs/v1/.../categories/{categoryId}/products | Full Refresh | id |
+| Categories | `GET /product/catalogs/v1/.../catalogs/{catalogId}/categories` | Full Refresh | id |
+| Products | `POST /product/catalogs/v1/.../categories/{categoryId}/products` | Full Refresh | id |
 | Promotions | POST /pricing/promotions/v1/.../promotions | Full Refresh | id |
 | Campaigns | POST /pricing/campaigns/v1/.../campaigns | Full Refresh | id |
 


### PR DESCRIPTION
## What

Adds a new manifest-only (declarative CDK) source connector for Salesforce Commerce Cloud using the [SCAPI](https://developer.salesforce.com/docs/commerce/commerce-api/references/about-commerce-api) REST API. Revives the previously vetted but never-built connector from [#26708](https://github.com/airbytehq/airbyte/issues/26708).

Includes 6 streams:
| Stream | Method | Sync Mode | Priority |
|---|---|---|---|
| `orders` | GET | Incremental (`lastModified`) | P1 |
| `catalogs` | GET | Full Refresh | P1 |
| `categories` | GET (substream of catalogs) | Full Refresh | P1 |
| `products` | POST search (substream of categories) | Full Refresh | P1 |
| `promotions` | POST (search) | Full Refresh | P2 |
| `campaigns` | POST (search) | Full Refresh | P2 |

**Not included (known limitations):**
- **Coupons / Gift Certificates** – SCAPI only exposes single-resource-by-ID endpoints for these.

**Testable in Connector Builder:** [Open in Connector Builder](https://cloud.airbyte.com/workspaces/266ebdfe-0d7b-4540-9817-de7e4505ba61/connector-builder/edit/7f3f0a0e-751a-4b2f-9fe5-0002320d936a) (Devin sandbox workspace — requires SCAPI credentials to test reads)

## How

- Pure manifest-only connector (no Python code) using `source-declarative-manifest:7.9.2` base image.
- OAuth 2.0 `client_credentials` grant via `OAuthAuthenticator` against `account.demandware.com`.
- OAuth scope is derived from `organization_id` config by stripping the `f_ecom_` prefix (e.g., `f_ecom_zzxy_prd` → `zzxy_prd`).
- Offset-based pagination (`OffsetIncrement`, page size 200) for all streams.
- Orders uses `DatetimeBasedCursor` with `lastModifiedDateFrom`/`lastModifiedDateTo` query params for incremental sync.
- POST search streams (promotions, campaigns, products) inject pagination into `body_json`.
- **Products stream uses a 3-level `SubstreamPartitionRouter` chain:** catalogs → categories → products. The `categories` stream partitions on `catalog_id` from the parent catalogs stream. The `products` stream partitions on `category_id` from categories and accesses the grandparent catalog ID via `stream_partition.parent_slice.catalog_id`. This works because the CDK's `SubstreamPartitionRouter` propagates `parent_slice` in the partition dict (verified in CDK source at `substream_partition_router.py:255-262`).

## Review guide

> ⚠️ **This connector has not been validated against a live SCAPI instance.** Several design choices are based on documentation and inference. Items marked with ❓ below need live validation.

1. **`manifest.yaml`** – The entire connector logic. Key areas to scrutinize:
   - **OAuth authenticator:** ❓ The CDK sends `client_id`/`client_secret` as form body params, but SCAPI docs show Basic Auth header. This **may not work** without adding `refresh_request_headers` with a base64-encoded Authorization header.
   - **Scope construction:** ❓ `replace('f_ecom_', '')` is fragile—assumes all org IDs have this prefix.
   - **POST search body (promotions, campaigns, products):** ❓ The `textQuery`/`searchPhrase: "*"` pattern and `start`/`count` pagination field names are **speculative** and need verification against actual SCAPI search endpoint contracts.
   - **Products endpoint path:** ❓ Path `.../categories/{categoryId}/products` with POST method is based on SCAPI documentation patterns but the exact path segment (could be `product-search` instead of `products`) needs live verification.
   - **Products response field path:** ❓ Uses `data` DPath extractor like other streams, but SCAPI search results sometimes use `hits` instead—needs live verification.
   - **SubstreamPartitionRouter chain (categories + products):** The `$ref` to parent streams gets resolved during manifest preprocessing. The 3-level chain (catalogs → categories → products) relies on `stream_partition.parent_slice.catalog_id` for the grandparent partition—confirmed this works via CDK source code inspection but not via live test.
   - **Incremental sync:** Orders offset+limit is capped at 10,000 by the API. Large volumes within a single time window could be truncated.
2. **`metadata.yaml`** – Standard manifest-only connector metadata. Uses wildcard `*.api.commercecloud.salesforce.com` in allowedHosts.
3. **`icon.svg`** – Placeholder icon (generic cloud shape in Salesforce blue), not the official logo.
4. **`docs/integrations/sources/salesforce-commerce-cloud.md`** – User-facing documentation with setup guide, supported streams, limitations, and changelog entry for v0.1.0.

### Human review checklist
- [ ] Verify OAuth token request format is compatible with SCAPI (Basic Auth header vs form body credentials)
- [ ] Confirm POST search request body structure matches actual SCAPI `/promotions`, `/campaigns`, and `/products` search endpoints
- [ ] Validate that `data` is the correct DPath for record extraction across all endpoints (especially products search which may use `hits`)
- [ ] Verify products endpoint path is `/categories/{categoryId}/products` and not `/categories/{categoryId}/product-search`
- [ ] Test SubstreamPartitionRouter chain with live data to confirm `parent_slice` propagation works as expected
- [ ] Check if placeholder icon needs to be replaced with official Salesforce Commerce Cloud branding

## Updates since last revision

- **Connector Builder project deployed** to Devin sandbox workspace for interactive testing: [Open in Connector Builder](https://cloud.airbyte.com/workspaces/266ebdfe-0d7b-4540-9817-de7e4505ba61/connector-builder/edit/7f3f0a0e-751a-4b2f-9fe5-0002320d936a)
- **Docs fix:** Escaped curly braces in markdown table (`{catalogId}`, `{categoryId}`) to fix Docusaurus MDX build error

## User Impact

New connector available for Salesforce Commerce Cloud (B2C) data extraction. Users can sync orders, catalogs, categories, products, promotions, and campaigns. This is an alpha/community connector that has **not been validated against a live SCAPI instance**.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Link to Devin run: https://app.devin.ai/sessions/3d0621624b62430890f6de0222b364cb
Requested by: Ilja Herdt (@iherdt-airbyte)