### PR TITLE
docs(docusaurus): POC dual-navbar with Data Replication and Agent Engine tabs

### DIFF
--- a/docusaurus/docusaurus.config.ts
+++ b/docusaurus/docusaurus.config.ts
@@ -365,48 +365,8 @@ const config: Config = {
         height: 40,
       },
       items: [
-        {
-          type: "docSidebar",
-          position: "left",
-          docsPluginId: "platform",
-          sidebarId: "platform",
-          label: "Platform",
-        },
-        {
-          type: "docSidebar",
-          position: "left",
-          docsPluginId: "connectors",
-          sidebarId: "connectors",
-          label: "Connectors",
-        },
-        {
-          type: "docSidebar",
-          position: "left",
-          docsPluginId: "release_notes",
-          sidebarId: "releaseNotes",
-          label: "Release notes",
-        },
-        {
-          type: "doc",
-          position: "left",
-          docsPluginId: "ai-agents",
-          docId: "README",
-          label: "AI agents",
-        },
-        {
-          type: "docSidebar",
-          position: "left",
-          docsPluginId: "developers",
-          sidebarId: "developers",
-          label: "Developers",
-        },
-        {
-          type: "docSidebar",
-          position: "left",
-          docsPluginId: "community",
-          sidebarId: "community",
-          label: "Community",
-        },
+        // Left side items removed - they now live in the secondary nav bar.
+        // The primary navbar only shows the logo + right-side utilities.
         {
           href: "https://status.airbyte.com",
           label: "Status",

--- a/docusaurus/docusaurus.config.ts
+++ b/docusaurus/docusaurus.config.ts
@@ -365,8 +365,23 @@ const config: Config = {
         height: 40,
       },
       items: [
-        // Left side items removed - they now live in the secondary nav bar.
-        // The primary navbar only shows the logo + right-side utilities.
+        // Top-level product tabs in the primary navbar row
+        {
+          type: "doc",
+          position: "left",
+          docsPluginId: "platform",
+          docId: "readme",
+          label: "Data Replication",
+          className: "navbar__product-tab",
+        },
+        {
+          type: "doc",
+          position: "left",
+          docsPluginId: "ai-agents",
+          docId: "README",
+          label: "Agent Engine",
+          className: "navbar__product-tab",
+        },
         {
           href: "https://status.airbyte.com",
           label: "Status",

--- a/docusaurus/src/theme/Navbar/index.js
+++ b/docusaurus/src/theme/Navbar/index.js
@@ -33,11 +33,9 @@ function isDataReplicationPath(pathname) {
 }
 
 function isSecondaryItemActive(href, pathname) {
-  // Exact match for trailing-slash items
   if (pathname === href || pathname === href.replace(/\/$/, "")) {
     return true;
   }
-  // Prefix match
   return pathname.startsWith(href);
 }
 
@@ -47,48 +45,30 @@ export default function NavbarWrapper(props) {
   const isDataReplication = isDataReplicationPath(pathname);
   const isHome = pathname === "/";
 
-  // Determine which top-level tab is active
-  const activeTopTab = isAgentEngine
-    ? "agent-engine"
-    : isDataReplication || isHome
-      ? "data-replication"
-      : "data-replication";
+  // Show secondary nav only for Data Replication pages and homepage.
+  // "Data Replication" and "Agent Engine" tabs are now in the primary
+  // navbar row (configured in docusaurus.config.ts), so the secondary
+  // row only contains section-level links.
+  const showSecondaryNav = !isAgentEngine && (isDataReplication || isHome);
+
+  if (!showSecondaryNav) {
+    return <Navbar {...props} />;
+  }
 
   return (
     <>
       <Navbar {...props} />
       <div className={styles.secondaryNavWrapper}>
         <div className={styles.secondaryNav}>
-          {/* Top-level platform tabs */}
-          <div className={styles.platformTabs}>
+          {dataReplicationItems.map((item) => (
             <a
-              href="/platform/"
-              className={`${styles.platformTab} ${activeTopTab === "data-replication" ? styles.platformTabActive : ""}`}
+              key={item.href}
+              href={item.href}
+              className={`${styles.secondaryItem} ${isSecondaryItemActive(item.href, pathname) ? styles.secondaryItemActive : ""}`}
             >
-              Data Replication
+              {item.label}
             </a>
-            <a
-              href="/ai-agents/"
-              className={`${styles.platformTab} ${activeTopTab === "agent-engine" ? styles.platformTabActive : ""}`}
-            >
-              Agent Engine
-            </a>
-          </div>
-
-          {/* Secondary nav items - only shown for Data Replication */}
-          {activeTopTab === "data-replication" && (
-            <div className={styles.secondaryItems}>
-              {dataReplicationItems.map((item) => (
-                <a
-                  key={item.href}
-                  href={item.href}
-                  className={`${styles.secondaryItem} ${isSecondaryItemActive(item.href, pathname) ? styles.secondaryItemActive : ""}`}
-                >
-                  {item.label}
-                </a>
-              ))}
-            </div>
-          )}
+          ))}
         </div>
       </div>
     </>

--- a/docusaurus/src/theme/Navbar/index.js
+++ b/docusaurus/src/theme/Navbar/index.js
@@ -56,7 +56,7 @@ export default function NavbarWrapper(props) {
   }
 
   return (
-    <>
+    <div className={styles.primaryNavBorder}>
       <Navbar {...props} />
       <div className={styles.secondaryNavWrapper}>
         <div className={styles.secondaryNav}>
@@ -71,6 +71,6 @@ export default function NavbarWrapper(props) {
           ))}
         </div>
       </div>
-    </>
+    </div>
   );
 }

--- a/docusaurus/src/theme/Navbar/index.js
+++ b/docusaurus/src/theme/Navbar/index.js
@@ -1,0 +1,96 @@
+import React from "react";
+import Navbar from "@theme-original/Navbar";
+import { useLocation } from "@docusaurus/router";
+import styles from "./styles.module.css";
+
+// The secondary nav items for "Data Replication" section
+const dataReplicationItems = [
+  { label: "Platform", href: "/platform/" },
+  { label: "Connectors", href: "/integrations/" },
+  { label: "Release Notes", href: "/release_notes/" },
+  { label: "Developers", href: "/developers/" },
+  { label: "Community", href: "/community/" },
+];
+
+// Route prefixes that belong to the Agent Engine section
+const agentEnginePrefixes = ["/ai-agents"];
+
+// Route prefixes that belong to the Data Replication section
+const dataReplicationPrefixes = [
+  "/platform",
+  "/integrations",
+  "/release_notes",
+  "/developers",
+  "/community",
+];
+
+function isAgentEnginePath(pathname) {
+  return agentEnginePrefixes.some((prefix) => pathname.startsWith(prefix));
+}
+
+function isDataReplicationPath(pathname) {
+  return dataReplicationPrefixes.some((prefix) => pathname.startsWith(prefix));
+}
+
+function isSecondaryItemActive(href, pathname) {
+  // Exact match for trailing-slash items
+  if (pathname === href || pathname === href.replace(/\/$/, "")) {
+    return true;
+  }
+  // Prefix match
+  return pathname.startsWith(href);
+}
+
+export default function NavbarWrapper(props) {
+  const { pathname } = useLocation();
+  const isAgentEngine = isAgentEnginePath(pathname);
+  const isDataReplication = isDataReplicationPath(pathname);
+  const isHome = pathname === "/";
+
+  // Determine which top-level tab is active
+  const activeTopTab = isAgentEngine
+    ? "agent-engine"
+    : isDataReplication || isHome
+      ? "data-replication"
+      : "data-replication";
+
+  return (
+    <>
+      <Navbar {...props} />
+      <div className={styles.secondaryNavWrapper}>
+        <div className={styles.secondaryNav}>
+          {/* Top-level platform tabs */}
+          <div className={styles.platformTabs}>
+            <a
+              href="/platform/"
+              className={`${styles.platformTab} ${activeTopTab === "data-replication" ? styles.platformTabActive : ""}`}
+            >
+              Data Replication
+            </a>
+            <a
+              href="/ai-agents/"
+              className={`${styles.platformTab} ${activeTopTab === "agent-engine" ? styles.platformTabActive : ""}`}
+            >
+              Agent Engine
+            </a>
+          </div>
+
+          {/* Secondary nav items - only shown for Data Replication */}
+          {activeTopTab === "data-replication" && (
+            <div className={styles.secondaryItems}>
+              {dataReplicationItems.map((item) => (
+                <a
+                  key={item.href}
+                  href={item.href}
+                  className={`${styles.secondaryItem} ${isSecondaryItemActive(item.href, pathname) ? styles.secondaryItemActive : ""}`}
+                >
+                  {item.label}
+                </a>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/docusaurus/src/theme/Navbar/styles.module.css
+++ b/docusaurus/src/theme/Navbar/styles.module.css
@@ -13,48 +13,7 @@
   align-items: center;
   padding: 0 1rem;
   height: 40px;
-  gap: 2rem;
-}
-
-.platformTabs {
-  display: flex;
-  align-items: center;
   gap: 0;
-  height: 100%;
-  flex-shrink: 0;
-}
-
-.platformTab {
-  display: flex;
-  align-items: center;
-  height: 100%;
-  padding: 0 1rem;
-  font-size: 0.875rem;
-  font-weight: 600;
-  color: var(--ifm-navbar-link-color);
-  text-decoration: none;
-  border-bottom: 3px solid transparent;
-  transition: color 0.2s ease, border-color 0.2s ease;
-}
-
-.platformTab:hover {
-  color: var(--ifm-color-primary);
-  text-decoration: none;
-}
-
-.platformTabActive {
-  color: var(--ifm-color-primary);
-  border-bottom-color: var(--ifm-color-primary);
-}
-
-/* Vertical divider between platform tabs and secondary items */
-.secondaryItems {
-  display: flex;
-  align-items: center;
-  gap: 0;
-  height: 100%;
-  border-left: 1px solid var(--ifm-toc-border-color);
-  padding-left: 1rem;
 }
 
 .secondaryItem {

--- a/docusaurus/src/theme/Navbar/styles.module.css
+++ b/docusaurus/src/theme/Navbar/styles.module.css
@@ -1,0 +1,88 @@
+.secondaryNavWrapper {
+  position: sticky;
+  top: var(--ifm-navbar-height);
+  z-index: var(--ifm-z-index-fixed);
+  background: var(--ifm-navbar-background-color);
+  border-bottom: 1px solid var(--ifm-toc-border-color);
+}
+
+.secondaryNav {
+  max-width: 100%;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  padding: 0 1rem;
+  height: 40px;
+  gap: 2rem;
+}
+
+.platformTabs {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  height: 100%;
+  flex-shrink: 0;
+}
+
+.platformTab {
+  display: flex;
+  align-items: center;
+  height: 100%;
+  padding: 0 1rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--ifm-navbar-link-color);
+  text-decoration: none;
+  border-bottom: 3px solid transparent;
+  transition: color 0.2s ease, border-color 0.2s ease;
+}
+
+.platformTab:hover {
+  color: var(--ifm-color-primary);
+  text-decoration: none;
+}
+
+.platformTabActive {
+  color: var(--ifm-color-primary);
+  border-bottom-color: var(--ifm-color-primary);
+}
+
+/* Vertical divider between platform tabs and secondary items */
+.secondaryItems {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  height: 100%;
+  border-left: 1px solid var(--ifm-toc-border-color);
+  padding-left: 1rem;
+}
+
+.secondaryItem {
+  display: flex;
+  align-items: center;
+  height: 100%;
+  padding: 0 0.75rem;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--ifm-navbar-link-color);
+  text-decoration: none;
+  border-bottom: 2px solid transparent;
+  transition: color 0.2s ease, border-color 0.2s ease;
+}
+
+.secondaryItem:hover {
+  color: var(--ifm-color-primary);
+  text-decoration: none;
+}
+
+.secondaryItemActive {
+  color: var(--ifm-color-primary);
+  border-bottom-color: var(--ifm-color-primary);
+}
+
+/* Hide secondary nav on mobile - use hamburger menu instead */
+@media (max-width: 996px) {
+  .secondaryNavWrapper {
+    display: none;
+  }
+}

--- a/docusaurus/src/theme/Navbar/styles.module.css
+++ b/docusaurus/src/theme/Navbar/styles.module.css
@@ -1,3 +1,9 @@
+/* Give the primary navbar the same bottom-border style as the secondary nav */
+.primaryNavBorder :global(.navbar) {
+  border-bottom: 1px solid var(--ifm-toc-border-color);
+  box-shadow: none;
+}
+
 .secondaryNavWrapper {
   position: sticky;
   top: var(--ifm-navbar-height);


### PR DESCRIPTION
## What

Proof-of-concept for **Idea 1** (dual-navbar) from the two-level nav header exploration. Adds a secondary navigation bar below the primary Docusaurus navbar to enforce visual separation between **Data Replication** (Platform, Connectors, Release Notes, Developers, Community) and **Agent Engine** (AI Agents). Inspired by the [Google Developers dual-navbar pattern](https://developers.google.com/program).

This is one of two POC branches; the other will explore a single-navbar dropdown/megamenu approach.

Requested by @ian-at-airbyte · [Devin session](https://app.devin.ai/sessions/775655e32e6348c287c19d5925937f60)

## How

**Layout:**
- **Row 1 (primary navbar):** Airbyte logo | **Data Replication** | **Agent Engine** | Status | GitHub | Search
- **Row 2 (secondary navbar):** Platform | Connectors | Release Notes | Developers | Community *(only shown on Data Replication pages and homepage)*

**Files changed:**

1. **`docusaurus.config.ts`** – Replaced the six individual left-side items (Platform, Connectors, Release Notes, AI Agents, Developers, Community) with two top-level product tabs: "Data Replication" (`type: "doc"`, pointing at platform readme) and "Agent Engine" (`type: "doc"`, pointing at AI agents README). Status, version dropdown, and GitHub link remain unchanged.
2. **`src/theme/Navbar/index.js`** – Swizzled Navbar wrapper that renders the original `<Navbar>` plus a conditional secondary nav row. Route-based logic determines whether the secondary nav is visible (hidden on Agent Engine pages) and which section link is active. The navbar and secondary nav are wrapped in a `<div>` that applies matching border styling.
3. **`src/theme/Navbar/styles.module.css`** – Sticky secondary nav bar with section-link highlighting and responsive behavior (hidden on mobile ≤996px). Includes a `.primaryNavBorder` rule that gives the primary navbar the same `border-bottom` as the secondary nav (replacing the default `box-shadow`).

### Updates since last revision

Addressed feedback from @ian-at-airbyte:

- **Matched navbar borders** — The primary navbar now has the same `border-bottom: 1px solid var(--ifm-toc-border-color)` as the secondary nav, with the default `box-shadow` removed. This creates a consistent visual separation between the two rows. The border styling only applies when the secondary nav is visible (Data Replication pages and homepage).

### Screenshots

**Homepage** – primary navbar with product tabs; secondary nav with section links:
![Homepage](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfaXE0N0YzeHhWMzlHMFpobiIsInVzZXJfaWQiOiJlbWFpbHw2N2JmOWM0NDI0NWRiM2U5MzhiY2Q1YzYiLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmdfaXE0N0YzeHhWMzlHMFpobi80NjgyMTRmOC0yODkwLTQxOTItYWRkYS02ZWU0OWUwZjUxNGEiLCJpYXQiOjE3NzE4NzQ5NDAsImV4cCI6MTc3MjQ3OTc0MH0.LXT3cP6mvlSbkd1y76RO0IFVDkyGUKDL8jB9ZyGODTY)

**Platform page** – "Data Replication" active in primary nav, "Platform" highlighted in secondary nav: ![Platform page](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfaXE0N0YzeHhWMzlHMFpobi IsInVzZXJfaWQiOiJlbWFpbHw2N2JmOWM0NDI0NWRiM2U5MzhiY2Q1YzYiLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmdfaXE0N0YzeHhWMzlHMFpobi85MTA5MjI2MS0xZDRmLTQ2MjUtODgxNC01YzY4MmI3MTQ3NmEiLCJpYXQiOjE3NzE4NzQ5NDAsImV4cCI6MTc3MjQ3OTc0MH0.brru91WaI-BHBmpocv-fCvSlAchPtLLl7S-xSJ1llJA)

**Agent Engine page** – "Agent Engine" active in primary nav, no secondary nav row:
![Agent Engine page](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfaXE0N0YzeHhWMzlHMFpobi IsInVzZXJfaWQiOiJlbWFpbHw2N2JmOWM0NDI0NWRiM2U5MzhiY2Q1YzYiLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmdfaXE0N0YzeHhWMzlHMFpobi84NjIzMTIxYi0wZjIzLTQ0MzQtODY4Yy1iMTJiZDEwMzY3NmUiLCJpYXQiOjE3NzE4NzQ5NDEsImV4cCI6MTc3MjQ4MjIzNH0.H4UQN3vG4MVOGAaoxOgiwGT0bYb5o4QeBxstTInabDs)

## Review guide

> **This is a POC, not production-ready.** The items below are known gaps to evaluate, not bugs to fix in this PR.

1. **`docusaurus/src/theme/Navbar/index.js`** – Core logic. Note:
   - Uses plain `<a>` tags instead of Docusaurus `<Link>` for secondary nav items, so navigation triggers full page reloads instead of client-side routing.
   - Route prefixes are hardcoded; any future route changes require a manual update here.
   - The wrapper `<div className={styles.primaryNavBorder}>` is only rendered when the secondary nav is visible (Data Replication pages + homepage).
2. **`docusaurus/docusaurus.config.ts`** – The two product tabs use `className: "navbar__product-tab"` which has no CSS defined yet — it's a hook for future styling differentiation (e.g. bolder font, different color) but currently renders with default navbar link styling.
3. **`docusaurus/src/theme/Navbar/styles.module.css`** – Styling and responsive breakpoint for secondary nav. The `.primaryNavBorder :global(.navbar)` selector uses `:global()` to break out of CSS module scoping and target the Docusaurus navbar component directly.

**⚠️ Known mobile regression:** The secondary nav is `display: none` on mobile, and the section-level items (Platform, Connectors, Release Notes, Developers, Community) are not added to the hamburger menu. The hamburger menu will show "Data Replication" and "Agent Engine" (from the primary navbar config), but users cannot navigate to the individual sections on mobile. A production implementation would need to re-add these items to the mobile sidebar or build a custom mobile menu.

**Human review checklist:**
- [ ] Verify the primary and secondary navbar borders match visually on Data Replication pages
- [ ] Verify the primary navbar does NOT have the custom border on Agent Engine pages (should use default Docusaurus styling)
- [ ] Test mobile hamburger menu to confirm the known regression (section links not accessible)

## User Impact

- **Desktop:** Users see a two-tier navigation with clear separation between Data Replication and Agent Engine product areas. The primary navbar contains the product-level tabs; the secondary navbar contains section-level links (only visible on Data Replication pages and homepage). Both navbar rows share the same bottom-border styling.
- **Mobile:** **Navigation is partially broken** – users can access "Data Replication" and "Agent Engine" from the hamburger menu, but cannot access Platform, Connectors, Release Notes, Developers, or Community.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

This is a POC branch for evaluation only. It should not be merged to production without addressing the mobile navigation gap and other known issues.