### PR TITLE
feat(destination-azure-blob-storage): ✨ add Parquet output formats

### DIFF
--- a/airbyte-integrations/connectors/destination-azure-blob-storage/src/test-integration/kotlin/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageCheckTest.kt
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage/src/test-integration/kotlin/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageCheckTest.kt
@@ -8,6 +8,7 @@ import io.airbyte.cdk.load.check.CheckIntegrationTest
 import io.airbyte.cdk.load.check.CheckTestConfig
 import io.airbyte.cdk.load.command.object_storage.CSVFormatSpecification
 import io.airbyte.cdk.load.command.object_storage.JsonFormatSpecification
+import io.airbyte.cdk.load.command.object_storage.ParquetFormatSpecification
 
 class AzureBlobStorageCheckTest :
     CheckIntegrationTest<AzureBlobStorageSpecification>(
@@ -20,6 +21,9 @@ class AzureBlobStorageCheckTest :
                     AzureBlobStorageTestUtil.getAccountKeyConfig(CSVFormatSpecification())
                 ),
                 CheckTestConfig(AzureBlobStorageTestUtil.getSasConfig(CSVFormatSpecification())),
+                CheckTestConfig(
+                    AzureBlobStorageTestUtil.getAccountKeyConfig(ParquetFormatSpecification())
+                ),
             ),
         failConfigFilenamesAndFailureReasons =
             mapOf(

--- a/airbyte-integrations/connectors/destination-azure-blob-storage/src/test-integration/kotlin/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageWriteTest.kt
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage/src/test-integration/kotlin/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageWriteTest.kt
@@ -7,6 +7,7 @@ package io.airbyte.integrations.destination.azure_blob_storage
 import io.airbyte.cdk.load.command.object_storage.CSVFormatSpecification
 import io.airbyte.cdk.load.command.object_storage.FlatteningSpecificationProvider.Flattening
 import io.airbyte.cdk.load.command.object_storage.JsonFormatSpecification
+import io.airbyte.cdk.load.command.object_storage.ParquetFormatSpecification
 import io.airbyte.cdk.load.config.DataChannelFormat
 import io.airbyte.cdk.load.config.DataChannelMedium
 import io.airbyte.cdk.load.test.util.NoopDestinationCleaner
@@ -156,6 +157,26 @@ class AzureBlobStorageSasCsvWithFlatteningWriteTestProto :
         AzureBlobStorageTestUtil.getSasConfig(
             CSVFormatSpecification(flattening = Flattening.ROOT_LEVEL_FLATTENING),
         ),
+        nullEqualsUnset = true,
+        mismatchedTypesUnrepresentable = true,
+        dataChannelFormat = DataChannelFormat.PROTOBUF,
+        dataChannelMedium = DataChannelMedium.SOCKET,
+        unknownTypesBehavior = UnknownTypesBehavior.NULL,
+    ) {
+    @Disabled("Not relevant for socket mode")
+    override fun testBasicWriteFile() {
+        super.testBasicWriteFile()
+    }
+}
+
+class AzureBlobStorageParquetWriteTest :
+    AzureBlobStorageWriteTest(
+        AzureBlobStorageTestUtil.getAccountKeyConfig(ParquetFormatSpecification()),
+    )
+
+class AzureBlobStorageParquetWriteTestProto :
+    AzureBlobStorageWriteTest(
+        AzureBlobStorageTestUtil.getAccountKeyConfig(ParquetFormatSpecification()),
         nullEqualsUnset = true,
         mismatchedTypesUnrepresentable = true,
         dataChannelFormat = DataChannelFormat.PROTOBUF,

--- a/airbyte-integrations/connectors/destination-azure-blob-storage/src/test-integration/resources/expected-spec-cloud.json
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage/src/test-integration/resources/expected-spec-cloud.json
@@ -104,6 +104,62 @@
             }
           },
           "required" : [ "format_type" ]
+        }, {
+          "title" : "Parquet: Columnar Storage",
+          "type" : "object",
+          "additionalProperties" : true,
+          "properties" : {
+            "format_type" : {
+              "type" : "string",
+              "enum" : [ "Parquet" ],
+              "default" : "Parquet",
+              "order" : 0
+            },
+            "compression_codec" : {
+              "type" : "string",
+              "default" : "UNCOMPRESSED",
+              "description" : "The compression algorithm used to compress data pages.",
+              "enum" : [ "UNCOMPRESSED", "SNAPPY", "GZIP", "LZO", "BROTLI", "LZ4", "ZSTD" ],
+              "title" : "Compression Codec",
+              "order" : 1
+            },
+            "block_size_mb" : {
+              "type" : "integer",
+              "default" : 128,
+              "description" : "This is the size of a row group being buffered in memory. It limits the memory usage when writing. Larger values will improve the IO when reading, but consume more memory when writing. Default: 128 MB.",
+              "title" : "Block Size (Row Group Size) (MB)",
+              "order" : 2
+            },
+            "max_padding_size_mb" : {
+              "type" : "integer",
+              "default" : 8,
+              "description" : "Maximum size allowed as padding to align row groups. This is also the minimum size of a row group. Default: 8 MB.",
+              "title" : "Max Padding Size (MB)",
+              "order" : 3
+            },
+            "page_size_kb" : {
+              "type" : "integer",
+              "default" : 1024,
+              "description" : "The page size is for compression. A block is composed of pages. A page is the smallest unit that must be read fully to access a single record. If this value is too small, the compression will deteriorate. Default: 1024 KB.",
+              "title" : "Page Size (KB)",
+              "order" : 4
+            },
+            "dictionary_page_size_kb" : {
+              "type" : "integer",
+              "default" : 1024,
+              "description" : "There is one dictionary page per column per row group when dictionary encoding is used. The dictionary page size works like the page size but for dictionary. Default: 1024 KB.",
+              "title" : "Dictionary Page Size (KB)",
+              "order" : 5
+            },
+            "dictionary_encoding" : {
+              "type" : "boolean",
+              "default" : true,
+              "description" : "Default: true.",
+              "title" : "Dictionary Encoding",
+              "order" : 6
+            }
+          },
+          "required" : [ "format_type" ]
         } ],
         "description" : "Format of the data output.",
         "title" : "Output Format",

--- a/airbyte-integrations/connectors/destination-azure-blob-storage/src/test-integration/resources/expected-spec-oss.json
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage/src/test-integration/resources/expected-spec-oss.json
@@ -104,6 +104,62 @@
             }
           },
           "required" : [ "format_type" ]
+        }, {
+          "title" : "Parquet: Columnar Storage",
+          "type" : "object",
+          "additionalProperties" : true,
+          "properties" : {
+            "format_type" : {
+              "type" : "string",
+              "enum" : [ "Parquet" ],
+              "default" : "Parquet",
+              "order" : 0
+            },
+            "compression_codec" : {
+              "type" : "string",
+              "default" : "UNCOMPRESSED",
+              "description" : "The compression algorithm used to compress data pages.",
+              "enum" : [ "UNCOMPRESSED", "SNAPPY", "GZIP", "LZO", "BROTLI", "LZ4", "ZSTD" ],
+              "title" : "Compression Codec",
+              "order" : 1
+            },
+            "block_size_mb" : {
+              "type" : "integer",
+              "default" : 128,
+              "description" : "This is the size of a row group being buffered in memory. It limits the memory usage when writing. Larger values will improve the IO when reading, but consume more memory when writing. Default: 128 MB.",
+              "title" : "Block Size (Row Group Size) (MB)",
+              "order" : 2
+            },
+            "max_padding_size_mb" : {
+              "type" : "integer",
+              "default" : 8,
+              "description" : "Maximum size allowed as padding to align row groups. This is also the minimum size of a row group. Default: 8 MB.",
+              "title" : "Max Padding Size (MB)",
+              "order" : 3
+            },
+            "page_size_kb" : {
+              "type" : "integer",
+              "default" : 1024,
+              "description" : "The page size is for compression. A block is composed of pages. A page is the smallest unit that must be read fully to access a single record. If this value is too small, the compression will deteriorate. Default: 1024 KB.",
+              "title" : "Page Size (KB)",
+              "order" : 4
+            },
+            "dictionary_page_size_kb" : {
+              "type" : "integer",
+              "default" : 1024,
+              "description" : "There is one dictionary page per column per row group when dictionary encoding is used. The dictionary page size works like the page size but for dictionary. Default: 1024 KB.",
+              "title" : "Dictionary Page Size (KB)",
+              "order" : 5
+            },
+            "dictionary_encoding" : {
+              "type" : "boolean",
+              "default" : true,
+              "description" : "Default: true.",
+              "title" : "Dictionary Encoding",
+              "order" : 6
+            }
+          },
+          "required" : [ "format_type" ]
         } ],
         "description" : "Format of the data output.",
         "title" : "Output Format",


### PR DESCRIPTION
## What
Adds support for Apache Parquet as an output format option for the Azure Blob Storage destination connector. This allows users to export data in columnar Parquet format with configurable compression and storage parameters.

Depends on #73598
Resolves #17234

## How
- Added `ParquetFormatSpecification` class with configurable parameters:
  - Compression codec (UNCOMPRESSED, SNAPPY, GZIP, LZO, BROTLI, LZ4, ZSTD)
  - Block size (row group size in MB, default 128)
  - Max padding size (MB, default 8)
  - Page size (KB, default 1024)
  - Dictionary page size (KB, default 1024)
  - Dictionary encoding (boolean, default true)
- Implemented provider logic to convert `ParquetFormatSpecification` to `ParquetFormatConfiguration`
- Updated JSON schema generation to include Parquet format in the connector spec
- Added comprehensive integration tests for Parquet format (both standard and protobuf modes)
- Updated documentation with Parquet format details and configuration options
- Data is automatically flattened to root level in Parquet output (consistent with existing behavior)

## Review guide
1. `ObjectStorageFormatSpecification.kt` - Core format specification and provider implementation
2. `AzureBlobStorageWriteTest.kt` - Integration tests for Parquet write operations
3. `AzureBlobStorageCheckTest.kt` - Configuration validation tests
4. `expected-spec-*.json` - Updated connector specifications
5. `azure-blob-storage.md` - User documentation

## User Impact
Users can now select Parquet as an output format when configuring Azure Blob Storage destinations. The format provides efficient columnar storage with tunable compression and performance parameters. All data is flattened to root level, with nested fields represented as dot-notation column names.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚

This is a new feature addition that doesn't modify existing CSV or JSONL format behavior. Reverting would simply remove Parquet as an available format option.
