### PR TITLE
ci: escape backticks and bash-special chars in discussion prompt-text

### DIFF
--- a/.github/workflows/oss-issue-triage.yml
+++ b/.github/workflows/oss-issue-triage.yml
@@ -130,21 +130,49 @@ jobs:
           app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
           private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
 
+      - name: Prepare discussion prompt
+        id: prepare-prompt
+        env:
+          DISC_NUM: ${{ github.event.discussion.number }}
+          DISC_AUTHOR: ${{ github.event.discussion.user.login }}
+          DISC_TITLE: ${{ github.event.discussion.title }}
+          DISC_URL: ${{ github.event.discussion.html_url }}
+          DISC_CAT: ${{ github.event.discussion.category.name }}
+          DISC_BODY: ${{ github.event.discussion.body }}
+          DISC_NODE_ID: ${{ github.event.discussion.node_id }}
+        run: |
+          escape_for_bash() {
+            local text="$1"
+            text="${text//\\/\\\\}"
+            text="${text//\`/\\\`}"
+            text="${text//\$/\\\$}"
+            text="${text//\"/\\\"}"
+            printf '%s' "$text"
+          }
+
+          ESC_TITLE=$(escape_for_bash "$DISC_TITLE")
+          ESC_BODY=$(escape_for_bash "$DISC_BODY")
+
+          {
+            echo "prompt<<PROMPT_EOF"
+            printf 'Discussion #%s by @%s: %s\n' "$DISC_NUM" "$DISC_AUTHOR" "$ESC_TITLE"
+            printf 'Discussion URL: %s\n' "$DISC_URL"
+            printf 'Discussion Category: %s\n' "$DISC_CAT"
+            echo ""
+            echo "Discussion Body:"
+            printf '%s\n' "$ESC_BODY"
+            echo ""
+            printf 'IMPORTANT: This is a GitHub Discussion, not an issue. You should post your response as a comment on the discussion using the GitHub GraphQL API. The discussion node ID is: %s\n' "$DISC_NODE_ID"
+            echo "PROMPT_EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Run AI Triage
         uses: aaronsteers/devin-action@v0.2.0
         with:
           playbook-macro: "!oss_issue_triage"
           devin-token: ${{ secrets.DEVIN_AI_API_KEY }}
           github-token: ${{ steps.get-app-token.outputs.token }}
-          prompt-text: |
-            Discussion #${{ github.event.discussion.number }} by @${{ github.event.discussion.user.login }}: ${{ github.event.discussion.title }}
-            Discussion URL: ${{ github.event.discussion.html_url }}
-            Discussion Category: ${{ github.event.discussion.category.name }}
-
-            Discussion Body:
-            ${{ github.event.discussion.body }}
-
-            IMPORTANT: This is a GitHub Discussion, not an issue. You should post your response as a comment on the discussion using the GitHub GraphQL API. The discussion node ID is: ${{ github.event.discussion.node_id }}
+          prompt-text: ${{ steps.prepare-prompt.outputs.prompt }}
           tags: |
             oss-issue-triage
             community-discussion


### PR DESCRIPTION
## What

Fixes a bash command substitution error in the OSS discussion triage workflow (merged in #73618). When a discussion title or body contains backticks (e.g., `` `source-foo` ``), the `devin-action` composite action expands the `prompt-text` input into double-quoted bash strings, causing backticks to be interpreted as command substitution. See [failed run](https://github.com/airbytehq/airbyte/actions/runs/22122395028/job/63945187660).

Error: `/home/runner/work/_temp/...sh: line 48: source-foo: command not found`

## How

Instead of interpolating raw `${{ github.event.discussion.body }}` directly into the `prompt-text` YAML input, a new "Prepare discussion prompt" step:

1. Receives discussion content via `env:` variables (safe — bash doesn't re-evaluate env var values for command substitution)
2. Escapes bash-special characters (`\`, `` ` ``, `$`, `"`) in the title and body before writing to a step output
3. The escaped output is then passed to `prompt-text`, so when `devin-action` places it in double-quoted bash strings, the escape sequences produce the intended literal characters

## Review guide

1. `.github/workflows/oss-issue-triage.yml` — the `escape_for_bash` function and prompt construction step

Key things to verify:
- Escaping order matters: backslashes are escaped first to avoid double-escaping
- Only user-generated fields (title, body) are escaped; GitHub-controlled fields (author, URL, category, node_id) are not
- The `PROMPT_EOF` heredoc delimiter is unlikely to appear in discussion content but is a theoretical edge case

## User Impact

Discussion triage will no longer fail when community members use backticks, dollar signs, or double quotes in their discussion titles or bodies.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Reverting restores the previous inline interpolation, which would re-introduce the bash interpretation bug for discussions containing special characters.

---

Link to Devin run: https://app.devin.ai/sessions/8168faedb0384aa5afc967e5e57323b2
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/73620" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
