### PR TITLE
docs: add file download documentation to execute operations page

### DIFF
--- a/docs/ai-agents/platform/execute.md
+++ b/docs/ai-agents/platform/execute.md
@@ -90,8 +90,6 @@ async def github_execute(entity: str, action: str, params: dict | None = None):
     return await connector.execute(entity, action, params or {})
 ```
 
-
-
 ### Download files
 
 Some connectors support a `download` action that returns file content as a binary stream instead of JSON. This is used for entities like attachments, audio recordings, and documents. To check whether a connector supports downloads, see the connector's [reference documentation](/ai-agents/connectors).

--- a/docs/ai-agents/platform/execute.md
+++ b/docs/ai-agents/platform/execute.md
@@ -92,6 +92,74 @@ async def github_execute(entity: str, action: str, params: dict | None = None):
 
 
 
+### Download files
+
+Some connectors support a `download` action that returns file content as a binary stream instead of JSON. This is used for entities like attachments, audio recordings, and documents. To check whether a connector supports downloads, see the connector's [reference documentation](/ai-agents/connectors).
+
+Connectors provide two methods for downloading files:
+
+- **`download()`** returns an `AsyncIterator[bytes]`, giving you full control over how and where to write the data.
+- **`download_local()`** is a convenience wrapper that downloads the file and saves it to a path you specify.
+
+#### Local mode
+
+In local mode, you provide API credentials directly. Use `download_local()` to download a file and save it to disk in one step:
+
+```python title="download.py"
+import asyncio
+from airbyte_agent_zendesk_support import ZendeskSupportConnector
+
+connector = ZendeskSupportConnector(
+    auth_config={"api_token": "your_api_token", "email": "you@example.com"},
+    config_values={"subdomain": "your_subdomain"},
+)
+
+async def main():
+    file_path = await connector.attachments.download_local(
+        attachment_id="12345",
+        path="./downloads/ticket_attachment.pdf",
+    )
+    print(f"Saved to {file_path}")
+
+asyncio.run(main())
+```
+
+If you need more control, use `download()` directly to get the raw byte stream:
+
+```python title="download_raw.py"
+async def main():
+    stream = await connector.attachments.download(attachment_id="12345")
+    with open("./downloads/ticket_attachment.pdf", "wb") as f:
+        async for chunk in stream:
+            f.write(chunk)
+```
+
+#### Hosted mode
+
+In hosted mode, credentials are managed by Airbyte Cloud. The download methods work the same way — only the connector setup differs:
+
+```python title="download_hosted.py"
+import asyncio
+from airbyte_agent_zendesk_support import ZendeskSupportConnector, AirbyteHostedAuthConfig
+
+connector = ZendeskSupportConnector(
+    auth_config=AirbyteHostedAuthConfig(
+        airbyte_client_id="your_client_id",
+        airbyte_client_secret="your_client_secret",
+        connector_id="your_connector_id",
+    ),
+)
+
+async def main():
+    file_path = await connector.attachments.download_local(
+        attachment_id="12345",
+        path="./downloads/ticket_attachment.pdf",
+    )
+    print(f"Saved to {file_path}")
+
+asyncio.run(main())
+```
+
 ### Introspection
 
 Connectors provide programmatic introspection methods for runtime discovery. These methods are available in the Python SDK.
@@ -197,6 +265,50 @@ curl -X POST 'https://api.airbyte.ai/api/v1/integrations/connectors/<connector_i
       "limit": 100
     }
   }'
+```
+
+### Example: Download a file
+
+Some connectors support a `download` action for entities like attachments and media files. Unlike other actions that return JSON, download responses return raw binary content with a `Content-Disposition` header.
+
+This example downloads a ticket attachment from a Zendesk Support connector:
+
+```bash title="Request"
+curl -X POST 'https://api.airbyte.ai/api/v1/integrations/connectors/<connector_id>/execute' \
+  --header 'Authorization: Bearer <your_application_token>' \
+  --header 'Content-Type: application/json' \
+  --output attachment.pdf \
+  --data '{
+    "entity": "attachments",
+    "action": "download",
+    "params": {
+      "attachment_id": "<attachment_id>"
+    }
+  }'
+```
+
+You can also stream the response in your application code. For example, using Python with `requests`:
+
+```python title="download_api.py"
+import requests
+
+response = requests.post(
+    "https://api.airbyte.ai/api/v1/integrations/connectors/<connector_id>/execute",
+    headers={
+        "Authorization": "Bearer <your_application_token>",
+        "Content-Type": "application/json",
+    },
+    json={
+        "entity": "attachments",
+        "action": "download",
+        "params": {"attachment_id": "<attachment_id>"},
+    },
+    stream=True,
+)
+
+with open("attachment.pdf", "wb") as f:
+    for chunk in response.iter_content(chunk_size=8192):
+        f.write(chunk)
 ```
 
 ### Response format

--- a/docs/ai-agents/platform/execute.md
+++ b/docs/ai-agents/platform/execute.md
@@ -101,7 +101,7 @@ Typically, you first need to discover which files are available before downloadi
 ```python
 comments = await zendesk_support.ticket_comments.list(ticket_id="456")
 for comment in comments.data:
-    for attachment in comment.get("attachments", []):
+    for attachment in comment.attachments or []:
         print(f"Attachment: {attachment['id']} - {attachment['file_name']}")
 ```
 
@@ -110,8 +110,9 @@ Once you have the attachment ID, you can download the file.
 You can stream the file content and write it to disk:
 
 ```python
+stream = await zendesk_support.attachments.download(attachment_id="12345")
 with open("./downloads/ticket_attachment.pdf", "wb") as f:
-    async for chunk in zendesk_support.attachments.download(attachment_id="12345"):
+    async for chunk in stream:
         f.write(chunk)
 ```
 

--- a/docs/ai-agents/platform/execute.md
+++ b/docs/ai-agents/platform/execute.md
@@ -94,68 +94,55 @@ async def github_execute(entity: str, action: str, params: dict | None = None):
 
 Some connectors support a `download` action that returns file content as a binary stream instead of JSON. This is used for entities like attachments, audio recordings, and documents. To check whether a connector supports downloads, see the connector's [reference documentation](/ai-agents/connectors).
 
-Connectors provide two methods for downloading files:
+Download operations return an `AsyncIterator[bytes]` for memory-efficient streaming. Use `async for` to process chunks as they arrive. To save a file to disk, you can either stream the chunks directly or use the `download_local()` convenience method.
 
-- **`download()`** returns an `AsyncIterator[bytes]`, giving you full control over how and where to write the data.
-- **`download_local()`** is a convenience wrapper that downloads the file and saves it to a path you specify.
+Typically, you first need to discover which files are available before downloading them. For example, you might list ticket comments to find attachment IDs, then download a specific attachment:
+
+```python
+comments = await zendesk_support.ticket_comments.list(ticket_id="456")
+for comment in comments.data:
+    for attachment in comment.get("attachments", []):
+        print(f"Attachment: {attachment['id']} - {attachment['file_name']}")
+```
+
+Once you have the attachment ID, you can download the file.
 
 #### Local mode
 
-In local mode, you provide API credentials directly. Use `download_local()` to download a file and save it to disk in one step:
+In local mode, you provide API credentials directly. You can stream the file content and write it to disk:
 
-```python title="download.py"
-import asyncio
-from airbyte_agent_zendesk_support import ZendeskSupportConnector
-
-connector = ZendeskSupportConnector(
-    auth_config={"api_token": "your_api_token", "email": "you@example.com"},
-    config_values={"subdomain": "your_subdomain"},
-)
-
-async def main():
-    file_path = await connector.attachments.download_local(
-        attachment_id="12345",
-        path="./downloads/ticket_attachment.pdf",
-    )
-    print(f"Saved to {file_path}")
-
-asyncio.run(main())
+```python
+with open("./downloads/ticket_attachment.pdf", "wb") as f:
+    async for chunk in zendesk_support.attachments.download(attachment_id="12345"):
+        f.write(chunk)
 ```
 
-If you need more control, use `download()` directly to get the raw byte stream:
+Or use `download_local()` to save to a path in one step:
 
-```python title="download_raw.py"
-async def main():
-    stream = await connector.attachments.download(attachment_id="12345")
-    with open("./downloads/ticket_attachment.pdf", "wb") as f:
-        async for chunk in stream:
-            f.write(chunk)
+```python
+file_path = await zendesk_support.attachments.download_local(
+    attachment_id="12345",
+    path="./downloads/ticket_attachment.pdf",
+)
 ```
 
 #### Hosted mode
 
 In hosted mode, credentials are managed by Airbyte Cloud. The download methods work the same way — only the connector setup differs:
 
-```python title="download_hosted.py"
-import asyncio
-from airbyte_agent_zendesk_support import ZendeskSupportConnector, AirbyteHostedAuthConfig
+```python
+from airbyte_agent_zendesk_support import ZendeskSupportConnector
 
-connector = ZendeskSupportConnector(
-    auth_config=AirbyteHostedAuthConfig(
-        airbyte_client_id="your_client_id",
-        airbyte_client_secret="your_client_secret",
-        connector_id="your_connector_id",
-    ),
+zendesk_support = ZendeskSupportConnector(
+    connector_id="your_connector_id",
+    airbyte_client_id="your_client_id",
+    airbyte_client_secret="your_client_secret",
 )
 
-async def main():
-    file_path = await connector.attachments.download_local(
-        attachment_id="12345",
-        path="./downloads/ticket_attachment.pdf",
-    )
-    print(f"Saved to {file_path}")
-
-asyncio.run(main())
+file_path = await zendesk_support.attachments.download_local(
+    attachment_id="12345",
+    path="./downloads/ticket_attachment.pdf",
+)
 ```
 
 ### Introspection
@@ -285,28 +272,27 @@ curl -X POST 'https://api.airbyte.ai/api/v1/integrations/connectors/<connector_i
   }'
 ```
 
-You can also stream the response in your application code. For example, using Python with `requests`:
+You can also stream the response in your application code. For example, using JavaScript with `fetch`:
 
-```python title="download_api.py"
-import requests
-
-response = requests.post(
-    "https://api.airbyte.ai/api/v1/integrations/connectors/<connector_id>/execute",
-    headers={
-        "Authorization": "Bearer <your_application_token>",
-        "Content-Type": "application/json",
+```javascript title="download.js"
+const response = await fetch(
+  `https://api.airbyte.ai/api/v1/integrations/connectors/${connectorId}/execute`,
+  {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${applicationToken}`,
+      "Content-Type": "application/json",
     },
-    json={
-        "entity": "attachments",
-        "action": "download",
-        "params": {"attachment_id": "<attachment_id>"},
-    },
-    stream=True,
-)
+    body: JSON.stringify({
+      entity: "attachments",
+      action: "download",
+      params: { attachment_id: attachmentId },
+    }),
+  }
+);
 
-with open("attachment.pdf", "wb") as f:
-    for chunk in response.iter_content(chunk_size=8192):
-        f.write(chunk)
+const blob = await response.blob();
+const url = URL.createObjectURL(blob);
 ```
 
 ### Response format

--- a/docs/ai-agents/platform/execute.md
+++ b/docs/ai-agents/platform/execute.md
@@ -232,7 +232,7 @@ curl -X POST 'https://api.airbyte.ai/api/v1/integrations/connectors/<connector_i
   }'
 ```
 
-### Download a file
+### Download files
 
 Some connectors support a `download` action for entities like attachments and media files. Unlike other actions that return JSON, download responses return raw binary content with a `Content-Disposition` header.
 

--- a/docs/ai-agents/platform/execute.md
+++ b/docs/ai-agents/platform/execute.md
@@ -107,9 +107,7 @@ for comment in comments.data:
 
 Once you have the attachment ID, you can download the file.
 
-#### Local mode
-
-In local mode, you provide API credentials directly. You can stream the file content and write it to disk:
+You can stream the file content and write it to disk:
 
 ```python
 with open("./downloads/ticket_attachment.pdf", "wb") as f:
@@ -120,25 +118,6 @@ with open("./downloads/ticket_attachment.pdf", "wb") as f:
 Or use `download_local()` to save to a path in one step:
 
 ```python
-file_path = await zendesk_support.attachments.download_local(
-    attachment_id="12345",
-    path="./downloads/ticket_attachment.pdf",
-)
-```
-
-#### Hosted mode
-
-In hosted mode, credentials are managed by Airbyte Cloud. The download methods work the same way — only the connector setup differs:
-
-```python
-from airbyte_agent_zendesk_support import ZendeskSupportConnector
-
-zendesk_support = ZendeskSupportConnector(
-    connector_id="your_connector_id",
-    airbyte_client_id="your_client_id",
-    airbyte_client_secret="your_client_secret",
-)
-
 file_path = await zendesk_support.attachments.download_local(
     attachment_id="12345",
     path="./downloads/ticket_attachment.pdf",
@@ -256,9 +235,24 @@ curl -X POST 'https://api.airbyte.ai/api/v1/integrations/connectors/<connector_i
 
 Some connectors support a `download` action for entities like attachments and media files. Unlike other actions that return JSON, download responses return raw binary content with a `Content-Disposition` header.
 
-This example downloads a ticket attachment from a Zendesk Support connector:
+To find downloadable files, first list the relevant entity to discover IDs. For example, list a ticket's comments to find attachment metadata, then download a specific attachment:
 
-```bash title="Request"
+```bash title="Step 1: Discover attachments"
+curl -X POST 'https://api.airbyte.ai/api/v1/integrations/connectors/<connector_id>/execute' \
+  --header 'Authorization: Bearer <your_application_token>' \
+  --header 'Content-Type: application/json' \
+  --data '{
+    "entity": "ticket_comments",
+    "action": "list",
+    "params": {
+      "ticket_id": "<ticket_id>"
+    }
+  }'
+```
+
+The response includes attachment metadata (IDs, filenames, content types) within each comment. Use the attachment ID to download the file:
+
+```bash title="Step 2: Download the file"
 curl -X POST 'https://api.airbyte.ai/api/v1/integrations/connectors/<connector_id>/execute' \
   --header 'Authorization: Bearer <your_application_token>' \
   --header 'Content-Type: application/json' \

--- a/docs/ai-agents/platform/execute.md
+++ b/docs/ai-agents/platform/execute.md
@@ -92,13 +92,13 @@ async def github_execute(entity: str, action: str, params: dict | None = None):
 
 ### Download files
 
-Some connectors support a `download` action that returns file content as a binary stream instead of JSON. This is used for entities like attachments, audio recordings, and documents. To check whether a connector supports downloads, see the connector's [reference documentation](/ai-agents/connectors).
+Some connectors support a `download` action that returns file content as a binary stream instead of JSON. This is for entities like attachments, audio recordings, and documents. To check whether a connector supports downloads, see that connector's [reference documentation](/ai-agents/connectors).
 
-Download operations return an `AsyncIterator[bytes]` for memory-efficient streaming. Use `async for` to process chunks as they arrive. To save a file to disk, you can either stream the chunks directly or use the `download_local()` convenience method.
+Download operations return an `AsyncIterator[bytes]` for memory-efficient streaming. Use `async for` to process chunks as they arrive. To save a file, you can either stream the chunks directly or use the `download_local()` convenience method.
 
 Typically, you first need to discover which files are available before downloading them. For example, you might list ticket comments to find attachment IDs, then download a specific attachment:
 
-```python
+```python title="agent.py"
 comments = await zendesk_support.ticket_comments.list(ticket_id="456")
 for comment in comments.data:
     for attachment in comment.attachments or []:
@@ -109,7 +109,7 @@ Once you have the attachment ID, you can download the file.
 
 You can stream the file content and write it to disk:
 
-```python
+```python title="agent.py"
 stream = await zendesk_support.attachments.download(attachment_id="12345")
 with open("./downloads/ticket_attachment.pdf", "wb") as f:
     async for chunk in stream:
@@ -118,7 +118,7 @@ with open("./downloads/ticket_attachment.pdf", "wb") as f:
 
 Or use `download_local()` to save to a path in one step:
 
-```python
+```python title="agent.py"
 file_path = await zendesk_support.attachments.download_local(
     attachment_id="12345",
     path="./downloads/ticket_attachment.pdf",
@@ -232,11 +232,11 @@ curl -X POST 'https://api.airbyte.ai/api/v1/integrations/connectors/<connector_i
   }'
 ```
 
-### Example: Download a file
+### Download a file
 
 Some connectors support a `download` action for entities like attachments and media files. Unlike other actions that return JSON, download responses return raw binary content with a `Content-Disposition` header.
 
-To find downloadable files, first list the relevant entity to discover IDs. For example, list a ticket's comments to find attachment metadata, then download a specific attachment:
+To find downloadable files, first list the relevant entity to discover IDs. For example, list a ticket's comments to find attachment metadata, then download a specific attachment.
 
 ```bash title="Step 1: Discover attachments"
 curl -X POST 'https://api.airbyte.ai/api/v1/integrations/connectors/<connector_id>/execute' \
@@ -251,7 +251,7 @@ curl -X POST 'https://api.airbyte.ai/api/v1/integrations/connectors/<connector_i
   }'
 ```
 
-The response includes attachment metadata (IDs, filenames, content types) within each comment. Use the attachment ID to download the file:
+ The response includes attachment metadata (IDs, filenames, content types) within each comment. Use the attachment ID to download the file:
 
 ```bash title="Step 2: Download the file"
 curl -X POST 'https://api.airbyte.ai/api/v1/integrations/connectors/<connector_id>/execute' \
@@ -267,7 +267,7 @@ curl -X POST 'https://api.airbyte.ai/api/v1/integrations/connectors/<connector_i
   }'
 ```
 
-You can also stream the response in your application code. For example, using JavaScript with `fetch`:
+You can also stream the response in your app code. For example, using JavaScript with `fetch`:
 
 ```javascript title="download.js"
 const response = await fetch(


### PR DESCRIPTION
## What

Adds documentation for downloading files via agent connectors to the existing [Execute operations](/ai-agents/platform/execute) page. Some connectors (e.g. Zendesk Support, Google Drive, Gong, Salesforce) support a `download` action that returns binary file content instead of JSON, and this was previously undocumented.

## How

Two new sections added to `docs/ai-agents/platform/execute.md`:

1. **"Download files"** (`### Download files`) under "With Python" — covers the discovery flow (list entities to find attachment IDs), `download()` (raw `AsyncIterator[bytes]` with `async for`), and `download_local()` (save-to-disk convenience method). Examples assume the connector is already imported and authenticated, consistent with a separate authentication page.

2. **"Example: Download a file"** (`### Example: Download a file`) under "With the API" — two-step curl flow (discover attachments via `ticket_comments` list, then download by ID) and a JavaScript `fetch` streaming example, noting that download responses return binary content rather than JSON.

### Updates since last revision

- **Removed auth setup from Python examples** — per feedback, authentication is covered on a separate page. Python snippets now assume the connector is already instantiated (no import/constructor boilerplate). Hosted mode sub-section removed entirely.
- **Added discovery flow to API section** — two-step curl example: first list `ticket_comments` to find attachment metadata, then download by ID. Mirrors the Python discovery example.
- **Aligned Python examples with connector reference docs** — uses `zendesk_support.attachments.download(attachment_id=...)` style matching [auto-generated reference pages](https://docs.airbyte.com/ai-agents/connectors/zendesk-support/REFERENCE#attachments-download).
- **Replaced Python `requests` with JavaScript `fetch`** in the API section — if you're using Python, you'd use the SDK; the API section targets non-Python consumers.
- **Fixed Python examples based on live testing** against the `d3v-airbyte` Zendesk sandbox (ticket #172 with attachment):
  - `comment.get("attachments", [])` → `comment.attachments or []` — `comments.data` returns Pydantic `TicketComment` objects, not plain dicts, so attribute access is required.
  - `download()` must be `await`ed before iterating — it's an async method returning `AsyncIterator[bytes]`, so the correct pattern is `stream = await connector.attachments.download(...)` followed by `async for chunk in stream`.

## Review guide

1. `docs/ai-agents/platform/execute.md` — single file, two insertion points:
   - Lines 93–126: Python SDK download docs (discovery + download examples)
   - Lines 235–295: API download example (discovery curl + download curl + JavaScript fetch)

**Human review checklist:**
- [x] ~~Does the discovery example correctly reflect the shape of `TicketCommentsListResult`?~~ Confirmed via live testing: `.data` contains `TicketComment` Pydantic models with an `.attachments` attribute (`list[dict]`).
- [ ] The `attachment_id` parameter is typed as `integer` in the [reference docs](https://docs.airbyte.com/ai-agents/connectors/zendesk-support/REFERENCE#attachments-download) but shown as string `"12345"` in examples. Live testing passed strings successfully, but confirm this is the intended pattern.
- [ ] The JS `fetch` example uses `response.blob()` which is a browser API. Consider whether a Node.js-compatible alternative would be more appropriate for the audience.
- [ ] Python code snippets don't use `title=` attributes on fenced code blocks, unlike other examples on the page (e.g. `title="agent.py"`). Decide if this should be made consistent.
- [ ] Is the placement within the page hierarchy correct (before Introspection in Python, before Response format in API)?

## User Impact

Users now have documentation and working examples for downloading files from connectors that support the `download` action, in both Python SDK and API contexts.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Requested by: @ian-at-airbyte
[Devin session](https://app.devin.ai/sessions/aacb93dda9e346e495f95d151c2f511b)