### PR TITLE
Hstore provides its own value type for protobuf encoding

### DIFF
--- a/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/output/NativeRecord.kt
+++ b/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/output/NativeRecord.kt
@@ -44,7 +44,7 @@ fun NativeRecordPayload.toJson(parentNode: ObjectNode = Jsons.objectNode()): Obj
     return parentNode
 }
 
-interface ProtobufAwareCustomConnectorJsonCodec<T>: JsonCodec<T> {
+interface ProtobufAwareCustomConnectorJsonCodec<T> : JsonCodec<T> {
     fun valueForProtobufEncoding(v: T): Any?
 }
 
@@ -62,7 +62,10 @@ fun <R> valueForProtobufEncoding(fve: FieldValueEncoder<R>): Any? {
             is CdcOffsetDateTimeCodec ->
                 (value as OffsetDateTime).format(OffsetDateTimeCodec.formatter)
             is ArrayEncoder<*> -> fve.encode().toString()
-            is ProtobufAwareCustomConnectorJsonCodec<*> -> (fve.jsonEncoder as ProtobufAwareCustomConnectorJsonCodec).valueForProtobufEncoding(value)
+            is ProtobufAwareCustomConnectorJsonCodec<*> ->
+                (fve.jsonEncoder as ProtobufAwareCustomConnectorJsonCodec).valueForProtobufEncoding(
+                    value
+                )
             else -> value
         }
     }

--- a/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/output/NativeRecord.kt
+++ b/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/output/NativeRecord.kt
@@ -10,6 +10,7 @@ import io.airbyte.cdk.data.ArrayEncoder
 import io.airbyte.cdk.data.BigDecimalIntegerCodec
 import io.airbyte.cdk.data.ByteCodec
 import io.airbyte.cdk.data.CdcOffsetDateTimeCodec
+import io.airbyte.cdk.data.JsonCodec
 import io.airbyte.cdk.data.JsonEncoder
 import io.airbyte.cdk.data.NullCodec
 import io.airbyte.cdk.data.OffsetDateTimeCodec
@@ -43,44 +44,9 @@ fun NativeRecordPayload.toJson(parentNode: ObjectNode = Jsons.objectNode()): Obj
     return parentNode
 }
 
-/*interface ConnectorJsonEncoder {
-    fun toProtobufEncoder(): ProtoEncoder<*>
+interface ProtobufAwareCustomConnectorJsonCodec<T>: JsonCodec<T> {
+    fun valueForProtobufEncoding(v: T): Any?
 }
-
-fun <T> JsonEncoder<T>.toProtobufEncoder(): ProtoEncoder<*> {
-    return when (this) {
-        is ConnectorJsonEncoder -> toProtobufEncoder()
-        is LongCodec, -> longProtoEncoder
-        is IntCodec, -> intProtoEncoder
-        is TextCodec, -> textProtoEncoder
-        is BooleanCodec, -> booleanProtoEncoder
-        is OffsetDateTimeCodec, -> offsetDateTimeProtoEncoder
-        is FloatCodec, -> floatProtoEncoder
-        is NullCodec, -> nullProtoEncoder
-        is BinaryCodec, -> binaryProtoEncoder
-        is BigDecimalCodec, -> bigDecimalProtoEncoder
-        is BigDecimalIntegerCodec, -> bigDecimalProtoEncoder
-        is ShortCodec, -> shortProtoEncoder
-        is ByteCodec, -> byteProtoEncoder
-        is DoubleCodec, -> doubleProtoEncoder
-        is JsonBytesCodec, -> binaryProtoEncoder
-        is JsonStringCodec, -> textProtoEncoder
-        is UrlCodec, -> urlProtoEncoder
-        is LocalDateCodec, -> localDateProtoEncoder
-        is LocalTimeCodec, -> localTimeProtoEncoder
-        is LocalDateTimeCodec, -> localDateTimeProtoEncoder
-        is OffsetTimeCodec, -> offsetTimeProtoEncoder
-        is ArrayEncoder<*>, -> arrayProtoEncoder
-        else -> anyProtoEncoder
-    }
-}
-
-fun interface ProtoEncoder<T> {
-    fun encode(
-        builder: AirbyteRecordMessage.AirbyteValueProtobuf.Builder,
-        decoded: T
-    ): AirbyteRecordMessage.AirbyteValueProtobuf.Builder
-}*/
 
 /**
  * Transforms a field value into a protobuf-compatible representation. Handles special conversions
@@ -96,6 +62,7 @@ fun <R> valueForProtobufEncoding(fve: FieldValueEncoder<R>): Any? {
             is CdcOffsetDateTimeCodec ->
                 (value as OffsetDateTime).format(OffsetDateTimeCodec.formatter)
             is ArrayEncoder<*> -> fve.encode().toString()
+            is ProtobufAwareCustomConnectorJsonCodec<*> -> (fve.jsonEncoder as ProtobufAwareCustomConnectorJsonCodec).valueForProtobufEncoding(value)
             else -> value
         }
     }

--- a/airbyte-integrations/connectors/source-postgres/src/main/kotlin/io/airbyte/integrations/source/postgres/operations/types/HstoreFieldType.kt
+++ b/airbyte-integrations/connectors/source-postgres/src/main/kotlin/io/airbyte/integrations/source/postgres/operations/types/HstoreFieldType.kt
@@ -8,10 +8,10 @@ import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.TextNode
-import io.airbyte.cdk.data.JsonCodec
 import io.airbyte.cdk.data.LeafAirbyteSchemaType
 import io.airbyte.cdk.jdbc.JdbcAccessor
 import io.airbyte.cdk.jdbc.SymmetricJdbcFieldType
+import io.airbyte.cdk.output.sockets.ProtobufAwareCustomConnectorJsonCodec
 import java.sql.PreparedStatement
 import java.sql.ResultSet
 
@@ -45,7 +45,7 @@ object HstoreAccessor : JdbcAccessor<Map<String, String?>> {
     }
 }
 
-object HstoreCodec : JsonCodec<Map<String, String?>> {
+object HstoreCodec : ProtobufAwareCustomConnectorJsonCodec<Map<String, String?>> {
     override fun encode(decoded: Map<String, String?>): JsonNode {
         return TextNode(nullValuePreservingObjectMapper.writeValueAsString(decoded))
     }
@@ -55,6 +55,10 @@ object HstoreCodec : JsonCodec<Map<String, String?>> {
             encoded.asText(),
             object : TypeReference<Map<String, String?>>() {}
         )
+    }
+
+    override fun valueForProtobufEncoding(v: Map<String, String?>): Any? {
+        return encode(v).asText()
     }
 }
 


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->
Protobuf encoding relies it strictly types and the encoder class has a set of accepted incoming types when encoding, according to the request schema type in the airbyte catalog.
For that matter, a catalog STRING type only accepts a jvm String as a valid input.

Connector defined field types present a challenge as the embedded jvm type doesn't have to match the output catalog type - as long as the json encoder can turn input into a valid json node. There is no enforcement on the type of json node either.

This change deals with protobuf encoding of postgres Hstore type (a dictionary) which is saved in the native jvm `Map<String, String?>` type.

Resolves #15784
## How
<!--
* Describe how code changes achieve the solution.
-->
By adding an auxiliary function that return a valid jvm type the CDK can encode the field to protobuf

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
