### PR TITLE
fix(source-braintree): window transaction_stream to avoid 422

### DIFF
--- a/airbyte-integrations/connectors/source-braintree/metadata.yaml
+++ b/airbyte-integrations/connectors/source-braintree/metadata.yaml
@@ -5,7 +5,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 63cea06f-1c75-458d-88fe-ad48c7cb27fd
-  dockerImageTag: 0.3.28
+  dockerImageTag: 0.3.29
   dockerRepository: airbyte/source-braintree
   documentationUrl: https://docs.airbyte.com/integrations/sources/braintree
   githubIssueLabel: source-braintree

--- a/airbyte-integrations/connectors/source-braintree/pyproject.toml
+++ b/airbyte-integrations/connectors/source-braintree/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "0.3.28"
+version = "0.3.29"
 name = "source-braintree"
 description = "Source implementation for Braintree."
 authors = ["Airbyte <contact@airbyte.io>"]

--- a/airbyte-integrations/connectors/source-braintree/source_braintree/manifest.yaml
+++ b/airbyte-integrations/connectors/source-braintree/source_braintree/manifest.yaml
@@ -9750,6 +9750,7 @@ streams:
           search:
             created_at:
               min: "{{ format_datetime(stream_interval.start_time, '%Y-%m-%d %H:%M:%S %z') }}"
+              max: "{{ format_datetime(stream_interval.end_time, '%Y-%m-%d %H:%M:%S %z') }}"
       record_selector:
         type: RecordSelector
         extractor:
@@ -9771,6 +9772,8 @@ streams:
       cursor_datetime_formats:
         - "%Y-%m-%d %H:%M:%S"
         - "%Y-%m-%dT%H:%M:%S"
+      cursor_granularity: PT1S
+      step: P7D
       start_datetime:
         type: MinMaxDatetime
         datetime: "{{ config['start_date'] }}"


### PR DESCRIPTION
## 🤖 Generative AI Disclosure 

I used Gemini 3 Pro to help write and improve the pull request description and commit message. I reviewed everything myself and checked all technical details to make sure they are correct 🥇 

## What

This PR fixes `source-braintree` `transaction_stream` failures during high-volume historical backfills.

Context:

- The stream uses `/transactions/advanced_search` with page-based pagination (`page_size: 50`).
- Braintree returns `422` when results exceed the searchable page limit (observed as requests reaching `page=1001`).
- The stream previously sent only `created_at.min`, which makes backfills query from `start_date` to "now" in one large range.

Change summary:

- Bound each request to a finite interval by adding `created_at.max` using `stream_interval.end_time`.
- Slice incremental reads into weekly windows by adding `step: P7D` with `cursor_granularity: PT1S`.

No other stream behaviour was intentionally changed.

## How

Updated `transaction_stream` in `source_braintree/manifest.yaml`:

1. Added upper time bound in request body:
   - `search.created_at.max: "{{ format_datetime(stream_interval.end_time, '%Y-%m-%d %H:%M:%S %z') }}"`

2. Added datetime slicing controls in incremental cursor:
   - `cursor_granularity: PT1S`
   - `step: P7D`

This converts one large, open-ended backfill query into multiple bounded weekly queries, reducing the chance of hitting Braintree's page/result cap per query.

Validation performed:

- `poetry run python main.py spec` succeeds.
- Verified against our Production environment on a historical backfill that previously failed once the result set exceeded 50,000 transactions (1,000 pages) with `422` at `page=1001`.
- With this change, the same backfill pattern was able to proceed successfully by querying in bounded time windows instead of one unbounded range.

## Review guide

1. `airbyte-integrations/connectors/source-braintree/source_braintree/manifest.yaml` (transaction stream block)

## User Impact

- Large backfills for `transaction_stream` are less likely to fail with `422` from `page=1001`.
- Sync behavior becomes time-windowed (weekly) instead of one broad interval.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌