### PR TITLE
Do not merge: pre-release connector builds with CDK security patches

### DIFF
--- a/airbyte-cdk/bulk/core/base/build.gradle.kts
+++ b/airbyte-cdk/bulk/core/base/build.gradle.kts
@@ -58,9 +58,11 @@ tasks.withType<Copy>().configureEach {
 
 dependencies {
 
+    // Include security patches since transitive dependency versions pulled in by
+    // mbknor-jackson-jsonschema (scala-library:2.13.1, classgraph:4.8.21) have known vulnerabilities.
     constraints {
-        api("org.scala-lang:scala-library:2.13.9") // fix CVE-2022-36944
-        api("io.github.classgraph:classgraph:4.8.112") // fix CVE-2021-47621
+        api("org.scala-lang:scala-library:2.13.9")
+        api("io.github.classgraph:classgraph:4.8.112")
     }
 
     api("com.fasterxml.jackson.core:jackson-annotations")

--- a/airbyte-cdk/bulk/core/base/build.gradle.kts
+++ b/airbyte-cdk/bulk/core/base/build.gradle.kts
@@ -58,10 +58,11 @@ tasks.withType<Copy>().configureEach {
 
 dependencies {
 
-    // Include security patches since transitive dependency versions pulled in by
-    // mbknor-jackson-jsonschema (scala-library:2.13.1, classgraph:4.8.21) have known vulnerabilities.
+    // Include security patches since transitive dependency versions pulled in by `mbknor-jackson-jsonschema`.
     constraints {
+        // Patched from `2.13.1`
         api("org.scala-lang:scala-library:2.13.9")
+        // Patched from `4.8.21`
         api("io.github.classgraph:classgraph:4.8.112")
     }
 

--- a/airbyte-cdk/bulk/core/base/build.gradle.kts
+++ b/airbyte-cdk/bulk/core/base/build.gradle.kts
@@ -58,6 +58,11 @@ tasks.withType<Copy>().configureEach {
 
 dependencies {
 
+    constraints {
+        api("org.scala-lang:scala-library:2.13.9") // fix CVE-2022-36944
+        api("io.github.classgraph:classgraph:4.8.112") // fix CVE-2021-47621
+    }
+
     api("com.fasterxml.jackson.core:jackson-annotations")
     api("com.fasterxml.jackson.core:jackson-databind")
     api("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")

--- a/airbyte-cdk/bulk/core/base/build.gradle.kts
+++ b/airbyte-cdk/bulk/core/base/build.gradle.kts
@@ -58,7 +58,8 @@ tasks.withType<Copy>().configureEach {
 
 dependencies {
 
-    // Include security patches since transitive dependency versions pulled in by `mbknor-jackson-jsonschema`.
+    // Include security patches since transitive dependency versions
+    // pulled in by `mbknor-jackson-jsonschema`.
     constraints {
         // Patched from `2.13.1`
         api("org.scala-lang:scala-library:2.13.9")

--- a/airbyte-integrations/connectors/destination-postgres/gradle.properties
+++ b/airbyte-integrations/connectors/destination-postgres/gradle.properties
@@ -1,4 +1,4 @@
-cdkVersion=0.2.8
+cdkVersion=local
 # our testcontainer has issues with too much concurrency.
 # 4 threads seems to be the sweet spot.
 testExecutionConcurrency=4

--- a/airbyte-integrations/connectors/destination-snowflake/gradle.properties
+++ b/airbyte-integrations/connectors/destination-snowflake/gradle.properties
@@ -1,3 +1,3 @@
 testExecutionConcurrency=-1
-cdkVersion=0.2.8
+cdkVersion=local
 JunitMethodExecutionTimeout=10m

--- a/airbyte-integrations/connectors/source-snowflake/gradle.properties
+++ b/airbyte-integrations/connectors/source-snowflake/gradle.properties
@@ -1,3 +1,3 @@
 testExecutionConcurrency=1
 JunitMethodExecutionTimeout=5m
-cdkVersion=0.1.31
+cdkVersion=local


### PR DESCRIPTION
This PR targets the following PR:
- #73728

---

## What

Pre-release testing vehicle for 3 connectors (source-snowflake, destination-postgres, destination-snowflake) built against a CDK with security patches for vulnerable transitive dependencies.

The fixes (from #73728) add Gradle `constraints` to force minimum versions of transitive deps pulled in by `mbknor-jackson-jsonschema_2.13:1.0.39`:
- `scala-library`: 2.13.1 → 2.13.9
- `classgraph`: 4.8.21 → 4.8.112

**⚠️ This PR is NOT intended to be merged.** The `cdkVersion=local` connector changes are only for triggering pre-release builds. Once validated, the CDK fix (#73728) merges separately, and connectors pick up the fix through normal CDK version pinning.

## How

1. `airbyte-cdk/bulk/core/base/build.gradle.kts` — Adds a `constraints` block forcing minimum versions of two transitive dependencies with known vulnerabilities. No library swap, no code changes.
2. Three connector `gradle.properties` files — Set `cdkVersion=local` so connector builds resolve CDK dependencies from the monorepo source (including the constraints fix) instead of a published artifact.

## Review guide

1. `airbyte-cdk/bulk/core/base/build.gradle.kts` — The actual fix. Verify the constraint versions resolve correctly.
2. `*/gradle.properties` — Temporary `cdkVersion=local` for pre-release builds. **Must not be merged to master.**

### Key risks to verify
- [ ] Scala 2.13.x binary compatibility: 2.13.1 → 2.13.9 should be safe per [Scala's compatibility guarantees](https://docs.scala-lang.org/overviews/core/binary-compatibility-of-scala-releases.html), but worth confirming.
- [ ] Classgraph 4.8.21 → 4.8.112 backwards compatibility (large version jump within 4.x).
- [ ] source-snowflake is pinned to `cdkVersion=0.1.31` (vs `0.2.8` for the destinations). Building with `local` means it jumps across the 0.2.0 breaking change boundary — pre-release testing may surface issues specific to this connector.

## User Impact

No user-facing impact. This PR exists solely to trigger pre-release connector builds for validation.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Requested by @aaronsteers.

[Devin session](https://app.devin.ai/sessions/1cc4e75ad99c433ba5953c418a1039be)