### PR TITLE
feat(source-sftp-bulk): support elliptic curve SSH keys (Ed25519, ECDSA)

### DIFF
--- a/airbyte-integrations/connectors/source-sftp-bulk/integration_tests/conftest.py
+++ b/airbyte-integrations/connectors/source-sftp-bulk/integration_tests/conftest.py
@@ -14,6 +14,9 @@ from typing import Any, Mapping, Tuple
 import docker
 import paramiko
 import pytest
+from cryptography.hazmat.primitives.asymmetric.ec import SECP256R1, generate_private_key as ec_generate
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.serialization import Encoding, NoEncryption, PrivateFormat
 
 from airbyte_cdk import AirbyteStream, ConfiguredAirbyteCatalog, ConfiguredAirbyteStream, DestinationSyncMode, SyncMode
 
@@ -22,17 +25,17 @@ from .utils import get_docker_ip, load_config
 
 logger = logging.getLogger("airbyte")
 
-PRIVATE_KEY = str()
+RSA_PRIVATE_KEY = str()
+ED25519_PRIVATE_KEY = str()
+ECDSA_PRIVATE_KEY = str()
 TMP_FOLDER = "/tmp/test_sftp_source"
 
 
 # HELPERS
-def generate_ssh_keys() -> Tuple[str, str]:
-    key = paramiko.RSAKey.generate(2048)
-    privateString = StringIO()
-    key.write_private_key(privateString)
-
-    return privateString.getvalue(), "ssh-rsa " + key.get_base64()
+def _write_private_key(key: paramiko.PKey) -> str:
+    buf = StringIO()
+    key.write_private_key(buf)
+    return buf.getvalue()
 
 
 @pytest.fixture(scope="session")
@@ -77,12 +80,26 @@ def connector_setup_fixture(docker_client) -> None:
     shutil.copytree(f"{dir_path}/files", TMP_FOLDER)
     prepare_test_files(TMP_FOLDER)
     os.makedirs(ssh_path)
-    private_key, public_key = generate_ssh_keys()
-    global PRIVATE_KEY
-    PRIVATE_KEY = private_key
-    pub_key_path = ssh_path + "/id_rsa.pub"
-    with open(pub_key_path, "w") as f:
-        f.write(public_key)
+
+    global RSA_PRIVATE_KEY, ED25519_PRIVATE_KEY, ECDSA_PRIVATE_KEY
+
+    rsa_key = paramiko.RSAKey.generate(2048)
+    RSA_PRIVATE_KEY = _write_private_key(rsa_key)
+    with open(ssh_path + "/id_rsa.pub", "w") as f:
+        f.write("ssh-rsa " + rsa_key.get_base64())
+
+    _ed25519_raw = Ed25519PrivateKey.generate()
+    ED25519_PRIVATE_KEY = _ed25519_raw.private_bytes(Encoding.PEM, PrivateFormat.OpenSSH, NoEncryption()).decode()
+    _ed25519_pub = paramiko.Ed25519Key.from_private_key(StringIO(ED25519_PRIVATE_KEY))
+    with open(ssh_path + "/id_ed25519.pub", "w") as f:
+        f.write("ssh-ed25519 " + _ed25519_pub.get_base64())
+
+    _ecdsa_raw = ec_generate(SECP256R1())
+    ECDSA_PRIVATE_KEY = _ecdsa_raw.private_bytes(Encoding.PEM, PrivateFormat.OpenSSH, NoEncryption()).decode()
+    _ecdsa_pub = paramiko.ECDSAKey.from_private_key(StringIO(ECDSA_PRIVATE_KEY))
+    with open(ssh_path + "/id_ecdsa.pub", "w") as f:
+        f.write("ecdsa-sha2-nistp256 " + _ecdsa_pub.get_base64())
+
     config = load_config("config_password.json")
     container = docker_client.containers.run(
         "atmoz/sftp",
@@ -91,7 +108,7 @@ def connector_setup_fixture(docker_client) -> None:
         ports={22: ("0.0.0.0", config["port"])},
         volumes={
             f"{TMP_FOLDER}": {"bind": "/home/foo/files", "mode": "rw"},
-            f"{pub_key_path}": {"bind": "/home/foo/.ssh/keys/id_rsa.pub", "mode": "ro"},
+            f"{ssh_path}": {"bind": "/home/foo/.ssh/keys", "mode": "ro"},
         },
         detach=True,
     )
@@ -145,13 +162,36 @@ def config_fixture_not_mirroring_paths_with_duplicates(docker_client) -> Mapping
     yield config
 
 
-@pytest.fixture(name="config_private_key", scope="session")
-def config_fixture_private_key(docker_client) -> Mapping[str, Any]:
+@pytest.fixture(name="config_private_key_rsa", scope="session")
+def config_fixture_private_key_rsa(docker_client) -> Mapping[str, Any]:
     config = load_config("config_private_key.json") | {
-        "credentials": {"auth_type": "private_key", "private_key": PRIVATE_KEY},
+        "credentials": {"auth_type": "private_key", "private_key": RSA_PRIVATE_KEY},
     }
     config["host"] = get_docker_ip()
     yield config
+
+
+@pytest.fixture(name="config_private_key_ed25519", scope="session")
+def config_fixture_private_key_ed25519(docker_client) -> Mapping[str, Any]:
+    config = load_config("config_private_key.json") | {
+        "credentials": {"auth_type": "private_key", "private_key": ED25519_PRIVATE_KEY},
+    }
+    config["host"] = get_docker_ip()
+    yield config
+
+
+@pytest.fixture(name="config_private_key_ecdsa", scope="session")
+def config_fixture_private_key_ecdsa(docker_client) -> Mapping[str, Any]:
+    config = load_config("config_private_key.json") | {
+        "credentials": {"auth_type": "private_key", "private_key": ECDSA_PRIVATE_KEY},
+    }
+    config["host"] = get_docker_ip()
+    yield config
+
+
+@pytest.fixture(name="config_private_key", scope="session")
+def config_fixture_private_key(config_private_key_rsa) -> Mapping[str, Any]:
+    yield config_private_key_rsa
 
 
 @pytest.fixture(name="config_private_key_csv", scope="session")

--- a/airbyte-integrations/connectors/source-sftp-bulk/integration_tests/conftest.py
+++ b/airbyte-integrations/connectors/source-sftp-bulk/integration_tests/conftest.py
@@ -14,7 +14,8 @@ from typing import Any, Mapping, Tuple
 import docker
 import paramiko
 import pytest
-from cryptography.hazmat.primitives.asymmetric.ec import SECP256R1, generate_private_key as ec_generate
+from cryptography.hazmat.primitives.asymmetric.ec import SECP256R1
+from cryptography.hazmat.primitives.asymmetric.ec import generate_private_key as ec_generate
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 from cryptography.hazmat.primitives.serialization import Encoding, NoEncryption, PrivateFormat
 

--- a/airbyte-integrations/connectors/source-sftp-bulk/integration_tests/integration_test.py
+++ b/airbyte-integrations/connectors/source-sftp-bulk/integration_tests/integration_test.py
@@ -50,13 +50,19 @@ def test_check_valid_config_private_key_rsa(configured_catalog: ConfiguredAirbyt
     assert outcome.status == Status.SUCCEEDED
 
 
-def test_check_valid_config_private_key_ed25519(configured_catalog: ConfiguredAirbyteCatalog, config_private_key_ed25519: Mapping[str, Any]):
-    outcome = SourceSFTPBulk(catalog=configured_catalog, config=config_private_key_ed25519, state=None).check(logger, config_private_key_ed25519)
+def test_check_valid_config_private_key_ed25519(
+    configured_catalog: ConfiguredAirbyteCatalog, config_private_key_ed25519: Mapping[str, Any]
+):
+    outcome = SourceSFTPBulk(catalog=configured_catalog, config=config_private_key_ed25519, state=None).check(
+        logger, config_private_key_ed25519
+    )
     assert outcome.status == Status.SUCCEEDED
 
 
 def test_check_valid_config_private_key_ecdsa(configured_catalog: ConfiguredAirbyteCatalog, config_private_key_ecdsa: Mapping[str, Any]):
-    outcome = SourceSFTPBulk(catalog=configured_catalog, config=config_private_key_ecdsa, state=None).check(logger, config_private_key_ecdsa)
+    outcome = SourceSFTPBulk(catalog=configured_catalog, config=config_private_key_ecdsa, state=None).check(
+        logger, config_private_key_ecdsa
+    )
     assert outcome.status == Status.SUCCEEDED
 
 

--- a/airbyte-integrations/connectors/source-sftp-bulk/integration_tests/integration_test.py
+++ b/airbyte-integrations/connectors/source-sftp-bulk/integration_tests/integration_test.py
@@ -45,8 +45,18 @@ def test_check_invalid_config(configured_catalog: ConfiguredAirbyteCatalog, conf
     assert exc_info.value.failure_type.value == FailureType.config_error.value
 
 
-def test_check_valid_config_private_key(configured_catalog: ConfiguredAirbyteCatalog, config_private_key: Mapping[str, Any]):
-    outcome = SourceSFTPBulk(catalog=configured_catalog, config=config_private_key, state=None).check(logger, config_private_key)
+def test_check_valid_config_private_key_rsa(configured_catalog: ConfiguredAirbyteCatalog, config_private_key_rsa: Mapping[str, Any]):
+    outcome = SourceSFTPBulk(catalog=configured_catalog, config=config_private_key_rsa, state=None).check(logger, config_private_key_rsa)
+    assert outcome.status == Status.SUCCEEDED
+
+
+def test_check_valid_config_private_key_ed25519(configured_catalog: ConfiguredAirbyteCatalog, config_private_key_ed25519: Mapping[str, Any]):
+    outcome = SourceSFTPBulk(catalog=configured_catalog, config=config_private_key_ed25519, state=None).check(logger, config_private_key_ed25519)
+    assert outcome.status == Status.SUCCEEDED
+
+
+def test_check_valid_config_private_key_ecdsa(configured_catalog: ConfiguredAirbyteCatalog, config_private_key_ecdsa: Mapping[str, Any]):
+    outcome = SourceSFTPBulk(catalog=configured_catalog, config=config_private_key_ecdsa, state=None).check(logger, config_private_key_ecdsa)
     assert outcome.status == Status.SUCCEEDED
 
 

--- a/airbyte-integrations/connectors/source-sftp-bulk/source_sftp_bulk/__init__.py
+++ b/airbyte-integrations/connectors/source-sftp-bulk/source_sftp_bulk/__init__.py
@@ -5,4 +5,5 @@
 
 from .source import SourceSFTPBulk
 
+
 __all__ = ["SourceSFTPBulk"]

--- a/airbyte-integrations/connectors/source-sftp-bulk/source_sftp_bulk/client.py
+++ b/airbyte-integrations/connectors/source-sftp-bulk/source_sftp_bulk/client.py
@@ -24,6 +24,16 @@ def handle_backoff(details):
     logger.warning("SSH Connection closed unexpectedly. Waiting {wait} seconds and retrying...".format(**details))
 
 
+def _load_private_key(key_str: str) -> paramiko.PKey:
+    """Load a private key string, auto-detecting type (RSA, Ed25519, ECDSA, DSS)."""
+    for cls in (paramiko.RSAKey, paramiko.Ed25519Key, paramiko.ECDSAKey, paramiko.DSSKey):
+        try:
+            return cls.from_private_key(io.StringIO(key_str))
+        except (paramiko.ssh_exception.SSHException, ValueError):
+            continue
+    raise paramiko.ssh_exception.SSHException("Unable to identify private key type")
+
+
 class SFTPClient:
     _connection: paramiko.SFTPClient = None
 
@@ -41,7 +51,7 @@ class SFTPClient:
         self.password = password
         self.port = int(port) or 22
 
-        self.key = paramiko.RSAKey.from_private_key(io.StringIO(private_key)) if private_key else None
+        self.key = _load_private_key(private_key) if private_key else None
         self.timeout = float(timeout) if timeout else REQUEST_TIMEOUT
 
         self._connect()

--- a/airbyte-integrations/connectors/source-sftp-bulk/unit_tests/client_test.py
+++ b/airbyte-integrations/connectors/source-sftp-bulk/unit_tests/client_test.py
@@ -1,10 +1,14 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 
 
+from io import StringIO
 from unittest.mock import MagicMock, patch
 
 import paramiko
 import pytest
+from cryptography.hazmat.primitives.asymmetric.ec import SECP256R1, generate_private_key as ec_generate
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.serialization import Encoding, NoEncryption, PrivateFormat
 from paramiko.ssh_exception import SSHException
 from source_sftp_bulk.client import SFTPClient
 
@@ -28,3 +32,34 @@ def test_client_connection():
             port=123,
         )
         assert SFTPClient
+
+
+def _paramiko_key_to_str(key: paramiko.PKey) -> str:
+    buf = StringIO()
+    key.write_private_key(buf)
+    return buf.getvalue()
+
+
+def _cryptography_key_to_str(key) -> str:
+    return key.private_bytes(Encoding.PEM, PrivateFormat.OpenSSH, NoEncryption()).decode()
+
+
+def test_client_rsa_key_parsed():
+    rsa_key = paramiko.RSAKey.generate(2048)
+    with patch.object(paramiko, "Transport", MagicMock()), patch.object(paramiko, "SFTPClient", MagicMock()):
+        client = SFTPClient(host="localhost", username="username", private_key=_paramiko_key_to_str(rsa_key), port=22)
+        assert isinstance(client.key, paramiko.RSAKey)
+
+
+def test_client_ed25519_key_parsed():
+    ed25519_key = Ed25519PrivateKey.generate()
+    with patch.object(paramiko, "Transport", MagicMock()), patch.object(paramiko, "SFTPClient", MagicMock()):
+        client = SFTPClient(host="localhost", username="username", private_key=_cryptography_key_to_str(ed25519_key), port=22)
+        assert isinstance(client.key, paramiko.Ed25519Key)
+
+
+def test_client_ecdsa_key_parsed():
+    ecdsa_key = ec_generate(SECP256R1())
+    with patch.object(paramiko, "Transport", MagicMock()), patch.object(paramiko, "SFTPClient", MagicMock()):
+        client = SFTPClient(host="localhost", username="username", private_key=_cryptography_key_to_str(ecdsa_key), port=22)
+        assert isinstance(client.key, paramiko.ECDSAKey)

--- a/airbyte-integrations/connectors/source-sftp-bulk/unit_tests/client_test.py
+++ b/airbyte-integrations/connectors/source-sftp-bulk/unit_tests/client_test.py
@@ -6,7 +6,8 @@ from unittest.mock import MagicMock, patch
 
 import paramiko
 import pytest
-from cryptography.hazmat.primitives.asymmetric.ec import SECP256R1, generate_private_key as ec_generate
+from cryptography.hazmat.primitives.asymmetric.ec import SECP256R1
+from cryptography.hazmat.primitives.asymmetric.ec import generate_private_key as ec_generate
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 from cryptography.hazmat.primitives.serialization import Encoding, NoEncryption, PrivateFormat
 from paramiko.ssh_exception import SSHException


### PR DESCRIPTION
## What

This change allows for keys other than RSA to be used by the sftp bulk source.

## How

Replaced hardcoded RSAKey parsing with a helper that tries each paramiko key subclass in turn, supporting RSA, Ed25519, ECDSA, and DSS keys.


## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
