### PR TITLE
chore(docs): Remove unused code from public API scripts

### DIFF
--- a/docusaurus/src/scripts/public-api/constants.js
+++ b/docusaurus/src/scripts/public-api/constants.js
@@ -27,14 +27,6 @@ const SOURCE_CONFIGS_DEREFERENCED_PATH = path.join(
   "source-configs-dereferenced.json",
 );
 
-// Path to the dereferenced destination configurations (extracted at build time)
-const DESTINATION_CONFIGS_DEREFERENCED_PATH = path.join(
-  PROJECT_ROOT,
-  "src",
-  "data",
-  "destination-configs-dereferenced.json",
-);
-
 // URL for fetching the latest public API specification
 const PUBLIC_API_SPEC_BASE_URL =
   "https://raw.githubusercontent.com/airbytehq/airbyte-platform/refs/heads/main/airbyte-api/server-api/src/main/openapi/";
@@ -81,7 +73,6 @@ module.exports = {
   PROJECT_ROOT,
   PUBLIC_API_SPEC_CACHE_PATH,
   SOURCE_CONFIGS_DEREFERENCED_PATH,
-  DESTINATION_CONFIGS_DEREFERENCED_PATH,
   PUBLIC_API_SPEC_BASE_URL,
   PUBLIC_SPEC_FILE_NAMES,
   PUBLIC_API_DOCS_OUTPUT_DIR,

--- a/docusaurus/src/scripts/public-api/prepare-public-api-spec.js
+++ b/docusaurus/src/scripts/public-api/prepare-public-api-spec.js
@@ -7,7 +7,6 @@ const fs = require("fs");
 const https = require("https");
 const path = require("path");
 const yaml = require("js-yaml");
-const RefParser = require("json-schema-ref-parser");
 const { validateOpenAPISpec } = require("./openapi-validator");
 const { fetchRegistry } = require("../fetch-registry");
 const {
@@ -15,7 +14,6 @@ const {
   PUBLIC_API_SPEC_BASE_URL,
   PUBLIC_SPEC_FILE_NAMES,
   SOURCE_CONFIGS_DEREFERENCED_PATH,
-  DESTINATION_CONFIGS_DEREFERENCED_PATH,
   PUBLIC_API_TAGS_PATH,
 } = require("./constants");
 
@@ -354,17 +352,6 @@ function extractCertifiedSourceNames(registry) {
   return new Set(certifiedSources);
 }
 
-function extractCertifiedDestinationNames(registry) {
-  const certifiedDestinations = registry
-    .filter(connector =>
-      connector.supportLevel === 'certified' &&
-      connector.dockerRepository_oss &&
-      connector.dockerRepository_oss.includes('destination-')
-    )
-    .map(connector => connector.dockerRepository_oss.replace('airbyte/', ''));
-
-  return new Set(certifiedDestinations);
-}
 
 /**
  * Filters SourceConfiguration.oneOf to include only certified connectors
@@ -394,25 +381,6 @@ function filterSourceConfigurationToCertified(spec, certifiedSourceNames) {
   return spec;
 }
 
-function filterDestinationConfigurationToCertified(spec, certifiedDestinationNames) {
-  if (!spec.components?.schemas?.DestinationConfiguration?.oneOf) {
-    console.warn('\u26a0\ufe0f  DestinationConfiguration.oneOf not found in spec - skipping filtering');
-    return spec;
-  }
-
-  const destConfig = spec.components.schemas.DestinationConfiguration;
-  const originalCount = destConfig.oneOf.length;
-
-  destConfig.oneOf = destConfig.oneOf.filter(item =>
-    item.title && certifiedDestinationNames.has(item.title)
-  );
-
-  const filteredCount = destConfig.oneOf.length;
-
-  console.log(`\u2705 Filtered DestinationConfiguration.oneOf: ${originalCount} \u2192 ${filteredCount} certified destinations`);
-
-  return spec;
-}
 
 /**
  * Recursively dereference a schema by resolving all $ref pointers
@@ -485,17 +453,6 @@ function formatSourceName(name) {
     .join(' ');
 }
 
-function formatDestinationName(name) {
-  if (!name.startsWith('destination-')) {
-    return name;
-  }
-
-  const withoutPrefix = name.substring(12);
-  return withoutPrefix
-    .split('-')
-    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(' ');
-}
 
 /**
  * Extract and dereference all source schemas from SourceConfiguration
@@ -550,51 +507,6 @@ function extractAndDereferenceSourceSchemas(spec) {
   return sourceConfigs;
 }
 
-function extractAndDereferenceDestinationSchemas(spec) {
-  if (!spec.components?.schemas?.DestinationConfiguration?.oneOf) {
-    console.warn('\u26a0\ufe0f  DestinationConfiguration.oneOf not found - skipping extraction');
-    return [];
-  }
-
-  const destConfig = spec.components.schemas.DestinationConfiguration;
-  const allSchemas = spec.components.schemas;
-  const destConfigs = [];
-
-  console.log(`\ud83d\udd0d Extracting ${destConfig.oneOf.length} destination configurations...`);
-
-  for (const destRef of destConfig.oneOf) {
-    if (!destRef.title) {
-      console.warn('\u26a0\ufe0f  Destination config without title found, skipping');
-      continue;
-    }
-
-    const destId = destRef.title;
-    const destSchema = allSchemas[destId];
-
-    if (!destSchema) {
-      console.warn(`\u26a0\ufe0f  Could not find schema for ${destId}`);
-      continue;
-    }
-
-    try {
-      const dereferenced = dereferenceSchema(destSchema, allSchemas);
-
-      destConfigs.push({
-        id: destId,
-        displayName: formatDestinationName(destId),
-        schema: dereferenced
-      });
-    } catch (error) {
-      console.warn(`\u26a0\ufe0f  Error dereferencing ${destId}:`, error instanceof Error ? error.message : String(error));
-    }
-  }
-
-  destConfigs.sort((a, b) => a.displayName.localeCompare(b.displayName));
-
-  console.log(`\u2705 Extracted and dereferenced ${destConfigs.length} destination configurations`);
-
-  return destConfigs;
-}
 
 /**
  * Main processing function


### PR DESCRIPTION
This PR targets the following PR:
- #73734

---

## What

Removes dead destination-related code and an unused import from the public API prebuild scripts. These functions were defined but never called from `main()` — only their source-equivalent counterparts are used.

## How

Pure deletions across two files:

**`prepare-public-api-spec.js`:**
- Removed unused `RefParser` import (`json-schema-ref-parser` — loaded at module init but never called)
- Removed `DESTINATION_CONFIGS_DEREFERENCED_PATH` import
- Removed 4 dead functions: `extractCertifiedDestinationNames()`, `filterDestinationConfigurationToCertified()`, `formatDestinationName()`, `extractAndDereferenceDestinationSchemas()`

**`constants.js`:**
- Removed `DESTINATION_CONFIGS_DEREFERENCED_PATH` constant definition and export

The source equivalents (`extractCertifiedSourceNames`, `filterSourceConfigurationToCertified`, `formatSourceName`, `extractAndDereferenceSourceSchemas`) are retained — they are actively called from `main()`.

## Review guide

1. **`prepare-public-api-spec.js`** — Verify that the removed functions are truly not called. Scan `main()` (starts around line 514 after this diff) for any references to destination extraction/filtering. The only destination-related call site would be in `main()`, which only calls the source variants.
2. **`constants.js`** — Verify no other file in `docusaurus/src/` imports `DESTINATION_CONFIGS_DEREFERENCED_PATH`. A quick `grep -r DESTINATION_CONFIGS_DEREFERENCED_PATH docusaurus/src/` should return zero results after this change.
3. **Note:** The diff leaves a couple of double blank lines where functions were removed. Cosmetic only.

## User Impact

No user-facing impact. Removes ~97 lines of dead code and one unused npm module load (`json-schema-ref-parser`) from the prebuild script.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Reverting re-adds dead code — no functional impact.

---

Requested by: @ian-at-airbyte
[Devin session](https://app.devin.ai/sessions/6aa3954c638c4c95a5834a117d11fed7)