### PR TITLE
ci: run semantic title check on draft PRs

### DIFF
--- a/.github/workflows/semantic-pr-check.yml
+++ b/.github/workflows/semantic-pr-check.yml
@@ -38,7 +38,6 @@ jobs:
     steps:
       - name: Check semantic PR title
         uses: amannn/action-semantic-pull-request@v6
-        if: ${{ github.event.pull_request.draft == false }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
## What

Fixes the semantic PR title linter (added in #73608) to run on draft PRs. The `if: draft == false` condition was preventing title validation on drafts, which is the default PR state in this repo — so the check was effectively never running.

The "do not merge" title check keeps its draft condition, since that phrase is expected in draft PR titles.

Requested by @aaronsteers.
[Link to Devin run](https://app.devin.ai/sessions/f2539ea371bb4ebb842b981663d28a1e)

## How

Removes the `if: ${{ github.event.pull_request.draft == false }}` condition from the "Check semantic PR title" step. The "Check for do not merge" step retains the condition.

## Review guide

1. `.github/workflows/semantic-pr-check.yml` — single line removal. Verify the "do not merge" step (not shown in diff) still has its own `if: draft == false` guard.

## User Impact

PR title validation will now run on draft PRs, giving authors early feedback on title format.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/73612" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
