### PR TITLE
chore: bump source-postgres base image from 2.0.1 to 2.0.3

### DIFF
--- a/airbyte-integrations/connectors/source-postgres/metadata.yaml
+++ b/airbyte-integrations/connectors/source-postgres/metadata.yaml
@@ -29,7 +29,7 @@ data:
   tags:
     - language:java
   connectorBuildOptions:
-    baseImage: docker.io/airbyte/java-connector-base:2.0.1@sha256:ec89bd1a89e825514dd2fc8730ba299a3ae1544580a078df0e35c5202c2085b3
+    baseImage: docker.io/airbyte/java-connector-base:2.0.3@sha256:119b8506bca069bbc8357a275936c7e2b0994e6947b81f1bf8d6ce9e16db7d47
   connectorTestSuitesOptions:
     - suite: unitTests
     - suite: integrationTests

--- a/airbyte-integrations/connectors/source-postgres/metadata.yaml
+++ b/airbyte-integrations/connectors/source-postgres/metadata.yaml
@@ -9,7 +9,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: decd338e-5647-4c0b-adf4-da0e75f5a750
-  dockerImageTag: 3.7.1
+  dockerImageTag: 3.7.2
   dockerRepository: airbyte/source-postgres
   documentationUrl: https://docs.airbyte.com/integrations/sources/postgres
   githubIssueLabel: source-postgres

--- a/docs/integrations/sources/postgres.md
+++ b/docs/integrations/sources/postgres.md
@@ -355,6 +355,7 @@ According to Postgres [documentation](https://www.postgresql.org/docs/14/datatyp
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                                                                                    |
 |---------|------------|------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 3.7.2 | 2026-02-20 | [73690](https://github.com/airbytehq/airbyte/pull/73690) | Bump base image from java-connector-base 2.0.1 to 2.0.3 |
 | 3.7.1 | 2026-01-27 | [72396](https://github.com/airbytehq/airbyte/pull/72396) | Promoting release candidate 3.7.1-rc.1 to a main version. |
 | 3.7.0 | 2025-08-12 | [57511](https://github.com/airbytehq/airbyte/pull/57511) | Add configurations for Azure authentication to Azure Postgres servers. |
 | 3.6.35  | 2025-06-12 | [61527](https://github.com/airbytehq/airbyte/pull/61527)   | Add error handling for connection issues and adopt the latest CDK version.


### PR DESCRIPTION
## What

Bumps the `source-postgres` connector base image from `java-connector-base:2.0.1` (created 2025-01-27) to `java-connector-base:2.0.3` (created 2025-07-11).

Includes several security-related patches.

## How

- Updated `baseImage` tag and pinned SHA256 digest in `metadata.yaml`
- Bumped connector version from 3.7.1 → 3.7.2
- Added changelog entry in `docs/integrations/sources/postgres.md`

## User Impact

No user-facing behavior change. The connector will be built on a newer base image with more recent OS-level packages.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

[Link to Devin run](https://app.devin.ai/sessions/453fd1e5bd404bf2839fd8a80eaca13c) | Requested by @aaronsteers