### PR TITLE
test: dummy PR for connector label testing (do not merge)

### DIFF
--- a/airbyte-integrations/connectors/source-github/source_github/__init__.py
+++ b/airbyte-integrations/connectors/source-github/source_github/__init__.py
@@ -26,3 +26,4 @@ from .source import SourceGithub
 
 
 __all__ = ["SourceGithub"]
+# test-label-iteration-4: source-github only (verify stripe label removed)

--- a/airbyte-integrations/connectors/source-github/source_github/__init__.py
+++ b/airbyte-integrations/connectors/source-github/source_github/__init__.py
@@ -26,4 +26,3 @@ from .source import SourceGithub
 
 
 __all__ = ["SourceGithub"]
-# test-label-iteration-1: source-github

--- a/airbyte-integrations/connectors/source-github/source_github/__init__.py
+++ b/airbyte-integrations/connectors/source-github/source_github/__init__.py
@@ -26,3 +26,4 @@ from .source import SourceGithub
 
 
 __all__ = ["SourceGithub"]
+# test-label-iteration-1: source-github

--- a/airbyte-integrations/connectors/source-stripe/manifest.yaml
+++ b/airbyte-integrations/connectors/source-stripe/manifest.yaml
@@ -1,5 +1,5 @@
 version: 6.42.1
-# test-label-iteration-2: source-stripe
+
 type: DeclarativeSource
 
 check:

--- a/airbyte-integrations/connectors/source-stripe/manifest.yaml
+++ b/airbyte-integrations/connectors/source-stripe/manifest.yaml
@@ -1,5 +1,5 @@
 version: 6.42.1
-
+# test-label-iteration-2: source-stripe
 type: DeclarativeSource
 
 check:

--- a/label-test-dummy.txt
+++ b/label-test-dummy.txt
@@ -1,0 +1,1 @@
+# Label test iteration 3 - no connector changes


### PR DESCRIPTION
## What

This is a **throwaway test PR** to empirically verify the connector auto-labeling system in CI. Specifically, we are testing:

1. Whether connector labels (e.g. `connectors/source/github`) are correctly **added** when a connector's files are modified.
2. Whether connector labels are correctly **removed** when those files are reverted or replaced with changes to a different connector.
3. Whether the diff mechanism uses the merge-base (common ancestor) to avoid false-positive labels from unrelated changes on `master`.

**Do not merge.** This PR will go through several iterations of pushes to observe labeling behavior.

## How

A single no-op comment is added to `source-github`'s `__init__.py`. Subsequent commits will modify different connectors (and revert this one) to observe label changes.

## Review guide

Nothing to review for correctness — this is a CI/infrastructure test.

1. `airbyte-integrations/connectors/source-github/source_github/__init__.py` — trivial comment addition

## User Impact

None. This PR will not be merged.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

[Link to Devin run](https://app.devin.ai/sessions/750665640d3a45a8b7baa0e583e6d6e5) | Requested by @aaronsteers