### PR TITLE
ci: enforce semantic PR titles and fix bot title formats

### DIFF
--- a/.github/workflows/semantic-pr-check.yml
+++ b/.github/workflows/semantic-pr-check.yml
@@ -1,0 +1,70 @@
+# Semantic PR Title Validation
+#
+# This workflow validates PR titles follow conventional commit format.
+# This is required for consistent release notes and changelog generation.
+#
+# Valid formats:
+# - feat(source-postgres): add new stream
+# - fix(destination-bigquery): handle null values
+# - chore(source-github): update dependencies [2026-01-15]
+# - release(source-stripe): promote 5.15.18
+# - docs: update connector setup guide
+# - ci: update workflow-actions pinned SHA
+#
+# Optional scope: type(scope): description
+# Breaking changes: type!: description or type(scope)!: description
+
+name: Semantic PR Title Validation
+
+on:
+  pull_request:
+    types: [opened, edited, ready_for_review, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  validate-pr-title:
+    name: Validate PR Title
+    # Skip if 'edited' event but the title wasn't changed (e.g., only description was edited)
+    if: >
+      github.event.action != 'edited'
+      || (
+        github.event.changes.title &&
+        github.event.changes.title.from != ''
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check semantic PR title
+        uses: amannn/action-semantic-pull-request@v6
+        if: ${{ github.event.pull_request.draft == false }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Configure which types are allowed (newline-delimited).
+          # Comparison is case-insensitive, so only lowercase variants are needed.
+          # See: https://github.com/commitizen/conventional-commit-types/blob/master/index.json
+          types: |
+            fix
+            feat
+            docs
+            ci
+            chore
+            build
+            test
+            refactor
+            perf
+            style
+            revert
+            release
+
+      - name: Check for "do not merge" in PR title
+        if: ${{ github.event.pull_request.draft == false }}
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const title = context.payload.pull_request.title.toLowerCase();
+            if (title.includes('do not merge') || title.includes('do-not-merge')) {
+              core.setFailed('PR title contains "do not merge" or "do-not-merge". Please remove this before merging.');
+            }

--- a/.github/workflows/semantic-pr-check.yml
+++ b/.github/workflows/semantic-pr-check.yml
@@ -46,18 +46,19 @@ jobs:
           # Comparison is case-insensitive, so only lowercase variants are needed.
           # See: https://github.com/commitizen/conventional-commit-types/blob/master/index.json
           types: |
-            fix
-            feat
-            docs
-            ci
-            chore
             build
-            test
-            refactor
+            chore
+            ci
+            deps
+            docs
+            feat
+            fix
             perf
-            style
-            revert
+            refactor
             release
+            revert
+            style
+            test
 
       - name: Check for "do not merge" in PR title
         if: ${{ github.event.pull_request.draft == false }}

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/publish/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/publish/pipeline.py
@@ -646,7 +646,7 @@ def get_rollback_pr_creation_arguments(
             "branch_id": f"{context.connector.technical_name}/rollback-{release_candidate_version}",
             "commit_message": "[auto-publish] "  # << We can skip Vercel builds if this is in the commit message
             + "; ".join(step_result.step.title for step_result in step_results if step_result.success),
-            "pr_title": f"revert({context.connector.technical_name}): stop progressive rollout for {release_candidate_version}",
+            "pr_title": f"revert({context.connector.technical_name}): \U0001f419 stop progressive rollout for {release_candidate_version}",
             "pr_body": f"The release candidate version {release_candidate_version} has been deemed unstable. This PR stops its progressive rollout. This PR will be automatically merged as part of the `auto-merge` workflow. This workflow runs every 2 hours.",
         },
     )
@@ -714,7 +714,7 @@ def get_promotion_pr_creation_arguments(
             "branch_id": f"{context.connector.technical_name}/{promoted_version}",
             "commit_message": "[auto-publish] "  # << We can skip Vercel builds if this is in the commit message
             + "; ".join(step_result.step.title for step_result in step_results if step_result.success),
-            "pr_title": f"release({context.connector.technical_name}): promote {promoted_version}",
+            "pr_title": f"release({context.connector.technical_name}): \U0001f419 promote {promoted_version}",
             "pr_body": f"The release candidate version {release_candidate_version} has been deemed stable and is now ready to be promoted to an official release ({promoted_version}). This PR will be automatically merged as part of the `auto-merge` workflow. This workflow runs every 2 hours.",
         },
     )

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/publish/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/publish/pipeline.py
@@ -646,7 +646,7 @@ def get_rollback_pr_creation_arguments(
             "branch_id": f"{context.connector.technical_name}/rollback-{release_candidate_version}",
             "commit_message": "[auto-publish] "  # << We can skip Vercel builds if this is in the commit message
             + "; ".join(step_result.step.title for step_result in step_results if step_result.success),
-            "pr_title": f"🐙 {context.connector.technical_name}: Stop progressive rollout for {release_candidate_version}",
+            "pr_title": f"revert({context.connector.technical_name}): stop progressive rollout for {release_candidate_version}",
             "pr_body": f"The release candidate version {release_candidate_version} has been deemed unstable. This PR stops its progressive rollout. This PR will be automatically merged as part of the `auto-merge` workflow. This workflow runs every 2 hours.",
         },
     )
@@ -714,7 +714,7 @@ def get_promotion_pr_creation_arguments(
             "branch_id": f"{context.connector.technical_name}/{promoted_version}",
             "commit_message": "[auto-publish] "  # << We can skip Vercel builds if this is in the commit message
             + "; ".join(step_result.step.title for step_result in step_results if step_result.success),
-            "pr_title": f"🐙 {context.connector.technical_name}: release {promoted_version}",
+            "pr_title": f"release({context.connector.technical_name}): promote {promoted_version}",
             "pr_body": f"The release candidate version {release_candidate_version} has been deemed stable and is now ready to be promoted to an official release ({promoted_version}). This PR will be automatically merged as part of the `auto-merge` workflow. This workflow runs every 2 hours.",
         },
     )

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/publish/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/publish/pipeline.py
@@ -646,7 +646,7 @@ def get_rollback_pr_creation_arguments(
             "branch_id": f"{context.connector.technical_name}/rollback-{release_candidate_version}",
             "commit_message": "[auto-publish] "  # << We can skip Vercel builds if this is in the commit message
             + "; ".join(step_result.step.title for step_result in step_results if step_result.success),
-            "pr_title": f"revert({context.connector.technical_name}): \U0001f419 stop progressive rollout for {release_candidate_version}",
+            "pr_title": f"revert({context.connector.technical_name}): 🐙 stop progressive rollout for {release_candidate_version}",
             "pr_body": f"The release candidate version {release_candidate_version} has been deemed unstable. This PR stops its progressive rollout. This PR will be automatically merged as part of the `auto-merge` workflow. This workflow runs every 2 hours.",
         },
     )
@@ -714,7 +714,7 @@ def get_promotion_pr_creation_arguments(
             "branch_id": f"{context.connector.technical_name}/{promoted_version}",
             "commit_message": "[auto-publish] "  # << We can skip Vercel builds if this is in the commit message
             + "; ".join(step_result.step.title for step_result in step_results if step_result.success),
-            "pr_title": f"release({context.connector.technical_name}): \U0001f419 promote {promoted_version}",
+            "pr_title": f"release({context.connector.technical_name}): 🐙 promote {promoted_version}",
             "pr_body": f"The release candidate version {release_candidate_version} has been deemed stable and is now ready to be promoted to an official release ({promoted_version}). This PR will be automatically merged as part of the `auto-merge` workflow. This workflow runs every 2 hours.",
         },
     )

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/up_to_date/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/up_to_date/pipeline.py
@@ -68,7 +68,7 @@ def get_pr_creation_arguments(
             "branch_id": f"up-to-date/{context.connector.technical_name}",
             "commit_message": "[up-to-date]"  # << We can skip Vercel builds if this is in the commit message
             + "; ".join(step_result.step.title for step_result in step_results if step_result.success),
-            "pr_title": f"🐙 {context.connector.technical_name}: run up-to-date pipeline [{datetime.now(timezone.utc).strftime('%Y-%m-%d')}]",
+            "pr_title": f"chore({context.connector.technical_name}): update dependencies [{datetime.now(timezone.utc).strftime('%Y-%m-%d')}]",
             "pr_body": get_pr_body(context, step_results, dependency_updates),
         },
     )

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/up_to_date/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/up_to_date/pipeline.py
@@ -68,7 +68,7 @@ def get_pr_creation_arguments(
             "branch_id": f"up-to-date/{context.connector.technical_name}",
             "commit_message": "[up-to-date]"  # << We can skip Vercel builds if this is in the commit message
             + "; ".join(step_result.step.title for step_result in step_results if step_result.success),
-            "pr_title": f"chore({context.connector.technical_name}): update dependencies [{datetime.now(timezone.utc).strftime('%Y-%m-%d')}]",
+            "pr_title": f"chore({context.connector.technical_name}): \U0001f419 update dependencies [{datetime.now(timezone.utc).strftime('%Y-%m-%d')}]",
             "pr_body": get_pr_body(context, step_results, dependency_updates),
         },
     )

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/up_to_date/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/up_to_date/pipeline.py
@@ -68,7 +68,7 @@ def get_pr_creation_arguments(
             "branch_id": f"up-to-date/{context.connector.technical_name}",
             "commit_message": "[up-to-date]"  # << We can skip Vercel builds if this is in the commit message
             + "; ".join(step_result.step.title for step_result in step_results if step_result.success),
-            "pr_title": f"chore({context.connector.technical_name}): \U0001f419 update dependencies [{datetime.now(timezone.utc).strftime('%Y-%m-%d')}]",
+            "pr_title": f"deps({context.connector.technical_name}): \U0001f419 update dependencies [{datetime.now(timezone.utc).strftime('%Y-%m-%d')}]",
             "pr_body": get_pr_body(context, step_results, dependency_updates),
         },
     )

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/up_to_date/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/up_to_date/pipeline.py
@@ -68,7 +68,7 @@ def get_pr_creation_arguments(
             "branch_id": f"up-to-date/{context.connector.technical_name}",
             "commit_message": "[up-to-date]"  # << We can skip Vercel builds if this is in the commit message
             + "; ".join(step_result.step.title for step_result in step_results if step_result.success),
-            "pr_title": f"deps({context.connector.technical_name}): \U0001f419 update dependencies [{datetime.now(timezone.utc).strftime('%Y-%m-%d')}]",
+            "pr_title": f"deps({context.connector.technical_name}): 🐙 update dependencies [{datetime.now(timezone.utc).strftime('%Y-%m-%d')}]",
             "pr_body": get_pr_body(context, step_results, dependency_updates),
         },
     )


### PR DESCRIPTION
## What

Adds a semantic PR title linter to the monorepo and updates all bot-generated PR titles to conform to the `type(scope): description` conventional commit format.

Analysis of the last 250 merged PRs showed only 17.6% conformance — almost entirely because bot PRs (199 up-to-date + 2 release + rollbacks) used `🐙 connector-name: action` instead of a semantic format. Human and Devin PRs were ~93% conforming already.

Requested by @aaronsteers.
[Link to Devin run](https://app.devin.ai/sessions/f2539ea371bb4ebb842b981663d28a1e)

## How

**Bot title fixes** (3 string changes — 🐙 emoji preserved in description per review feedback):
| Pipeline | Old format | New format |
|---|---|---|
| up-to-date | `🐙 source-x: run up-to-date pipeline [date]` | `deps(source-x): 🐙 update dependencies [date]` |
| promote | `🐙 source-x: release 4.1.5` | `release(source-x): 🐙 promote 4.1.5` |
| rollback | `🐙 source-x: Stop progressive rollout for 4.1.5-rc.1` | `revert(source-x): 🐙 stop progressive rollout for 4.1.5-rc.1` |

**New workflow** (`.github/workflows/semantic-pr-check.yml`):
- Uses `amannn/action-semantic-pull-request@v6`, matching the pattern from `airbyte-ops-mcp`, `PyAirbyte`, and `airbyte-python-cdk`
- Only enforced on non-draft PRs
- Allowed types (alpha-sorted): `build`, `chore`, `ci`, `deps`, `docs`, `feat`, `fix`, `perf`, `refactor`, `release`, `revert`, `style`, `test`
- Includes "do not merge" title check

## Review guide

1. `.github/workflows/semantic-pr-check.yml` — new workflow; compare against [`airbyte-ops-mcp` version](https://github.com/airbytehq/airbyte-ops-mcp/blob/main/.github/workflows/semantic-pr-check.yml) for consistency
2. `airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/up_to_date/pipeline.py` — line 71, title string only
3. `airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/publish/pipeline.py` — lines 649 and 717, title strings only

**Items for reviewer to verify:**
- [ ] The emoji is embedded via `\U0001f419` (Python Unicode escape for 🐙) — confirm this renders correctly in GitHub PR titles when the bot runs
- [ ] `release`, `deps`, and `revert` are non-standard conventional commit types — confirm these are intentionally allowed
- [ ] Action versions are unpinned (`@v6`, `@v8`) — should they be pinned to SHAs? (PyAirbyte pins; ops-mcp does not)

## User Impact

- All future bot-generated connector PRs will have semantic titles with the 🐙 emoji preserved in the description portion
- PR title linter will fail non-draft PRs that don't follow `type(scope): description` format
- No impact on existing merged PRs or release notes

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Reverting would restore the old bot title formats and remove the linter. No data loss or breaking changes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/73608" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
