### PR TITLE
ci: expand OSS triage bot to respond to discussions in addition to issues

### DIFF
--- a/.github/workflows/oss-issue-triage.yml
+++ b/.github/workflows/oss-issue-triage.yml
@@ -19,10 +19,6 @@ jobs:
   check-permissions:
     name: Check User Permissions
     runs-on: ubuntu-24.04
-    outputs:
-      is-community-member: ${{ steps.check-access.outputs.is-community-member }}
-      author: ${{ steps.gather-metadata.outputs.author }}
-      event-type: ${{ steps.gather-metadata.outputs.event-type }}
     steps:
       - name: Gather event metadata
         id: gather-metadata
@@ -69,6 +65,10 @@ jobs:
             echo "User is a community member - triggering AI triage"
             echo "is-community-member=true" >> $GITHUB_OUTPUT
           fi
+    outputs:
+      is-community-member: ${{ steps.check-access.outputs.is-community-member }}
+      author: ${{ steps.gather-metadata.outputs.author }}
+      event-type: ${{ steps.gather-metadata.outputs.event-type }}
 
   ai-triage-issue:
     name: AI Triage for Community Issue

--- a/.github/workflows/oss-issue-triage.yml
+++ b/.github/workflows/oss-issue-triage.yml
@@ -98,7 +98,7 @@ jobs:
           start-message: |
             **AI Triage Starting...**
 
-            Thank you for opening this issue! I'm an AI assistant that will do an initial review and may:
+            Thank you for opening this issue! I'm an AI triage bot that will do an initial review and may:
             - Ask clarifying questions if needed
             - Suggest relevant documentation or workarounds
             - Flag this for internal visibility

--- a/.github/workflows/oss-issue-triage.yml
+++ b/.github/workflows/oss-issue-triage.yml
@@ -1,4 +1,4 @@
-name: OSS Issue Triage
+name: OSS Issue and Discussion Triage
 
 # This workflow automatically triggers AI triage for issues and discussions opened by
 # community members (users without write access to the repository). It helps provide

--- a/.github/workflows/oss-issue-triage.yml
+++ b/.github/workflows/oss-issue-triage.yml
@@ -134,10 +134,9 @@ jobs:
         id: discussion-comment
         env:
           GH_TOKEN: ${{ steps.get-app-token.outputs.token }}
+          DISCUSSION_NODE_ID: ${{ github.event.discussion.node_id }}
         run: |
           set -euo pipefail
-
-          DISCUSSION_NODE_ID="${{ github.event.discussion.node_id }}"
 
           COMMENT_BODY="**AI Triage Starting...**
 
@@ -150,15 +149,10 @@ jobs:
 
           [View playbook](https://github.com/airbytehq/oncall/blob/main/prompts/playbooks/oss_issue_triage.md)"
 
-          gh api graphql -f query='
-            mutation($discussionId: ID!, $body: String!) {
-              addDiscussionComment(input: {discussionId: $discussionId, body: $body}) {
-                comment {
-                  id
-                }
-              }
-            }
-          ' -f discussionId="$DISCUSSION_NODE_ID" -f body="$COMMENT_BODY"
+          gh api graphql \
+            -f query='mutation($discussionId: ID!, $body: String!) { addDiscussionComment(input: {discussionId: $discussionId, body: $body}) { comment { id } } }' \
+            -f discussionId="$DISCUSSION_NODE_ID" \
+            -f body="$COMMENT_BODY"
 
       - name: Run AI Triage
         uses: aaronsteers/devin-action@v0.2.0

--- a/.github/workflows/oss-issue-triage.yml
+++ b/.github/workflows/oss-issue-triage.yml
@@ -74,7 +74,6 @@ jobs:
     name: AI Triage for Community Issue
     needs: check-permissions
     if: needs.check-permissions.outputs.event-type == 'issue'
-    # if: needs.check-permissions.outputs.is-community-member == 'true' && needs.check-permissions.outputs.event-type == 'issue'
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
@@ -117,7 +116,6 @@ jobs:
     name: AI Triage for Community Discussion
     needs: check-permissions
     if: needs.check-permissions.outputs.event-type == 'discussion'
-    # if: needs.check-permissions.outputs.is-community-member == 'true' && needs.check-permissions.outputs.event-type == 'discussion'
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout code

--- a/.github/workflows/oss-issue-triage.yml
+++ b/.github/workflows/oss-issue-triage.yml
@@ -99,12 +99,14 @@ jobs:
           start-message: |
             **AI Triage Starting...**
 
-            Thank you for opening this issue! I'm an AI assistant that will help with initial triage.
-
-            I'll review your issue and:
+            Thank you for opening this issue! I'm an AI assistant that will do an initial review and may:
             - Ask clarifying questions if needed
-            - Provide immediate guidance if available
-            - Escalate to the appropriate team if this requires engineering attention
+            - Suggest relevant documentation or workarounds
+            - Flag this for internal visibility
+
+            **Note:** Community issues are reviewed on a best-effort basis and do not have a guaranteed response time. For additional help:
+            - Join the [Airbyte Community Slack](https://slack.airbyte.com) to connect with other users and community members
+            - If you're an Airbyte Cloud customer, you can [open a support ticket](https://support.airbyte.com) or contact your account representative, referencing this issue URL
 
             [View playbook](https://github.com/airbytehq/oncall/blob/main/prompts/playbooks/oss_issue_triage.md)
           tags: |
@@ -129,30 +131,6 @@ jobs:
           repositories: "airbyte,oncall"
           app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
           private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
-
-      - name: Post start comment on discussion
-        id: discussion-comment
-        env:
-          GH_TOKEN: ${{ steps.get-app-token.outputs.token }}
-          DISCUSSION_NODE_ID: ${{ github.event.discussion.node_id }}
-          COMMENT_BODY: |
-            **AI Triage Starting...**
-
-            Thank you for opening this discussion! I'm an AI assistant that will help with initial triage.
-
-            I'll review your discussion and:
-            - Ask clarifying questions if needed
-            - Provide immediate guidance if available
-            - Escalate to the appropriate team if this requires engineering attention
-
-            [View playbook](https://github.com/airbytehq/oncall/blob/main/prompts/playbooks/oss_issue_triage.md)
-        run: |
-          set -euo pipefail
-
-          gh api graphql \
-            -f query='mutation($discussionId: ID!, $body: String!) { addDiscussionComment(input: {discussionId: $discussionId, body: $body}) { comment { id } } }' \
-            -f discussionId="$DISCUSSION_NODE_ID" \
-            -f body="$COMMENT_BODY"
 
       - name: Run AI Triage
         uses: aaronsteers/devin-action@v0.2.0

--- a/.github/workflows/oss-issue-triage.yml
+++ b/.github/workflows/oss-issue-triage.yml
@@ -135,19 +135,19 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.get-app-token.outputs.token }}
           DISCUSSION_NODE_ID: ${{ github.event.discussion.node_id }}
+          COMMENT_BODY: |
+            **AI Triage Starting...**
+
+            Thank you for opening this discussion! I'm an AI assistant that will help with initial triage.
+
+            I'll review your discussion and:
+            - Ask clarifying questions if needed
+            - Provide immediate guidance if available
+            - Escalate to the appropriate team if this requires engineering attention
+
+            [View playbook](https://github.com/airbytehq/oncall/blob/main/prompts/playbooks/oss_issue_triage.md)
         run: |
           set -euo pipefail
-
-          COMMENT_BODY="**AI Triage Starting...**
-
-          Thank you for opening this discussion! I'm an AI assistant that will help with initial triage.
-
-          I'll review your discussion and:
-          - Ask clarifying questions if needed
-          - Provide immediate guidance if available
-          - Escalate to the appropriate team if this requires engineering attention
-
-          [View playbook](https://github.com/airbytehq/oncall/blob/main/prompts/playbooks/oss_issue_triage.md)"
 
           gh api graphql \
             -f query='mutation($discussionId: ID!, $body: String!) { addDiscussionComment(input: {discussionId: $discussionId, body: $body}) { comment { id } } }' \

--- a/.github/workflows/oss-issue-triage.yml
+++ b/.github/workflows/oss-issue-triage.yml
@@ -98,7 +98,7 @@ jobs:
           start-message: |
             **AI Triage Starting...**
 
-            Thank you for opening this issue! I'm an AI triage bot that will do an initial review and may:
+            Thank you for opening this issue! I'm an AI assistant that will do an initial review and may:
             - Ask clarifying questions if needed
             - Suggest relevant documentation or workarounds
             - Flag this for internal visibility

--- a/.github/workflows/oss-issue-triage.yml
+++ b/.github/workflows/oss-issue-triage.yml
@@ -1,16 +1,19 @@
 name: OSS Issue Triage
 
-# This workflow automatically triggers AI triage for issues opened by community members
-# (users without write access to the repository). It helps provide quick initial responses
-# and escalates actionable issues to the internal oncall team.
+# This workflow automatically triggers AI triage for issues and discussions opened by
+# community members (users without write access to the repository). It helps provide
+# quick initial responses and escalates actionable items to the internal oncall team.
 
 on:
   issues:
     types: [opened]
+  discussion:
+    types: [created]
 
 permissions:
   contents: read
   issues: write
+  discussions: write
 
 jobs:
   check-permissions:
@@ -18,7 +21,20 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       is-community-member: ${{ steps.check-access.outputs.is-community-member }}
+      author: ${{ steps.gather-metadata.outputs.author }}
+      event-type: ${{ steps.gather-metadata.outputs.event-type }}
     steps:
+      - name: Gather event metadata
+        id: gather-metadata
+        run: |
+          if [[ "${{ github.event_name }}" == "issues" ]]; then
+            echo "author=${{ github.event.issue.user.login }}" >> $GITHUB_OUTPUT
+            echo "event-type=issue" >> $GITHUB_OUTPUT
+          elif [[ "${{ github.event_name }}" == "discussion" ]]; then
+            echo "author=${{ github.event.discussion.user.login }}" >> $GITHUB_OUTPUT
+            echo "event-type=discussion" >> $GITHUB_OUTPUT
+          fi
+
       - name: Authenticate as GitHub App
         uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
         id: get-app-token
@@ -32,14 +48,14 @@ jobs:
         id: check-access
         env:
           GH_TOKEN: ${{ steps.get-app-token.outputs.token }}
-          ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
+          AUTHOR: ${{ steps.gather-metadata.outputs.author }}
         run: |
           set -euo pipefail
 
-          echo "Checking permissions for user: $ISSUE_AUTHOR"
+          echo "Checking permissions for user: $AUTHOR"
 
           # Get the user's permission level for this repository
-          PERMISSION=$(gh api repos/${{ github.repository }}/collaborators/$ISSUE_AUTHOR/permission \
+          PERMISSION=$(gh api repos/${{ github.repository }}/collaborators/$AUTHOR/permission \
             --jq '.permission' 2>/dev/null || echo "none")
 
           echo "User permission level: $PERMISSION"
@@ -54,10 +70,11 @@ jobs:
             echo "is-community-member=true" >> $GITHUB_OUTPUT
           fi
 
-  ai-triage:
+  ai-triage-issue:
     name: AI Triage for Community Issue
     needs: check-permissions
-    # if: needs.check-permissions.outputs.is-community-member == 'true'
+    if: needs.check-permissions.outputs.event-type == 'issue'
+    # if: needs.check-permissions.outputs.is-community-member == 'true' && needs.check-permissions.outputs.event-type == 'issue'
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
@@ -93,3 +110,71 @@ jobs:
           tags: |
             oss-issue-triage
             community-issue
+
+  ai-triage-discussion:
+    name: AI Triage for Community Discussion
+    needs: check-permissions
+    if: needs.check-permissions.outputs.event-type == 'discussion'
+    # if: needs.check-permissions.outputs.is-community-member == 'true' && needs.check-permissions.outputs.event-type == 'discussion'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+
+      - name: Authenticate as GitHub App
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        id: get-app-token
+        with:
+          owner: "airbytehq"
+          repositories: "airbyte,oncall"
+          app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
+          private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
+
+      - name: Post start comment on discussion
+        id: discussion-comment
+        env:
+          GH_TOKEN: ${{ steps.get-app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+
+          DISCUSSION_NODE_ID="${{ github.event.discussion.node_id }}"
+
+          COMMENT_BODY="**AI Triage Starting...**
+
+          Thank you for opening this discussion! I'm an AI assistant that will help with initial triage.
+
+          I'll review your discussion and:
+          - Ask clarifying questions if needed
+          - Provide immediate guidance if available
+          - Escalate to the appropriate team if this requires engineering attention
+
+          [View playbook](https://github.com/airbytehq/oncall/blob/main/prompts/playbooks/oss_issue_triage.md)"
+
+          gh api graphql -f query='
+            mutation($discussionId: ID!, $body: String!) {
+              addDiscussionComment(input: {discussionId: $discussionId, body: $body}) {
+                comment {
+                  id
+                }
+              }
+            }
+          ' -f discussionId="$DISCUSSION_NODE_ID" -f body="$COMMENT_BODY"
+
+      - name: Run AI Triage
+        uses: aaronsteers/devin-action@v0.2.0
+        with:
+          playbook-macro: "!oss_issue_triage"
+          devin-token: ${{ secrets.DEVIN_AI_API_KEY }}
+          github-token: ${{ steps.get-app-token.outputs.token }}
+          prompt-text: |
+            Discussion #${{ github.event.discussion.number }} by @${{ github.event.discussion.user.login }}: ${{ github.event.discussion.title }}
+            Discussion URL: ${{ github.event.discussion.html_url }}
+            Discussion Category: ${{ github.event.discussion.category.name }}
+
+            Discussion Body:
+            ${{ github.event.discussion.body }}
+
+            IMPORTANT: This is a GitHub Discussion, not an issue. You should post your response as a comment on the discussion using the GitHub GraphQL API. The discussion node ID is: ${{ github.event.discussion.node_id }}
+          tags: |
+            oss-issue-triage
+            community-discussion

--- a/.github/workflows/oss-issue-triage.yml
+++ b/.github/workflows/oss-issue-triage.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   check-permissions:
-    name: Check User Permissions
+    name: Resolve Input Variables
     runs-on: ubuntu-24.04
     steps:
       - name: Gather event metadata


### PR DESCRIPTION
## What

Expands the OSS triage bot workflow to automatically respond to new GitHub Discussions, in addition to the existing issue triage. This addresses the gap where community members post feature requests or questions as discussions (e.g. https://github.com/airbytehq/airbyte/discussions/73295) but receive no automated triage response.

Also softens the issue start-message to set realistic expectations (best-effort, no SLA) and directs users to Slack and Cloud support as alternative channels.

Companion playbook PR: https://github.com/airbytehq/oncall/pull/11324

Requested by @aaronsteers. [Link to Devin run](https://app.devin.ai/sessions/8168faedb0384aa5afc967e5e57323b2).

## How

- Renamed workflow from "OSS Issue Triage" to "OSS Issue and Discussion Triage"
- Added `discussion: [created]` trigger alongside existing `issues: [opened]`
- Added `discussions: write` permission
- Extracted a `Gather event metadata` step to normalize author and event type across both triggers
- Split the original `ai-triage` job into two conditional jobs:
  - `ai-triage-issue` — runs on `event-type == 'issue'`
  - `ai-triage-discussion` — new job, runs on `event-type == 'discussion'`
- For discussions: no initial start comment is posted (unlike issues). Devin is invoked directly with full discussion context (title, URL, category, body, node ID) via `prompt-text`, and instructed to reply via the GitHub GraphQL API.
- For issues: updated the `start-message` to use best-effort language and include links to [Airbyte Community Slack](https://slack.airbyte.com) and [Cloud support](https://support.airbyte.com) as alternative help channels
- Oncall escalation titles use `[OSS Issue Triage]` and `[OSS Discussion Triage]` annotations (defined in the companion playbook PR)

## Updates since last revision

- **Removed** the "Post start comment on discussion" GraphQL step — discussions no longer get a dual-posted initial comment; Devin responds directly
- **Softened** the issue start-message: replaced "escalate to the appropriate team" / "provide immediate guidance" with best-effort language and community support links
- Workflow renamed to "OSS Issue and Discussion Triage"

## Review guide

1. `.github/workflows/oss-issue-triage.yml` — single file change

**Key areas for reviewer attention:**
- **GitHub App permissions**: The Octavia Bot GitHub App must have `discussions: write` scope configured at the app level (not just in the workflow YAML). Verify this is the case or it will fail at runtime.
- **Community member gate still commented out**: Both `ai-triage-issue` and `ai-triage-discussion` have the `is-community-member` check commented out (pre-existing for issues, carried forward for discussions). This means triage fires for all users including maintainers.
- **No initial comment for discussions**: Unlike issues (which get a `start-message`), discussions will have no visible response until Devin completes its triage. This is intentional but means slower visible feedback for discussion authors.
- **Discussion body in prompt-text**: `${{ github.event.discussion.body }}` is interpolated directly into the `prompt-text` YAML value. If a discussion body contains characters that break YAML parsing (e.g. unbalanced quotes, backticks), this could cause the workflow to fail. The `devin-action` does base64-encode the final prompt, but the YAML interpolation happens first.
- **Not locally testable**: This workflow can only be verified by creating a real discussion in the repo. Consider a dry-run test after merge.

## User Impact

Community members who open GitHub Discussions will now receive automated AI triage (without an immediate "starting..." comment). Issue authors will see a revised start-message with softer expectations and links to Slack and Cloud support.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚