### PR TITLE
This is a bad PR title without semantic prefix

### DIFF
--- a/.github/dummy-test-bad-2.md
+++ b/.github/dummy-test-bad-2.md
@@ -1,0 +1,1 @@
+# dummy test file for semantic PR title validation v2


### PR DESCRIPTION
## What

Throwaway test PR to validate the semantic PR title linter (added in #73608, fixed in #73612) **correctly rejects** non-conforming PR titles — including on draft PRs.

This PR intentionally uses a non-semantic title. **Close after confirming the `Validate PR Title` check fails. Do not merge.**

Requested by @aaronsteers.
[Link to Devin run](https://app.devin.ai/sessions/f2539ea371bb4ebb842b981663d28a1e)

## How

Adds a single dummy file (`.github/dummy-test-bad-2.md`) to produce a non-empty diff so CI runs.

## Review guide

Nothing to review — this is a throwaway test PR. The only thing to verify:
- [ ] The `Validate PR Title` check **fails** because the title lacks a semantic prefix

## User Impact

None. Test PR only.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚