### PR TITLE
docs: add Hydra SDLC cross-link to PR welcome messages

### DIFF
--- a/.github/pr-welcome-community.md
+++ b/.github/pr-welcome-community.md
@@ -19,7 +19,7 @@ As needed or by request, Airbyte Maintainers can execute the following slash com
 - `/build-connector-images` - Builds and publishes a pre-release docker image for the modified connector(s).
 - `/publish-connectors-prerelease` - Publishes pre-release connector builds (tagged as `{version}-preview.{git-sha}`) for all modified connectors in the PR.
 - `/ai-review` - AI-powered PR review for connector safety and quality gates.
-- Learn more about Airbyte's AI-powered development process: [Hydra SDLC Docs](https://github.com/airbytehq/ai-skills/blob/main/docs/hydra/)
+- _Maintainers: [AI-SDLC Docs](https://github.com/airbytehq/ai-skills/blob/main/docs/hydra/) (internal link)_
 - `/force-merge reason="<A_GOOD_REASON>"` - Force merges the PR using admin privileges, bypassing CI checks. Requires a reason.
 
 ### Tips for Working with CI

--- a/.github/pr-welcome-community.md
+++ b/.github/pr-welcome-community.md
@@ -19,7 +19,6 @@ As needed or by request, Airbyte Maintainers can execute the following slash com
 - `/build-connector-images` - Builds and publishes a pre-release docker image for the modified connector(s).
 - `/publish-connectors-prerelease` - Publishes pre-release connector builds (tagged as `{version}-preview.{git-sha}`) for all modified connectors in the PR.
 - `/ai-review` - AI-powered PR review for connector safety and quality gates.
-- _Maintainers: [AI-SDLC Docs](https://github.com/airbytehq/ai-skills/blob/main/docs/hydra/) (internal link)_
 - `/force-merge reason="<A_GOOD_REASON>"` - Force merges the PR using admin privileges, bypassing CI checks. Requires a reason.
 
 ### Tips for Working with CI
@@ -36,6 +35,7 @@ As needed or by request, Airbyte Maintainers can execute the following slash com
 
 ### Helpful Resources
 
+- _Maintainers: [AI-SDLC Docs](https://github.com/airbytehq/ai-skills/blob/main/docs/hydra/) (internal link)_
 - [PR Guidelines](https://docs.airbyte.com/contributing-to-airbyte): Check our guidelines for contributions.
 - [Breaking Changes Guide](https://docs.airbyte.com/platform/connector-development/connector-breaking-changes): Guide to breaking changes, migration guides, and upgrade deadlines.
 - [Developing Connectors Locally](https://docs.airbyte.com/platform/connector-development/local-connector-development): Learn how to set up your environment and develop connectors locally.

--- a/.github/pr-welcome-community.md
+++ b/.github/pr-welcome-community.md
@@ -19,6 +19,7 @@ As needed or by request, Airbyte Maintainers can execute the following slash com
 - `/build-connector-images` - Builds and publishes a pre-release docker image for the modified connector(s).
 - `/publish-connectors-prerelease` - Publishes pre-release connector builds (tagged as `{version}-preview.{git-sha}`) for all modified connectors in the PR.
 - `/ai-review` - AI-powered PR review for connector safety and quality gates.
+- Learn more about Airbyte's AI-powered development process: [Hydra SDLC Docs](https://github.com/airbytehq/ai-skills/blob/main/docs/hydra/)
 - `/force-merge reason="<A_GOOD_REASON>"` - Force merges the PR using admin privileges, bypassing CI checks. Requires a reason.
 
 ### Tips for Working with CI

--- a/.github/pr-welcome-internal.md
+++ b/.github/pr-welcome-internal.md
@@ -12,7 +12,7 @@ Airbyte Maintainers (that's you!) can execute the following slash commands on yo
 - 🛠️ Quick Fixes
   - `/format-fix` - Fixes most formatting issues.
   - `/bump-version` - Bumps connector versions, scraping `changelog` description from the PR title.
-- ❇️ AI Testing and Review ([Hydra SDLC Docs](https://github.com/airbytehq/ai-skills/blob/main/docs/hydra/)):
+- ❇️ AI Testing and Review (internal link: [AI-SDLC Docs](https://github.com/airbytehq/ai-skills/blob/main/docs/hydra/)):
   - `/ai-prove-fix` - Runs prerelease readiness checks, including testing against customer connections.
   - `/ai-canary-prerelease` - Rolls out prerelease to 5-10 connections for canary testing.
   - `/ai-review` - AI-powered PR review for connector safety and quality gates.

--- a/.github/pr-welcome-internal.md
+++ b/.github/pr-welcome-internal.md
@@ -12,8 +12,7 @@ Airbyte Maintainers (that's you!) can execute the following slash commands on yo
 - 🛠️ Quick Fixes
   - `/format-fix` - Fixes most formatting issues.
   - `/bump-version` - Bumps connector versions, scraping `changelog` description from the PR title.
-- ❇️ AI Testing and Review:
-  - `/ai-docs-review` - Provides AI-powered documentation recommendations for PRs with connector changes.
+- ❇️ AI Testing and Review ([Hydra SDLC Docs](https://github.com/airbytehq/ai-skills/blob/main/docs/hydra/)):
   - `/ai-prove-fix` - Runs prerelease readiness checks, including testing against customer connections.
   - `/ai-canary-prerelease` - Rolls out prerelease to 5-10 connections for canary testing.
   - `/ai-review` - AI-powered PR review for connector safety and quality gates.


### PR DESCRIPTION
## What

Adds cross-links from the PR welcome messages to the [Hydra SDLC documentation](https://github.com/airbytehq/ai-skills/blob/main/docs/hydra/) that was recently merged in `airbytehq/ai-skills`. Also removes `/ai-docs-review` from the internal welcome message per prior discussion.

## How

- **`pr-welcome-internal.md`**: Adds a link to Hydra docs in the "AI Testing and Review" section header. Removes `/ai-docs-review` from the listed slash commands.
- **`pr-welcome-community.md`**: Adds a "Learn more" link to Hydra docs in the slash commands section.

## Review guide

1. `.github/pr-welcome-internal.md` — Verify the `/ai-docs-review` removal is desired and the Hydra link placement reads well.
2. `.github/pr-welcome-community.md` — The Hydra docs link sits between `/ai-review` and `/force-merge` in the slash commands list. Consider whether it would read better at the end of the list or in the "Helpful Resources" section instead.

## User Impact

Internal and community contributors will see a link to the Hydra SDLC docs in the PR welcome message, making it easier to understand the AI-powered development process. Internal contributors will no longer see `/ai-docs-review` listed.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Requested by: @aaronsteers
[Devin session](https://app.devin.ai/sessions/0c10c31e0b974f8c87db183335c73ad1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/74005" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
