### PR TITLE
fix(docs): prevent version dropdown from showing on /ai-agents/platform/

### DIFF
--- a/docusaurus/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.js
+++ b/docusaurus/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.js
@@ -6,12 +6,17 @@ export default function DocsVersionDropdownNavbarItemWrapper(props) {
   const { docsPluginId, className, type } = props;
   const { pathname } = useLocation();
 
-  // Check if the docsPluginId property for this instance contains the URL pathname. If it does, show the version dropdown. If it doesn't, don't show it. This is a workaround for the fact that Docusaurus shows the version dropdown for all instances of the DocsVersionDropdownNavbarItem component, even if the current page or instance is not versioned.
+  // Check if the current page belongs to this docs plugin by verifying the pathname
+  // starts with the plugin's route base path (e.g. "/platform/"). Using a prefix check
+  // instead of a substring match avoids false positives like "/ai-agents/platform/"
+  // matching the "platform" plugin.
 
   // Swizzling this component is technically unsafe, although the risk is very low. Worst-case scenario, we have to upgrade it ourselves in a future breaking change with Docusaurus.
 
-  const doesPathnameContainDocsPluginId = pathname.includes(docsPluginId);
-  if (!doesPathnameContainDocsPluginId) {
+  const pluginBasePath = `/${docsPluginId}/`;
+  const isOnPluginPage =
+    pathname.startsWith(pluginBasePath) || pathname === `/${docsPluginId}`;
+  if (!isOnPluginPage) {
     return null;
   }
   return <DocsVersionDropdownNavbarItem {...props} />;


### PR DESCRIPTION
## What

The data replication platform version selector dropdown incorrectly appears on Agent Engine pages under `/ai-agents/platform/` (e.g. [docs.airbyte.com/ai-agents/platform/](https://docs.airbyte.com/ai-agents/platform/)), where it should only appear on `/platform/` pages (e.g. [docs.airbyte.com/platform/](https://docs.airbyte.com/platform/)).

## How

The swizzled `DocsVersionDropdownNavbarItem` component used `pathname.includes(docsPluginId)` to decide visibility. Since `docsPluginId` is `"platform"`, the substring check matched any URL containing "platform" — including `/ai-agents/platform/`.

Replaced with a `startsWith("/${docsPluginId}/")` prefix check (plus an exact-match fallback for the bare path without trailing slash), so only pages whose path actually begins with `/platform/` show the dropdown.

## Review guide

1. `docusaurus/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.js` — the only file changed. Verify the prefix matching logic covers edge cases (trailing slash vs. no trailing slash).

**Key assumption to verify:** the fix assumes `docsPluginId` matches the route base path segment (i.e., the `"platform"` plugin serves from `/platform/`). This holds true in the current `docusaurus.config.ts` and was the same assumption the original code relied on.

## User Impact

The version selector dropdown will no longer incorrectly appear when browsing Agent Engine docs at `/ai-agents/platform/`. No impact on `/platform/` pages where the dropdown should appear.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Requested by: @ian-at-airbyte
[Devin session](https://app.devin.ai/sessions/fec8035fcbd54c6086a0b6ea08523581)