### PR TITLE
chore(docs): Remove MDX Debug Plugin from docusaurus.config.ts

### DIFF
--- a/docusaurus/docusaurus.config.ts
+++ b/docusaurus/docusaurus.config.ts
@@ -339,42 +339,6 @@ const config: Config = {
         };
       },
     }),
-    // MDX Debug Plugin - logs which files are being processed
-    () => ({
-      name: "MDX Debug Plugin",
-      configureWebpack(config, isServer) {
-        const plugin = {
-          apply(compiler) {
-            let processedCount = 0;
-            const startTime = Date.now();
-
-            // Track module processing
-            compiler.hooks.thisCompilation.tap(
-              "MDXDebugPlugin",
-              (compilation) => {
-                compilation.hooks.buildModule.tap(
-                  "MDXDebugPlugin",
-                  (module) => {
-                    if (module.resource && module.resource.endsWith(".mdx")) {
-                      processedCount++;
-                      const elapsed = Date.now() - startTime;
-                      const fileName = module.resource.split("/").pop();
-                      console.log(
-                        `📄 [${elapsed}ms] Processing #${processedCount}: ${fileName}`,
-                      );
-                    }
-                  },
-                );
-              },
-            );
-          },
-        };
-
-        return {
-          plugins: [plugin],
-        };
-      },
-    }),
   ],
   customFields: {
     requestErdApiUrl: process.env.REQUEST_ERD_API_URL,


### PR DESCRIPTION
This PR targets the following PR:
- #73732

---

## What

Removes an inline MDX Debug Plugin from `docusaurus.config.ts` that was left over from development of the public API documentation feature (#70865). The plugin hooks into webpack's compilation pipeline and logs every `.mdx` file processed with a timestamp and counter to the console — this runs in production builds and is not needed.

## How

Pure deletion of the anonymous plugin function (36 lines) from the `plugins` array in `docusaurus.config.ts`.

## Review guide

1. `docusaurus/docusaurus.config.ts` — verify the `plugins` array is still syntactically valid after the removal (the preceding plugin entry's closing `),` and the array's `],` remain intact).

## User Impact

No user-facing impact. Removes noisy console output during builds and eliminates a minor webpack hook overhead.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Requested by: @ian-at-airbyte
[Devin session](https://app.devin.ai/sessions/6aa3954c638c4c95a5834a117d11fed7)