### PR TITLE
source-postgres: disable automatic flush

### DIFF
--- a/airbyte-integrations/connectors/source-postgres/src/main/kotlin/io/airbyte/integrations/source/postgres/cdc/ReplicationSlotManager.kt
+++ b/airbyte-integrations/connectors/source-postgres/src/main/kotlin/io/airbyte/integrations/source/postgres/cdc/ReplicationSlotManager.kt
@@ -44,8 +44,7 @@ class ReplicationSlotManager(
                 .withSlotName("\"${cdcConfig.replicationSlot}\"")
                 .withSlotOption("proto_version", 1)
                 .withSlotOption("publication_names", cdcConfig.publication)
-                // TODO: This may become necessary when taking up Debezium 3.2+ with PgJDBC 42.7.6+
-                // .withAutomaticFlush(false)
+                .withAutomaticFlush(false)
                 .apply {
                     val serverVersionStr = conn.parameterStatuses["server_version"]
                     if (serverVersionStr == null) {


### PR DESCRIPTION
## What
Disable automatic LSN flushing when setting up a replication connection for advancing the LSN. The automatic flushing feature was added in newer PgJDBC versions, and then the ability to disable it was added. It might not be strictly necessary to supply this configuration in this case, since we never stream data using the replication connection, but our intent is to manage the replication slot's LSNs manually, so providing this configuration is probably safest.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌
