### PR TITLE
chore: remove unused dd java tracer.

### DIFF
--- a/docker-images/Dockerfile.java-connector
+++ b/docker-images/Dockerfile.java-connector
@@ -12,7 +12,7 @@ ARG CONNECTOR_NAME
 
 # Set permissions for downloaded files
 RUN chmod +x /airbyte/base.sh /airbyte/javabase.sh && \
-    chown airbyte:airbyte /airbyte/base.sh /airbyte/javabase.sh /airbyte/dd-java-agent.jar
+    chown airbyte:airbyte /airbyte/base.sh /airbyte/javabase.sh
 
 ENV AIRBYTE_ENTRYPOINT="/airbyte/base.sh"
 ENV APPLICATION="${CONNECTOR_NAME}"

--- a/docker-images/Dockerfile.java-connector-base
+++ b/docker-images/Dockerfile.java-connector-base
@@ -40,8 +40,6 @@ ADD https://raw.githubusercontent.com/airbytehq/airbyte/6d8a3a2bc4f4ca79f1016444
     /airbyte/base.sh
 ADD https://raw.githubusercontent.com/airbytehq/airbyte/6d8a3a2bc4f4ca79f10164447a90fdce5c9ad6f9/airbyte-integrations/bases/base-java/javabase.sh \
     /airbyte/javabase.sh
-ADD https://dtdg.co/latest-java-tracer \
-    /airbyte/dd-java-agent.jar
 
-RUN chown airbyte:airbyte /airbyte/base.sh /airbyte/javabase.sh /airbyte/dd-java-agent.jar && \
+RUN chown airbyte:airbyte /airbyte/base.sh /airbyte/javabase.sh && \
     chmod 750 /airbyte/base.sh /airbyte/javabase.sh

--- a/docker-images/Dockerfile.java-connector-non-airbyte-ci
+++ b/docker-images/Dockerfile.java-connector-non-airbyte-ci
@@ -12,7 +12,7 @@ ARG CONNECTOR_NAME
 
 # Set permissions for downloaded files
 RUN chmod +x /airbyte/base.sh /airbyte/javabase.sh && \
-    chown airbyte:airbyte /airbyte/base.sh /airbyte/javabase.sh /airbyte/dd-java-agent.jar
+    chown airbyte:airbyte /airbyte/base.sh /airbyte/javabase.sh
 
 ENV AIRBYTE_ENTRYPOINT="/airbyte/base.sh"
 ENV APPLICATION="${CONNECTOR_NAME}"


### PR DESCRIPTION
## What
Removes a mostly unused dd dep from the base java image that has a vulnerability

## Why tho?
* I'm trying to build a new base java connector image to patch a bunch of CVEs ([OC ticket](https://github.com/orgs/airbytehq/projects/23/views/3?pane=issue&itemId=157897100&issue=airbytehq%7Concall%7C11323)) but it fails on a vuln in a transitive dep of this dd agent [link to run](https://github.com/airbytehq/airbyte/actions/runs/22207982392/job/64236041731)
* We don't seem to use this except _maybe_ in `source postgres` but that's pretty non-standard. We certainly don't intentionally use it on destinations

@airbytehq/extract can you confirm you're not dependent on this dep and we're safe to 🔪 ?

NOTE: we can add it back pretty trivially by reverting this PR and building