### PR TITLE
ci: remove unnecessary checkout steps from OSS triage workflow

### DIFF
--- a/.github/workflows/oss-issue-triage.yml
+++ b/.github/workflows/oss-issue-triage.yml
@@ -11,7 +11,6 @@ on:
     types: [created]
 
 permissions:
-  contents: read
   issues: write
   discussions: write
 
@@ -76,9 +75,6 @@ jobs:
     if: needs.check-permissions.outputs.event-type == 'issue'
     runs-on: ubuntu-24.04
     steps:
-      - name: Checkout code
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
-
       - name: Authenticate as GitHub App
         uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
         id: get-app-token
@@ -118,9 +114,6 @@ jobs:
     if: needs.check-permissions.outputs.event-type == 'discussion'
     runs-on: ubuntu-24.04
     steps:
-      - name: Checkout code
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
-
       - name: Authenticate as GitHub App
         uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
         id: get-app-token


### PR DESCRIPTION
## What

Removes the `actions/checkout` steps and `contents: read` permission from the OSS triage workflow, since neither triage job reads any files from the repository.

## How

- Removed `actions/checkout` from both `ai-triage-issue` and `ai-triage-discussion` jobs
- Removed `contents: read` from workflow-level permissions (no longer needed)

## Review guide

1. `.github/workflows/oss-issue-triage.yml` — verify that `devin-action@v0.2.0` does not require a local checkout to function (it's a remote composite action fetched by GitHub independently, and operates entirely via API calls)

## User Impact

Slightly faster workflow execution (skips ~5-10s checkout step per run). No functional change.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Link to Devin run: https://app.devin.ai/sessions/8168faedb0384aa5afc967e5e57323b2
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/73622" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
