### PR TITLE
docs(docusaurus): single-navbar dropdown with clickable label and active state

### DIFF
--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -1,6 +1,6 @@
 import ConnectorRegistry from '@site/src/components/ConnectorRegistry';
 
-# Connectors
+# Data replication connectors
 
 Airbyte's library of connectors is used by the [data replication platform](/platform). A connector is a tool to pull data from a source or push data to a destination. To learn more about connectors, see [Sources, destinations, and connectors](../platform/move-data/sources-destinations-connectors). To learn how to use a specific connector, find the documentation for the connector you want to use, below.
 

--- a/docs/platform/readme.md
+++ b/docs/platform/readme.md
@@ -2,7 +2,7 @@
 products: all
 ---
 
-# Platform
+# Data replication platform
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";

--- a/docusaurus/docusaurus.config.ts
+++ b/docusaurus/docusaurus.config.ts
@@ -377,7 +377,7 @@ const config: Config = {
               type: "docSidebar",
               docsPluginId: "platform",
               sidebarId: "platform",
-              label: "Data replication platform",
+              label: "Platform",
             },
             {
               type: "docSidebar",

--- a/docusaurus/docusaurus.config.ts
+++ b/docusaurus/docusaurus.config.ts
@@ -377,7 +377,7 @@ const config: Config = {
               type: "docSidebar",
               docsPluginId: "platform",
               sidebarId: "platform",
-              label: "Platform",
+              label: "Data replication platform",
             },
             {
               type: "docSidebar",

--- a/docusaurus/docusaurus.config.ts
+++ b/docusaurus/docusaurus.config.ts
@@ -366,10 +366,12 @@ const config: Config = {
       },
       items: [
         // "Data Replication" dropdown groups the five sub-sections
+        // `to` makes the label itself clickable (navigates to Platform)
         {
           type: "dropdown",
           position: "left",
           label: "Data Replication",
+          to: "/platform/",
           items: [
             {
               type: "docSidebar",

--- a/docusaurus/docusaurus.config.ts
+++ b/docusaurus/docusaurus.config.ts
@@ -365,47 +365,51 @@ const config: Config = {
         height: 40,
       },
       items: [
+        // "Data Replication" dropdown groups the five sub-sections
         {
-          type: "docSidebar",
+          type: "dropdown",
           position: "left",
-          docsPluginId: "platform",
-          sidebarId: "platform",
-          label: "Platform",
+          label: "Data Replication",
+          items: [
+            {
+              type: "docSidebar",
+              docsPluginId: "platform",
+              sidebarId: "platform",
+              label: "Platform",
+            },
+            {
+              type: "docSidebar",
+              docsPluginId: "connectors",
+              sidebarId: "connectors",
+              label: "Connectors",
+            },
+            {
+              type: "docSidebar",
+              docsPluginId: "release_notes",
+              sidebarId: "releaseNotes",
+              label: "Release notes",
+            },
+            {
+              type: "docSidebar",
+              docsPluginId: "developers",
+              sidebarId: "developers",
+              label: "Developers",
+            },
+            {
+              type: "docSidebar",
+              docsPluginId: "community",
+              sidebarId: "community",
+              label: "Community",
+            },
+          ],
         },
-        {
-          type: "docSidebar",
-          position: "left",
-          docsPluginId: "connectors",
-          sidebarId: "connectors",
-          label: "Connectors",
-        },
-        {
-          type: "docSidebar",
-          position: "left",
-          docsPluginId: "release_notes",
-          sidebarId: "releaseNotes",
-          label: "Release notes",
-        },
+        // "Agent Engine" is a direct link (no dropdown needed)
         {
           type: "doc",
           position: "left",
           docsPluginId: "ai-agents",
           docId: "README",
-          label: "AI agents",
-        },
-        {
-          type: "docSidebar",
-          position: "left",
-          docsPluginId: "developers",
-          sidebarId: "developers",
-          label: "Developers",
-        },
-        {
-          type: "docSidebar",
-          position: "left",
-          docsPluginId: "community",
-          sidebarId: "community",
-          label: "Community",
+          label: "Agent Engine",
         },
         {
           href: "https://status.airbyte.com",

--- a/docusaurus/src/css/custom.css
+++ b/docusaurus/src/css/custom.css
@@ -363,6 +363,21 @@ nav a.navbar__link--active {
   border-bottom: 3px solid var(--ifm-color-primary);
 }
 
+/* Active-route indicator for the Data Replication dropdown.
+   The wrapper <div> must stretch to full navbar height so the
+   border-bottom aligns with Agent Engine's underline. */
+@media (min-width: 996px) {
+  .dropdown--active-route {
+    display: flex;
+    align-items: center;
+    height: 100%;
+    border-bottom: 3px solid var(--ifm-color-primary);
+  }
+  .dropdown--active-route > .navbar__link {
+    color: var(--ifm-color-primary) !important;
+  }
+}
+
 /* Hide Ask AI button until Osano consent is granted */
 .kapa-ai-hidden {
   display: none !important;

--- a/docusaurus/src/theme/NavbarItem/DropdownNavbarItem/Desktop/index.js
+++ b/docusaurus/src/theme/NavbarItem/DropdownNavbarItem/Desktop/index.js
@@ -49,8 +49,12 @@ export default function DropdownNavbarItemDesktop({
   const dropdownRef = useRef(null);
   const [showDropdown, setShowDropdown] = useState(false);
 
-  // Detect whether any child page is active so we can highlight the parent.
-  const containsActivePage = useIsDataReplicationActive();
+  // Always call the hook (React rules of hooks) but only use the result
+  // for the "Data Replication" dropdown so other dropdowns (e.g. version
+  // selector) are not affected.
+  const isOnDataReplicationRoute = useIsDataReplicationActive();
+  const containsActivePage =
+    props.label === "Data Replication" && isOnDataReplicationRoute;
 
   useEffect(() => {
     const handleClickOutside = (event) => {
@@ -80,6 +84,7 @@ export default function DropdownNavbarItemDesktop({
       className={clsx("navbar__item", "dropdown", "dropdown--hoverable", {
         "dropdown--right": position === "right",
         "dropdown--show": showDropdown,
+        "dropdown--active-route": containsActivePage,
       })}
     >
       <NavbarNavLink
@@ -87,9 +92,7 @@ export default function DropdownNavbarItemDesktop({
         aria-expanded={showDropdown}
         role="button"
         href={props.to ? undefined : "#"}
-        className={clsx("navbar__link", className, {
-          "navbar__link--active": containsActivePage,
-        })}
+        className={clsx("navbar__link", className)}
         {...props}
         onClick={props.to ? undefined : (e) => e.preventDefault()}
         onKeyDown={(e) => {

--- a/docusaurus/src/theme/NavbarItem/DropdownNavbarItem/Desktop/index.js
+++ b/docusaurus/src/theme/NavbarItem/DropdownNavbarItem/Desktop/index.js
@@ -1,0 +1,116 @@
+/**
+ * Swizzled DropdownNavbarItem/Desktop component.
+ *
+ * Adds route-based "active" styling to the dropdown parent label so that
+ * "Data Replication" is underlined whenever the user is viewing any of its
+ * child doc instances (Platform, Connectors, Release Notes, Developers,
+ * Community).
+ *
+ * The only behavioural change vs. the upstream component is the
+ * `containsActivePage` check and the conditional `navbar__link--active` class.
+ */
+
+import React, { useState, useRef, useEffect } from "react";
+import clsx from "clsx";
+import { useLocation } from "@docusaurus/router";
+import NavbarNavLink from "@theme/NavbarItem/NavbarNavLink";
+import NavbarItem from "@theme/NavbarItem";
+
+/**
+ * Route prefixes that belong to the "Data Replication" product area.
+ * Defined here so only this component needs updating if routes change.
+ */
+const DATA_REPLICATION_PREFIXES = [
+  "/platform",
+  "/integrations",
+  "/release_notes",
+  "/developers",
+  "/community",
+];
+
+/**
+ * Returns true when the current pathname falls under any of the Data
+ * Replication doc instances listed above.
+ */
+function useIsDataReplicationActive() {
+  const { pathname } = useLocation();
+  return DATA_REPLICATION_PREFIXES.some(
+    (prefix) => pathname === prefix || pathname.startsWith(prefix + "/")
+  );
+}
+
+export default function DropdownNavbarItemDesktop({
+  items,
+  position,
+  className,
+  onClick,
+  ...props
+}) {
+  const dropdownRef = useRef(null);
+  const [showDropdown, setShowDropdown] = useState(false);
+
+  // Detect whether any child page is active so we can highlight the parent.
+  const containsActivePage = useIsDataReplicationActive();
+
+  useEffect(() => {
+    const handleClickOutside = (event) => {
+      if (
+        !dropdownRef.current ||
+        dropdownRef.current.contains(event.target)
+      ) {
+        return;
+      }
+      setShowDropdown(false);
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    document.addEventListener("touchstart", handleClickOutside);
+    document.addEventListener("focusin", handleClickOutside);
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("touchstart", handleClickOutside);
+      document.removeEventListener("focusin", handleClickOutside);
+    };
+  }, [dropdownRef]);
+
+  return (
+    <div
+      ref={dropdownRef}
+      className={clsx("navbar__item", "dropdown", "dropdown--hoverable", {
+        "dropdown--right": position === "right",
+        "dropdown--show": showDropdown,
+      })}
+    >
+      <NavbarNavLink
+        aria-haspopup="true"
+        aria-expanded={showDropdown}
+        role="button"
+        href={props.to ? undefined : "#"}
+        className={clsx("navbar__link", className, {
+          "navbar__link--active": containsActivePage,
+        })}
+        {...props}
+        onClick={props.to ? undefined : (e) => e.preventDefault()}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault();
+            setShowDropdown(!showDropdown);
+          }
+        }}
+      >
+        {props.children ?? props.label}
+      </NavbarNavLink>
+      <ul className="dropdown__menu">
+        {items.map((childItemProps, i) => (
+          <NavbarItem
+            isDropdownItem
+            activeClassName="dropdown__link--active"
+            {...childItemProps}
+            key={i}
+          />
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/docusaurus/src/theme/NavbarItem/DropdownNavbarItem/index.js
+++ b/docusaurus/src/theme/NavbarItem/DropdownNavbarItem/index.js
@@ -1,0 +1,14 @@
+/**
+ * Swizzled DropdownNavbarItem wrapper.
+ * Routes to the custom Desktop component (which adds active-state detection)
+ * or falls back to the upstream Mobile component.
+ */
+
+import React from "react";
+import DropdownNavbarItemMobile from "@theme-original/NavbarItem/DropdownNavbarItem/Mobile";
+import DropdownNavbarItemDesktop from "./Desktop";
+
+export default function DropdownNavbarItem({ mobile = false, ...props }) {
+  const Comp = mobile ? DropdownNavbarItemMobile : DropdownNavbarItemDesktop;
+  return <Comp {...props} />;
+}


### PR DESCRIPTION
## What

Reorganizes the flat docs.airbyte.com navbar items into two top-level groups — **Data Replication** (dropdown) and **Agent Engine** (direct link) — to enforce visual separation between the two product areas. Also renames the Platform and Connectors landing page headings to "Data replication platform" and "Data replication connectors" respectively.

This navigation structure is intended to be temporary while the DR and AE docs exist on the same site.

Selected by @ian-at-airbyte as the preferred approach from two evaluated options (the other was a [dual-navbar approach in #73724](https://github.com/airbytehq/airbyte/pull/73724)).

[Devin session](https://app.devin.ai/sessions/775655e32e6348c287c19d5925937f60)

## How

**Config (`docusaurus/docusaurus.config.ts`):**
- Replaced six flat left-side navbar items with a Docusaurus `dropdown` type labeled "Data Replication" containing Platform, Connectors, Release notes, Developers, and Community.
- Added `to: "/platform/"` so the "Data Replication" label itself is clickable and navigates to the Platform docs.
- "AI agents" renamed to "Agent Engine" as a direct `doc` link.
- All right-side items (Status, version dropdown, GitHub) unchanged.

**Swizzled components (`docusaurus/src/theme/NavbarItem/DropdownNavbarItem/`):**
- `index.js` — Wrapper that routes to the custom Desktop component or falls back to the upstream Mobile component via `@theme-original`.
- `Desktop/index.js` — Near-copy of the upstream `DropdownNavbarItemDesktop` with one addition: a `useIsDataReplicationActive()` hook that checks the current pathname against known Data Replication route prefixes (`/platform`, `/integrations`, `/release_notes`, `/developers`, `/community`). When active, a `dropdown--active-route` class is applied to the wrapper `<div>`, not to the `<a>` link. The check is scoped to only the "Data Replication" dropdown via `props.label === "Data Replication"` so other dropdowns (e.g. the version selector) are unaffected.

**CSS (`docusaurus/src/css/custom.css`):**
- New `.dropdown--active-route` rule (desktop-only via `@media`) sets `height: 100%` and `display: flex` on the dropdown wrapper so it stretches to full navbar height, then applies `border-bottom: 3px solid` matching the existing `navbar__link--active` underline. This ensures the Data Replication underline aligns exactly with Agent Engine's underline at the bottom of the navbar.

**Page heading renames:**
- `docs/platform/readme.md` — `# Platform` → `# Data replication platform`
- `docs/integrations/README.md` — `# Connectors` → `# Data replication connectors`

## Review guide

1. `docusaurus/docusaurus.config.ts` — dropdown structure and `to: "/platform/"` addition
2. `docusaurus/src/theme/NavbarItem/DropdownNavbarItem/index.js` — thin wrapper routing Desktop vs Mobile
3. `docusaurus/src/theme/NavbarItem/DropdownNavbarItem/Desktop/index.js` — the main logic; review the `useIsDataReplicationActive` hook, the `props.label === "Data Replication"` check, and the `dropdown--active-route` class application on the wrapper `<div>`
4. `docusaurus/src/css/custom.css` — `.dropdown--active-route` CSS for underline alignment
5. `docs/platform/readme.md` and `docs/integrations/README.md` — heading renames

**Maintenance considerations for reviewers:**
- `DATA_REPLICATION_PREFIXES` is hardcoded in the Desktop component. If doc instance routes change, this array needs manual updating.
- The swizzled Desktop component is a near-copy of the upstream Docusaurus component. It could drift on Docusaurus upgrades and would need re-syncing.
- The `props.label === "Data Replication"` string check is fragile — if the label text changes in the config, the active state logic will break. Consider using a more robust identifier (e.g. a custom prop) for production.
- The `height: 100%` CSS approach for alignment depends on the navbar having proper flex layout. If Docusaurus changes navbar structure in future versions, this may break.
- Mobile behavior: The swizzle delegates to `@theme-original/NavbarItem/DropdownNavbarItem/Mobile` for mobile, which should work but hasn't been thoroughly tested.

**Human review checklist:**
- [ ] On `/platform/`, verify the "Cloud" version selector is NOT purple/underlined
- [ ] On `/platform/`, verify the "Data Replication" underline aligns exactly with "Agent Engine" underline (both at bottom of navbar)
- [ ] Verify the Platform page heading shows "Data replication platform" (not just the dropdown label)
- [ ] Verify the Connectors page heading shows "Data replication connectors"
- [ ] Test mobile hamburger menu to ensure dropdown items are accessible
- [ ] Verify page headings render correctly in sidebar/navigation (not just on the page itself)

## User Impact

- **Desktop:** Users see "Data Replication" (with dropdown caret) and "Agent Engine" in the navbar. Clicking "Data Replication" navigates to `/platform/`. Hovering reveals Platform, Connectors, Release notes, Developers, and Community. The "Data Replication" label is underlined when viewing any Data Replication sub-instance. The underline aligns with Agent Engine's underline at the bottom of the navbar.
- **Mobile:** Docusaurus should render the dropdown items in the hamburger menu natively via the upstream Mobile component.
- "AI agents" is renamed to "Agent Engine" throughout the navbar.
- The platform version selector is no longer affected by the active state logic.
- Platform landing page heading changes from "Platform" to "Data replication platform".
- Connectors landing page heading changes from "Connectors" to "Data replication connectors".

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

All changes are isolated to the docs site navbar and two page headings. No breaking changes to connectors, platform, or APIs.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/73725" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->