### PR TITLE
ci: mark draft PRs as ready-for-review when /ai-review starts

### DIFF
--- a/.github/workflows/ai-review-command.yml
+++ b/.github/workflows/ai-review-command.yml
@@ -55,10 +55,10 @@ jobs:
           HEAD_REF=$(echo "$PR_INFO" | jq -r '.head.ref')
           IS_DRAFT=$(echo "$PR_INFO" | jq -r '.draft')
           NODE_ID=$(echo "$PR_INFO" | jq -r '.node_id')
-          echo "head-sha=$HEAD_SHA" >> $GITHUB_OUTPUT
-          echo "head-ref=$HEAD_REF" >> $GITHUB_OUTPUT
-          echo "is-draft=$IS_DRAFT" >> $GITHUB_OUTPUT
-          echo "node-id=$NODE_ID" >> $GITHUB_OUTPUT
+          echo "head-sha=$HEAD_SHA" | tee -a $GITHUB_OUTPUT
+          echo "head-ref=$HEAD_REF" | tee -a $GITHUB_OUTPUT
+          echo "is-draft=$IS_DRAFT" | tee -a $GITHUB_OUTPUT
+          echo "node-id=$NODE_ID" | tee -a $GITHUB_OUTPUT
 
       - name: Mark PR as ready for review
         if: steps.pr-details.outputs.is-draft == 'true'

--- a/.github/workflows/ai-review-command.yml
+++ b/.github/workflows/ai-review-command.yml
@@ -53,8 +53,28 @@ jobs:
           PR_INFO=$(curl -sS -H "Authorization: Bearer $GH_TOKEN" -H "Accept: application/vnd.github+json" "$PR_URL")
           HEAD_SHA=$(echo "$PR_INFO" | jq -r '.head.sha')
           HEAD_REF=$(echo "$PR_INFO" | jq -r '.head.ref')
+          IS_DRAFT=$(echo "$PR_INFO" | jq -r '.draft')
+          NODE_ID=$(echo "$PR_INFO" | jq -r '.node_id')
           echo "head-sha=$HEAD_SHA" >> $GITHUB_OUTPUT
           echo "head-ref=$HEAD_REF" >> $GITHUB_OUTPUT
+          echo "is-draft=$IS_DRAFT" >> $GITHUB_OUTPUT
+          echo "node-id=$NODE_ID" >> $GITHUB_OUTPUT
+
+      - name: Mark PR as ready for review
+        if: steps.pr-details.outputs.is-draft == 'true'
+        env:
+          GH_TOKEN: ${{ steps.get-app-token.outputs.token }}
+          NODE_ID: ${{ steps.pr-details.outputs.node-id }}
+        run: |
+          echo "PR is draft — marking as ready for review..."
+          # The REST API does not support changing draft status;
+          # the GraphQL markPullRequestReadyForReview mutation is required.
+          curl -sS -X POST \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Content-Type: application/json" \
+            https://api.github.com/graphql \
+            -d "{\"query\": \"mutation { markPullRequestReadyForReview(input: { pullRequestId: \\\"$NODE_ID\\\" }) { pullRequest { isDraft } } }\"}"
+          echo "PR marked as ready for review."
 
       - name: Post start comment
         if: ${{ inputs.comment-id }}


### PR DESCRIPTION
## What

When `/ai-review` is triggered on a draft PR, the PR should be automatically marked as ready-for-review. At that point in the pipeline the PR has already passed CI and `/ai-prove-fix`, so draft status no longer serves a purpose — and keeping it draft delays human reviewer visibility.

Companion to [airbytehq/oncall#11416](https://github.com/airbytehq/oncall/pull/11416), which updates the triage playbook decision trees to unify `/ai-review` gating for draft and non-draft PRs.

## How

Adds a new step to the `ai-review-command.yml` workflow, placed between "Get PR details" and "Post start comment":

1. The existing "Get PR details" step now also extracts `draft` status and `node_id` from the REST API response and exports them as step outputs.
2. A new "Mark PR as ready for review" step runs **only** when `is-draft == 'true'` (via step-level `if`). It calls the GitHub GraphQL `markPullRequestReadyForReview` mutation, since the REST API does not support changing draft status.

For non-draft PRs, the new step is skipped entirely.

## Review guide

1. `.github/workflows/ai-review-command.yml` — single file change

**Key items for reviewers:**
- [ ] Verify the octavia-bot GitHub App has permission to call the `markPullRequestReadyForReview` GraphQL mutation (requires `pull_requests: write` — already declared in the workflow `permissions` block)
- [ ] The GraphQL `curl` call does not check for errors in the response body (GraphQL returns HTTP 200 even on failures). If the mutation fails, the workflow continues silently. Decide if this is acceptable or if error checking should be added.
- [ ] This applies to **all** `/ai-review` invocations, not just those from the automated triage pipeline. Confirm this is desired — e.g., a human manually running `/ai-review` on a draft PR will also mark it ready.

## User Impact

Draft PRs entering `/ai-review` will automatically transition to "ready for review" status, making them visible to human reviewers sooner. No negative impact for PRs already in ready state (step is skipped).

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Requested by: @aaronsteers
[Link to Devin run](https://app.devin.ai/sessions/bf071c4d95fc4055a28beea0a848526d)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/73741" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
