### PR TITLE
ci: restore poe-tasks from default branch when publishing from PR branches

### DIFF
--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -81,6 +81,15 @@ jobs:
           ref: ${{ inputs.gitref || '' }}
           fetch-depth: 2 # Required so we can conduct a diff from the previous commit to understand what connectors have changed.
           submodules: true # Required for the enterprise repo since it uses a submodule that needs to exist for this workflow to run successfully.
+      - name: Restore poe-tasks from default branch
+        if: inputs.gitref != ''
+        shell: bash
+        run: |
+          # When building from a PR branch, the poe-tasks/ scripts may be outdated
+          # and incompatible with the workflow YAML (which always comes from master).
+          # Restore from the default branch to ensure compatibility.
+          git fetch origin ${{ github.event.repository.default_branch }} --depth=1
+          git checkout origin/${{ github.event.repository.default_branch }} -- poe-tasks/
       - name: List connectors to publish [manual]
         id: list-connectors-manual
         if: github.event_name == 'workflow_dispatch'
@@ -161,6 +170,16 @@ jobs:
           ref: ${{ inputs.gitref || '' }}
           fetch-depth: 2 # Required so we can conduct a diff from the previous commit to understand what connectors have changed.
           submodules: true # Required for the enterprise repo since it uses a submodule that needs to exist for this workflow to run successfully.
+
+      - name: Restore poe-tasks from default branch
+        if: inputs.gitref != ''
+        shell: bash
+        run: |
+          # When building from a PR branch, the poe-tasks/ scripts may be outdated
+          # and incompatible with the workflow YAML (which always comes from master).
+          # Restore from the default branch to ensure compatibility.
+          git fetch origin ${{ github.event.repository.default_branch }} --depth=1
+          git checkout origin/${{ github.event.repository.default_branch }} -- poe-tasks/
 
       - name: Create docker buildx builder
         id: create-buildx-builder
@@ -356,6 +375,16 @@ jobs:
           ref: ${{ inputs.gitref || '' }}
           fetch-depth: 2 # Required so we can conduct a diff from the previous commit to understand what connectors have changed.
           submodules: true # Required for the enterprise repo since it uses a submodule that needs to exist for this workflow to run successfully.
+
+      - name: Restore poe-tasks from default branch
+        if: inputs.gitref != ''
+        shell: bash
+        run: |
+          # When building from a PR branch, the poe-tasks/ scripts may be outdated
+          # and incompatible with the workflow YAML (which always comes from master).
+          # Restore from the default branch to ensure compatibility.
+          git fetch origin ${{ github.event.repository.default_branch }} --depth=1
+          git checkout origin/${{ github.event.repository.default_branch }} -- poe-tasks/
 
       - name: Set up Python
         # v5


### PR DESCRIPTION
## What

Fixes the prerelease publish failure for Java connectors when the PR branch is based on an older version of master.

**Failed run:** https://github.com/airbytehq/airbyte/actions/runs/22323832915/job/64589240230
**Error:** `Error: Unknown flag --with-semver-suffix`

**Root cause:** The workflow YAML (always loaded from `master`) passes `--with-semver-suffix preview` to the poe-tasks scripts. But when building from a PR branch, the scripts come from the PR branch checkout. PR branches created before #72805 still have scripts that expect `--release-type` instead of `--with-semver-suffix`, causing the failure.

## How

After each checkout of PR branch code (when `inputs.gitref` is set), restore `poe-tasks/` from the default branch so the scripts always match the workflow YAML. The step is added in all three jobs that check out code:
1. `publish_options`
2. `publish_connectors`
3. `publish_connector_registry_entries`

The step is gated on `inputs.gitref != ''` so it only runs for PR/branch builds, not for push-to-master production publishes.

## Review guide

1. `.github/workflows/publish_connectors.yml` — all three additions are identical; review one and verify the placement relative to checkout steps.

**Key things to verify:**
- Does `${{ github.event.repository.default_branch }}` resolve correctly in a `workflow_call` context? (It should inherit from the caller's event context, but worth confirming.)
- **Trade-off:** Any PR that intentionally modifies `poe-tasks/` will have those changes silently overwritten during prerelease publish. This is the intended "hacky" behavior — a proper fix would be PR 2 (rewriting the bash scripts out entirely).

## User Impact

Prerelease publishes (via `/publish-connectors-prerelease`) will work for Java connectors on PR branches regardless of how old the branch is.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Requested by: @aaronsteers
[Link to Devin run](https://app.devin.ai/sessions/e519f5f9e00f43aaa96a2410770fbb0e)