### PR TITLE
docs: slim Terraform docs page to registry landing page, add pre-1.0 reference

### DIFF
--- a/docs/developers/terraform-documentation.md
+++ b/docs/developers/terraform-documentation.md
@@ -2,322 +2,65 @@
 products: all
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 # Terraform provider
-
-Follow this tutorial to learn how to use Airbyte's Terraform Provider.
 
 [Terraform](https://www.terraform.io/), developed by HashiCorp, is an Infrastructure as Code (IaC) tool that empowers you to define and provision infrastructure using a declarative configuration language. If you use Terraform to manage your infrastructure, you can use Airbyte's Terraform provider to automate and version control your Airbyte configuration as code. Airbyte's Terraform provider is built off [Airbyte's API](https://reference.airbyte.com).
 
-If you don't need a tutorial, go straight to the [Terraform docs](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs).
+## Documentation
 
-## Limitations and considerations
+The Airbyte Terraform provider documentation lives on the [Terraform Registry](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs), which is the source of truth for all provider reference docs, guides, and examples.
+
+| Resource | Description |
+|----------|-------------|
+| [Getting Started guide](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs/guides/getting_started) | Set up the provider and create your first source, destination, and connection. |
+| [Provider reference](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs) | Provider configuration, authentication, and schema. |
+| [Resource and data source docs](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs/resources/source) | Full reference for all resources and data sources. |
+| [Migrating to 1.0](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs/guides/v1_migration_guide) | Upgrade from typed connector-specific resources to the generic `airbyte_source` / `airbyte_destination` resources. |
+
+## Quick example
+
+```hcl
+terraform {
+  required_providers {
+    airbyte = {
+      source  = "airbytehq/airbyte"
+      version = "~> 1.0"
+    }
+  }
+}
+
+provider "airbyte" {
+  client_id     = var.client_id
+  client_secret = var.client_secret
+}
+
+data "airbyte_connector_configuration" "postgres_config" {
+  connector_name = "source-postgres"
+  configuration = {
+    host     = "db.example.com"
+    port     = 5432
+    database = "mydb"
+    username = "readonly"
+  }
+  configuration_secrets = {
+    password = var.db_password
+  }
+}
+
+resource "airbyte_source" "postgres" {
+  name          = "Production Postgres"
+  workspace_id  = var.workspace_id
+  definition_id = data.airbyte_connector_configuration.postgres_config.definition_id
+  configuration = data.airbyte_connector_configuration.postgres_config.configuration_json
+}
+```
+
+## Limitations
 
 The Airbyte Terraform provider supports connectors that are available in **both** self-managed and cloud plans. It doesn't support connectors that are only available in self-managed plans.
 
-## Requirements before you begin
-
-Before starting this tutorial, make sure you have the following:
-
-- Basic familiarity with Terraform is helpful, but not required.
-
-- Install a code editor, like Visual Studio Code, optionally with a Terraform extension.
-
-- Ensure [Terraform is installed](https://developer.hashicorp.com/terraform/install) on your machine.
-
-- Obtain your Airbyte credentials:
-
-    - [An API application](/platform/using-airbyte/configuring-api-access) in Airbyte, your client ID, and your client secret.
-
-    - The URL of your Airbyte server (e.g. `http://localhost:8000/api/public/v1/`).
-
-    - Your workspace ID. To get your workspace ID, open your workspace in Airbyte, then copy the ID from the URL. It looks like this: `039da657-f061-493e-a836-9bce86bc5e35`.
-
-- Source and destination credentials. This tutorial uses [Stripe](/integrations/sources/stripe) and [BigQuery](/integrations/destinations/bigquery), but you can substitute any other connector. Consult the documentation for those connectors to ensure you have what you need to connect.
-
-## Strongly typed versus weakly typed {#typing}
-
-The Airbyte provider offers two types of resources, and there are benefits and drawbacks to both. Review this information before creating your sources and destinations.
-
-### Strongly typed configurations
-
-Resources with strongly typed configurations have strict rules about how you write configuration attributes. If they're written incorrectly, these resources prevent `terraform apply` from running.
-
-These resources depend on the underlying Airbyte connectors. Connectors are continually updated as third-party APIs change. This creates two primary points of failure for Terraform.
-
-- You upgrade the Terraform provider version, and fetch a new version of the `config` block. However, you don't upgrade your version of the connector in your Airbyte instance. The setup now crashes because there is a mismatch between the Terraform provider and the connector itself.
-
-- Airbyte builds the Terraform SDK at a given time. Then, the connector has a breaking change, like a third-party deprecating an API endpoint. You upgrade your connector, but Airbyte hasn't upgraded the Terraform provider yet and it doesn't work as expected.
-
-Essentially, using this option creates an ongoing risk that upgrading the Terraform provider or a connector causes a breaking change.
-
-### Weakly typed (JSON) configurations
-
-Instead of using a connector-specific resource, you can use [`airbyte_source_custom`](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs/resources/source_custom) and [`airbyte_destination_custom`](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs/resources/destination_custom). These are normally Airbyte's resources for custom connectors, but you can use them with any existing Airbyte or Marketplace connector and write your configurations as JSON objects. These configurations are more robust when connectors change. Mismatches between a Terraform provider and a connector do not prevent `terraform apply` from running. The absence of a newly added configuration option might have no impact at all on your data and your use of that connector.
-
-The main issue with this method is that JSON can technically contain anything, and you could make a mistake that Terraform doesn't warn you about. 
-
-The best way to get a JSON object is to set up a new connector in Airbyte's UI, fill out all the fields, then click **Copy JSON**. You don't actually need to create the connector in the UI since you want to do this with Terraform, but you do need to get the JSON. Currently, Airbyte optimizes this JSON object for the API, and you need to make some adjustments to use it in Terraform. The examples later in this article demonstrate the expected format.
-
-### How to choose
-
-This tutorial demonstrates how to use both options.
-
-- For Airbyte and Marketplace connectors, you can choose which type of resource you prefer. Airbyte generally recommends using a JSON configuration. Based on the feedback we receive, JSON causes less Terraform drift and makes upgrades less problematic in the long run.
-
-- For custom connectors, only weakly typed JSON configurations are possible.
-
-## Step 1: Set up the Terraform provider
-
-Download the Terraform provider and configure it to run with your Airbyte instance.
-
-1. Create a directory to house your Terraform project, navigate to it, and create a file named `main.tf`.
-
-2. Go to https://registry.terraform.io/providers/airbytehq/airbyte/latest.
-
-3. Click **Use Provider**, copy the code, and paste it into `main.tf`. It should look something like this:
-
-    ```hcl title="main.tf"
-    terraform {
-        required_providers {
-            airbyte = {
-            source = "airbytehq/airbyte"
-            version = "0.6.5"
-            }
-        }
-    }
-
-    provider "airbyte" {
-        # Configuration options
-    }
-    ```
-
-4. Configure the Airbyte provider to use your credentials, but don't put your sensitive data into `main.tf`. Instead, insert variables you'll populate later.
-
-    ```hcl title="main.tf"
-    terraform {
-        required_providers {
-            airbyte = {
-            source = "airbytehq/airbyte"
-            version = "0.6.5"
-            }
-        }
-    }
-
-    provider "airbyte" {
-        // highlight-start
-        client_id = var.client_id
-        client_secret = var.client_secret
-
-        # Include server_url if running locally
-        server_url = "http://localhost:8000/api/public/v1/"
-        // highlight-end
-    }
-    ```
-
-5. In your terminal, create a file named `variables.tf`. This file stores sensitive variables you don't want to appear in `main.tf`, plus other values you'll reuse often.
-
-6. Populate `variables.tf`. Define `client_id`, `client_secret`, and `workspace_id`.
-
-    ```hcl title="variables.tf"
-    variable "client_id" {
-        type = string
-        default = "YOUR_CLIENT_ID"
-    }
-
-    variable "client_secret" {
-        type = string
-        default = "YOUR_CLIENT_SECRET"
-    }
-
-    variable "workspace_id" {
-        type = string
-        default = "YOUR_AIRBYTE_WORKSPACE_ID"
-    }
-    ```
-
-7. Run `terraform init`. Terraform tells you it initialized successfully. If it didn't, check your code against the code samples above.
-
-8. Run `terraform plan`. Terraform tells you there are no changes.
-
-9. Run `terraform apply`. Terraform tells you there are no changes.
-
-## Step 2: Create a source
-
-Add a source from which you want to get data. In this example, you add Stripe as a source. If you want to use a different source, you can find the code sample for the corresponding resource in the [Terraform provider reference docs](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs).
-
-1. Add your source to `main.tf`.
-
-    <Tabs>
-    <TabItem value="JSON" label="JSON">
-        
-        For this and any other Airbyte or Marketplace connector, you can define the source type in the JSON object.
-        
-        ```hcl title="main.tf"
-        resource "airbyte_source_custom" "my_source_stripe" {
-            configuration = jsonencode({
-                "source_type" : "stripe",
-                "account_id" : "YOUR_STRIPE_ACCOUNT_ID",
-                "client_secret" : "YOUR_STRIPE_CLIENT_SECRET",
-                "start_date" : "2023-07-01T00:00:00Z",
-                "lookback_window_days" : 0,
-                "slice_range" : 365
-                })
-            name = "Stripe"
-            workspace_id = var.workspace_id
-        }
-        ```
-
-        If this is your own custom connector, use `definition_id` to define the source type. To get this value, open your custom connector in Airbyte and copy the definition ID from the URL of that connector.
-
-        ```hcl title="main.tf"
-        resource "airbyte_source_custom" "my_source_stripe" {
-            configuration = jsonencode({
-                "account_id" : "YOUR_STRIPE_ACCOUNT_ID",
-                "client_secret" : "YOUR_STRIPE_CLIENT_SECRET",
-                "start_date" : "2023-07-01T00:00:00Z",
-                "lookback_window_days" : 0,
-                "slice_range" : 365
-                })
-            name = "Stripe"
-            workspace_id = var.workspace_id
-            // highlight-next-line
-            definition_id = "e094cb9a-26de-4645-8761-65c0c425d1de"
-        }
-        ```
-
-    </TabItem>
-    <TabItem value="Strongly typed" label="Strongly typed">
-        ```hcl title="main.tf"
-        resource "airbyte_source_stripe" "my_source_stripe" {
-            configuration = {
-                source_type = "stripe"
-                account_id = "YOUR_STRIPE_ACCOUNT_ID"
-                client_secret = "YOUR_STRIPE_CLIENT_SECRET"
-                start_date = "2023-07-01T00:00:00Z"
-                lookback_window_days = 0
-                slice_range = 365
-            }
-            name = "Stripe"
-            workspace_id = var.workspace_id
-        }
-        ```
-    </TabItem>
-
-    
-    </Tabs>
-
-2. Run `terraform apply`. Terraform tells you it will add 1 resource. Type `yes` and press <kbd>Enter</kbd>.
-
-Terraform adds the source to Airbyte. To see your new source, open your Airbyte workspace and click **Sources**. Or, use the [List sources](https://reference.airbyte.com/reference/listsources) API endpoint.
-
-## Step 3: Create a destination
-
-Add a destination to which you want to send data. In this example, you add BigQuery as a destination. If you want to use a different destination, you can find the code sample for the corresponding resource in the [Terraform provider reference docs](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs).
-
-1. Add your destination to `main.tf`.
-
-    :::tip
-    For BigQuery, you must use a [service account](https://cloud.google.com/iam/docs/service-account-overview) with credentials provided as a JSON string. This creates a unique situation that isn't true for all destinations.
-
-    - If you're using the JSON configuration, use a heredoc and write the JSON string yourself to avoid encoding issues. Escape all slashes and newlines as illustrated in the code sample below.
-    
-    - If you're using the strongly typed configuration, it's helpful to wrap your credentials JSON in [jsonencode](https://developer.hashicorp.com/terraform/language/functions/jsonencode). This way, you don't have to manually escape slashes and newlines in your credentials and your Terraform code looks more human-readable.    
-    :::
-
-    <Tabs>
-    <TabItem value="JSON" label="JSON">
-
-        ```hcl title="main.tf"
-        resource "airbyte_destination_custom" "my_destination_bigquery_custom" {
-            configuration = <<-EOF
-                {
-                    "destination_type": "BigQuery",
-                    "credentials_json": "{ \"type\": \"service_account\", \"project_id\": \"YOUR_PROJECT_ID\", \"private_key_id\": \"YOUR_PRIVATE_KEY_ID\", \"private_key\": \"-----BEGIN PRIVATE KEY-----\\n...YOUR_KEY...\\n-----END PRIVATE KEY-----\\n\", \"client_email\": \"you@example.iam.gserviceaccount.com\", \"client_id\": \"YOUR_CLIENT_ID\", \"auth_uri\": \"https://accounts.google.com/o/oauth2/auth\", \"token_uri\": \"https://oauth2.googleapis.com/token\", \"auth_provider_x509_cert_url\": \"https://www.googleapis.com/oauth2/v1/certs\", \"client_x509_cert_url\": \"https://www.googleapis.com/robot/v1/metadata/x509/you@example.iam.gserviceaccount.com\", \"universe_domain\": \"googleapis.com\" }",
-                    "loading_method": {
-                        "method": "Standard",
-                        "batched_standard_inserts": {}
-                    },
-                    "dataset_id": "YOUR_DATASET_ID",
-                    "dataset_location": "us-central1",
-                    "project_id": "YOUR_PROJECT_ID",
-                    "transformation_priority": "batch"
-                }
-            EOF
-            name          = "BigQuery"
-            workspace_id  = var.workspace_id
-        }
-        ```
-
-    </TabItem>
-    <TabItem value="Strongly typed" label="Strongly typed">
-
-        ```hcl title="main.tf"
-        resource "airbyte_destination_bigquery" "my_destination_bigquery" {
-            configuration = {
-                destination_type       = "BigQuery"
-                credentials_json       = jsonencode({
-                    "type"                        = "service_account",
-                    "project_id"                  = "YOUR_PROJECT_ID",
-                    "private_key_id"              = "YOUR_PRIVATE_KEY_ID",
-                    "private_key"                 = "-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n",
-                    "client_email"                = "you@example.iam.gserviceaccount.com",
-                    "client_id"                   = "YOUR_CLIENT_ID",
-                    "auth_uri"                    = "https://accounts.google.com/o/oauth2/auth",
-                    "token_uri"                   = "https://oauth2.googleapis.com/token",
-                    "auth_provider_x509_cert_url" = "https://www.googleapis.com/oauth2/v1/certs",
-                    "client_x509_cert_url"        = "https://www.googleapis.com/robot/v1/metadata/x509/you@example.iam.gserviceaccount.com"
-                })
-                dataset_id              = "YOUR_DATASET_ID"
-                dataset_location        = "us-central1"
-                loading_method          = {
-                    batched_standard_inserts = {}
-                }
-                project_id              = "YOUR_PROJECT_ID"
-                transformation_priority = "batch"
-            }
-            name         = "BigQuery"
-            workspace_id = var.workspace_id
-        }
-        ```
-
-    </TabItem>
-    </Tabs>
-
-    :::note
-    Most destinations have a large number of optional attributes. For simplicity, this tutorial uses defaults. See the [reference docs](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs/resources/destination_bigquery) for additional attributes.
-    :::
-
-2. Run `terraform apply`. Terraform tells you it will add 1 resource. Type `yes` and press <kbd>Enter</kbd>.
-
-Terraform adds the destination to Airbyte. To see your new destination, open your Airbyte workspace and click **Destinations**. Or, use the [List destinations](https://reference.airbyte.com/reference/listdestinations) API endpoint.
-
-## Step 4: Create a connection
-
-Create a connection from your source to your destination.
-
-1. Add your connection to `main.tf` using the [Airbyte connection](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs/resources/connection) resource.
-
-    ```hcl title="main.tf"
-    resource "airbyte_connection" "stripe_to_bigquery" {
-        name           = "Stripe to BigQuery"
-        source_id      = airbyte_source_stripe.my_source_stripe.source_id
-        destination_id = airbyte_destination_bigquery.my_destination_bigquery.destination_id
-    }
-    ```
-
-    This example connection will not sync automatically. The [reference docs](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs/resources/connection) describe a number of attributes you can use to schedule how and when your connections sync.
-
-2. Run `terraform apply`. Terraform tells you it will add 1 resource. Type `yes` and press <kbd>Enter</kbd>.
-
-Terraform adds the connection to Airbyte. To see your new connection, open your Airbyte workspace and click **Connections**. Or, use the [List connections](https://reference.airbyte.com/reference/listconnections) API endpoint.
-
-## What's next?
-
-Congratulations! You created your first source, your first destination, and a connection between the two.
-
-- Continue building your sources, destinations, and connections for all your data using Airbyte's [Terraform docs](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs).
-
-- Check out the [Quickstarts repository](https://github.com/airbytehq/quickstarts). It's full of templates and shortcuts to help you build common data stacks using Terraform and Python.
+## Additional resources
+
+- [Quickstarts repository](https://github.com/airbytehq/quickstarts) — Templates for common data stacks using Terraform and Python.
+- [Airbyte API reference](https://reference.airbyte.com) — The API that powers the Terraform provider.
+- [API access configuration](/platform/using-airbyte/configuring-api-access) — Set up API credentials for the Terraform provider.

--- a/docs/developers/terraform-documentation.md
+++ b/docs/developers/terraform-documentation.md
@@ -17,50 +17,8 @@ The Airbyte Terraform provider documentation lives on the [Terraform Registry](h
 | [Resource and data source docs](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs/resources/source) | Full reference for all resources and data sources. |
 | [Migrating to 1.0](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs/guides/v1_migration_guide) | Upgrade from typed connector-specific resources to the generic `airbyte_source` / `airbyte_destination` resources. |
 
-## Quick example
-
-```hcl
-terraform {
-  required_providers {
-    airbyte = {
-      source  = "airbytehq/airbyte"
-      version = "~> 1.0"
-    }
-  }
-}
-
-provider "airbyte" {
-  client_id     = var.client_id
-  client_secret = var.client_secret
-}
-
-data "airbyte_connector_configuration" "postgres_config" {
-  connector_name = "source-postgres"
-  configuration = {
-    host     = "db.example.com"
-    port     = 5432
-    database = "mydb"
-    username = "readonly"
-  }
-  configuration_secrets = {
-    password = var.db_password
-  }
-}
-
-resource "airbyte_source" "postgres" {
-  name          = "Production Postgres"
-  workspace_id  = var.workspace_id
-  definition_id = data.airbyte_connector_configuration.postgres_config.definition_id
-  configuration = data.airbyte_connector_configuration.postgres_config.configuration_json
-}
-```
-
-## Limitations
-
-The Airbyte Terraform provider supports connectors that are available in **both** self-managed and cloud plans. It doesn't support connectors that are only available in self-managed plans.
-
 ## Additional resources
 
-- [Quickstarts repository](https://github.com/airbytehq/quickstarts) — Templates for common data stacks using Terraform and Python.
 - [Airbyte API reference](https://reference.airbyte.com) — The API that powers the Terraform provider.
 - [API access configuration](/platform/using-airbyte/configuring-api-access) — Set up API credentials for the Terraform provider.
+- [Pre-1.0 getting started tutorial](terraform-provider-pre-1.0) — Reference for users on provider versions before 1.0.

--- a/docs/developers/terraform-provider-pre-1.0.md
+++ b/docs/developers/terraform-provider-pre-1.0.md
@@ -54,7 +54,7 @@ Essentially, using this option creates an ongoing risk that upgrading the Terraf
 
 Instead of using a connector-specific resource, you can use `airbyte_source_custom` and `airbyte_destination_custom`. These are normally Airbyte's resources for custom connectors, but you can use them with any existing Airbyte or Marketplace connector and write your configurations as JSON objects. These configurations are more robust when connectors change. Mismatches between a Terraform provider and a connector do not prevent `terraform apply` from running. The absence of a newly added configuration option might have no impact at all on your data and your use of that connector.
 
-The main issue with this method is that JSON can technically contain anything, and you could make a mistake that Terraform doesn't warn you about. 
+The main issue with this method is that JSON can technically contain anything, and you could make a mistake that Terraform doesn't warn you about.
 
 The best way to get a JSON object is to set up a new connector in Airbyte's UI, fill out all the fields, then click **Copy JSON**. You don't actually need to create the connector in the UI since you want to do this with Terraform, but you do need to get the JSON. Currently, Airbyte optimizes this JSON object for the API, and you need to make some adjustments to use it in Terraform. The examples later in this article demonstrate the expected format.
 
@@ -146,9 +146,9 @@ Add a source from which you want to get data. In this example, you add Stripe as
 1. Add your source to `main.tf`.
 
     **JSON configuration:**
-        
+
     For this and any other Airbyte or Marketplace connector, you can define the source type in the JSON object.
-        
+
     ```hcl title="main.tf"
     resource "airbyte_source_custom" "my_source_stripe" {
         configuration = jsonencode({
@@ -212,8 +212,8 @@ Add a destination to which you want to send data. In this example, you add BigQu
     For BigQuery, you must use a [service account](https://cloud.google.com/iam/docs/service-account-overview) with credentials provided as a JSON string. This creates a unique situation that isn't true for all destinations.
 
     - If you're using the JSON configuration, use a heredoc and write the JSON string yourself to avoid encoding issues. Escape all slashes and newlines as illustrated in the code sample below.
-    
-    - If you're using the strongly typed configuration, it's helpful to wrap your credentials JSON in [jsonencode](https://developer.hashicorp.com/terraform/language/functions/jsonencode). This way, you don't have to manually escape slashes and newlines in your credentials and your Terraform code looks more human-readable.    
+
+    - If you're using the strongly typed configuration, it's helpful to wrap your credentials JSON in [jsonencode](https://developer.hashicorp.com/terraform/language/functions/jsonencode). This way, you don't have to manually escape slashes and newlines in your credentials and your Terraform code looks more human-readable.
     :::
 
     **JSON configuration:**

--- a/docs/developers/terraform-provider-pre-1.0.md
+++ b/docs/developers/terraform-provider-pre-1.0.md
@@ -1,0 +1,299 @@
+---
+products: all
+---
+
+# Terraform provider — Pre-1.0 getting started
+
+:::caution
+This tutorial covers the **pre-1.0** Terraform provider, which used typed connector-specific resources (e.g., `airbyte_source_stripe`) and weakly typed JSON resources (e.g., `airbyte_source_custom`). These resource types are **deprecated** in provider 1.0+.
+
+For the current getting started guide using the generic `airbyte_source` / `airbyte_destination` resources, see the [Getting Started guide on the Terraform Registry](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs/guides/getting_started). To migrate existing configurations, see the [v1 Migration Guide](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs/guides/v1_migration_guide).
+:::
+
+Follow this tutorial to learn how to use the pre-1.0 Airbyte Terraform Provider.
+
+[Terraform](https://www.terraform.io/), developed by HashiCorp, is an Infrastructure as Code (IaC) tool that empowers you to define and provision infrastructure using a declarative configuration language. If you use Terraform to manage your infrastructure, you can use Airbyte's Terraform provider to automate and version control your Airbyte configuration as code. Airbyte's Terraform provider is built off [Airbyte's API](https://reference.airbyte.com).
+
+## Requirements before you begin
+
+Before starting this tutorial, make sure you have the following:
+
+- Basic familiarity with Terraform is helpful, but not required.
+
+- Install a code editor, like Visual Studio Code, optionally with a Terraform extension.
+
+- Ensure [Terraform is installed](https://developer.hashicorp.com/terraform/install) on your machine.
+
+- Obtain your Airbyte credentials:
+
+    - [An API application](/platform/using-airbyte/configuring-api-access) in Airbyte, your client ID, and your client secret.
+
+    - The URL of your Airbyte server (e.g. `http://localhost:8000/api/public/v1/`).
+
+    - Your workspace ID. To get your workspace ID, open your workspace in Airbyte, then copy the ID from the URL. It looks like this: `039da657-f061-493e-a836-9bce86bc5e35`.
+
+- Source and destination credentials. This tutorial uses [Stripe](/integrations/sources/stripe) and [BigQuery](/integrations/destinations/bigquery), but you can substitute any other connector. Consult the documentation for those connectors to ensure you have what you need to connect.
+
+## Strongly typed versus weakly typed {#typing}
+
+The pre-1.0 Airbyte provider offered two types of resources, and there were benefits and drawbacks to both. Review this information before creating your sources and destinations.
+
+### Strongly typed configurations
+
+Resources with strongly typed configurations have strict rules about how you write configuration attributes. If they're written incorrectly, these resources prevent `terraform apply` from running.
+
+These resources depend on the underlying Airbyte connectors. Connectors are continually updated as third-party APIs change. This creates two primary points of failure for Terraform.
+
+- You upgrade the Terraform provider version, and fetch a new version of the `config` block. However, you don't upgrade your version of the connector in your Airbyte instance. The setup now crashes because there is a mismatch between the Terraform provider and the connector itself.
+
+- Airbyte builds the Terraform SDK at a given time. Then, the connector has a breaking change, like a third-party deprecating an API endpoint. You upgrade your connector, but Airbyte hasn't upgraded the Terraform provider yet and it doesn't work as expected.
+
+Essentially, using this option creates an ongoing risk that upgrading the Terraform provider or a connector causes a breaking change.
+
+### Weakly typed (JSON) configurations
+
+Instead of using a connector-specific resource, you can use `airbyte_source_custom` and `airbyte_destination_custom`. These are normally Airbyte's resources for custom connectors, but you can use them with any existing Airbyte or Marketplace connector and write your configurations as JSON objects. These configurations are more robust when connectors change. Mismatches between a Terraform provider and a connector do not prevent `terraform apply` from running. The absence of a newly added configuration option might have no impact at all on your data and your use of that connector.
+
+The main issue with this method is that JSON can technically contain anything, and you could make a mistake that Terraform doesn't warn you about. 
+
+The best way to get a JSON object is to set up a new connector in Airbyte's UI, fill out all the fields, then click **Copy JSON**. You don't actually need to create the connector in the UI since you want to do this with Terraform, but you do need to get the JSON. Currently, Airbyte optimizes this JSON object for the API, and you need to make some adjustments to use it in Terraform. The examples later in this article demonstrate the expected format.
+
+### How to choose
+
+This tutorial demonstrates how to use both options.
+
+- For Airbyte and Marketplace connectors, you can choose which type of resource you prefer. Airbyte generally recommends using a JSON configuration. Based on the feedback we receive, JSON causes less Terraform drift and makes upgrades less problematic in the long run.
+
+- For custom connectors, only weakly typed JSON configurations are possible.
+
+## Step 1: Set up the Terraform provider
+
+Download the Terraform provider and configure it to run with your Airbyte instance.
+
+1. Create a directory to house your Terraform project, navigate to it, and create a file named `main.tf`.
+
+2. Go to https://registry.terraform.io/providers/airbytehq/airbyte/latest.
+
+3. Click **Use Provider**, copy the code, and paste it into `main.tf`. It should look something like this:
+
+    ```hcl title="main.tf"
+    terraform {
+        required_providers {
+            airbyte = {
+            source = "airbytehq/airbyte"
+            version = "0.6.5"
+            }
+        }
+    }
+
+    provider "airbyte" {
+        # Configuration options
+    }
+    ```
+
+4. Configure the Airbyte provider to use your credentials, but don't put your sensitive data into `main.tf`. Instead, insert variables you'll populate later.
+
+    ```hcl title="main.tf"
+    terraform {
+        required_providers {
+            airbyte = {
+            source = "airbytehq/airbyte"
+            version = "0.6.5"
+            }
+        }
+    }
+
+    provider "airbyte" {
+        client_id = var.client_id
+        client_secret = var.client_secret
+
+        # Include server_url if running locally
+        server_url = "http://localhost:8000/api/public/v1/"
+    }
+    ```
+
+5. In your terminal, create a file named `variables.tf`. This file stores sensitive variables you don't want to appear in `main.tf`, plus other values you'll reuse often.
+
+6. Populate `variables.tf`. Define `client_id`, `client_secret`, and `workspace_id`.
+
+    ```hcl title="variables.tf"
+    variable "client_id" {
+        type = string
+        default = "YOUR_CLIENT_ID"
+    }
+
+    variable "client_secret" {
+        type = string
+        default = "YOUR_CLIENT_SECRET"
+    }
+
+    variable "workspace_id" {
+        type = string
+        default = "YOUR_AIRBYTE_WORKSPACE_ID"
+    }
+    ```
+
+7. Run `terraform init`. Terraform tells you it initialized successfully. If it didn't, check your code against the code samples above.
+
+8. Run `terraform plan`. Terraform tells you there are no changes.
+
+9. Run `terraform apply`. Terraform tells you there are no changes.
+
+## Step 2: Create a source
+
+Add a source from which you want to get data. In this example, you add Stripe as a source. If you want to use a different source, you can find the code sample for the corresponding resource in the [Terraform provider reference docs](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs).
+
+1. Add your source to `main.tf`.
+
+    **JSON configuration:**
+        
+    For this and any other Airbyte or Marketplace connector, you can define the source type in the JSON object.
+        
+    ```hcl title="main.tf"
+    resource "airbyte_source_custom" "my_source_stripe" {
+        configuration = jsonencode({
+            "source_type" : "stripe",
+            "account_id" : "YOUR_STRIPE_ACCOUNT_ID",
+            "client_secret" : "YOUR_STRIPE_CLIENT_SECRET",
+            "start_date" : "2023-07-01T00:00:00Z",
+            "lookback_window_days" : 0,
+            "slice_range" : 365
+            })
+        name = "Stripe"
+        workspace_id = var.workspace_id
+    }
+    ```
+
+    If this is your own custom connector, use `definition_id` to define the source type. To get this value, open your custom connector in Airbyte and copy the definition ID from the URL of that connector.
+
+    ```hcl title="main.tf"
+    resource "airbyte_source_custom" "my_source_stripe" {
+        configuration = jsonencode({
+            "account_id" : "YOUR_STRIPE_ACCOUNT_ID",
+            "client_secret" : "YOUR_STRIPE_CLIENT_SECRET",
+            "start_date" : "2023-07-01T00:00:00Z",
+            "lookback_window_days" : 0,
+            "slice_range" : 365
+            })
+        name = "Stripe"
+        workspace_id = var.workspace_id
+        definition_id = "e094cb9a-26de-4645-8761-65c0c425d1de"
+    }
+    ```
+
+    **Strongly typed configuration:**
+
+    ```hcl title="main.tf"
+    resource "airbyte_source_stripe" "my_source_stripe" {
+        configuration = {
+            source_type = "stripe"
+            account_id = "YOUR_STRIPE_ACCOUNT_ID"
+            client_secret = "YOUR_STRIPE_CLIENT_SECRET"
+            start_date = "2023-07-01T00:00:00Z"
+            lookback_window_days = 0
+            slice_range = 365
+        }
+        name = "Stripe"
+        workspace_id = var.workspace_id
+    }
+    ```
+
+2. Run `terraform apply`. Terraform tells you it will add 1 resource. Type `yes` and press <kbd>Enter</kbd>.
+
+Terraform adds the source to Airbyte. To see your new source, open your Airbyte workspace and click **Sources**. Or, use the [List sources](https://reference.airbyte.com/reference/listsources) API endpoint.
+
+## Step 3: Create a destination
+
+Add a destination to which you want to send data. In this example, you add BigQuery as a destination. If you want to use a different destination, you can find the code sample for the corresponding resource in the [Terraform provider reference docs](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs).
+
+1. Add your destination to `main.tf`.
+
+    :::tip
+    For BigQuery, you must use a [service account](https://cloud.google.com/iam/docs/service-account-overview) with credentials provided as a JSON string. This creates a unique situation that isn't true for all destinations.
+
+    - If you're using the JSON configuration, use a heredoc and write the JSON string yourself to avoid encoding issues. Escape all slashes and newlines as illustrated in the code sample below.
+    
+    - If you're using the strongly typed configuration, it's helpful to wrap your credentials JSON in [jsonencode](https://developer.hashicorp.com/terraform/language/functions/jsonencode). This way, you don't have to manually escape slashes and newlines in your credentials and your Terraform code looks more human-readable.    
+    :::
+
+    **JSON configuration:**
+
+    ```hcl title="main.tf"
+    resource "airbyte_destination_custom" "my_destination_bigquery_custom" {
+        configuration = <<-EOF
+            {
+                "destination_type": "BigQuery",
+                "credentials_json": "{ \"type\": \"service_account\", \"project_id\": \"YOUR_PROJECT_ID\", \"private_key_id\": \"YOUR_PRIVATE_KEY_ID\", \"private_key\": \"-----BEGIN PRIVATE KEY-----\\n...YOUR_KEY...\\n-----END PRIVATE KEY-----\\n\", \"client_email\": \"you@example.iam.gserviceaccount.com\", \"client_id\": \"YOUR_CLIENT_ID\", \"auth_uri\": \"https://accounts.google.com/o/oauth2/auth\", \"token_uri\": \"https://oauth2.googleapis.com/token\", \"auth_provider_x509_cert_url\": \"https://www.googleapis.com/oauth2/v1/certs\", \"client_x509_cert_url\": \"https://www.googleapis.com/robot/v1/metadata/x509/you@example.iam.gserviceaccount.com\", \"universe_domain\": \"googleapis.com\" }",
+                "loading_method": {
+                    "method": "Standard",
+                    "batched_standard_inserts": {}
+                },
+                "dataset_id": "YOUR_DATASET_ID",
+                "dataset_location": "us-central1",
+                "project_id": "YOUR_PROJECT_ID",
+                "transformation_priority": "batch"
+            }
+        EOF
+        name          = "BigQuery"
+        workspace_id  = var.workspace_id
+    }
+    ```
+
+    **Strongly typed configuration:**
+
+    ```hcl title="main.tf"
+    resource "airbyte_destination_bigquery" "my_destination_bigquery" {
+        configuration = {
+            destination_type       = "BigQuery"
+            credentials_json       = jsonencode({
+                "type"                        = "service_account",
+                "project_id"                  = "YOUR_PROJECT_ID",
+                "private_key_id"              = "YOUR_PRIVATE_KEY_ID",
+                "private_key"                 = "-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n",
+                "client_email"                = "you@example.iam.gserviceaccount.com",
+                "client_id"                   = "YOUR_CLIENT_ID",
+                "auth_uri"                    = "https://accounts.google.com/o/oauth2/auth",
+                "token_uri"                   = "https://oauth2.googleapis.com/token",
+                "auth_provider_x509_cert_url" = "https://www.googleapis.com/oauth2/v1/certs",
+                "client_x509_cert_url"        = "https://www.googleapis.com/robot/v1/metadata/x509/you@example.iam.gserviceaccount.com"
+            })
+            dataset_id              = "YOUR_DATASET_ID"
+            dataset_location        = "us-central1"
+            loading_method          = {
+                batched_standard_inserts = {}
+            }
+            project_id              = "YOUR_PROJECT_ID"
+            transformation_priority = "batch"
+        }
+        name         = "BigQuery"
+        workspace_id = var.workspace_id
+    }
+    ```
+
+    :::note
+    Most destinations have a large number of optional attributes. For simplicity, this tutorial uses defaults. See the [reference docs](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs/resources/destination_bigquery) for additional attributes.
+    :::
+
+2. Run `terraform apply`. Terraform tells you it will add 1 resource. Type `yes` and press <kbd>Enter</kbd>.
+
+Terraform adds the destination to Airbyte. To see your new destination, open your Airbyte workspace and click **Destinations**. Or, use the [List destinations](https://reference.airbyte.com/reference/listdestinations) API endpoint.
+
+## Step 4: Create a connection
+
+Create a connection from your source to your destination.
+
+1. Add your connection to `main.tf` using the [Airbyte connection](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs/resources/connection) resource.
+
+    ```hcl title="main.tf"
+    resource "airbyte_connection" "stripe_to_bigquery" {
+        name           = "Stripe to BigQuery"
+        source_id      = airbyte_source_stripe.my_source_stripe.source_id
+        destination_id = airbyte_destination_bigquery.my_destination_bigquery.destination_id
+    }
+    ```
+
+    This example connection will not sync automatically. The [reference docs](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs/resources/connection) describe a number of attributes you can use to schedule how and when your connections sync.
+
+2. Run `terraform apply`. Terraform tells you it will add 1 resource. Type `yes` and press <kbd>Enter</kbd>.
+
+Terraform adds the connection to Airbyte. To see your new connection, open your Airbyte workspace and click **Connections**. Or, use the [List connections](https://reference.airbyte.com/reference/listconnections) API endpoint.

--- a/docusaurus/platform_versioned_docs/version-1.6/terraform-documentation.md
+++ b/docusaurus/platform_versioned_docs/version-1.6/terraform-documentation.md
@@ -17,50 +17,8 @@ The Airbyte Terraform provider documentation lives on the [Terraform Registry](h
 | [Resource and data source docs](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs/resources/source) | Full reference for all resources and data sources. |
 | [Migrating to 1.0](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs/guides/v1_migration_guide) | Upgrade from typed connector-specific resources to the generic `airbyte_source` / `airbyte_destination` resources. |
 
-## Quick example
-
-```hcl
-terraform {
-  required_providers {
-    airbyte = {
-      source  = "airbytehq/airbyte"
-      version = "~> 1.0"
-    }
-  }
-}
-
-provider "airbyte" {
-  client_id     = var.client_id
-  client_secret = var.client_secret
-}
-
-data "airbyte_connector_configuration" "postgres_config" {
-  connector_name = "source-postgres"
-  configuration = {
-    host     = "db.example.com"
-    port     = 5432
-    database = "mydb"
-    username = "readonly"
-  }
-  configuration_secrets = {
-    password = var.db_password
-  }
-}
-
-resource "airbyte_source" "postgres" {
-  name          = "Production Postgres"
-  workspace_id  = var.workspace_id
-  definition_id = data.airbyte_connector_configuration.postgres_config.definition_id
-  configuration = data.airbyte_connector_configuration.postgres_config.configuration_json
-}
-```
-
-## Limitations
-
-The Airbyte Terraform provider supports connectors that are available in **both** self-managed and cloud plans. It doesn't support connectors that are only available in self-managed plans.
-
 ## Additional resources
 
-- [Quickstarts repository](https://github.com/airbytehq/quickstarts) — Templates for common data stacks using Terraform and Python.
 - [Airbyte API reference](https://reference.airbyte.com) — The API that powers the Terraform provider.
 - [API access configuration](/platform/using-airbyte/configuring-api-access) — Set up API credentials for the Terraform provider.
+- [Pre-1.0 getting started tutorial](/developers/terraform-provider-pre-1.0) — Reference for users on provider versions before 1.0.

--- a/docusaurus/platform_versioned_docs/version-1.6/terraform-documentation.md
+++ b/docusaurus/platform_versioned_docs/version-1.6/terraform-documentation.md
@@ -2,320 +2,65 @@
 products: all
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 # Terraform provider
-
-Follow this tutorial to learn how to use Airbyte's Terraform Provider.
 
 [Terraform](https://www.terraform.io/), developed by HashiCorp, is an Infrastructure as Code (IaC) tool that empowers you to define and provision infrastructure using a declarative configuration language. If you use Terraform to manage your infrastructure, you can use Airbyte's Terraform provider to automate and version control your Airbyte configuration as code. Airbyte's Terraform provider is built off [Airbyte's API](https://reference.airbyte.com).
 
-If you don't need a tutorial, go straight to the [Terraform docs](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs).
-
-## Limitations and considerations
-
-The Airbyte Terraform provider supports connectors that are available in **both** Self-Managed Community and Cloud. It doesn't support connectors that are only available in Self-Managed Community.
-
-## Requirements before you begin
-
-Before starting this tutorial, make sure you have the following:
-
-- Basic familiarity with Terraform is helpful, but not required.
-
-- Install a code editor, like Visual Studio Code, optionally with a Terraform extension.
-
-- Ensure [Terraform is installed](https://developer.hashicorp.com/terraform/install) on your machine.
-
-- Obtain your Airbyte credentials:
-
-  - [An API application](using-airbyte/configuring-api-access.md) in Airbyte, your client ID, and your client secret.
-
-  - The URL of your Airbyte server (e.g. `http://localhost:8000/api/public/v1/`).
-
-  - Your workspace ID. To get your workspace ID, open your workspace in Airbyte, then copy the ID from the URL. It looks like this: `039da657-f061-493e-a836-9bce86bc5e35`.
-
-- Source and destination credentials. This tutorial uses [Stripe](/integrations/sources/stripe) and [BigQuery](/integrations/destinations/bigquery), but you can substitute any other connector. Consult the documentation for those connectors to ensure you have what you need to connect.
-
-## Strongly typed versus weakly typed {#typing}
-
-The Airbyte provider offers two types of resources, and there are benefits and drawbacks to both. Review this information before creating your sources and destinations.
-
-### Strongly typed configurations
-
-Resources with strongly typed configurations have strict rules about how you write configuration attributes. If they're written incorrectly, these resources prevent `terraform apply` from running.
-
-These resources depend on the underlying Airbyte connectors. Connectors are continually updated as third-party APIs change. This creates two primary points of failure for Terraform.
-
-- You upgrade the Terraform provider version, and fetch a new version of the `config` block. However, you don't upgrade your version of the connector in your Airbyte instance. The setup now crashes because there is a mismatch between the Terraform provider and the connector itself.
-
-- Airbyte builds the Terraform SDK at a given time. Then, the connector has a breaking change, like a third-party deprecating an API endpoint. You upgrade your connector, but Airbyte hasn't upgraded the Terraform provider yet and it doesn't work as expected.
-
-Essentially, using this option creates an ongoing risk that upgrading the Terraform provider or a connector causes a breaking change.
-
-### Weakly typed (JSON) configurations
-
-Instead of using a connector-specific resource, you can use [`airbyte_source_custom`](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs/resources/source_custom) and [`airbyte_destination_custom`](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs/resources/destination_custom). These are normally Airbyte's resources for custom connectors, but you can use them with any existing Airbyte or Marketplace connector and write your configurations as JSON objects. These configurations are more robust when connectors change. Mismatches between a Terraform provider and a connector do not prevent `terraform apply` from running. The absence of a newly added configuration option might have no impact at all on your data and your use of that connector.
-
-The main issue with this method is that JSON can technically contain anything, and you could make a mistake that Terraform doesn't warn you about.
-
-The best way to get a JSON object is to set up a new connector in Airbyte's UI, fill out all the fields, then click **Copy JSON**. You don't actually need to create the connector in the UI since you want to do this with Terraform, but you do need to get the JSON. Currently, Airbyte optimizes this JSON object for the API, and you need to make some adjustments to use it in Terraform. The examples later in this article demonstrate the expected format.
-
-### How to choose
-
-This tutorial demonstrates how to use both options.
-
-- For Airbyte and Marketplace connectors, you can choose which type of resource you prefer. Airbyte generally recommends using a JSON configuration. Based on the feedback we receive, JSON causes less Terraform drift and makes upgrades less problematic in the long run.
-
-- For custom connectors, only weakly typed JSON configurations are possible.
-
-## Step 1: Set up the Terraform provider
-
-Download the Terraform provider and configure it to run with your Airbyte instance.
-
-1. Create a directory to house your Terraform project, navigate to it, and create a file named `main.tf`.
-
-2. Go to https://registry.terraform.io/providers/airbytehq/airbyte/latest.
-
-3. Click **Use Provider**, copy the code, and paste it into `main.tf`. It should look something like this:
-
-   ```hcl title="main.tf"
-   terraform {
-       required_providers {
-           airbyte = {
-           source = "airbytehq/airbyte"
-           version = "0.6.5"
-           }
-       }
-   }
-
-   provider "airbyte" {
-       # Configuration options
-   }
-   ```
-
-4. Configure the Airbyte provider to use your credentials, but don't put your sensitive data into `main.tf`. Instead, insert variables you'll populate later.
-
-   ```hcl title="main.tf"
-   terraform {
-       required_providers {
-           airbyte = {
-           source = "airbytehq/airbyte"
-           version = "0.6.5"
-           }
-       }
-   }
-
-   provider "airbyte" {
-       // highlight-start
-       client_id = var.client_id
-       client_secret = var.client_secret
-
-       # Include server_url if running locally
-       server_url = "http://localhost:8000/api/public/v1/"
-       // highlight-end
-   }
-   ```
-
-5. In your terminal, create a file named `variables.tf`. This file stores sensitive variables you don't want to appear in `main.tf`, plus other values you'll reuse often.
-
-6. Populate `variables.tf`. Define `client_id`, `client_secret`, and `workspace_id`.
-
-   ```hcl title="variables.tf"
-   variable "client_id" {
-       type = string
-       default = "YOUR_CLIENT_ID"
-   }
-
-   variable "client_secret" {
-       type = string
-       default = "YOUR_CLIENT_SECRET"
-   }
-
-   variable "workspace_id" {
-       type = string
-       default = "YOUR_AIRBYTE_WORKSPACE_ID"
-   }
-   ```
-
-7. Run `terraform init`. Terraform tells you it initialized successfully. If it didn't, check your code against the code samples above.
-
-8. Run `terraform plan`. Terraform tells you there are no changes.
-
-9. Run `terraform apply`. Terraform tells you there are no changes.
-
-## Step 2: Create a source
-
-Add a source from which you want to get data. In this example, you add Stripe as a source. If you want to use a different source, you can find the code sample for the corresponding resource in the [Terraform provider reference docs](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs).
-
-1.  Add your source to `main.tf`.
-
-    <Tabs>
-    <TabItem value="JSON" label="JSON">
-        
-        For this and any other Airbyte or Marketplace connector, you can define the source type in the JSON object.
-        
-        ```hcl title="main.tf"
-        resource "airbyte_source_custom" "my_source_stripe" {
-            configuration = jsonencode({
-                "source_type" : "stripe",
-                "account_id" : "YOUR_STRIPE_ACCOUNT_ID",
-                "client_secret" : "YOUR_STRIPE_CLIENT_SECRET",
-                "start_date" : "2023-07-01T00:00:00Z",
-                "lookback_window_days" : 0,
-                "slice_range" : 365
-                })
-            name = "Stripe"
-            workspace_id = var.workspace_id
-        }
-        ```
-
-        If this is your own custom connector, use `definition_id` to define the source type. To get this value, open your custom connector in Airbyte and copy the definition ID from the URL of that connector.
-
-        ```hcl title="main.tf"
-        resource "airbyte_source_custom" "my_source_stripe" {
-            configuration = jsonencode({
-                "account_id" : "YOUR_STRIPE_ACCOUNT_ID",
-                "client_secret" : "YOUR_STRIPE_CLIENT_SECRET",
-                "start_date" : "2023-07-01T00:00:00Z",
-                "lookback_window_days" : 0,
-                "slice_range" : 365
-                })
-            name = "Stripe"
-            workspace_id = var.workspace_id
-            // highlight-next-line
-            definition_id = "e094cb9a-26de-4645-8761-65c0c425d1de"
-        }
-        ```
-
-    </TabItem>
-    <TabItem value="Strongly typed" label="Strongly typed">
-        ```hcl title="main.tf"
-        resource "airbyte_source_stripe" "my_source_stripe" {
-            configuration = {
-                source_type = "stripe"
-                account_id = "YOUR_STRIPE_ACCOUNT_ID"
-                client_secret = "YOUR_STRIPE_CLIENT_SECRET"
-                start_date = "2023-07-01T00:00:00Z"
-                lookback_window_days = 0
-                slice_range = 365
-            }
-            name = "Stripe"
-            workspace_id = var.workspace_id
-        }
-        ```
-    </TabItem>
-
-    </Tabs>
-
-2.  Run `terraform apply`. Terraform tells you it will add 1 resource. Type `yes` and press <kbd>Enter</kbd>.
-
-Terraform adds the source to Airbyte. To see your new source, open your Airbyte workspace and click **Sources**. Or, use the [List sources](https://reference.airbyte.com/reference/listsources) API endpoint.
-
-## Step 3: Create a destination
-
-Add a destination to which you want to send data. In this example, you add BigQuery as a destination. If you want to use a different destination, you can find the code sample for the corresponding resource in the [Terraform provider reference docs](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs).
-
-1.  Add your destination to `main.tf`.
-
-    :::tip
-    For BigQuery, you must use a [service account](https://cloud.google.com/iam/docs/service-account-overview) with credentials provided as a JSON string. This creates a unique situation that isn't true for all destinations.
-
-    - If you're using the JSON configuration, use a heredoc and write the JSON string yourself to avoid encoding issues. Escape all slashes and newlines as illustrated in the code sample below.
-    - If you're using the strongly typed configuration, it's helpful to wrap your credentials JSON in [jsonencode](https://developer.hashicorp.com/terraform/language/functions/jsonencode). This way, you don't have to manually escape slashes and newlines in your credentials and your Terraform code looks more human-readable.  
-      :::
-
-    <Tabs>
-    <TabItem value="JSON" label="JSON">
-
-        ```hcl title="main.tf"
-        resource "airbyte_destination_custom" "my_destination_bigquery_custom" {
-            configuration = <<-EOF
-                {
-                    "destination_type": "BigQuery",
-                    "credentials_json": "{ \"type\": \"service_account\", \"project_id\": \"YOUR_PROJECT_ID\", \"private_key_id\": \"YOUR_PRIVATE_KEY_ID\", \"private_key\": \"-----BEGIN PRIVATE KEY-----\\n...YOUR_KEY...\\n-----END PRIVATE KEY-----\\n\", \"client_email\": \"you@example.iam.gserviceaccount.com\", \"client_id\": \"YOUR_CLIENT_ID\", \"auth_uri\": \"https://accounts.google.com/o/oauth2/auth\", \"token_uri\": \"https://oauth2.googleapis.com/token\", \"auth_provider_x509_cert_url\": \"https://www.googleapis.com/oauth2/v1/certs\", \"client_x509_cert_url\": \"https://www.googleapis.com/robot/v1/metadata/x509/you@example.iam.gserviceaccount.com\", \"universe_domain\": \"googleapis.com\" }",
-                    "loading_method": {
-                        "method": "Standard",
-                        "batched_standard_inserts": {}
-                    },
-                    "dataset_id": "YOUR_DATASET_ID",
-                    "dataset_location": "us-central1",
-                    "project_id": "YOUR_PROJECT_ID",
-                    "transformation_priority": "batch"
-                }
-            EOF
-            name          = "BigQuery"
-            workspace_id  = var.workspace_id
-        }
-        ```
-
-    </TabItem>
-    <TabItem value="Strongly typed" label="Strongly typed">
-
-        ```hcl title="main.tf"
-        resource "airbyte_destination_bigquery" "my_destination_bigquery" {
-            configuration = {
-                destination_type       = "BigQuery"
-                credentials_json       = jsonencode({
-                    "type"                        = "service_account",
-                    "project_id"                  = "YOUR_PROJECT_ID",
-                    "private_key_id"              = "YOUR_PRIVATE_KEY_ID",
-                    "private_key"                 = "-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n",
-                    "client_email"                = "you@example.iam.gserviceaccount.com",
-                    "client_id"                   = "YOUR_CLIENT_ID",
-                    "auth_uri"                    = "https://accounts.google.com/o/oauth2/auth",
-                    "token_uri"                   = "https://oauth2.googleapis.com/token",
-                    "auth_provider_x509_cert_url" = "https://www.googleapis.com/oauth2/v1/certs",
-                    "client_x509_cert_url"        = "https://www.googleapis.com/robot/v1/metadata/x509/you@example.iam.gserviceaccount.com"
-                })
-                dataset_id              = "YOUR_DATASET_ID"
-                dataset_location        = "us-central1"
-                loading_method          = {
-                    batched_standard_inserts = {}
-                }
-                project_id              = "YOUR_PROJECT_ID"
-                transformation_priority = "batch"
-            }
-            name         = "BigQuery"
-            workspace_id = var.workspace_id
-        }
-        ```
-
-    </TabItem>
-    </Tabs>
-
-    :::note
-    Most destinations have a large number of optional attributes. For simplicity, this tutorial uses defaults. See the [reference docs](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs/resources/destination_bigquery) for additional attributes.
-    :::
-
-2.  Run `terraform apply`. Terraform tells you it will add 1 resource. Type `yes` and press <kbd>Enter</kbd>.
-
-Terraform adds the destination to Airbyte. To see your new destination, open your Airbyte workspace and click **Destinations**. Or, use the [List destinations](https://reference.airbyte.com/reference/listdestinations) API endpoint.
-
-## Step 4: Create a connection
-
-Create a connection from your source to your destination.
-
-1. Add your connection to `main.tf` using the [Airbyte connection](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs/resources/connection) resource.
-
-   ```hcl title="main.tf"
-   resource "airbyte_connection" "stripe_to_bigquery" {
-       name           = "Stripe to BigQuery"
-       source_id      = airbyte_source_stripe.my_source_stripe.source_id
-       destination_id = airbyte_destination_bigquery.my_destination_bigquery.destination_id
-   }
-   ```
-
-   This example connection will not sync automatically. The [reference docs](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs/resources/connection) describe a number of attributes you can use to schedule how and when your connections sync.
-
-2. Run `terraform apply`. Terraform tells you it will add 1 resource. Type `yes` and press <kbd>Enter</kbd>.
-
-Terraform adds the connection to Airbyte. To see your new connection, open your Airbyte workspace and click **Connections**. Or, use the [List connections](https://reference.airbyte.com/reference/listconnections) API endpoint.
-
-## What's next?
-
-Congratulations! You created your first source, your first destination, and a connection between the two.
-
-- Continue building your sources, destinations, and connections for all your data using Airbyte's [Terraform docs](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs).
-
-- Check out the [Quickstarts repository](https://github.com/airbytehq/quickstarts). It's full of templates and shortcuts to help you build common data stacks using Terraform and Python.
+## Documentation
+
+The Airbyte Terraform provider documentation lives on the [Terraform Registry](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs), which is the source of truth for all provider reference docs, guides, and examples.
+
+| Resource | Description |
+|----------|-------------|
+| [Getting Started guide](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs/guides/getting_started) | Set up the provider and create your first source, destination, and connection. |
+| [Provider reference](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs) | Provider configuration, authentication, and schema. |
+| [Resource and data source docs](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs/resources/source) | Full reference for all resources and data sources. |
+| [Migrating to 1.0](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs/guides/v1_migration_guide) | Upgrade from typed connector-specific resources to the generic `airbyte_source` / `airbyte_destination` resources. |
+
+## Quick example
+
+```hcl
+terraform {
+  required_providers {
+    airbyte = {
+      source  = "airbytehq/airbyte"
+      version = "~> 1.0"
+    }
+  }
+}
+
+provider "airbyte" {
+  client_id     = var.client_id
+  client_secret = var.client_secret
+}
+
+data "airbyte_connector_configuration" "postgres_config" {
+  connector_name = "source-postgres"
+  configuration = {
+    host     = "db.example.com"
+    port     = 5432
+    database = "mydb"
+    username = "readonly"
+  }
+  configuration_secrets = {
+    password = var.db_password
+  }
+}
+
+resource "airbyte_source" "postgres" {
+  name          = "Production Postgres"
+  workspace_id  = var.workspace_id
+  definition_id = data.airbyte_connector_configuration.postgres_config.definition_id
+  configuration = data.airbyte_connector_configuration.postgres_config.configuration_json
+}
+```
+
+## Limitations
+
+The Airbyte Terraform provider supports connectors that are available in **both** self-managed and cloud plans. It doesn't support connectors that are only available in self-managed plans.
+
+## Additional resources
+
+- [Quickstarts repository](https://github.com/airbytehq/quickstarts) — Templates for common data stacks using Terraform and Python.
+- [Airbyte API reference](https://reference.airbyte.com) — The API that powers the Terraform provider.
+- [API access configuration](/platform/using-airbyte/configuring-api-access) — Set up API credentials for the Terraform provider.

--- a/docusaurus/platform_versioned_docs/version-1.7/terraform-documentation.md
+++ b/docusaurus/platform_versioned_docs/version-1.7/terraform-documentation.md
@@ -2,322 +2,65 @@
 products: all
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 # Terraform provider
-
-Follow this tutorial to learn how to use Airbyte's Terraform Provider. 
 
 [Terraform](https://www.terraform.io/), developed by HashiCorp, is an Infrastructure as Code (IaC) tool that empowers you to define and provision infrastructure using a declarative configuration language. If you use Terraform to manage your infrastructure, you can use Airbyte's Terraform provider to automate and version control your Airbyte configuration as code. Airbyte's Terraform provider is built off [Airbyte's API](https://reference.airbyte.com).
 
-If you don't need a tutorial, go straight to the [Terraform docs](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs).
+## Documentation
 
-## Limitations and considerations
+The Airbyte Terraform provider documentation lives on the [Terraform Registry](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs), which is the source of truth for all provider reference docs, guides, and examples.
 
-The Airbyte Terraform provider supports connectors that are available in **both** Self-Managed Community and Cloud. It doesn't support connectors that are only available in Self-Managed Community.
+| Resource | Description |
+|----------|-------------|
+| [Getting Started guide](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs/guides/getting_started) | Set up the provider and create your first source, destination, and connection. |
+| [Provider reference](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs) | Provider configuration, authentication, and schema. |
+| [Resource and data source docs](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs/resources/source) | Full reference for all resources and data sources. |
+| [Migrating to 1.0](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs/guides/v1_migration_guide) | Upgrade from typed connector-specific resources to the generic `airbyte_source` / `airbyte_destination` resources. |
 
-## Requirements before you begin
+## Quick example
 
-Before starting this tutorial, make sure you have the following:
-
-- Basic familiarity with Terraform is helpful, but not required.
-
-- Install a code editor, like Visual Studio Code, optionally with a Terraform extension.
-
-- Ensure [Terraform is installed](https://developer.hashicorp.com/terraform/install) on your machine.
-
-- Obtain your Airbyte credentials:
-
-    - [An API application](using-airbyte/configuring-api-access.md) in Airbyte, your client ID, and your client secret.
-
-    - The URL of your Airbyte server (e.g. `http://localhost:8000/api/public/v1/`).
-
-    - Your workspace ID. To get your workspace ID, open your workspace in Airbyte, then copy the ID from the URL. It looks like this: `039da657-f061-493e-a836-9bce86bc5e35`.
-
-- Source and destination credentials. This tutorial uses [Stripe](/integrations/sources/stripe) and [BigQuery](/integrations/destinations/bigquery), but you can substitute any other connector. Consult the documentation for those connectors to ensure you have what you need to connect.
-
-## Strongly typed versus weakly typed {#typing}
-
-The Airbyte provider offers two types of resources, and there are benefits and drawbacks to both. Review this information before creating your sources and destinations.
-
-### Strongly typed configurations
-
-Resources with strongly typed configurations have strict rules about how you write configuration attributes. If they're written incorrectly, these resources prevent `terraform apply` from running.
-
-These resources depend on the underlying Airbyte connectors. Connectors are continually updated as third-party APIs change. This creates two primary points of failure for Terraform.
-
-- You upgrade the Terraform provider version, and fetch a new version of the `config` block. However, you don't upgrade your version of the connector in your Airbyte instance. The setup now crashes because there is a mismatch between the Terraform provider and the connector itself.
-
-- Airbyte builds the Terraform SDK at a given time. Then, the connector has a breaking change, like a third-party deprecating an API endpoint. You upgrade your connector, but Airbyte hasn't upgraded the Terraform provider yet and it doesn't work as expected.
-
-Essentially, using this option creates an ongoing risk that upgrading the Terraform provider or a connector causes a breaking change.
-
-### Weakly typed (JSON) configurations
-
-Instead of using a connector-specific resource, you can use [`airbyte_source_custom`](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs/resources/source_custom) and [`airbyte_destination_custom`](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs/resources/destination_custom). These are normally Airbyte's resources for custom connectors, but you can use them with any existing Airbyte or Marketplace connector and write your configurations as JSON objects. These configurations are more robust when connectors change. Mismatches between a Terraform provider and a connector do not prevent `terraform apply` from running. The absence of a newly added configuration option might have no impact at all on your data and your use of that connector.
-
-The main issue with this method is that JSON can technically contain anything, and you could make a mistake that Terraform doesn't warn you about. 
-
-The best way to get a JSON object is to set up a new connector in Airbyte's UI, fill out all the fields, then click **Copy JSON**. You don't actually need to create the connector in the UI since you want to do this with Terraform, but you do need to get the JSON. Currently, Airbyte optimizes this JSON object for the API, and you need to make some adjustments to use it in Terraform. The examples later in this article demonstrate the expected format.
-
-### How to choose
-
-This tutorial demonstrates how to use both options.
-
-- For Airbyte and Marketplace connectors, you can choose which type of resource you prefer. Airbyte generally recommends using a JSON configuration. Based on the feedback we receive, JSON causes less Terraform drift and makes upgrades less problematic in the long run.
-
-- For custom connectors, only weakly typed JSON configurations are possible.
-
-## Step 1: Set up the Terraform provider
-
-Download the Terraform provider and configure it to run with your Airbyte instance.
-
-1. Create a directory to house your Terraform project, navigate to it, and create a file named `main.tf`.
-
-2. Go to https://registry.terraform.io/providers/airbytehq/airbyte/latest.
-
-3. Click **Use Provider**, copy the code, and paste it into `main.tf`. It should look something like this:
-
-    ```hcl title="main.tf"
-    terraform {
-        required_providers {
-            airbyte = {
-            source = "airbytehq/airbyte"
-            version = "0.6.5"
-            }
-        }
+```hcl
+terraform {
+  required_providers {
+    airbyte = {
+      source  = "airbytehq/airbyte"
+      version = "~> 1.0"
     }
+  }
+}
 
-    provider "airbyte" {
-        # Configuration options
-    }
-    ```
+provider "airbyte" {
+  client_id     = var.client_id
+  client_secret = var.client_secret
+}
 
-4. Configure the Airbyte provider to use your credentials, but don't put your sensitive data into `main.tf`. Instead, insert variables you'll populate later.
+data "airbyte_connector_configuration" "postgres_config" {
+  connector_name = "source-postgres"
+  configuration = {
+    host     = "db.example.com"
+    port     = 5432
+    database = "mydb"
+    username = "readonly"
+  }
+  configuration_secrets = {
+    password = var.db_password
+  }
+}
 
-    ```hcl title="main.tf"
-    terraform {
-        required_providers {
-            airbyte = {
-            source = "airbytehq/airbyte"
-            version = "0.6.5"
-            }
-        }
-    }
+resource "airbyte_source" "postgres" {
+  name          = "Production Postgres"
+  workspace_id  = var.workspace_id
+  definition_id = data.airbyte_connector_configuration.postgres_config.definition_id
+  configuration = data.airbyte_connector_configuration.postgres_config.configuration_json
+}
+```
 
-    provider "airbyte" {
-        // highlight-start
-        client_id = var.client_id
-        client_secret = var.client_secret
+## Limitations
 
-        # Include server_url if running locally
-        server_url = "http://localhost:8000/api/public/v1/"
-        // highlight-end
-    }
-    ```
+The Airbyte Terraform provider supports connectors that are available in **both** self-managed and cloud plans. It doesn't support connectors that are only available in self-managed plans.
 
-5. In your terminal, create a file named `variables.tf`. This file stores sensitive variables you don't want to appear in `main.tf`, plus other values you'll reuse often.
+## Additional resources
 
-6. Populate `variables.tf`. Define `client_id`, `client_secret`, and `workspace_id`.
-
-    ```hcl title="variables.tf"
-    variable "client_id" {
-        type = string
-        default = "YOUR_CLIENT_ID"
-    }
-
-    variable "client_secret" {
-        type = string
-        default = "YOUR_CLIENT_SECRET"
-    }
-
-    variable "workspace_id" {
-        type = string
-        default = "YOUR_AIRBYTE_WORKSPACE_ID"
-    }
-    ```
-
-7. Run `terraform init`. Terraform tells you it initialized successfully. If it didn't, check your code against the code samples above.
-
-8. Run `terraform plan`. Terraform tells you there are no changes.
-
-9. Run `terraform apply`. Terraform tells you there are no changes.
-
-## Step 2: Create a source
-
-Add a source from which you want to get data. In this example, you add Stripe as a source. If you want to use a different source, you can find the code sample for the corresponding resource in the [Terraform provider reference docs](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs).
-
-1. Add your source to `main.tf`.
-
-    <Tabs>
-    <TabItem value="JSON" label="JSON">
-        
-        For this and any other Airbyte or Marketplace connector, you can define the source type in the JSON object.
-        
-        ```hcl title="main.tf"
-        resource "airbyte_source_custom" "my_source_stripe" {
-            configuration = jsonencode({
-                "source_type" : "stripe",
-                "account_id" : "YOUR_STRIPE_ACCOUNT_ID",
-                "client_secret" : "YOUR_STRIPE_CLIENT_SECRET",
-                "start_date" : "2023-07-01T00:00:00Z",
-                "lookback_window_days" : 0,
-                "slice_range" : 365
-                })
-            name = "Stripe"
-            workspace_id = var.workspace_id
-        }
-        ```
-
-        If this is your own custom connector, use `definition_id` to define the source type. To get this value, open your custom connector in Airbyte and copy the definition ID from the URL of that connector.
-
-        ```hcl title="main.tf"
-        resource "airbyte_source_custom" "my_source_stripe" {
-            configuration = jsonencode({
-                "account_id" : "YOUR_STRIPE_ACCOUNT_ID",
-                "client_secret" : "YOUR_STRIPE_CLIENT_SECRET",
-                "start_date" : "2023-07-01T00:00:00Z",
-                "lookback_window_days" : 0,
-                "slice_range" : 365
-                })
-            name = "Stripe"
-            workspace_id = var.workspace_id
-            // highlight-next-line
-            definition_id = "e094cb9a-26de-4645-8761-65c0c425d1de"
-        }
-        ```
-
-    </TabItem>
-    <TabItem value="Strongly typed" label="Strongly typed">
-        ```hcl title="main.tf"
-        resource "airbyte_source_stripe" "my_source_stripe" {
-            configuration = {
-                source_type = "stripe"
-                account_id = "YOUR_STRIPE_ACCOUNT_ID"
-                client_secret = "YOUR_STRIPE_CLIENT_SECRET"
-                start_date = "2023-07-01T00:00:00Z"
-                lookback_window_days = 0
-                slice_range = 365
-            }
-            name = "Stripe"
-            workspace_id = var.workspace_id
-        }
-        ```
-    </TabItem>
-
-    
-    </Tabs>
-
-2. Run `terraform apply`. Terraform tells you it will add 1 resource. Type `yes` and press <kbd>Enter</kbd>.
-
-Terraform adds the source to Airbyte. To see your new source, open your Airbyte workspace and click **Sources**. Or, use the [List sources](https://reference.airbyte.com/reference/listsources) API endpoint.
-
-## Step 3: Create a destination
-
-Add a destination to which you want to send data. In this example, you add BigQuery as a destination. If you want to use a different destination, you can find the code sample for the corresponding resource in the [Terraform provider reference docs](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs).
-
-1. Add your destination to `main.tf`.
-
-    :::tip
-    For BigQuery, you must use a [service account](https://cloud.google.com/iam/docs/service-account-overview) with credentials provided as a JSON string. This creates a unique situation that isn't true for all destinations.
-
-    - If you're using the JSON configuration, use a heredoc and write the JSON string yourself to avoid encoding issues. Escape all slashes and newlines as illustrated in the code sample below.
-    
-    - If you're using the strongly typed configuration, it's helpful to wrap your credentials JSON in [jsonencode](https://developer.hashicorp.com/terraform/language/functions/jsonencode). This way, you don't have to manually escape slashes and newlines in your credentials and your Terraform code looks more human-readable.    
-    :::
-
-    <Tabs>
-    <TabItem value="JSON" label="JSON">
-
-        ```hcl title="main.tf"
-        resource "airbyte_destination_custom" "my_destination_bigquery_custom" {
-            configuration = <<-EOF
-                {
-                    "destination_type": "BigQuery",
-                    "credentials_json": "{ \"type\": \"service_account\", \"project_id\": \"YOUR_PROJECT_ID\", \"private_key_id\": \"YOUR_PRIVATE_KEY_ID\", \"private_key\": \"-----BEGIN PRIVATE KEY-----\\n...YOUR_KEY...\\n-----END PRIVATE KEY-----\\n\", \"client_email\": \"you@example.iam.gserviceaccount.com\", \"client_id\": \"YOUR_CLIENT_ID\", \"auth_uri\": \"https://accounts.google.com/o/oauth2/auth\", \"token_uri\": \"https://oauth2.googleapis.com/token\", \"auth_provider_x509_cert_url\": \"https://www.googleapis.com/oauth2/v1/certs\", \"client_x509_cert_url\": \"https://www.googleapis.com/robot/v1/metadata/x509/you@example.iam.gserviceaccount.com\", \"universe_domain\": \"googleapis.com\" }",
-                    "loading_method": {
-                        "method": "Standard",
-                        "batched_standard_inserts": {}
-                    },
-                    "dataset_id": "YOUR_DATASET_ID",
-                    "dataset_location": "us-central1",
-                    "project_id": "YOUR_PROJECT_ID",
-                    "transformation_priority": "batch"
-                }
-            EOF
-            name          = "BigQuery"
-            workspace_id  = var.workspace_id
-        }
-        ```
-
-    </TabItem>
-    <TabItem value="Strongly typed" label="Strongly typed">
-
-        ```hcl title="main.tf"
-        resource "airbyte_destination_bigquery" "my_destination_bigquery" {
-            configuration = {
-                destination_type       = "BigQuery"
-                credentials_json       = jsonencode({
-                    "type"                        = "service_account",
-                    "project_id"                  = "YOUR_PROJECT_ID",
-                    "private_key_id"              = "YOUR_PRIVATE_KEY_ID",
-                    "private_key"                 = "-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n",
-                    "client_email"                = "you@example.iam.gserviceaccount.com",
-                    "client_id"                   = "YOUR_CLIENT_ID",
-                    "auth_uri"                    = "https://accounts.google.com/o/oauth2/auth",
-                    "token_uri"                   = "https://oauth2.googleapis.com/token",
-                    "auth_provider_x509_cert_url" = "https://www.googleapis.com/oauth2/v1/certs",
-                    "client_x509_cert_url"        = "https://www.googleapis.com/robot/v1/metadata/x509/you@example.iam.gserviceaccount.com"
-                })
-                dataset_id              = "YOUR_DATASET_ID"
-                dataset_location        = "us-central1"
-                loading_method          = {
-                    batched_standard_inserts = {}
-                }
-                project_id              = "YOUR_PROJECT_ID"
-                transformation_priority = "batch"
-            }
-            name         = "BigQuery"
-            workspace_id = var.workspace_id
-        }
-        ```
-
-    </TabItem>
-    </Tabs>
-
-    :::note
-    Most destinations have a large number of optional attributes. For simplicity, this tutorial uses defaults. See the [reference docs](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs/resources/destination_bigquery) for additional attributes.
-    :::
-
-2. Run `terraform apply`. Terraform tells you it will add 1 resource. Type `yes` and press <kbd>Enter</kbd>.
-
-Terraform adds the destination to Airbyte. To see your new destination, open your Airbyte workspace and click **Destinations**. Or, use the [List destinations](https://reference.airbyte.com/reference/listdestinations) API endpoint.
-
-## Step 4: Create a connection
-
-Create a connection from your source to your destination.
-
-1. Add your connection to `main.tf` using the [Airbyte connection](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs/resources/connection) resource.
-
-    ```hcl title="main.tf"
-    resource "airbyte_connection" "stripe_to_bigquery" {
-        name           = "Stripe to BigQuery"
-        source_id      = airbyte_source_stripe.my_source_stripe.source_id
-        destination_id = airbyte_destination_bigquery.my_destination_bigquery.destination_id
-    }
-    ```
-
-    This example connection will not sync automatically. The [reference docs](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs/resources/connection) describe a number of attributes you can use to schedule how and when your connections sync.
-
-2. Run `terraform apply`. Terraform tells you it will add 1 resource. Type `yes` and press <kbd>Enter</kbd>.
-
-Terraform adds the connection to Airbyte. To see your new connection, open your Airbyte workspace and click **Connections**. Or, use the [List connections](https://reference.airbyte.com/reference/listconnections) API endpoint.
-
-## What's next?
-
-Congratulations! You created your first source, your first destination, and a connection between the two.
-
-- Continue building your sources, destinations, and connections for all your data using Airbyte's [Terraform docs](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs).
-
-- Check out the [Quickstarts repository](https://github.com/airbytehq/quickstarts). It's full of templates and shortcuts to help you build common data stacks using Terraform and Python.
+- [Quickstarts repository](https://github.com/airbytehq/quickstarts) — Templates for common data stacks using Terraform and Python.
+- [Airbyte API reference](https://reference.airbyte.com) — The API that powers the Terraform provider.
+- [API access configuration](/platform/using-airbyte/configuring-api-access) — Set up API credentials for the Terraform provider.

--- a/docusaurus/platform_versioned_docs/version-1.7/terraform-documentation.md
+++ b/docusaurus/platform_versioned_docs/version-1.7/terraform-documentation.md
@@ -17,50 +17,8 @@ The Airbyte Terraform provider documentation lives on the [Terraform Registry](h
 | [Resource and data source docs](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs/resources/source) | Full reference for all resources and data sources. |
 | [Migrating to 1.0](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs/guides/v1_migration_guide) | Upgrade from typed connector-specific resources to the generic `airbyte_source` / `airbyte_destination` resources. |
 
-## Quick example
-
-```hcl
-terraform {
-  required_providers {
-    airbyte = {
-      source  = "airbytehq/airbyte"
-      version = "~> 1.0"
-    }
-  }
-}
-
-provider "airbyte" {
-  client_id     = var.client_id
-  client_secret = var.client_secret
-}
-
-data "airbyte_connector_configuration" "postgres_config" {
-  connector_name = "source-postgres"
-  configuration = {
-    host     = "db.example.com"
-    port     = 5432
-    database = "mydb"
-    username = "readonly"
-  }
-  configuration_secrets = {
-    password = var.db_password
-  }
-}
-
-resource "airbyte_source" "postgres" {
-  name          = "Production Postgres"
-  workspace_id  = var.workspace_id
-  definition_id = data.airbyte_connector_configuration.postgres_config.definition_id
-  configuration = data.airbyte_connector_configuration.postgres_config.configuration_json
-}
-```
-
-## Limitations
-
-The Airbyte Terraform provider supports connectors that are available in **both** self-managed and cloud plans. It doesn't support connectors that are only available in self-managed plans.
-
 ## Additional resources
 
-- [Quickstarts repository](https://github.com/airbytehq/quickstarts) — Templates for common data stacks using Terraform and Python.
 - [Airbyte API reference](https://reference.airbyte.com) — The API that powers the Terraform provider.
 - [API access configuration](/platform/using-airbyte/configuring-api-access) — Set up API credentials for the Terraform provider.
+- [Pre-1.0 getting started tutorial](/developers/terraform-provider-pre-1.0) — Reference for users on provider versions before 1.0.

--- a/docusaurus/platform_versioned_docs/version-1.8/terraform-documentation.md
+++ b/docusaurus/platform_versioned_docs/version-1.8/terraform-documentation.md
@@ -2,322 +2,65 @@
 products: all
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 # Terraform provider
-
-Follow this tutorial to learn how to use Airbyte's Terraform Provider. 
 
 [Terraform](https://www.terraform.io/), developed by HashiCorp, is an Infrastructure as Code (IaC) tool that empowers you to define and provision infrastructure using a declarative configuration language. If you use Terraform to manage your infrastructure, you can use Airbyte's Terraform provider to automate and version control your Airbyte configuration as code. Airbyte's Terraform provider is built off [Airbyte's API](https://reference.airbyte.com).
 
-If you don't need a tutorial, go straight to the [Terraform docs](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs).
+## Documentation
 
-## Limitations and considerations
+The Airbyte Terraform provider documentation lives on the [Terraform Registry](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs), which is the source of truth for all provider reference docs, guides, and examples.
 
-The Airbyte Terraform provider supports connectors that are available in **both** Self-Managed Community and Cloud. It doesn't support connectors that are only available in Self-Managed Community.
+| Resource | Description |
+|----------|-------------|
+| [Getting Started guide](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs/guides/getting_started) | Set up the provider and create your first source, destination, and connection. |
+| [Provider reference](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs) | Provider configuration, authentication, and schema. |
+| [Resource and data source docs](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs/resources/source) | Full reference for all resources and data sources. |
+| [Migrating to 1.0](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs/guides/v1_migration_guide) | Upgrade from typed connector-specific resources to the generic `airbyte_source` / `airbyte_destination` resources. |
 
-## Requirements before you begin
+## Quick example
 
-Before starting this tutorial, make sure you have the following:
-
-- Basic familiarity with Terraform is helpful, but not required.
-
-- Install a code editor, like Visual Studio Code, optionally with a Terraform extension.
-
-- Ensure [Terraform is installed](https://developer.hashicorp.com/terraform/install) on your machine.
-
-- Obtain your Airbyte credentials:
-
-    - [An API application](using-airbyte/configuring-api-access.md) in Airbyte, your client ID, and your client secret.
-
-    - The URL of your Airbyte server (e.g. `http://localhost:8000/api/public/v1/`).
-
-    - Your workspace ID. To get your workspace ID, open your workspace in Airbyte, then copy the ID from the URL. It looks like this: `039da657-f061-493e-a836-9bce86bc5e35`.
-
-- Source and destination credentials. This tutorial uses [Stripe](/integrations/sources/stripe) and [BigQuery](/integrations/destinations/bigquery), but you can substitute any other connector. Consult the documentation for those connectors to ensure you have what you need to connect.
-
-## Strongly typed versus weakly typed {#typing}
-
-The Airbyte provider offers two types of resources, and there are benefits and drawbacks to both. Review this information before creating your sources and destinations.
-
-### Strongly typed configurations
-
-Resources with strongly typed configurations have strict rules about how you write configuration attributes. If they're written incorrectly, these resources prevent `terraform apply` from running.
-
-These resources depend on the underlying Airbyte connectors. Connectors are continually updated as third-party APIs change. This creates two primary points of failure for Terraform.
-
-- You upgrade the Terraform provider version, and fetch a new version of the `config` block. However, you don't upgrade your version of the connector in your Airbyte instance. The setup now crashes because there is a mismatch between the Terraform provider and the connector itself.
-
-- Airbyte builds the Terraform SDK at a given time. Then, the connector has a breaking change, like a third-party deprecating an API endpoint. You upgrade your connector, but Airbyte hasn't upgraded the Terraform provider yet and it doesn't work as expected.
-
-Essentially, using this option creates an ongoing risk that upgrading the Terraform provider or a connector causes a breaking change.
-
-### Weakly typed (JSON) configurations
-
-Instead of using a connector-specific resource, you can use [`airbyte_source_custom`](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs/resources/source_custom) and [`airbyte_destination_custom`](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs/resources/destination_custom). These are normally Airbyte's resources for custom connectors, but you can use them with any existing Airbyte or Marketplace connector and write your configurations as JSON objects. These configurations are more robust when connectors change. Mismatches between a Terraform provider and a connector do not prevent `terraform apply` from running. The absence of a newly added configuration option might have no impact at all on your data and your use of that connector.
-
-The main issue with this method is that JSON can technically contain anything, and you could make a mistake that Terraform doesn't warn you about. 
-
-The best way to get a JSON object is to set up a new connector in Airbyte's UI, fill out all the fields, then click **Copy JSON**. You don't actually need to create the connector in the UI since you want to do this with Terraform, but you do need to get the JSON. Currently, Airbyte optimizes this JSON object for the API, and you need to make some adjustments to use it in Terraform. The examples later in this article demonstrate the expected format.
-
-### How to choose
-
-This tutorial demonstrates how to use both options.
-
-- For Airbyte and Marketplace connectors, you can choose which type of resource you prefer. Airbyte generally recommends using a JSON configuration. Based on the feedback we receive, JSON causes less Terraform drift and makes upgrades less problematic in the long run.
-
-- For custom connectors, only weakly typed JSON configurations are possible.
-
-## Step 1: Set up the Terraform provider
-
-Download the Terraform provider and configure it to run with your Airbyte instance.
-
-1. Create a directory to house your Terraform project, navigate to it, and create a file named `main.tf`.
-
-2. Go to https://registry.terraform.io/providers/airbytehq/airbyte/latest.
-
-3. Click **Use Provider**, copy the code, and paste it into `main.tf`. It should look something like this:
-
-    ```hcl title="main.tf"
-    terraform {
-        required_providers {
-            airbyte = {
-            source = "airbytehq/airbyte"
-            version = "0.6.5"
-            }
-        }
+```hcl
+terraform {
+  required_providers {
+    airbyte = {
+      source  = "airbytehq/airbyte"
+      version = "~> 1.0"
     }
+  }
+}
 
-    provider "airbyte" {
-        # Configuration options
-    }
-    ```
+provider "airbyte" {
+  client_id     = var.client_id
+  client_secret = var.client_secret
+}
 
-4. Configure the Airbyte provider to use your credentials, but don't put your sensitive data into `main.tf`. Instead, insert variables you'll populate later.
+data "airbyte_connector_configuration" "postgres_config" {
+  connector_name = "source-postgres"
+  configuration = {
+    host     = "db.example.com"
+    port     = 5432
+    database = "mydb"
+    username = "readonly"
+  }
+  configuration_secrets = {
+    password = var.db_password
+  }
+}
 
-    ```hcl title="main.tf"
-    terraform {
-        required_providers {
-            airbyte = {
-            source = "airbytehq/airbyte"
-            version = "0.6.5"
-            }
-        }
-    }
+resource "airbyte_source" "postgres" {
+  name          = "Production Postgres"
+  workspace_id  = var.workspace_id
+  definition_id = data.airbyte_connector_configuration.postgres_config.definition_id
+  configuration = data.airbyte_connector_configuration.postgres_config.configuration_json
+}
+```
 
-    provider "airbyte" {
-        // highlight-start
-        client_id = var.client_id
-        client_secret = var.client_secret
+## Limitations
 
-        # Include server_url if running locally
-        server_url = "http://localhost:8000/api/public/v1/"
-        // highlight-end
-    }
-    ```
+The Airbyte Terraform provider supports connectors that are available in **both** self-managed and cloud plans. It doesn't support connectors that are only available in self-managed plans.
 
-5. In your terminal, create a file named `variables.tf`. This file stores sensitive variables you don't want to appear in `main.tf`, plus other values you'll reuse often.
+## Additional resources
 
-6. Populate `variables.tf`. Define `client_id`, `client_secret`, and `workspace_id`.
-
-    ```hcl title="variables.tf"
-    variable "client_id" {
-        type = string
-        default = "YOUR_CLIENT_ID"
-    }
-
-    variable "client_secret" {
-        type = string
-        default = "YOUR_CLIENT_SECRET"
-    }
-
-    variable "workspace_id" {
-        type = string
-        default = "YOUR_AIRBYTE_WORKSPACE_ID"
-    }
-    ```
-
-7. Run `terraform init`. Terraform tells you it initialized successfully. If it didn't, check your code against the code samples above.
-
-8. Run `terraform plan`. Terraform tells you there are no changes.
-
-9. Run `terraform apply`. Terraform tells you there are no changes.
-
-## Step 2: Create a source
-
-Add a source from which you want to get data. In this example, you add Stripe as a source. If you want to use a different source, you can find the code sample for the corresponding resource in the [Terraform provider reference docs](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs).
-
-1. Add your source to `main.tf`.
-
-    <Tabs>
-    <TabItem value="JSON" label="JSON">
-        
-        For this and any other Airbyte or Marketplace connector, you can define the source type in the JSON object.
-        
-        ```hcl title="main.tf"
-        resource "airbyte_source_custom" "my_source_stripe" {
-            configuration = jsonencode({
-                "source_type" : "stripe",
-                "account_id" : "YOUR_STRIPE_ACCOUNT_ID",
-                "client_secret" : "YOUR_STRIPE_CLIENT_SECRET",
-                "start_date" : "2023-07-01T00:00:00Z",
-                "lookback_window_days" : 0,
-                "slice_range" : 365
-                })
-            name = "Stripe"
-            workspace_id = var.workspace_id
-        }
-        ```
-
-        If this is your own custom connector, use `definition_id` to define the source type. To get this value, open your custom connector in Airbyte and copy the definition ID from the URL of that connector.
-
-        ```hcl title="main.tf"
-        resource "airbyte_source_custom" "my_source_stripe" {
-            configuration = jsonencode({
-                "account_id" : "YOUR_STRIPE_ACCOUNT_ID",
-                "client_secret" : "YOUR_STRIPE_CLIENT_SECRET",
-                "start_date" : "2023-07-01T00:00:00Z",
-                "lookback_window_days" : 0,
-                "slice_range" : 365
-                })
-            name = "Stripe"
-            workspace_id = var.workspace_id
-            // highlight-next-line
-            definition_id = "e094cb9a-26de-4645-8761-65c0c425d1de"
-        }
-        ```
-
-    </TabItem>
-    <TabItem value="Strongly typed" label="Strongly typed">
-        ```hcl title="main.tf"
-        resource "airbyte_source_stripe" "my_source_stripe" {
-            configuration = {
-                source_type = "stripe"
-                account_id = "YOUR_STRIPE_ACCOUNT_ID"
-                client_secret = "YOUR_STRIPE_CLIENT_SECRET"
-                start_date = "2023-07-01T00:00:00Z"
-                lookback_window_days = 0
-                slice_range = 365
-            }
-            name = "Stripe"
-            workspace_id = var.workspace_id
-        }
-        ```
-    </TabItem>
-
-    
-    </Tabs>
-
-2. Run `terraform apply`. Terraform tells you it will add 1 resource. Type `yes` and press <kbd>Enter</kbd>.
-
-Terraform adds the source to Airbyte. To see your new source, open your Airbyte workspace and click **Sources**. Or, use the [List sources](https://reference.airbyte.com/reference/listsources) API endpoint.
-
-## Step 3: Create a destination
-
-Add a destination to which you want to send data. In this example, you add BigQuery as a destination. If you want to use a different destination, you can find the code sample for the corresponding resource in the [Terraform provider reference docs](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs).
-
-1. Add your destination to `main.tf`.
-
-    :::tip
-    For BigQuery, you must use a [service account](https://cloud.google.com/iam/docs/service-account-overview) with credentials provided as a JSON string. This creates a unique situation that isn't true for all destinations.
-
-    - If you're using the JSON configuration, use a heredoc and write the JSON string yourself to avoid encoding issues. Escape all slashes and newlines as illustrated in the code sample below.
-    
-    - If you're using the strongly typed configuration, it's helpful to wrap your credentials JSON in [jsonencode](https://developer.hashicorp.com/terraform/language/functions/jsonencode). This way, you don't have to manually escape slashes and newlines in your credentials and your Terraform code looks more human-readable.    
-    :::
-
-    <Tabs>
-    <TabItem value="JSON" label="JSON">
-
-        ```hcl title="main.tf"
-        resource "airbyte_destination_custom" "my_destination_bigquery_custom" {
-            configuration = <<-EOF
-                {
-                    "destination_type": "BigQuery",
-                    "credentials_json": "{ \"type\": \"service_account\", \"project_id\": \"YOUR_PROJECT_ID\", \"private_key_id\": \"YOUR_PRIVATE_KEY_ID\", \"private_key\": \"-----BEGIN PRIVATE KEY-----\\n...YOUR_KEY...\\n-----END PRIVATE KEY-----\\n\", \"client_email\": \"you@example.iam.gserviceaccount.com\", \"client_id\": \"YOUR_CLIENT_ID\", \"auth_uri\": \"https://accounts.google.com/o/oauth2/auth\", \"token_uri\": \"https://oauth2.googleapis.com/token\", \"auth_provider_x509_cert_url\": \"https://www.googleapis.com/oauth2/v1/certs\", \"client_x509_cert_url\": \"https://www.googleapis.com/robot/v1/metadata/x509/you@example.iam.gserviceaccount.com\", \"universe_domain\": \"googleapis.com\" }",
-                    "loading_method": {
-                        "method": "Standard",
-                        "batched_standard_inserts": {}
-                    },
-                    "dataset_id": "YOUR_DATASET_ID",
-                    "dataset_location": "us-central1",
-                    "project_id": "YOUR_PROJECT_ID",
-                    "transformation_priority": "batch"
-                }
-            EOF
-            name          = "BigQuery"
-            workspace_id  = var.workspace_id
-        }
-        ```
-
-    </TabItem>
-    <TabItem value="Strongly typed" label="Strongly typed">
-
-        ```hcl title="main.tf"
-        resource "airbyte_destination_bigquery" "my_destination_bigquery" {
-            configuration = {
-                destination_type       = "BigQuery"
-                credentials_json       = jsonencode({
-                    "type"                        = "service_account",
-                    "project_id"                  = "YOUR_PROJECT_ID",
-                    "private_key_id"              = "YOUR_PRIVATE_KEY_ID",
-                    "private_key"                 = "-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n",
-                    "client_email"                = "you@example.iam.gserviceaccount.com",
-                    "client_id"                   = "YOUR_CLIENT_ID",
-                    "auth_uri"                    = "https://accounts.google.com/o/oauth2/auth",
-                    "token_uri"                   = "https://oauth2.googleapis.com/token",
-                    "auth_provider_x509_cert_url" = "https://www.googleapis.com/oauth2/v1/certs",
-                    "client_x509_cert_url"        = "https://www.googleapis.com/robot/v1/metadata/x509/you@example.iam.gserviceaccount.com"
-                })
-                dataset_id              = "YOUR_DATASET_ID"
-                dataset_location        = "us-central1"
-                loading_method          = {
-                    batched_standard_inserts = {}
-                }
-                project_id              = "YOUR_PROJECT_ID"
-                transformation_priority = "batch"
-            }
-            name         = "BigQuery"
-            workspace_id = var.workspace_id
-        }
-        ```
-
-    </TabItem>
-    </Tabs>
-
-    :::note
-    Most destinations have a large number of optional attributes. For simplicity, this tutorial uses defaults. See the [reference docs](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs/resources/destination_bigquery) for additional attributes.
-    :::
-
-2. Run `terraform apply`. Terraform tells you it will add 1 resource. Type `yes` and press <kbd>Enter</kbd>.
-
-Terraform adds the destination to Airbyte. To see your new destination, open your Airbyte workspace and click **Destinations**. Or, use the [List destinations](https://reference.airbyte.com/reference/listdestinations) API endpoint.
-
-## Step 4: Create a connection
-
-Create a connection from your source to your destination.
-
-1. Add your connection to `main.tf` using the [Airbyte connection](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs/resources/connection) resource.
-
-    ```hcl title="main.tf"
-    resource "airbyte_connection" "stripe_to_bigquery" {
-        name           = "Stripe to BigQuery"
-        source_id      = airbyte_source_stripe.my_source_stripe.source_id
-        destination_id = airbyte_destination_bigquery.my_destination_bigquery.destination_id
-    }
-    ```
-
-    This example connection will not sync automatically. The [reference docs](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs/resources/connection) describe a number of attributes you can use to schedule how and when your connections sync.
-
-2. Run `terraform apply`. Terraform tells you it will add 1 resource. Type `yes` and press <kbd>Enter</kbd>.
-
-Terraform adds the connection to Airbyte. To see your new connection, open your Airbyte workspace and click **Connections**. Or, use the [List connections](https://reference.airbyte.com/reference/listconnections) API endpoint.
-
-## What's next?
-
-Congratulations! You created your first source, your first destination, and a connection between the two.
-
-- Continue building your sources, destinations, and connections for all your data using Airbyte's [Terraform docs](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs).
-
-- Check out the [Quickstarts repository](https://github.com/airbytehq/quickstarts). It's full of templates and shortcuts to help you build common data stacks using Terraform and Python.
+- [Quickstarts repository](https://github.com/airbytehq/quickstarts) — Templates for common data stacks using Terraform and Python.
+- [Airbyte API reference](https://reference.airbyte.com) — The API that powers the Terraform provider.
+- [API access configuration](/platform/using-airbyte/configuring-api-access) — Set up API credentials for the Terraform provider.

--- a/docusaurus/platform_versioned_docs/version-1.8/terraform-documentation.md
+++ b/docusaurus/platform_versioned_docs/version-1.8/terraform-documentation.md
@@ -17,50 +17,8 @@ The Airbyte Terraform provider documentation lives on the [Terraform Registry](h
 | [Resource and data source docs](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs/resources/source) | Full reference for all resources and data sources. |
 | [Migrating to 1.0](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs/guides/v1_migration_guide) | Upgrade from typed connector-specific resources to the generic `airbyte_source` / `airbyte_destination` resources. |
 
-## Quick example
-
-```hcl
-terraform {
-  required_providers {
-    airbyte = {
-      source  = "airbytehq/airbyte"
-      version = "~> 1.0"
-    }
-  }
-}
-
-provider "airbyte" {
-  client_id     = var.client_id
-  client_secret = var.client_secret
-}
-
-data "airbyte_connector_configuration" "postgres_config" {
-  connector_name = "source-postgres"
-  configuration = {
-    host     = "db.example.com"
-    port     = 5432
-    database = "mydb"
-    username = "readonly"
-  }
-  configuration_secrets = {
-    password = var.db_password
-  }
-}
-
-resource "airbyte_source" "postgres" {
-  name          = "Production Postgres"
-  workspace_id  = var.workspace_id
-  definition_id = data.airbyte_connector_configuration.postgres_config.definition_id
-  configuration = data.airbyte_connector_configuration.postgres_config.configuration_json
-}
-```
-
-## Limitations
-
-The Airbyte Terraform provider supports connectors that are available in **both** self-managed and cloud plans. It doesn't support connectors that are only available in self-managed plans.
-
 ## Additional resources
 
-- [Quickstarts repository](https://github.com/airbytehq/quickstarts) — Templates for common data stacks using Terraform and Python.
 - [Airbyte API reference](https://reference.airbyte.com) — The API that powers the Terraform provider.
 - [API access configuration](/platform/using-airbyte/configuring-api-access) — Set up API credentials for the Terraform provider.
+- [Pre-1.0 getting started tutorial](/developers/terraform-provider-pre-1.0) — Reference for users on provider versions before 1.0.

--- a/docusaurus/platform_versioned_docs/version-2.0/terraform-documentation.md
+++ b/docusaurus/platform_versioned_docs/version-2.0/terraform-documentation.md
@@ -17,50 +17,8 @@ The Airbyte Terraform provider documentation lives on the [Terraform Registry](h
 | [Resource and data source docs](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs/resources/source) | Full reference for all resources and data sources. |
 | [Migrating to 1.0](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs/guides/v1_migration_guide) | Upgrade from typed connector-specific resources to the generic `airbyte_source` / `airbyte_destination` resources. |
 
-## Quick example
-
-```hcl
-terraform {
-  required_providers {
-    airbyte = {
-      source  = "airbytehq/airbyte"
-      version = "~> 1.0"
-    }
-  }
-}
-
-provider "airbyte" {
-  client_id     = var.client_id
-  client_secret = var.client_secret
-}
-
-data "airbyte_connector_configuration" "postgres_config" {
-  connector_name = "source-postgres"
-  configuration = {
-    host     = "db.example.com"
-    port     = 5432
-    database = "mydb"
-    username = "readonly"
-  }
-  configuration_secrets = {
-    password = var.db_password
-  }
-}
-
-resource "airbyte_source" "postgres" {
-  name          = "Production Postgres"
-  workspace_id  = var.workspace_id
-  definition_id = data.airbyte_connector_configuration.postgres_config.definition_id
-  configuration = data.airbyte_connector_configuration.postgres_config.configuration_json
-}
-```
-
-## Limitations
-
-The Airbyte Terraform provider supports connectors that are available in **both** self-managed and cloud plans. It doesn't support connectors that are only available in self-managed plans.
-
 ## Additional resources
 
-- [Quickstarts repository](https://github.com/airbytehq/quickstarts) — Templates for common data stacks using Terraform and Python.
 - [Airbyte API reference](https://reference.airbyte.com) — The API that powers the Terraform provider.
 - [API access configuration](/platform/using-airbyte/configuring-api-access) — Set up API credentials for the Terraform provider.
+- [Pre-1.0 getting started tutorial](/developers/terraform-provider-pre-1.0) — Reference for users on provider versions before 1.0.

--- a/docusaurus/platform_versioned_docs/version-2.0/terraform-documentation.md
+++ b/docusaurus/platform_versioned_docs/version-2.0/terraform-documentation.md
@@ -2,322 +2,65 @@
 products: all
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 # Terraform provider
-
-Follow this tutorial to learn how to use Airbyte's Terraform Provider.
 
 [Terraform](https://www.terraform.io/), developed by HashiCorp, is an Infrastructure as Code (IaC) tool that empowers you to define and provision infrastructure using a declarative configuration language. If you use Terraform to manage your infrastructure, you can use Airbyte's Terraform provider to automate and version control your Airbyte configuration as code. Airbyte's Terraform provider is built off [Airbyte's API](https://reference.airbyte.com).
 
-If you don't need a tutorial, go straight to the [Terraform docs](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs).
+## Documentation
 
-## Limitations and considerations
+The Airbyte Terraform provider documentation lives on the [Terraform Registry](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs), which is the source of truth for all provider reference docs, guides, and examples.
+
+| Resource | Description |
+|----------|-------------|
+| [Getting Started guide](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs/guides/getting_started) | Set up the provider and create your first source, destination, and connection. |
+| [Provider reference](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs) | Provider configuration, authentication, and schema. |
+| [Resource and data source docs](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs/resources/source) | Full reference for all resources and data sources. |
+| [Migrating to 1.0](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs/guides/v1_migration_guide) | Upgrade from typed connector-specific resources to the generic `airbyte_source` / `airbyte_destination` resources. |
+
+## Quick example
+
+```hcl
+terraform {
+  required_providers {
+    airbyte = {
+      source  = "airbytehq/airbyte"
+      version = "~> 1.0"
+    }
+  }
+}
+
+provider "airbyte" {
+  client_id     = var.client_id
+  client_secret = var.client_secret
+}
+
+data "airbyte_connector_configuration" "postgres_config" {
+  connector_name = "source-postgres"
+  configuration = {
+    host     = "db.example.com"
+    port     = 5432
+    database = "mydb"
+    username = "readonly"
+  }
+  configuration_secrets = {
+    password = var.db_password
+  }
+}
+
+resource "airbyte_source" "postgres" {
+  name          = "Production Postgres"
+  workspace_id  = var.workspace_id
+  definition_id = data.airbyte_connector_configuration.postgres_config.definition_id
+  configuration = data.airbyte_connector_configuration.postgres_config.configuration_json
+}
+```
+
+## Limitations
 
 The Airbyte Terraform provider supports connectors that are available in **both** self-managed and cloud plans. It doesn't support connectors that are only available in self-managed plans.
 
-## Requirements before you begin
-
-Before starting this tutorial, make sure you have the following:
-
-- Basic familiarity with Terraform is helpful, but not required.
-
-- Install a code editor, like Visual Studio Code, optionally with a Terraform extension.
-
-- Ensure [Terraform is installed](https://developer.hashicorp.com/terraform/install) on your machine.
-
-- Obtain your Airbyte credentials:
-
-    - [An API application](using-airbyte/configuring-api-access.md) in Airbyte, your client ID, and your client secret.
-
-    - The URL of your Airbyte server (e.g. `http://localhost:8000/api/public/v1/`).
-
-    - Your workspace ID. To get your workspace ID, open your workspace in Airbyte, then copy the ID from the URL. It looks like this: `039da657-f061-493e-a836-9bce86bc5e35`.
-
-- Source and destination credentials. This tutorial uses [Stripe](/integrations/sources/stripe) and [BigQuery](/integrations/destinations/bigquery), but you can substitute any other connector. Consult the documentation for those connectors to ensure you have what you need to connect.
-
-## Strongly typed versus weakly typed {#typing}
-
-The Airbyte provider offers two types of resources, and there are benefits and drawbacks to both. Review this information before creating your sources and destinations.
-
-### Strongly typed configurations
-
-Resources with strongly typed configurations have strict rules about how you write configuration attributes. If they're written incorrectly, these resources prevent `terraform apply` from running.
-
-These resources depend on the underlying Airbyte connectors. Connectors are continually updated as third-party APIs change. This creates two primary points of failure for Terraform.
-
-- You upgrade the Terraform provider version, and fetch a new version of the `config` block. However, you don't upgrade your version of the connector in your Airbyte instance. The setup now crashes because there is a mismatch between the Terraform provider and the connector itself.
-
-- Airbyte builds the Terraform SDK at a given time. Then, the connector has a breaking change, like a third-party deprecating an API endpoint. You upgrade your connector, but Airbyte hasn't upgraded the Terraform provider yet and it doesn't work as expected.
-
-Essentially, using this option creates an ongoing risk that upgrading the Terraform provider or a connector causes a breaking change.
-
-### Weakly typed (JSON) configurations
-
-Instead of using a connector-specific resource, you can use [`airbyte_source_custom`](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs/resources/source_custom) and [`airbyte_destination_custom`](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs/resources/destination_custom). These are normally Airbyte's resources for custom connectors, but you can use them with any existing Airbyte or Marketplace connector and write your configurations as JSON objects. These configurations are more robust when connectors change. Mismatches between a Terraform provider and a connector do not prevent `terraform apply` from running. The absence of a newly added configuration option might have no impact at all on your data and your use of that connector.
-
-The main issue with this method is that JSON can technically contain anything, and you could make a mistake that Terraform doesn't warn you about. 
-
-The best way to get a JSON object is to set up a new connector in Airbyte's UI, fill out all the fields, then click **Copy JSON**. You don't actually need to create the connector in the UI since you want to do this with Terraform, but you do need to get the JSON. Currently, Airbyte optimizes this JSON object for the API, and you need to make some adjustments to use it in Terraform. The examples later in this article demonstrate the expected format.
-
-### How to choose
-
-This tutorial demonstrates how to use both options.
-
-- For Airbyte and Marketplace connectors, you can choose which type of resource you prefer. Airbyte generally recommends using a JSON configuration. Based on the feedback we receive, JSON causes less Terraform drift and makes upgrades less problematic in the long run.
-
-- For custom connectors, only weakly typed JSON configurations are possible.
-
-## Step 1: Set up the Terraform provider
-
-Download the Terraform provider and configure it to run with your Airbyte instance.
-
-1. Create a directory to house your Terraform project, navigate to it, and create a file named `main.tf`.
-
-2. Go to https://registry.terraform.io/providers/airbytehq/airbyte/latest.
-
-3. Click **Use Provider**, copy the code, and paste it into `main.tf`. It should look something like this:
-
-    ```hcl title="main.tf"
-    terraform {
-        required_providers {
-            airbyte = {
-            source = "airbytehq/airbyte"
-            version = "0.6.5"
-            }
-        }
-    }
-
-    provider "airbyte" {
-        # Configuration options
-    }
-    ```
-
-4. Configure the Airbyte provider to use your credentials, but don't put your sensitive data into `main.tf`. Instead, insert variables you'll populate later.
-
-    ```hcl title="main.tf"
-    terraform {
-        required_providers {
-            airbyte = {
-            source = "airbytehq/airbyte"
-            version = "0.6.5"
-            }
-        }
-    }
-
-    provider "airbyte" {
-        // highlight-start
-        client_id = var.client_id
-        client_secret = var.client_secret
-
-        # Include server_url if running locally
-        server_url = "http://localhost:8000/api/public/v1/"
-        // highlight-end
-    }
-    ```
-
-5. In your terminal, create a file named `variables.tf`. This file stores sensitive variables you don't want to appear in `main.tf`, plus other values you'll reuse often.
-
-6. Populate `variables.tf`. Define `client_id`, `client_secret`, and `workspace_id`.
-
-    ```hcl title="variables.tf"
-    variable "client_id" {
-        type = string
-        default = "YOUR_CLIENT_ID"
-    }
-
-    variable "client_secret" {
-        type = string
-        default = "YOUR_CLIENT_SECRET"
-    }
-
-    variable "workspace_id" {
-        type = string
-        default = "YOUR_AIRBYTE_WORKSPACE_ID"
-    }
-    ```
-
-7. Run `terraform init`. Terraform tells you it initialized successfully. If it didn't, check your code against the code samples above.
-
-8. Run `terraform plan`. Terraform tells you there are no changes.
-
-9. Run `terraform apply`. Terraform tells you there are no changes.
-
-## Step 2: Create a source
-
-Add a source from which you want to get data. In this example, you add Stripe as a source. If you want to use a different source, you can find the code sample for the corresponding resource in the [Terraform provider reference docs](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs).
-
-1. Add your source to `main.tf`.
-
-    <Tabs>
-    <TabItem value="JSON" label="JSON">
-        
-        For this and any other Airbyte or Marketplace connector, you can define the source type in the JSON object.
-        
-        ```hcl title="main.tf"
-        resource "airbyte_source_custom" "my_source_stripe" {
-            configuration = jsonencode({
-                "source_type" : "stripe",
-                "account_id" : "YOUR_STRIPE_ACCOUNT_ID",
-                "client_secret" : "YOUR_STRIPE_CLIENT_SECRET",
-                "start_date" : "2023-07-01T00:00:00Z",
-                "lookback_window_days" : 0,
-                "slice_range" : 365
-                })
-            name = "Stripe"
-            workspace_id = var.workspace_id
-        }
-        ```
-
-        If this is your own custom connector, use `definition_id` to define the source type. To get this value, open your custom connector in Airbyte and copy the definition ID from the URL of that connector.
-
-        ```hcl title="main.tf"
-        resource "airbyte_source_custom" "my_source_stripe" {
-            configuration = jsonencode({
-                "account_id" : "YOUR_STRIPE_ACCOUNT_ID",
-                "client_secret" : "YOUR_STRIPE_CLIENT_SECRET",
-                "start_date" : "2023-07-01T00:00:00Z",
-                "lookback_window_days" : 0,
-                "slice_range" : 365
-                })
-            name = "Stripe"
-            workspace_id = var.workspace_id
-            // highlight-next-line
-            definition_id = "e094cb9a-26de-4645-8761-65c0c425d1de"
-        }
-        ```
-
-    </TabItem>
-    <TabItem value="Strongly typed" label="Strongly typed">
-        ```hcl title="main.tf"
-        resource "airbyte_source_stripe" "my_source_stripe" {
-            configuration = {
-                source_type = "stripe"
-                account_id = "YOUR_STRIPE_ACCOUNT_ID"
-                client_secret = "YOUR_STRIPE_CLIENT_SECRET"
-                start_date = "2023-07-01T00:00:00Z"
-                lookback_window_days = 0
-                slice_range = 365
-            }
-            name = "Stripe"
-            workspace_id = var.workspace_id
-        }
-        ```
-    </TabItem>
-
-    
-    </Tabs>
-
-2. Run `terraform apply`. Terraform tells you it will add 1 resource. Type `yes` and press <kbd>Enter</kbd>.
-
-Terraform adds the source to Airbyte. To see your new source, open your Airbyte workspace and click **Sources**. Or, use the [List sources](https://reference.airbyte.com/reference/listsources) API endpoint.
-
-## Step 3: Create a destination
-
-Add a destination to which you want to send data. In this example, you add BigQuery as a destination. If you want to use a different destination, you can find the code sample for the corresponding resource in the [Terraform provider reference docs](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs).
-
-1. Add your destination to `main.tf`.
-
-    :::tip
-    For BigQuery, you must use a [service account](https://cloud.google.com/iam/docs/service-account-overview) with credentials provided as a JSON string. This creates a unique situation that isn't true for all destinations.
-
-    - If you're using the JSON configuration, use a heredoc and write the JSON string yourself to avoid encoding issues. Escape all slashes and newlines as illustrated in the code sample below.
-    
-    - If you're using the strongly typed configuration, it's helpful to wrap your credentials JSON in [jsonencode](https://developer.hashicorp.com/terraform/language/functions/jsonencode). This way, you don't have to manually escape slashes and newlines in your credentials and your Terraform code looks more human-readable.    
-    :::
-
-    <Tabs>
-    <TabItem value="JSON" label="JSON">
-
-        ```hcl title="main.tf"
-        resource "airbyte_destination_custom" "my_destination_bigquery_custom" {
-            configuration = <<-EOF
-                {
-                    "destination_type": "BigQuery",
-                    "credentials_json": "{ \"type\": \"service_account\", \"project_id\": \"YOUR_PROJECT_ID\", \"private_key_id\": \"YOUR_PRIVATE_KEY_ID\", \"private_key\": \"-----BEGIN PRIVATE KEY-----\\n...YOUR_KEY...\\n-----END PRIVATE KEY-----\\n\", \"client_email\": \"you@example.iam.gserviceaccount.com\", \"client_id\": \"YOUR_CLIENT_ID\", \"auth_uri\": \"https://accounts.google.com/o/oauth2/auth\", \"token_uri\": \"https://oauth2.googleapis.com/token\", \"auth_provider_x509_cert_url\": \"https://www.googleapis.com/oauth2/v1/certs\", \"client_x509_cert_url\": \"https://www.googleapis.com/robot/v1/metadata/x509/you@example.iam.gserviceaccount.com\", \"universe_domain\": \"googleapis.com\" }",
-                    "loading_method": {
-                        "method": "Standard",
-                        "batched_standard_inserts": {}
-                    },
-                    "dataset_id": "YOUR_DATASET_ID",
-                    "dataset_location": "us-central1",
-                    "project_id": "YOUR_PROJECT_ID",
-                    "transformation_priority": "batch"
-                }
-            EOF
-            name          = "BigQuery"
-            workspace_id  = var.workspace_id
-        }
-        ```
-
-    </TabItem>
-    <TabItem value="Strongly typed" label="Strongly typed">
-
-        ```hcl title="main.tf"
-        resource "airbyte_destination_bigquery" "my_destination_bigquery" {
-            configuration = {
-                destination_type       = "BigQuery"
-                credentials_json       = jsonencode({
-                    "type"                        = "service_account",
-                    "project_id"                  = "YOUR_PROJECT_ID",
-                    "private_key_id"              = "YOUR_PRIVATE_KEY_ID",
-                    "private_key"                 = "-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n",
-                    "client_email"                = "you@example.iam.gserviceaccount.com",
-                    "client_id"                   = "YOUR_CLIENT_ID",
-                    "auth_uri"                    = "https://accounts.google.com/o/oauth2/auth",
-                    "token_uri"                   = "https://oauth2.googleapis.com/token",
-                    "auth_provider_x509_cert_url" = "https://www.googleapis.com/oauth2/v1/certs",
-                    "client_x509_cert_url"        = "https://www.googleapis.com/robot/v1/metadata/x509/you@example.iam.gserviceaccount.com"
-                })
-                dataset_id              = "YOUR_DATASET_ID"
-                dataset_location        = "us-central1"
-                loading_method          = {
-                    batched_standard_inserts = {}
-                }
-                project_id              = "YOUR_PROJECT_ID"
-                transformation_priority = "batch"
-            }
-            name         = "BigQuery"
-            workspace_id = var.workspace_id
-        }
-        ```
-
-    </TabItem>
-    </Tabs>
-
-    :::note
-    Most destinations have a large number of optional attributes. For simplicity, this tutorial uses defaults. See the [reference docs](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs/resources/destination_bigquery) for additional attributes.
-    :::
-
-2. Run `terraform apply`. Terraform tells you it will add 1 resource. Type `yes` and press <kbd>Enter</kbd>.
-
-Terraform adds the destination to Airbyte. To see your new destination, open your Airbyte workspace and click **Destinations**. Or, use the [List destinations](https://reference.airbyte.com/reference/listdestinations) API endpoint.
-
-## Step 4: Create a connection
-
-Create a connection from your source to your destination.
-
-1. Add your connection to `main.tf` using the [Airbyte connection](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs/resources/connection) resource.
-
-    ```hcl title="main.tf"
-    resource "airbyte_connection" "stripe_to_bigquery" {
-        name           = "Stripe to BigQuery"
-        source_id      = airbyte_source_stripe.my_source_stripe.source_id
-        destination_id = airbyte_destination_bigquery.my_destination_bigquery.destination_id
-    }
-    ```
-
-    This example connection will not sync automatically. The [reference docs](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs/resources/connection) describe a number of attributes you can use to schedule how and when your connections sync.
-
-2. Run `terraform apply`. Terraform tells you it will add 1 resource. Type `yes` and press <kbd>Enter</kbd>.
-
-Terraform adds the connection to Airbyte. To see your new connection, open your Airbyte workspace and click **Connections**. Or, use the [List connections](https://reference.airbyte.com/reference/listconnections) API endpoint.
-
-## What's next?
-
-Congratulations! You created your first source, your first destination, and a connection between the two.
-
-- Continue building your sources, destinations, and connections for all your data using Airbyte's [Terraform docs](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs).
-
-- Check out the [Quickstarts repository](https://github.com/airbytehq/quickstarts). It's full of templates and shortcuts to help you build common data stacks using Terraform and Python.
+## Additional resources
+
+- [Quickstarts repository](https://github.com/airbytehq/quickstarts) — Templates for common data stacks using Terraform and Python.
+- [Airbyte API reference](https://reference.airbyte.com) — The API that powers the Terraform provider.
+- [API access configuration](/platform/using-airbyte/configuring-api-access) — Set up API credentials for the Terraform provider.

--- a/docusaurus/sidebar-developers.js
+++ b/docusaurus/sidebar-developers.js
@@ -11,6 +11,7 @@ module.exports = {
       items: [
         "api-documentation",
         "terraform-documentation",
+        "terraform-provider-pre-1.0",
         {
           type: "category",
           label: "PyAirbyte",

--- a/docusaurus/sidebar-developers.js
+++ b/docusaurus/sidebar-developers.js
@@ -10,8 +10,17 @@ module.exports = {
       },
       items: [
         "api-documentation",
-        "terraform-documentation",
-        "terraform-provider-pre-1.0",
+        {
+          type: "category",
+          label: "Terraform Provider",
+          link: {
+            type: "doc",
+            id: "terraform-documentation",
+          },
+          items: [
+            "terraform-provider-pre-1.0",
+          ],
+        },
         {
           type: "category",
           label: "PyAirbyte",


### PR DESCRIPTION
## What

Replaces the full Terraform provider tutorial on docs.airbyte.com with a concise landing page that points to the [Terraform Registry](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs) as the source of truth. The detailed getting-started content for 1.0+ is being migrated to the registry itself in a companion PR: airbytehq/terraform-provider-airbyte#342.

The original pre-1.0 tutorial content (strongly-typed vs weakly-typed resources, Stripe→BigQuery walkthrough) is preserved as a separate reference page for users still on older provider versions.

## How

- Removed the 320-line step-by-step tutorial (provider setup, source/destination/connection creation with Tabs for JSON vs strongly-typed examples)
- Removed Docusaurus component imports (`Tabs`, `TabItem`)
- Replaced with a ~24-line landing page containing:
  - One-paragraph intro
  - Table linking to registry docs (Getting Started, Provider reference, Resource docs, v1 Migration guide)
  - Additional resource links (API reference, API access config, pre-1.0 tutorial)
- Removed the "Quick example" section (per reviewer feedback — examples belong on the registry)
- Removed the "Limitations" section (no longer accurate)
- Removed the Quickstarts repository link (examples are stale)
- Added `docs/developers/terraform-provider-pre-1.0.md` — the original tutorial content with a deprecation banner, `Tabs`/`TabItem` components replaced with plain markdown headers, and links to the 1.0 getting started guide and migration guide
- Changed sidebar entry from a flat link to a **"Terraform Provider" category** with the landing page as its doc link and the pre-1.0 page as a child item
- Updated all 4 versioned copies (1.6, 1.7, 1.8, 2.0) to the same landing page content with cross-link to the pre-1.0 reference
- Fixed trailing whitespace lint issues in the pre-1.0 page

## Review guide

1. `docs/developers/terraform-documentation.md` — the slimmed-down landing page
2. `docs/developers/terraform-provider-pre-1.0.md` — **new** pre-1.0 getting started reference (preserved from the original page)
3. `docusaurus/sidebar-developers.js` — sidebar restructured: "Terraform Provider" is now a category (with the landing page as its link) containing the pre-1.0 child page
4. `docusaurus/platform_versioned_docs/version-{1.6,1.7,1.8,2.0}/terraform-documentation.md` — identical landing page content applied to all versioned docs

**Key items for reviewer:**
- [ ] **Link dependency**: The [Getting Started guide link](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs/guides/getting_started) will 404 until the companion PR (airbytehq/terraform-provider-airbyte#342) is merged and a new provider version is released. Confirm this sequencing is acceptable or if the link should be deferred.
- [ ] **Sidebar category rendering**: The "Terraform Provider" sidebar entry is now a Docusaurus category with `link.type: "doc"`. Verify this renders correctly — clicking the category label should navigate to the landing page, and expanding it should show the pre-1.0 child.
- [ ] **Pre-1.0 page rendering**: The pre-1.0 page uses Docusaurus admonitions (`:::caution`, `:::tip`, `:::note`) and replaces the original `Tabs`/`TabItem` components with plain markdown headers. Verify this renders acceptably in the Vercel preview.
- [ ] **Cross-links in versioned docs**: Versioned copies link to `/developers/terraform-provider-pre-1.0` using absolute paths. Confirm these resolve correctly across versioned doc instances (the pre-1.0 page itself is not versioned — it lives only in `docs/developers/`).
- [ ] **Pre-1.0 content adequacy**: The pre-1.0 page references deprecated resources (`airbyte_source_stripe`, `airbyte_source_custom`, `airbyte_destination_bigquery`) that no longer exist in provider 1.0+. Confirm this content is still useful for users on older provider versions, or if it should be further updated/removed.

## Updates since last revision

- Removed "Quick example" section per reviewer feedback (AJ, Ian)
- Removed "Limitations" section (no longer accurate)
- Removed Quickstarts repository link (examples are stale)
- Added pre-1.0 getting started reference page to preserve original tutorial content for users on older provider versions
- Restructured sidebar: made pre-1.0 page a child of "Terraform Provider" category (per Ian's feedback)
- Fixed trailing whitespace lint issues in pre-1.0 page

## User Impact

Users visiting the Terraform provider page on docs.airbyte.com will see a shorter page with links to the Terraform Registry instead of an inline tutorial. The tutorial content itself is not lost:
- **1.0+ users**: Directed to the registry's getting started guide (once published)
- **Pre-1.0 users**: Can access the original tutorial via the "Pre-1.0 getting started tutorial" link (now nested under the Terraform Provider category in the sidebar)

This applies across all versioned docs (1.6–2.0) so users on any platform version see consistent, current guidance.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Requested by: @aaronsteers  
[Devin session](https://app.devin.ai/sessions/4373f4b852684c66a75d429f83ffbe24)