### PR TITLE
fix(cdk): override transitive deps to include security patches

### DIFF
--- a/airbyte-cdk/bulk/core/base/build.gradle.kts
+++ b/airbyte-cdk/bulk/core/base/build.gradle.kts
@@ -58,9 +58,11 @@ tasks.withType<Copy>().configureEach {
 
 dependencies {
 
+    // Include security patches since transitive dependency versions pulled in by
+    // mbknor-jackson-jsonschema (scala-library:2.13.1, classgraph:4.8.21) have known vulnerabilities.
     constraints {
-        api("org.scala-lang:scala-library:2.13.9") // fix CVE-2022-36944
-        api("io.github.classgraph:classgraph:4.8.112") // fix CVE-2021-47621
+        api("org.scala-lang:scala-library:2.13.9")
+        api("io.github.classgraph:classgraph:4.8.112")
     }
 
     api("com.fasterxml.jackson.core:jackson-annotations")

--- a/airbyte-cdk/bulk/core/base/build.gradle.kts
+++ b/airbyte-cdk/bulk/core/base/build.gradle.kts
@@ -58,10 +58,11 @@ tasks.withType<Copy>().configureEach {
 
 dependencies {
 
-    // Include security patches since transitive dependency versions pulled in by
-    // mbknor-jackson-jsonschema (scala-library:2.13.1, classgraph:4.8.21) have known vulnerabilities.
+    // Include security patches since transitive dependency versions pulled in by `mbknor-jackson-jsonschema`.
     constraints {
+        // Patched from `2.13.1`
         api("org.scala-lang:scala-library:2.13.9")
+        // Patched from `4.8.21`
         api("io.github.classgraph:classgraph:4.8.112")
     }
 

--- a/airbyte-cdk/bulk/core/base/build.gradle.kts
+++ b/airbyte-cdk/bulk/core/base/build.gradle.kts
@@ -58,6 +58,11 @@ tasks.withType<Copy>().configureEach {
 
 dependencies {
 
+    constraints {
+        api("org.scala-lang:scala-library:2.13.9") // fix CVE-2022-36944
+        api("io.github.classgraph:classgraph:4.8.112") // fix CVE-2021-47621
+    }
+
     api("com.fasterxml.jackson.core:jackson-annotations")
     api("com.fasterxml.jackson.core:jackson-databind")
     api("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")

--- a/airbyte-cdk/bulk/core/base/build.gradle.kts
+++ b/airbyte-cdk/bulk/core/base/build.gradle.kts
@@ -58,7 +58,8 @@ tasks.withType<Copy>().configureEach {
 
 dependencies {
 
-    // Include security patches since transitive dependency versions pulled in by `mbknor-jackson-jsonschema`.
+    // Include security patches since transitive dependency versions
+    // pulled in by `mbknor-jackson-jsonschema`.
     constraints {
         // Patched from `2.13.1`
         api("org.scala-lang:scala-library:2.13.9")


### PR DESCRIPTION
## What

Applies security patches to transitive dependencies of `com.kjetland:mbknor-jackson-jsonschema_2.13:1.0.39` by forcing minimum versions via Gradle constraints:
- `org.scala-lang:scala-library`: 2.13.1 → 2.13.9
- `io.github.classgraph:classgraph`: 4.8.21 → 4.8.112

Related: https://github.com/airbytehq/airbyte-internal-issues/issues/15827

## How

Adds a Gradle `constraints` block in `airbyte-cdk/bulk/core/base/build.gradle.kts` to force minimum versions for two transitive dependencies with known vulnerabilities. No library swap, no code changes — Gradle resolves the constrained versions automatically.

Before:
```
+--- com.kjetland:mbknor-jackson-jsonschema_2.13:1.0.39
|    +--- org.scala-lang:scala-library:2.13.1
|    \--- io.github.classgraph:classgraph:4.8.21
```

After:
```
+--- com.kjetland:mbknor-jackson-jsonschema_2.13:1.0.39
|    +--- org.scala-lang:scala-library:2.13.1 -> 2.13.9
|    \--- io.github.classgraph:classgraph:4.8.21 -> 4.8.112
```

## Review guide

1. **`airbyte-cdk/bulk/core/base/build.gradle.kts`** — The only file changed. 7 lines added (2-line comment + constraints block). Verify the constraints block syntax and that the minimum versions resolve correctly.

### Human review checklist
- [ ] Confirm `scala-library` 2.13.1 → 2.13.9 is binary compatible (Scala 2.13.x [guarantees binary compatibility](https://docs.scala-lang.org/overviews/core/binary-compatibility-of-scala-releases.html) within minor versions)
- [ ] Confirm `classgraph` 4.8.21 → 4.8.112 is backwards compatible (classgraph maintains backwards compat within 4.x)
- [ ] Verify no other modules in the build explicitly pin older versions that would conflict with these constraints

## User Impact

No user-facing impact. This is an internal dependency change that does not alter runtime behavior.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Requested by @aaronsteers.

[Devin session](https://app.devin.ai/sessions/1cc4e75ad99c433ba5953c418a1039be)