### PR TITLE
feat(source-facebook-marketing): add opt-in incrementality attribution window

### DIFF
--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/schemas/shared/ads_action_stats.json
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/schemas/shared/ads_action_stats.json
@@ -15,6 +15,9 @@
       "1d_view": {
         "type": ["null", "number"]
       },
+      "incrementality": {
+        "type": ["null", "number"]
+      },
       "7d_view": {
         "type": ["null", "number"]
       },

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/source.py
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/source.py
@@ -158,6 +158,7 @@ class SourceFacebookMarketing(AbstractSource):
             insights_lookback_window=config.insights_lookback_window,
             insights_job_timeout=config.insights_job_timeout,
             filter_statuses=[status.value for status in [*ValidAdStatuses]],
+            include_incrementality=config.include_incrementality,
         )
         streams = [
             AdAccount(api=api, account_ids=config.account_ids),
@@ -331,6 +332,7 @@ class SourceFacebookMarketing(AbstractSource):
                 insights_lookback_window=insight.insights_lookback_window or config.insights_lookback_window,
                 insights_job_timeout=insight.insights_job_timeout or config.insights_job_timeout,
                 level=insight.level,
+                include_incrementality=insight.include_incrementality,
             )
             streams.append(stream)
         return streams

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/spec.py
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/spec.py
@@ -173,6 +173,15 @@ class InsightConfig(BaseModel):
         default=60,
     )
 
+    include_incrementality: bool = Field(
+        title="Include Incrementality",
+        description=(
+            "If enabled, the incrementality attribution window will be included in the action attribution windows for this custom insight. "
+            "This allows you to retrieve incrementality data for action metrics."
+        ),
+        default=False,
+    )
+
 
 class ConnectorConfig(BaseConfig):
     """Connector config"""
@@ -321,6 +330,18 @@ class ConnectorConfig(BaseConfig):
         maximum=60,
         mininum=10,
         default=60,
+    )
+
+    include_incrementality: bool = Field(
+        title="Include Incrementality",
+        order=13,
+        description=(
+            "If enabled, the incrementality attribution window will be included in the action attribution windows for all built-in insight streams. "
+            "This allows you to retrieve incrementality data for action metrics. "
+            "See the Facebook Marketing API documentation for more details: "
+            "https://developers.facebook.com/docs/marketing-api/reference/ads-action-stats/"
+        ),
+        default=False,
     )
 
     action_breakdowns_allow_empty: bool = Field(

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/streams/base_insight_streams.py
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/streams/base_insight_streams.py
@@ -38,6 +38,8 @@ class AdsInsights(FBMarketingIncrementalStream):
         "1d_view",
     ]
 
+    INCREMENTALITY_WINDOW = "incrementality"
+
     breakdowns = []
     action_breakdowns = [
         "action_type",
@@ -77,6 +79,7 @@ class AdsInsights(FBMarketingIncrementalStream):
         insights_lookback_window: int = None,
         insights_job_timeout: int = 60,
         level: str = "ad",
+        include_incrementality: bool = False,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -97,6 +100,9 @@ class AdsInsights(FBMarketingIncrementalStream):
         self._insights_job_timeout = insights_job_timeout
         self.level = level
         self.entity_prefix = level
+
+        if include_incrementality:
+            self.action_attribution_windows = list(self.ALL_ACTION_ATTRIBUTION_WINDOWS) + [self.INCREMENTALITY_WINDOW]
 
         # state
         self._cursor_values: Optional[Mapping[str, date]] = None  # latest period that was read for each account


### PR DESCRIPTION
## What

Adds opt-in support for the Facebook Marketing API `incrementality` attribution window. This is a valid value for the `action_attribution_windows` parameter ([docs](https://developers.facebook.com/docs/marketing-api/reference/ads-action-stats/)) that was not previously available in the connector.

Requested by @tgonzalezc5.

## How

- Adds a new `include_incrementality` boolean config field (default `false`) to:
  - `ConnectorConfig` — controls all built-in insight streams
  - `InsightConfig` — controls individual custom insight streams independently
- When enabled, `"incrementality"` is appended to the `action_attribution_windows` list passed to the Facebook API.
- The `ads_action_stats.json` shared schema is updated to include the `"incrementality"` field unconditionally (it will be `null` when not requested).

## Review guide

1. `spec.py` — New config fields on `InsightConfig` and `ConnectorConfig`
2. `streams/base_insight_streams.py` — Core logic: new `include_incrementality` param in `__init__`, conditional list append
3. `source.py` — Plumbing: passes config value to built-in and custom insight streams
4. `schemas/shared/ads_action_stats.json` — Schema addition

**Items worth attention:**
- No new unit tests were added to explicitly verify the `include_incrementality=True` path produces the expected `action_attribution_windows` list. Existing 283 unit tests pass, but a targeted test would increase confidence.
- No connector version bump was made — this will likely be needed before release.
- The schema always declares `incrementality` even when the feature is off (field will be null/absent). Confirm this is acceptable.

## User Impact

Users can now opt in to receiving incrementality attribution data from the Facebook Marketing API by enabling the `Include Incrementality` toggle. This is fully backward-compatible — the default is `false`, so no existing syncs are affected.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

[Link to Devin run](https://app.devin.ai/sessions/52677edd62c3422ea4b3150e42683751)