### PR TITLE
fix(source-instagram): use day_delta(1) for end_datetime to cover UTC+ accounts

### DIFF
--- a/airbyte-integrations/connectors/source-instagram/manifest.yaml
+++ b/airbyte-integrations/connectors/source-instagram/manifest.yaml
@@ -602,7 +602,7 @@ definitions:
           datetime_format: "%Y-%m-%dT%H:%M:%SZ"
         end_datetime:
           type: MinMaxDatetime
-          datetime: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"
+          datetime: "{{ day_delta(1, format='%Y-%m-%dT%H:%M:%SZ') }}"
           datetime_format: "%Y-%m-%dT%H:%M:%SZ"
         datetime_format: "%Y-%m-%dT%H:%M:%S+00:00"
         cursor_datetime_formats:

--- a/airbyte-integrations/connectors/source-instagram/metadata.yaml
+++ b/airbyte-integrations/connectors/source-instagram/metadata.yaml
@@ -7,7 +7,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 6acf6b55-4f1e-4fca-944e-1a3caef8aba8
-  dockerImageTag: 4.2.17
+  dockerImageTag: 4.2.18
   dockerRepository: airbyte/source-instagram
   githubIssueLabel: source-instagram
   icon: instagram.svg

--- a/docs/integrations/sources/instagram.md
+++ b/docs/integrations/sources/instagram.md
@@ -146,6 +146,7 @@ for more information.
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:-----------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 4.2.18 | 2026-02-24 | [74006](https://github.com/airbytehq/airbyte/pull/74006) | Fix user_insights end_datetime to cover current day for UTC+ accounts |
 | 4.2.17 | 2026-02-24 | [72266](https://github.com/airbytehq/airbyte/pull/72266) | Add views metric and timestamp to media_insights stream |
 | 4.2.16 | 2026-01-20 | [71966](https://github.com/airbytehq/airbyte/pull/71966) | Update dependencies |
 | 4.2.15 | 2026-01-14 | [71406](https://github.com/airbytehq/airbyte/pull/71406) | Update dependencies |


### PR DESCRIPTION
## Summary

- **Root cause**: `user_insights` stream uses `now_utc()` as the `until` parameter. For `period=day` aggregation, Meta determines day boundaries using the ad account's timezone. For UTC+ accounts, the current local day's `end_time` (account midnight expressed in UTC) is later than `now_utc()`, so Meta excludes that day's data entirely from the response.
- **Fix**: Change `end_datetime` from `now_utc().strftime(...)` to `day_delta(1, format='%Y-%m-%dT%H:%M:%SZ')` (UTC tomorrow at 00:00:00Z). This ensures any UTC+ account's current-day `end_time` falls within the query window. Meta accepts future `until` values and returns whatever data is available — no error risk.
- **No lookback needed**: Unlike Snapchat (which has a documented 48h metric finalization window), Instagram's `period=day` returns only complete days. The cursor naturally stays pinned to the current day boundary until it's complete, so no additional lookback is required.

## Streams affected

Only `user_insights` (the sole incremental stream). All other streams are full-refresh.

## Test plan

- [ ] Verify `grep "day_delta" manifest.yaml` returns the updated `end_datetime` expression
- [ ] Verify `grep "now_utc" manifest.yaml` no longer appears in `end_datetime` (only in `start_datetime`)
- [ ] Confirm `dockerImageTag: 4.2.18` in metadata.yaml
- [ ] Test with a UTC+ ad account: confirm current local day's data appears in `user_insights` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Closes https://github.com/airbytehq/oncall/issues/11341