### PR TITLE
fix(connectors): override transitive deps to include security patches

### DIFF
--- a/airbyte-integrations/connectors/destination-gcs-data-lake/build.gradle
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/build.gradle
@@ -37,6 +37,15 @@ configurations.configureEach {
 //}
 
 dependencies {
+    // Include security patches since transitive dependency versions
+    // pulled in by `mbknor-jackson-jsonschema`.
+    constraints {
+        // Patched from `2.13.1`
+        implementation("org.scala-lang:scala-library:2.13.9")
+        // Patched from `4.8.21`
+        implementation("io.github.classgraph:classgraph:4.8.112")
+    }
+
     // Apache Iceberg
     implementation("org.apache.iceberg:iceberg-api:${project.ext.apacheIcebergVersion}")
     implementation("org.apache.iceberg:iceberg-core:${project.ext.apacheIcebergVersion}")

--- a/airbyte-integrations/connectors/destination-postgres/build.gradle
+++ b/airbyte-integrations/connectors/destination-postgres/build.gradle
@@ -37,6 +37,15 @@ def postgresqlVersion = "42.7.2"
 def testContainersVersion = "1.20.5"
 
 dependencies {
+    // Include security patches since transitive dependency versions
+    // pulled in by `mbknor-jackson-jsonschema`.
+    constraints {
+        // Patched from `2.13.1`
+        implementation("org.scala-lang:scala-library:2.13.9")
+        // Patched from `4.8.21`
+        implementation("io.github.classgraph:classgraph:4.8.112")
+    }
+
     implementation("org.postgresql:postgresql:$postgresqlVersion")
     implementation("com.zaxxer:HikariCP:$hikariCpVersion")
     // TODO: Consolidate what is used from the below deps into the modern CDK

--- a/airbyte-integrations/connectors/destination-s3-data-lake/build.gradle
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/build.gradle
@@ -36,6 +36,15 @@ configurations.configureEach {
 //}
 
 dependencies {
+    // Include security patches since transitive dependency versions
+    // pulled in by `mbknor-jackson-jsonschema`.
+    constraints {
+        // Patched from `2.13.1`
+        implementation("org.scala-lang:scala-library:2.13.9")
+        // Patched from `4.8.21`
+        implementation("io.github.classgraph:classgraph:4.8.112")
+    }
+
     implementation("org.apache.iceberg:iceberg-api:${project.ext.apacheIcebergVersion}")
     implementation("org.apache.iceberg:iceberg-core:${project.ext.apacheIcebergVersion}")
     implementation("org.apache.iceberg:iceberg-data:${project.ext.apacheIcebergVersion}")

--- a/airbyte-integrations/connectors/destination-snowflake/build.gradle.kts
+++ b/airbyte-integrations/connectors/destination-snowflake/build.gradle.kts
@@ -40,6 +40,15 @@ val junitPlatformVersion = "1.13.4"
 val snowflakeJdbcThinVersion = "3.26.1"
 
 dependencies {
+    // Include security patches since transitive dependency versions
+    // pulled in by `mbknor-jackson-jsonschema`.
+    constraints {
+        // Patched from `2.13.1`
+        implementation("org.scala-lang:scala-library:2.13.9")
+        // Patched from `4.8.21`
+        implementation("io.github.classgraph:classgraph:4.8.112")
+    }
+
     implementation("net.snowflake:snowflake-jdbc-thin:$snowflakeJdbcThinVersion")
     implementation("com.zaxxer:HikariCP:$hikariCpVersion")
     implementation("com.google.guava:guava:32.1.1-jre")

--- a/airbyte-integrations/connectors/source-snowflake/build.gradle
+++ b/airbyte-integrations/connectors/source-snowflake/build.gradle
@@ -21,6 +21,15 @@ application {
 }
 
 dependencies {
+    // Include security patches since transitive dependency versions
+    // pulled in by `mbknor-jackson-jsonschema`.
+    constraints {
+        // Patched from `2.13.1`
+        implementation("org.scala-lang:scala-library:2.13.9")
+        // Patched from `4.8.21`
+        implementation("io.github.classgraph:classgraph:4.8.112")
+    }
+
     implementation 'net.snowflake:snowflake-jdbc:3.23.1'
     implementation 'org.apache.commons:commons-lang3:3.17.0'
 

--- a/airbyte-integrations/connectors/source-snowflake/gradle.properties
+++ b/airbyte-integrations/connectors/source-snowflake/gradle.properties
@@ -1,3 +1,3 @@
 testExecutionConcurrency=1
 JunitMethodExecutionTimeout=5m
-cdkVersion=0.1.31
+cdkVersion=0.2.8


### PR DESCRIPTION
## What

Patches known vulnerabilities in transitive dependencies of `com.kjetland:mbknor-jackson-jsonschema_2.13:1.0.39` at the connector level, without modifying CDK source code or requiring a CDK release.

Also fixes a pre-existing `source-snowflake` compilation failure caused by a stale CDK version pin.

Related: #73728 (same security fix applied at the CDK level)

## How

**Security patches (all 5 connectors):** Adds Gradle `constraints` blocks to force minimum versions for two transitive dependencies:
- `org.scala-lang:scala-library`: 2.13.1 → 2.13.9
- `io.github.classgraph:classgraph`: 4.8.21 → 4.8.112

**source-snowflake compilation fix:** Bumps `cdkVersion` from `0.1.31` → `0.2.8`. The connector code was rewritten for a newer CDK in #61535 (certified source connector), but the CDK version was pinned to `0.1.31` when #66484 moved version declarations into property files. Subsequent code changes (#66200, #66226) added APIs from the newer CDK, breaking compilation on master.

## Review guide

### Security constraints (identical 9-line block in each file)
1. `airbyte-integrations/connectors/source-snowflake/build.gradle` — CDK transitive dep (via `airbyte-bulk-connector` extract)
2. `airbyte-integrations/connectors/destination-postgres/build.gradle` — CDK transitive dep (via `airbyte-bulk-connector` load)
3. `airbyte-integrations/connectors/destination-snowflake/build.gradle.kts` — CDK transitive dep (via `airbyte-bulk-connector` load). Note: Kotlin DSL, same syntax.
4. `airbyte-integrations/connectors/destination-gcs-data-lake/build.gradle` — Direct `mbknor-jackson-jsonschema` dependency (line 74)
5. `airbyte-integrations/connectors/destination-s3-data-lake/build.gradle` — Direct `mbknor-jackson-jsonschema` dependency (line 63)

### CDK version bump
6. `airbyte-integrations/connectors/source-snowflake/gradle.properties` — `cdkVersion` 0.1.31 → 0.2.8

### Human review checklist
- [ ] Confirm `scala-library` 2.13.x [binary compatibility](https://docs.scala-lang.org/overviews/core/binary-compatibility-of-scala-releases.html) holds for 2.13.1 → 2.13.9
- [ ] Confirm `classgraph` backward compatibility for 4.8.21 → 4.8.112
- [ ] Verify `implementation`-scoped constraints correctly override transitive versions in leaf projects (vs `api` scope used in #73728's CDK-level fix)
- [ ] Verify source-snowflake CDK bump from 0.1.31 → 0.2.8 has no runtime regressions (this crosses the 0.2.0 boundary, though source-snowflake uses the Extract CDK which had fewer breaking changes in 0.2.0)
- [ ] Are there additional connectors that should also receive this patch?

**Note:** No connector versions are bumped — these patches will ship with the next substantive release of each connector.

## User Impact

No user-facing impact. Internal dependency change that does not alter runtime behavior.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Requested by @aaronsteers.

[Link to Devin run](https://app.devin.ai/sessions/1cc4e75ad99c433ba5953c418a1039be)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/73738" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->