### PR TITLE
chore(docs): Re-enable signalwire llms.txt plugin

### DIFF
--- a/docusaurus/docusaurus.config.ts
+++ b/docusaurus/docusaurus.config.ts
@@ -7,6 +7,7 @@ import {
   replaceApiReferenceCategory,
 } from "./src/scripts/agent-engine-api/sidebar-generator";
 import { generateDevelopersSidebar } from "./src/scripts/public-api/sidebar-generator";
+import type { PluginOptions as LLmPluginOptions } from "@signalwire/docusaurus-plugin-llms-txt";
 
 // Import remark plugins - lazy load to prevent webpack from bundling Node.js code
 const getRemarkPlugins = () => ({
@@ -295,22 +296,22 @@ const config: Config = {
       },
     ],
     require.resolve("./src/plugins/enterpriseConnectors"),
-    // [
-    //   "@signalwire/docusaurus-plugin-llms-txt",
-    //   {
-    //     siteTitle: "docs.airbyte.com llms.txt",
-    //     siteDescription:
-    //       "Airbyte is an open source platform designed for building and managing data pipelines, offering extensive connector options to facilitate data movement from various sources to destinations efficiently and effectively.",
-    //     depth: 4,
-    //     content: {
-    //       includePages: true,
-    //       excludeRoutes: [
-    //         "./ai-agents/embedded/api-reference/**",
-    //         "./developers/api-reference/**",
-    //       ],
-    //     },
-    //   } satisfies LLmPluginOptions,
-    // ],
+    [
+      "@signalwire/docusaurus-plugin-llms-txt",
+      {
+        siteTitle: "docs.airbyte.com llms.txt",
+        siteDescription:
+          "Airbyte is an open source platform designed for building and managing data pipelines, offering extensive connector options to facilitate data movement from various sources to destinations efficiently and effectively.",
+        depth: 4,
+        content: {
+          includePages: true,
+          excludeRoutes: [
+            "./ai-agents/embedded/api-reference/**",
+            "./developers/api-reference/**",
+          ],
+        },
+      } satisfies LLmPluginOptions,
+    ],
     () => ({
       name: "Yaml loader",
       configureWebpack(config, isServer) {


### PR DESCRIPTION
This PR targets the following PR:
- #73735

---

## What

Re-enables the `@signalwire/docusaurus-plugin-llms-txt` plugin that was commented out during development of #70865 (public API reference docs). This plugin generates `llms.txt` for docs.airbyte.com, which is active on master today.

@ian-at-airbyte asked for this as a separate stacked PR to isolate whether the llms.txt plugin contributes to the warm build speed improvement observed in #70865.

## How

Single file change in `docusaurus.config.ts`:
1. Restores the `LLmPluginOptions` type import
2. Uncomments the plugin registration block (config is unchanged from master)

## Review guide

1. `docusaurus/docusaurus.config.ts` — Verify the uncommented plugin config matches master. In particular, confirm `excludeRoutes` covers any new routes introduced by #70865 (it already excludes `./developers/api-reference/**`).

## User Impact

Restores `llms.txt` generation at docs.airbyte.com, which would otherwise be lost when #70865 merges.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Reverting re-comments the plugin — no data loss or migration involved.

---

Requested by: @ian-at-airbyte
[Devin session](https://app.devin.ai/sessions/6aa3954c638c4c95a5834a117d11fed7)