### PR TITLE
ci: update workflow-actions pinned SHA to include connector label removal

### DIFF
--- a/.github/workflows/label-github-issues-by-context.yml
+++ b/.github/workflows/label-github-issues-by-context.yml
@@ -16,7 +16,7 @@ jobs:
         uses: nick-fields/private-action-loader@6fa713597d3de3707f8b7a3029a5c262f32c5bca # v3.0.12
         with:
           pal-repo-token: "${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}"
-          pal-repo-name: airbytehq/workflow-actions@2a848ffce5eaf8da66d4176b66f55dd2e1007016
+          pal-repo-name: airbytehq/workflow-actions@822588f078efcbc84601fff7f56a9ce8658f7c99
           # the following input gets passed to the private
           token: "${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}"
           # ref: https://github.com/airbytehq/workflow-actions/blob/main/src/bin_issue.ts

--- a/.github/workflows/label-prs-by-context.yml
+++ b/.github/workflows/label-prs-by-context.yml
@@ -18,7 +18,7 @@ jobs:
         uses: nick-fields/private-action-loader@6fa713597d3de3707f8b7a3029a5c262f32c5bca # v3.0.12
         with:
           pal-repo-token: "${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}"
-          pal-repo-name: airbytehq/workflow-actions@2a848ffce5eaf8da66d4176b66f55dd2e1007016
+          pal-repo-name: airbytehq/workflow-actions@822588f078efcbc84601fff7f56a9ce8658f7c99
           # the following input gets passed to the private action
           token: "${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}"
           command: "pull"


### PR DESCRIPTION
## What

Updates the pinned `airbytehq/workflow-actions` SHA in both labeling workflows to pick up [workflow-actions#135](https://github.com/airbytehq/workflow-actions/pull/135), which adds **connector label removal** to the PR auto-labeler.

Previously, `connectors/source/*` and `connectors/destination/*` labels were only ever added — never removed. After this change, when a PR's changed files no longer include a previously-labeled connector, the stale label is removed. A guard condition ensures removal only fires when ≥1 connector is detected (so manual tags survive on PRs with no detected connectors).

## How

Bumps the pinned SHA from `2a848ff` → `822588f` in:
- `.github/workflows/label-prs-by-context.yml` (PR labeler)
- `.github/workflows/label-github-issues-by-context.yml` (issue labeler — same action, kept in sync)

No runtime code changes in this repo; the behavioral change lives entirely in the upstream `workflow-actions` repository.

## Review guide

1. **Verify upstream change**: Review [workflow-actions#135](https://github.com/airbytehq/workflow-actions/pull/135) — specifically the `setConnector` function in `src/connector.ts` which now removes stale `connectors/source/*` and `connectors/destination/*` labels.
2. **Verify SHA**: Confirm `822588f078efcbc84601fff7f56a9ce8658f7c99` is the merge commit of workflow-actions#135 on `main`.
3. **Issue labeler impact**: The issue labeling workflow (`label-github-issues-by-context.yml`) calls the `"issue"` command path, which does not invoke `setConnector`. Bumping the SHA here is for consistency only — confirm no unintended side effects on issue labeling.

## User Impact

- PRs that modify connectors will have their `connectors/source/*` / `connectors/destination/*` labels kept in sync with the actual changed files on each push.
- Manually-applied connector labels will be preserved only when no connectors are auto-detected.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Reverting restores the previous SHA, returning to add-only label behavior.

---

[Link to Devin run](https://app.devin.ai/sessions/750665640d3a45a8b7baa0e583e6d6e5) | Requested by @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/73368" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
