### PR TITLE
fix(source-firehydrant)!: rename `enviroments` stream to `environments`

### DIFF
--- a/airbyte-integrations/connectors/source-firehydrant/manifest.yaml
+++ b/airbyte-integrations/connectors/source-firehydrant/manifest.yaml
@@ -14,13 +14,13 @@ description: >-
 check:
   type: CheckStream
   stream_names:
-    - enviroments
+    - environments
 
 definitions:
   streams:
-    enviroments:
+    environments:
       type: DeclarativeStream
-      name: enviroments
+      name: environments
       primary_key:
         - id
       retriever:
@@ -53,7 +53,7 @@ definitions:
       schema_loader:
         type: InlineSchemaLoader
         schema:
-          $ref: "#/schemas/enviroments"
+          $ref: "#/schemas/environments"
     services:
       type: DeclarativeStream
       name: services
@@ -1344,7 +1344,7 @@ definitions:
       api_token: "{{ config[\"api_token\"] }}"
 
 streams:
-  - $ref: "#/definitions/streams/enviroments"
+  - $ref: "#/definitions/streams/environments"
   - $ref: "#/definitions/streams/services"
   - $ref: "#/definitions/streams/functionalities"
   - $ref: "#/definitions/streams/teams"
@@ -1407,7 +1407,7 @@ spec:
 
 metadata:
   autoImportSchema:
-    enviroments: true
+    environments: true
     services: true
     functionalities: true
     teams: true
@@ -1447,7 +1447,7 @@ metadata:
     task_lists: true
     checklist_templates: true
   testedStreams:
-    enviroments:
+    environments:
       hasRecords: true
       streamHash: 71983108f8df8f1a8b9a2ff3995dfe29414d67fe
       hasResponse: true
@@ -1724,7 +1724,7 @@ metadata:
     docsUrl: https://developers.firehydrant.com/
 
 schemas:
-  enviroments:
+  environments:
     type: object
     $schema: http://json-schema.org/schema#
     additionalProperties: true

--- a/airbyte-integrations/connectors/source-firehydrant/metadata.yaml
+++ b/airbyte-integrations/connectors/source-firehydrant/metadata.yaml
@@ -17,7 +17,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: b58c3536-7900-439c-80a8-fc2b94460781
-  dockerImageTag: 0.0.45
+  dockerImageTag: 1.0.0
   dockerRepository: airbyte/source-firehydrant
   githubIssueLabel: source-firehydrant
   icon: icon.svg
@@ -27,6 +27,14 @@ data:
   releaseStage: alpha
   supportLevel: community
   documentationUrl: https://docs.airbyte.com/integrations/sources/firehydrant
+  breaking_changes:
+    1.0.0:
+      message: "The `enviroments` stream has been renamed to `environments` to fix a typo. Users must refresh their schema and reset the affected stream after upgrading."
+      upgradeDeadline: "2026-03-26"
+      scopedImpact:
+        - scopeType: stream
+          impactedScopes:
+            - "environments"
   tags:
     - language:manifest-only
     - cdk:low-code

--- a/airbyte-integrations/connectors/source-firehydrant/metadata.yaml
+++ b/airbyte-integrations/connectors/source-firehydrant/metadata.yaml
@@ -27,14 +27,15 @@ data:
   releaseStage: alpha
   supportLevel: community
   documentationUrl: https://docs.airbyte.com/integrations/sources/firehydrant
-  breaking_changes:
-    1.0.0:
-      message: "The `enviroments` stream has been renamed to `environments` to fix a typo. Users must refresh their schema and reset the affected stream after upgrading."
-      upgradeDeadline: "2026-03-26"
-      scopedImpact:
-        - scopeType: stream
-          impactedScopes:
-            - "environments"
+  releases:
+    breakingChanges:
+      1.0.0:
+        message: "The `enviroments` stream has been renamed to `environments` to fix a typo. Users must refresh their schema and reset the affected stream after upgrading."
+        upgradeDeadline: "2026-03-26"
+        scopedImpact:
+          - scopeType: stream
+            impactedScopes:
+              - "environments"
   tags:
     - language:manifest-only
     - cdk:low-code

--- a/docs/integrations/sources/firehydrant-migrations.md
+++ b/docs/integrations/sources/firehydrant-migrations.md
@@ -4,7 +4,7 @@
 
 This version fixes a typo in the `enviroments` stream name. The stream has been renamed to `environments`.
 
-### Summary of changes:
+### Summary of changes
 
 - The `enviroments` stream has been renamed to `environments`.
 

--- a/docs/integrations/sources/firehydrant-migrations.md
+++ b/docs/integrations/sources/firehydrant-migrations.md
@@ -10,27 +10,9 @@ This version fixes a typo in the `enviroments` stream name. The stream has been 
 
 ### Refresh affected schemas and reset data
 
-1. Select **Connections** in the main navbar.
-   1. Select the connection(s) affected by the update.
-2. Select the **Replication** tab.
-   1. Select **Refresh source schema**.
-   2. Select **OK**.
-
-:::note
-Any detected schema changes will be listed for your review.
-:::
-
-3. Select **Save changes** at the bottom of the page.
-   1. Ensure the **Reset affected streams** option is checked.
-
-:::note
-Depending on destination type you may not be prompted to reset your data.
-:::
-
-4. Select **Save connection**.
-
-:::note
-This will reset the data in your destination and initiate a fresh sync.
-:::
+1. Select **Connections** in the main navbar and select the connection(s) affected by the update.
+1. Select the **Replication** tab, then select **Refresh source schema** and select **OK**. Any detected schema changes will be listed for your review.
+1. Select **Save changes** at the bottom of the page. Ensure the **Reset affected streams** option is checked.
+1. Select **Save connection**. This will reset the data in your destination and initiate a fresh sync.
 
 For more information on resetting your data in Airbyte, see [this page](/platform/operator-guides/clear).

--- a/docs/integrations/sources/firehydrant-migrations.md
+++ b/docs/integrations/sources/firehydrant-migrations.md
@@ -1,18 +1,11 @@
+import MigrationGuide from '@site/static/_migration_guides_upgrade_guide.md';
+
 # FireHydrant Migration Guide
 
 ## Upgrading to 1.0.0
 
-This version fixes a typo in the `enviroments` stream name. The stream has been renamed to `environments`.
+The `enviroments` stream has been renamed to `environments` to fix a typo. After upgrading, you must clear the `environments` stream.
 
-### Summary of changes
+## Connector upgrade guide
 
-- The `enviroments` stream has been renamed to `environments`.
-
-### Refresh affected schemas and reset data
-
-1. Select **Connections** in the main navbar and select the connection(s) affected by the update.
-1. Select the **Replication** tab, then select **Refresh source schema** and select **OK**. Any detected schema changes will be listed for your review.
-1. Select **Save changes** at the bottom of the page. Ensure the **Reset affected streams** option is checked.
-1. Select **Save connection**. This will reset the data in your destination and initiate a fresh sync.
-
-For more information on resetting your data in Airbyte, see [this page](/platform/operator-guides/clear).
+<MigrationGuide />

--- a/docs/integrations/sources/firehydrant-migrations.md
+++ b/docs/integrations/sources/firehydrant-migrations.md
@@ -1,0 +1,36 @@
+# FireHydrant Migration Guide
+
+## Upgrading to 1.0.0
+
+This version fixes a typo in the `enviroments` stream name. The stream has been renamed to `environments`.
+
+### Summary of changes:
+
+- The `enviroments` stream has been renamed to `environments`.
+
+### Refresh affected schemas and reset data
+
+1. Select **Connections** in the main navbar.
+   1. Select the connection(s) affected by the update.
+2. Select the **Replication** tab.
+   1. Select **Refresh source schema**.
+   2. Select **OK**.
+
+:::note
+Any detected schema changes will be listed for your review.
+:::
+
+3. Select **Save changes** at the bottom of the page.
+   1. Ensure the **Reset affected streams** option is checked.
+
+:::note
+Depending on destination type you may not be prompted to reset your data.
+:::
+
+4. Select **Save connection**.
+
+:::note
+This will reset the data in your destination and initiate a fresh sync.
+:::
+
+For more information on resetting your data in Airbyte, see [this page](/platform/operator-guides/clear).

--- a/docs/integrations/sources/firehydrant.md
+++ b/docs/integrations/sources/firehydrant.md
@@ -58,6 +58,7 @@ The Airbyte connector for FireHydrant enables seamless data integration between 
 
 | Version | Date              | Pull Request | Subject        |
 |---------|-------------------|--------------|----------------|
+| 1.0.0 | 2026-02-24 | [74008](https://github.com/airbytehq/airbyte/pull/74008) | Rename `enviroments` stream to `environments` |
 | 0.0.45 | 2026-02-17 | [73410](https://github.com/airbytehq/airbyte/pull/73410) | Update dependencies |
 | 0.0.44 | 2026-02-10 | [73170](https://github.com/airbytehq/airbyte/pull/73170) | Update dependencies |
 | 0.0.43 | 2026-01-20 | [71971](https://github.com/airbytehq/airbyte/pull/71971) | Update dependencies |

--- a/docs/integrations/sources/firehydrant.md
+++ b/docs/integrations/sources/firehydrant.md
@@ -10,7 +10,7 @@ The Airbyte connector for FireHydrant enables seamless data integration between 
 ## Streams
 | Stream Name | Primary Key | Pagination | Supports Full Sync | Supports Incremental |
 |-------------|-------------|------------|---------------------|----------------------|
-| enviroments | id | DefaultPaginator | ✅ |  ❌  |
+| environments | id | DefaultPaginator | ✅ |  ❌  |
 | services | id | DefaultPaginator | ✅ |  ❌  |
 | functionalities | id | DefaultPaginator | ✅ |  ❌  |
 | teams | id | DefaultPaginator | ✅ |  ❌  |

--- a/docs/integrations/sources/firehydrant.md
+++ b/docs/integrations/sources/firehydrant.md
@@ -8,6 +8,7 @@ The Airbyte connector for FireHydrant enables seamless data integration between 
 | `api_token` | `string` | API Token. Bot token to use for authenticating with the FireHydrant API. You can find or create a bot token by logging into your organization and visiting the Bot users page at https://app.firehydrant.io/organizations/bots. |  |
 
 ## Streams
+
 | Stream Name | Primary Key | Pagination | Supports Full Sync | Supports Incremental |
 |-------------|-------------|------------|---------------------|----------------------|
 | environments | id | DefaultPaginator | ✅ |  ❌  |


### PR DESCRIPTION
## What

Fixes a typo in the `source-firehydrant` connector: the `enviroments` stream is renamed to `environments`. This is a breaking change for existing connections that sync this stream, as the stream name in the catalog will change.

## How

- **`manifest.yaml`**: Renamed all 8 occurrences of `enviroments` → `environments` (stream definition, check stream, schema ref, streams list, autoImportSchema, testedStreams, schemas key).
- **`metadata.yaml`**: Bumped `dockerImageTag` from `0.0.45` to `1.0.0` and added a `releases.breakingChanges` entry with an upgrade deadline of `2026-03-26` scoped to the `environments` stream.
- **`firehydrant.md`**: Updated the stream name in the docs table and added a changelog entry for `1.0.0`.
- **`firehydrant-migrations.md`**: Added a new migration guide using the reusable `<MigrationGuide />` component.

## Review guide

1. `airbyte-integrations/connectors/source-firehydrant/manifest.yaml` — core rename; verify all references are updated consistently
2. `airbyte-integrations/connectors/source-firehydrant/metadata.yaml` — breaking change metadata format (`releases.breakingChanges`) and version bump
3. `docs/integrations/sources/firehydrant-migrations.md` — new migration guide using reusable component; check if it needs to be registered in sidebar/nav config
4. `docs/integrations/sources/firehydrant.md` — docs table update and changelog entry

### Human review checklist

- [ ] Verify `releases.breakingChanges` metadata format matches what the platform expects (modeled after source-stripe)
- [ ] Confirm whether `firehydrant-migrations.md` needs to be registered in a sidebar or nav config to be discoverable
- [ ] Verify the `testedStreams` hash for `environments` is still valid after rename (currently unchanged from the `enviroments` entry — may need regeneration)

## User Impact

Existing connections syncing the `enviroments` stream will need to refresh their schema and reset the affected stream after upgrading to v1.0.0. The platform will surface the breaking change notice with the upgrade deadline. After upgrading, the stream will appear with the corrected name `environments`.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

### Updates since last revision

- Moved `breaking_changes` from `data.breaking_changes` to `data.releases.breakingChanges` to match the expected metadata schema (fixed CI pre-release check failure)
- Added changelog entry for `1.0.0` in `firehydrant.md` (fixed CI changelog check failure)

---

Requested by: @lleadbet
[Link to Devin run](https://app.devin.ai/sessions/fb96e3fbfece4142b171e389237fdfc3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/74008" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
