### PR TITLE
fix: improve error messages across Java CDK and connectors

### DIFF
--- a/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/ssh/TunnelSession.kt
+++ b/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/ssh/TunnelSession.kt
@@ -132,8 +132,7 @@ fun createTunnelSession(
 }
 
 const val SSH_TIMEOUT_DISPLAY_MESSAGE: String =
-    "Timed out while opening a SSH Tunnel. " +
-        "Please double check the given SSH configurations and try again."
+    "SSH tunnel connection timed out."
 
 private val tunnelSessionTimeout: Duration = Duration.ofMillis(15_000)
 

--- a/airbyte-cdk/bulk/toolkits/legacy-source-integration-tests/src/testFixtures/kotlin/io/airbyte/cdk/test/fixtures/legacy/AirbyteExceptionHandler.kt
+++ b/airbyte-cdk/bulk/toolkits/legacy-source-integration-tests/src/testFixtures/kotlin/io/airbyte/cdk/test/fixtures/legacy/AirbyteExceptionHandler.kt
@@ -91,7 +91,7 @@ class AirbyteExceptionHandler : Thread.UncaughtExceptionHandler {
     companion object {
 
         const val logMessage: String =
-            "Something went wrong in the connector. See the logs for more details."
+            "Unhandled connector error."
 
         // Basic deinterpolation helpers to avoid doing _really_ dumb deinterpolation.
         // E.g. if "id" is in the list of strings to remove, we don't want to modify the message

--- a/airbyte-cdk/bulk/toolkits/legacy-source-integration-tests/src/testFixtures/kotlin/io/airbyte/cdk/test/fixtures/legacy/FailureHelper.kt
+++ b/airbyte-cdk/bulk/toolkits/legacy-source-integration-tests/src/testFixtures/kotlin/io/airbyte/cdk/test/fixtures/legacy/FailureHelper.kt
@@ -74,7 +74,7 @@ object FailureHelper {
     fun sourceFailure(t: Throwable, jobId: Long, attemptNumber: Int): FailureReason {
         return connectorCommandFailure(t, jobId, attemptNumber, ConnectorCommand.READ)
             .withFailureOrigin(FailureReason.FailureOrigin.SOURCE)
-            .withExternalMessage("Something went wrong within the source connector")
+            .withExternalMessage("Source connector failed with an unexpected error. See logs for details.")
     }
 
     fun sourceFailure(m: AirbyteTraceMessage, jobId: Long?, attemptNumber: Int?): FailureReason {
@@ -85,7 +85,7 @@ object FailureHelper {
     fun destinationFailure(t: Throwable, jobId: Long, attemptNumber: Int): FailureReason {
         return connectorCommandFailure(t, jobId, attemptNumber, ConnectorCommand.WRITE)
             .withFailureOrigin(FailureReason.FailureOrigin.DESTINATION)
-            .withExternalMessage("Something went wrong within the destination connector")
+            .withExternalMessage("Destination connector failed with an unexpected error. See logs for details.")
     }
 
     fun destinationFailure(
@@ -109,7 +109,7 @@ object FailureHelper {
             .withRetryable(false)
             .withExternalMessage(
                 String.format(
-                    "Checking %s connection failed - please review this connection's configuration to prevent future syncs from failing",
+                    "%s connection check failed.",
                     origin
                 )
             )
@@ -118,7 +118,7 @@ object FailureHelper {
     fun unknownOriginFailure(t: Throwable, jobId: Long, attemptNumber: Int): FailureReason {
         return genericFailure(t, jobId, attemptNumber)
             .withFailureOrigin(FailureReason.FailureOrigin.UNKNOWN)
-            .withExternalMessage("An unknown failure occurred")
+            .withExternalMessage("Sync failed. Failure could not be attributed to source, destination, or platform.")
     }
 
     private fun jobAndAttemptMetadata(jobId: Long, attemptNumber: Int): Metadata {

--- a/airbyte-cdk/bulk/toolkits/legacy-source-integration-tests/src/testFixtures/kotlin/io/airbyte/cdk/test/fixtures/legacy/SshTunnel.kt
+++ b/airbyte-cdk/bulk/toolkits/legacy-source-integration-tests/src/testFixtures/kotlin/io/airbyte/cdk/test/fixtures/legacy/SshTunnel.kt
@@ -394,7 +394,7 @@ constructor(
     companion object {
 
         const val SSH_TIMEOUT_DISPLAY_MESSAGE: String =
-            "Timed out while opening a SSH Tunnel. Please double check the given SSH configurations and try again."
+            "SSH tunnel connection timed out."
 
         const val CONNECTION_OPTIONS_KEY: String = "ssh_connection_options"
         const val SESSION_HEARTBEAT_INTERVAL_KEY: String = "session_heartbeat_interval"

--- a/airbyte-cdk/java/airbyte-cdk/core/src/main/kotlin/io/airbyte/cdk/integrations/base/AirbyteExceptionHandler.kt
+++ b/airbyte-cdk/java/airbyte-cdk/core/src/main/kotlin/io/airbyte/cdk/integrations/base/AirbyteExceptionHandler.kt
@@ -90,7 +90,7 @@ class AirbyteExceptionHandler : Thread.UncaughtExceptionHandler {
     companion object {
 
         const val logMessage: String =
-            "Something went wrong in the connector. See the logs for more details."
+            "Unhandled connector error."
 
         // Basic deinterpolation helpers to avoid doing _really_ dumb deinterpolation.
         // E.g. if "id" is in the list of strings to remove, we don't want to modify the message

--- a/airbyte-cdk/java/airbyte-cdk/core/src/main/kotlin/io/airbyte/cdk/integrations/base/ssh/SshTunnel.kt
+++ b/airbyte-cdk/java/airbyte-cdk/core/src/main/kotlin/io/airbyte/cdk/integrations/base/ssh/SshTunnel.kt
@@ -400,7 +400,7 @@ constructor(
     companion object {
 
         const val SSH_TIMEOUT_DISPLAY_MESSAGE: String =
-            "Timed out while opening a SSH Tunnel. Please double check the given SSH configurations and try again."
+            "SSH tunnel connection timed out."
 
         const val CONNECTION_OPTIONS_KEY: String = "ssh_connection_options"
         const val SESSION_HEARTBEAT_INTERVAL_KEY: String = "session_heartbeat_interval"

--- a/airbyte-cdk/java/airbyte-cdk/db-sources/src/main/kotlin/io/airbyte/cdk/integrations/source/relationaldb/InvalidCursorInfoUtil.kt
+++ b/airbyte-cdk/java/airbyte-cdk/db-sources/src/main/kotlin/io/airbyte/cdk/integrations/source/relationaldb/InvalidCursorInfoUtil.kt
@@ -5,7 +5,7 @@ package io.airbyte.cdk.integrations.source.relationaldb
 
 object InvalidCursorInfoUtil {
     fun getInvalidCursorConfigMessage(tablesWithInvalidCursor: List<InvalidCursorInfo>): String {
-        return ("The following tables have invalid columns selected as cursor, please select a column with a well-defined ordering with no null values as a cursor. " +
+        return ("Invalid cursor column selected. Column must have a well-defined ordering with no null values. " +
             tablesWithInvalidCursor.joinToString(",") { obj: InvalidCursorInfo -> obj.toString() })
     }
 

--- a/airbyte-cdk/java/airbyte-cdk/dependencies/src/test/kotlin/io/airbyte/workers/helper/FailureHelperTest.kt
+++ b/airbyte-cdk/java/airbyte-cdk/dependencies/src/test/kotlin/io/airbyte/workers/helper/FailureHelperTest.kt
@@ -177,7 +177,7 @@ internal class FailureHelperTest {
         val attemptNumber = 1
         val failureReason = FailureHelper.unknownOriginFailure(t, jobId, attemptNumber)
         Assertions.assertEquals(FailureReason.FailureOrigin.UNKNOWN, failureReason.failureOrigin)
-        Assertions.assertEquals("An unknown failure occurred", failureReason.externalMessage)
+        Assertions.assertEquals("Sync failed. Failure could not be attributed to source, destination, or platform.", failureReason.externalMessage)
     }
 
     companion object {

--- a/airbyte-cdk/java/airbyte-cdk/dependencies/src/testFixtures/kotlin/io/airbyte/workers/helper/FailureHelper.kt
+++ b/airbyte-cdk/java/airbyte-cdk/dependencies/src/testFixtures/kotlin/io/airbyte/workers/helper/FailureHelper.kt
@@ -76,7 +76,7 @@ object FailureHelper {
     fun sourceFailure(t: Throwable, jobId: Long, attemptNumber: Int): FailureReason {
         return connectorCommandFailure(t, jobId, attemptNumber, ConnectorCommand.READ)
             .withFailureOrigin(FailureReason.FailureOrigin.SOURCE)
-            .withExternalMessage("Something went wrong within the source connector")
+            .withExternalMessage("Source connector failed with an unexpected error. See logs for details.")
     }
 
     fun sourceFailure(m: AirbyteTraceMessage, jobId: Long?, attemptNumber: Int?): FailureReason {
@@ -87,7 +87,7 @@ object FailureHelper {
     fun destinationFailure(t: Throwable, jobId: Long, attemptNumber: Int): FailureReason {
         return connectorCommandFailure(t, jobId, attemptNumber, ConnectorCommand.WRITE)
             .withFailureOrigin(FailureReason.FailureOrigin.DESTINATION)
-            .withExternalMessage("Something went wrong within the destination connector")
+            .withExternalMessage("Destination connector failed with an unexpected error. See logs for details.")
     }
 
     fun destinationFailure(
@@ -111,7 +111,7 @@ object FailureHelper {
             .withRetryable(false)
             .withExternalMessage(
                 String.format(
-                    "Checking %s connection failed - please review this connection's configuration to prevent future syncs from failing",
+                    "%s connection check failed.",
                     origin
                 )
             )
@@ -120,7 +120,7 @@ object FailureHelper {
     fun unknownOriginFailure(t: Throwable, jobId: Long, attemptNumber: Int): FailureReason {
         return genericFailure(t, jobId, attemptNumber)
             .withFailureOrigin(FailureReason.FailureOrigin.UNKNOWN)
-            .withExternalMessage("An unknown failure occurred")
+            .withExternalMessage("Sync failed. Failure could not be attributed to source, destination, or platform.")
     }
 
     private fun jobAndAttemptMetadata(jobId: Long, attemptNumber: Int): Metadata {

--- a/airbyte-integrations/connectors/source-amazon-ads/manifest.yaml
+++ b/airbyte-integrations/connectors/source-amazon-ads/manifest.yaml
@@ -60,7 +60,7 @@ definitions:
         http_codes: [ 425 ]
         action: FAIL
         failure_type: config_error
-        error_message: "Amazon detected duplicate report requests. This occurs when syncing the same report types with different time granularities simultaneously. To fix: create a separate source with only the needed report streams and set Number of concurrent workers to 2 for sequential processing."
+        error_message: "Duplicate Amazon Ads report request detected. Concurrent syncs with different time granularities conflict."
 
   report_polling_error_handler:
     type: DefaultErrorHandler

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/acceptance-test-config.yml
@@ -104,7 +104,7 @@ acceptance_tests:
           - name: GET_XML_ALL_ORDERS_DATA_BY_ORDER_DATE_GENERAL
             bypass_reason: "Data for the stream only available for 2 years. Expired for now. Seeding in progress."
           - name: GET_V2_SETTLEMENT_REPORT_DATA_FLAT_FILE
-            bypass_reason: "Data for the stream only available for 90 days. Expired and too tedious to keep up to date. Test creds also don't have access: 'Forbidden. You don't have permission to access this resource.'"
+            bypass_reason: "Data for the stream only available for 90 days. Expired and too tedious to keep up to date. Test creds also don't have access: 'Source's API denied access. Configured credentials have insufficient permissions.'"
           - name: ListFinancialEvents
             bypass_reason: "Data doesn't exist during the test time window. Requesting very large time windows on Amazon is prohibitively slow w/ our plan's rate limits"
           - name: ListFinancialEventGroups

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/unit_tests/integration/test_report_based_streams.py
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/unit_tests/integration/test_report_based_streams.py
@@ -333,7 +333,7 @@ class TestFullRefresh:
         http_mocker.post(_create_report_request(stream_name).build(), response_with_status(status_code=HTTPStatus.FORBIDDEN))
 
         output = self._read(stream_name, config())
-        message_on_access_forbidden = "Forbidden. You don't have permission to access this resource."
+        message_on_access_forbidden = "Source's API denied access. Configured credentials have insufficient permissions."
         assert output.errors[0].trace.error.failure_type == FailureType.config_error
         assert message_on_access_forbidden in output.errors[0].trace.error.message
 
@@ -776,7 +776,7 @@ class TestVendorSalesReportsFullRefresh:
         )
 
         output = self._read(stream_name, config())
-        message_on_access_forbidden = "Forbidden. You don't have permission to access this resource."
+        message_on_access_forbidden = "Source's API denied access. Configured credentials have insufficient permissions."
         assert output.errors[0].trace.error.failure_type == FailureType.config_error
         assert message_on_access_forbidden in output.errors[0].trace.error.message
 

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/streams/common.py
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/streams/common.py
@@ -163,55 +163,37 @@ def traced_exception(fb_exception: FacebookRequestError):
 
     if "Invalid OAuth access token" in msg:
         failure_type = FailureType.config_error
-        friendly_msg = (
-            "The access token for this connection is invalid or corrupted. "
-            "Please re-authenticate your Facebook connection in Airbyte. "
-            "If re-authentication does not resolve the issue, go to facebook.com > Settings > Business Integrations, "
-            "remove the Airbyte app, and then re-authenticate again."
-        )
+        friendly_msg = "Facebook OAuth access token is invalid or corrupted."
 
     elif "Error validating access token" in msg:
         failure_type = FailureType.config_error
-        friendly_msg = "Invalid access token. Re-authenticate if FB oauth is used or refresh access token with all required permissions"
+        friendly_msg = "Facebook access token is invalid."
 
     elif "(#100) Missing permissions" in msg:
         failure_type = FailureType.config_error
-        friendly_msg = (
-            "Credentials don't have enough permissions. Check if correct Ad Account Id is used (as in Ads Manager), "
-            "re-authenticate if FB oauth is used or refresh access token with all required permissions"
-        )
+        friendly_msg = "Insufficient Facebook API permissions for the specified Ad Account."
 
     elif "permission" in msg:
         failure_type = FailureType.config_error
-        friendly_msg = (
-            "Credentials don't have enough permissions. Re-authenticate if FB oauth is used or refresh access token "
-            "with all required permissions."
-        )
+        friendly_msg = "Insufficient Facebook API permissions."
 
     elif "An unknown error occurred" in msg and "error_user_title" in fb_exception._error:
         msg = fb_exception._error["error_user_title"]
         if "profile is not linked to delegate page" in msg or "el perfil no est" in msg:
             failure_type = FailureType.config_error
-            friendly_msg = (
-                "Current profile is not linked to delegate page. Check if correct business (not personal) "
-                "Ad Account Id is used (as in Ads Manager), re-authenticate if FB oauth is used or refresh "
-                "access token with all required permissions."
-            )
+            friendly_msg = "Current profile is not linked to delegate page. A business Ad Account is required."
     elif "reduce the amount of data" in msg:
         failure_type = FailureType.config_error
-        friendly_msg = (
-            "Please reduce the number of fields requested. Go to the schema tab, select your source, "
-            "and unselect the fields you do not need."
-        )
+        friendly_msg = "Facebook API field count limit exceeded. Reduce the number of selected fields."
     elif "The start date of the time range cannot be beyond 37 months from the current date" in msg:
         failure_type = FailureType.config_error
-        friendly_msg = "Please set the start date of your sync to be within the last 3 years."
+        friendly_msg = "Start date exceeds the 37-month lookback limit."
     elif (fb_exception.api_error_code(), fb_exception.api_error_subcode()) in FACEBOOK_CONFIG_ERRORS_TO_CATCH:
         failure_type = FailureType.config_error
         friendly_msg = msg
     elif fb_exception.api_error_code() in FACEBOOK_RATE_LIMIT_ERROR_CODES:
         return AirbyteTracedException(
-            message="The maximum number of requests on the Facebook API has been reached. See https://developers.facebook.com/docs/graph-api/overview/rate-limiting/ for more information",
+            message="Facebook API rate limit exceeded.",
             internal_message=str(fb_exception),
             failure_type=FailureType.transient_error,
             exception=fb_exception,
@@ -219,7 +201,7 @@ def traced_exception(fb_exception: FacebookRequestError):
 
     elif fb_exception.http_status() == 503:
         return AirbyteTracedException(
-            message="The Facebook API service is temporarily unavailable. This issue should resolve itself, and does not require further action.",
+            message="Facebook API service temporarily unavailable.",
             internal_message=str(fb_exception),
             failure_type=FailureType.transient_error,
             exception=fb_exception,

--- a/airbyte-integrations/connectors/source-facebook-marketing/unit_tests/test_errors.py
+++ b/airbyte-integrations/connectors/source-facebook-marketing/unit_tests/test_errors.py
@@ -60,7 +60,7 @@ ad_creative_response = {
 CONFIG_ERRORS = [
     (
         "error_400_validating_access_token_session_expired",
-        "Invalid access token. Re-authenticate if FB oauth is used or refresh access token with all required permissions",
+        "Facebook access token is invalid.",
         {
             "status_code": 400,
             "json": {
@@ -75,7 +75,7 @@ CONFIG_ERRORS = [
     ),
     (
         "error_400_validating_access_token_user_changed_their_password",
-        "Invalid access token. Re-authenticate if FB oauth is used or refresh access token with all required permissions",
+        "Facebook access token is invalid.",
         {
             "status_code": 400,
             "json": {
@@ -90,7 +90,7 @@ CONFIG_ERRORS = [
     ),
     (
         "error_400_validating_access_token_not_authorized_application",
-        "Invalid access token. Re-authenticate if FB oauth is used or refresh access token with all required permissions",
+        "Facebook access token is invalid.",
         {
             "status_code": 400,
             "json": {
@@ -106,7 +106,7 @@ CONFIG_ERRORS = [
     ),
     (
         "error_400_missing_permission",
-        "Credentials don't have enough permissions. Check if correct Ad Account Id is used (as in Ads Manager), re-authenticate if FB oauth is used or refresh access token with all required permissions",
+        "Insufficient Facebook API permissions for the specified Ad Account.",
         {
             "status_code": 400,
             "json": {
@@ -129,7 +129,7 @@ CONFIG_ERRORS = [
         # One of possible reasons why this error happen is an attempt to access `owner` field:
         #   GET /act_<account-id>?fields=<field-1>,owner,...<field-n>
         "error_403_requires_permission",
-        "Credentials don't have enough permissions. Re-authenticate if FB oauth is used or refresh access token with all required permissions.",
+        "Insufficient Facebook API permissions.",
         {
             "status_code": 403,
             "json": {
@@ -142,7 +142,7 @@ CONFIG_ERRORS = [
     ),
     (
         "error_400_permission_must_be_granted",
-        "Credentials don't have enough permissions. Re-authenticate if FB oauth is used or refresh access token with all required permissions.",
+        "Insufficient Facebook API permissions.",
         {
             "status_code": 400,
             "json": {
@@ -156,7 +156,7 @@ CONFIG_ERRORS = [
     ),
     (
         "error_unsupported_get_request",
-        "Credentials don't have enough permissions. Re-authenticate if FB oauth is used or refresh access token with all required permissions.",
+        "Insufficient Facebook API permissions.",
         {
             "json": {
                 "error": {
@@ -172,7 +172,7 @@ CONFIG_ERRORS = [
     ),
     (
         "error_400_unknown_profile_is_no_linked",
-        "Current profile is not linked to delegate page. Check if correct business (not personal) Ad Account Id is used (as in Ads Manager), re-authenticate if FB oauth is used or refresh access token with all required permissions.",
+        "Current profile is not linked to delegate page. A business Ad Account is required.",
         {
             "status_code": 400,
             "json": {
@@ -192,7 +192,7 @@ CONFIG_ERRORS = [
     ),
     (
         "error_400_unknown_profile_is_no_linked_es",
-        "Current profile is not linked to delegate page. Check if correct business (not personal) Ad Account Id is used (as in Ads Manager), re-authenticate if FB oauth is used or refresh access token with all required permissions.",
+        "Current profile is not linked to delegate page. A business Ad Account is required.",
         {
             "status_code": 400,
             "json": {
@@ -210,7 +210,7 @@ CONFIG_ERRORS = [
     ),
     (
         "error_400_start_date_not_within_three_years",
-        "Please set the start date of your sync to be within the last 3 years.",
+        "Start date exceeds the 37-month lookback limit.",
         {
             "status_code": 400,
             "json": {
@@ -241,10 +241,7 @@ CONFIG_ERRORS = [
     ),
     (
         "error_400_invalid_oauth_access_token_cannot_parse",
-        "The access token for this connection is invalid or corrupted. "
-        "Please re-authenticate your Facebook connection in Airbyte. "
-        "If re-authentication does not resolve the issue, go to facebook.com > Settings > Business Integrations, "
-        "remove the Airbyte app, and then re-authenticate again.",
+        "Facebook OAuth access token is invalid or corrupted.",
         {
             "status_code": 400,
             "json": {
@@ -449,14 +446,13 @@ class TestRealErrors:
         [
             (
                 REDUCE_FIELDS_ERROR_TEST_NAME,
-                "Please reduce the number of fields requested. Go to the schema tab, "
-                "select your source, and unselect the fields you do not need.",
+                "Facebook API field count limit exceeded. Reduce the number of selected fields.",
                 REDUCE_FIELDS_ERROR_RESPONSE,
                 FailureType.config_error,
             ),
             (
                 SERVICE_TEMPORARILY_UNAVAILABLE_TEST_NAME,
-                "The Facebook API service is temporarily unavailable. This issue should resolve itself, and does not require further action.",
+                "Facebook API service temporarily unavailable.",
                 SERVICE_TEMPORARILY_UNAVAILABLE_RESPONSE,
                 FailureType.transient_error,
             ),
@@ -644,7 +640,7 @@ def test_traced_exception_with_api_error():
 
     assert isinstance(result, AirbyteTracedException)
     assert (
-        result.message == "Invalid access token. Re-authenticate if FB oauth is used or refresh access token with all required permissions"
+        result.message == "Facebook access token is invalid."
     )
     assert result.failure_type == FailureType.config_error
 

--- a/airbyte-integrations/connectors/source-github/unit_tests/test_stream.py
+++ b/airbyte-integrations/connectors/source-github/unit_tests/test_stream.py
@@ -133,9 +133,9 @@ def test_backoff_time(time_mock, http_status, response_headers, expected_backoff
             ResponseAction.RATE_LIMITED,
             f"Response status code: {HTTPStatus.FORBIDDEN}. Retrying...",
         ),
-        (HTTPStatus.INTERNAL_SERVER_ERROR, {}, "", ResponseAction.RETRY, "HTTP Status Code: 500. Error: Internal server error."),
-        (HTTPStatus.BAD_GATEWAY, {}, "", ResponseAction.RETRY, "HTTP Status Code: 502. Error: Bad gateway."),
-        (HTTPStatus.SERVICE_UNAVAILABLE, {}, "", ResponseAction.RETRY, "HTTP Status Code: 503. Error: Service unavailable."),
+        (HTTPStatus.INTERNAL_SERVER_ERROR, {}, "", ResponseAction.RETRY, "Internal server error from source's API."),
+        (HTTPStatus.BAD_GATEWAY, {}, "", ResponseAction.RETRY, "Bad gateway response from source's API."),
+        (HTTPStatus.SERVICE_UNAVAILABLE, {}, "", ResponseAction.RETRY, "Source's API is temporarily unavailable."),
     ],
 )
 def test_error_handler(http_status, response_headers, text, response_action, error_message):

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/google_ads.py
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/google_ads.py
@@ -30,7 +30,7 @@ def on_give_up(details):
         raise AirbyteTracedException(
             failure_type=FailureType.transient_error,
             message=f"{error.message} {error.details}",
-            internal_message=f"{error.message} Unable to fetch data from Google Ads API due to temporal error on the Google Ads server. Please retry again later. ",
+            internal_message=f"{error.message} Google Ads API transient server error.",
         )
 
 

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/manifest.yaml
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/manifest.yaml
@@ -54,7 +54,7 @@ definitions:
         http_codes:
           - 500
         error_message: >-
-          Unable to fetch data from Google Ads API due to temporal error on the Google Ads server. Please retry again later.
+          Google Ads API transient server error.
       - type: HttpResponseFilter
         action: IGNORE
         http_codes:

--- a/airbyte-integrations/connectors/source-google-sheets/unit_tests/integration/test_auth_credentials.py
+++ b/airbyte-integrations/connectors/source-google-sheets/unit_tests/integration/test_auth_credentials.py
@@ -78,7 +78,7 @@ class TestCredentials(GoogleSheetsBaseTest):
             type=TraceType.ERROR,
             emitted_at=ANY,
             error=AirbyteErrorTraceMessage(
-                message="Something went wrong in the connector. See the logs for more details.",
+                message="Unhandled connector error. See logs for details.",
                 internal_message="401 Client Error: None for url: https://www.googleapis.com/oauth2/v4/token",
                 failure_type=FailureType.system_error,
                 stack_trace=ANY,
@@ -105,7 +105,7 @@ class TestCredentials(GoogleSheetsBaseTest):
             type=TraceType.ERROR,
             emitted_at=ANY,
             error=AirbyteErrorTraceMessage(
-                message="Something went wrong in the connector. See the logs for more details.",
+                message="Unhandled connector error. See logs for details.",
                 internal_message="401 Client Error: None for url: https://www.googleapis.com/oauth2/v4/token",
                 failure_type=FailureType.system_error,
                 stack_trace=ANY,

--- a/airbyte-integrations/connectors/source-jira/unit_tests/test_streams.py
+++ b/airbyte-integrations/connectors/source-jira/unit_tests/test_streams.py
@@ -22,7 +22,7 @@ def test_application_roles_stream_401_error(config, caplog):
 
     with pytest.raises(
         AirbyteTracedException,
-        match="Unauthorized. Please ensure you are authenticated correctly.",
+        match="Authentication failed on source's API. Credentials may be invalid, expired, or lack required access.",
     ):
         list(read_full_refresh(stream))
 
@@ -47,7 +47,7 @@ def test_application_roles_stream_http_error(config, application_roles_response)
     responses.add(responses.GET, f"https://{config['domain']}/rest/api/3/applicationrole", json={"error": "not found"}, status=404)
 
     stream = find_stream("application_roles", config)
-    with pytest.raises(AirbyteTracedException, match="Not found. The requested resource was not found on the server"):
+    with pytest.raises(AirbyteTracedException, match="Requested resource not found."):
         list(read_full_refresh(stream))
 
 
@@ -77,7 +77,7 @@ def test_board_stream_forbidden(config, boards_response, caplog):
     )
     stream = find_stream("boards", config)
 
-    with pytest.raises(AirbyteTracedException, match="Forbidden. You don't have permission to access this resource."):
+    with pytest.raises(AirbyteTracedException, match="Source's API denied access. Configured credentials have insufficient permissions."):
         list(read_full_refresh(stream))
 
 
@@ -575,7 +575,7 @@ def test_avatars_stream_should_retry(config, caplog):
     records = list(read_full_refresh(stream))
 
     assert len(records) == 0
-    assert "Bad request. Please check your request parameters" in caplog.text
+    assert "Bad request." in caplog.text
 
 
 @responses.activate
@@ -801,28 +801,28 @@ def test_project_versions_stream(config, mock_non_deleted_projects_responses, pr
             "issue_custom_field_contexts",
             2,
             4,
-            "Not found. The requested resource was not found on the server.",
+            "Requested resource not found.",
             # "Stream `issue_custom_field_contexts`. An error occurred, details: ['Not found issue custom field context for issue fields issuetype2']. Skipping for now. ",
         ),
         (
             "issue_custom_field_options",
             1,
             6,
-            "Not found. The requested resource was not found on the server.",
+            "Requested resource not found.",
             # "Stream `issue_custom_field_options`. An error occurred, details: ['Not found issue custom field options for issue fields issuetype3']. Skipping for now. ",
         ),
         (
             "issue_watchers",
             1,
             6,
-            "Not found. The requested resource was not found on the server.",
+            "Requested resource not found.",
             # "Stream `issue_watchers`. An error occurred, details: ['Not found watchers for issue TESTKEY13-2']. Skipping for now. ",
         ),
         (
             "project_email",
             4,
             4,
-            "Forbidden. You don't have permission to access this resource.",
+            "Source's API denied access. Configured credentials have insufficient permissions.",
             # "Stream `project_email`. An error occurred, details: ['No access to emails for project 3']. Skipping for now. ",
         ),
     ],

--- a/airbyte-integrations/connectors/source-linkedin-ads/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-linkedin-ads/unit_tests/test_source.py
@@ -169,12 +169,12 @@ class TestAllStreams:
             (
                 400,
                 ConnectionStatus.FAILED,
-                "Stream accounts is not available: HTTP Status Code: 400. Error: Bad request. Please check your request parameters.",
+                "Stream accounts is not available: Stream 'accounts': HTTP 400. Bad request response from source's API.",
             ),
             (
                 403,
                 ConnectionStatus.FAILED,
-                "Stream accounts is not available: HTTP Status Code: 403. Error: Forbidden. You don't have permission to access this resource.",
+                "Stream accounts is not available: Stream 'accounts': HTTP 403. Source's API denied access. Configured credentials have insufficient permissions.",
             ),
             (200, ConnectionStatus.SUCCEEDED, None),
         ),

--- a/airbyte-integrations/connectors/source-monday/unit_tests/integrations/test_teams_stream.py
+++ b/airbyte-integrations/connectors/source-monday/unit_tests/integrations/test_teams_stream.py
@@ -118,7 +118,7 @@ class TestTeamsStreamFullRefresh(TestCase):
         error_logs = [
             error
             for error in get_log_messages_by_log_level(output.logs, LogLevel.INFO)
-            if "Backing off _send(...) for 0.0s (airbyte_cdk.sources.streams.http.exceptions.UserDefinedBackoffException: HTTP Status Code: 500. Error: Internal server error.)"
+            if "Backing off _send(...) for 0.0s (airbyte_cdk.sources.streams.http.exceptions.UserDefinedBackoffException: Stream 'teams': HTTP 500. Internal server error from source's API.)"
             in error
         ]
         assert len(error_logs) == 5

--- a/airbyte-integrations/connectors/source-mongodb-v2/src/main/java/io/airbyte/integrations/source/mongodb/cdc/MongoDbCdcInitializer.java
+++ b/airbyte-integrations/connectors/source-mongodb-v2/src/main/java/io/airbyte/integrations/source/mongodb/cdc/MongoDbCdcInitializer.java
@@ -187,7 +187,7 @@ public class MongoDbCdcInitializer {
       AirbyteTraceMessageUtility.emitAnalyticsTrace(cdcCursorInvalidMessage());
       if (config.shouldFailSyncOnInvalidCursor()) {
         throw new ConfigErrorException(
-            "Saved offset is not valid. Please reset the connection, and then increase oplog retention and/or increase sync frequency to prevent his from happening in the future. See https://docs.airbyte.com/integrations/sources/mongodb-v2#mongodb-oplog-and-change-streams for more details");
+            "Saved offset is no longer valid. Oplog retention or sync frequency is insufficient.");
       }
       LOGGER.info("Saved offset is not valid. Airbyte will trigger a full refresh.");
       // If the offset in the state is invalid, reset the state to the initial STATE

--- a/airbyte-integrations/connectors/source-mongodb-v2/src/test-integration/java/io/airbyte/integrations/source/mongodb/MongoDbSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-mongodb-v2/src/test-integration/java/io/airbyte/integrations/source/mongodb/MongoDbSourceAcceptanceTest.java
@@ -703,7 +703,7 @@ class MongoDbSourceAcceptanceTest extends SourceAcceptanceTest {
     final boolean oplogTracePresent = traceMessages
         .stream()
         .anyMatch(trace -> trace.getTrace().getType().equals(AirbyteTraceMessage.Type.ERROR)
-            && trace.getTrace().getError().getMessage().contains("Saved offset is not valid"));
+            && trace.getTrace().getError().getMessage().contains("Saved offset is no longer valid"));
     assertTrue(oplogTracePresent);
   }
 

--- a/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/cdc/PostgresCdcCtidInitializer.java
+++ b/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/cdc/PostgresCdcCtidInitializer.java
@@ -182,7 +182,7 @@ public class PostgresCdcCtidInitializer {
       if (!sourceConfig.get("replication_method").has(INVALID_CDC_CURSOR_POSITION_PROPERTY) || sourceConfig.get("replication_method").get(
           INVALID_CDC_CURSOR_POSITION_PROPERTY).asText().equals(FAIL_SYNC_OPTION)) {
         throw new ConfigErrorException(
-            "Saved offset is before replication slot's confirmed lsn. Please reset the connection, and then increase WAL retention and/or increase sync frequency to prevent this from happening in the future. See https://docs.airbyte.com/integrations/sources/postgres/postgres-troubleshooting#under-cdc-incremental-mode-there-are-still-full-refresh-syncs for more details.");
+            "Saved offset precedes replication slot confirmed LSN. WAL retention or sync frequency is insufficient.");
       } else if (sourceConfig.get("replication_method").get(INVALID_CDC_CURSOR_POSITION_PROPERTY).asText().equals(RESYNC_DATA_OPTION)) {
         AirbyteTraceMessageUtility.emitAnalyticsTrace(cdcResyncMessage());
         LOGGER.warn("Saved offset is before Replication slot's confirmed_flush_lsn, Airbyte will trigger sync from scratch");

--- a/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresSourceTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresSourceTest.java
@@ -816,7 +816,7 @@ class PostgresSourceTest {
         catchThrowable(() -> MoreIterators.toSet(source().read(getConfig(), configuredAirbyteCatalog, null)));
     assertThat(throwable).isInstanceOf(ConfigErrorException.class)
         .hasMessageContaining(
-            "The following tables have invalid columns selected as cursor, please select a column with a well-defined ordering with no null values as a cursor. {tableName='public.test_table', cursorColumnName='id', cursorSqlType=OTHER, cause=Unsupported cursor type}");
+            "Invalid cursor column selected. Column must have a well-defined ordering with no null values. {tableName='public.test_table', cursorColumnName='id', cursorSqlType=OTHER, cause=Unsupported cursor type}");
   }
 
   private ConfiguredAirbyteStream createTableWithInvalidCursorType(final Database database) throws SQLException {
@@ -874,7 +874,7 @@ class PostgresSourceTest {
 
     final Throwable throwable = catchThrowable(() -> MoreIterators.toSet(source().read(getConfig(), catalog, null)));
     assertThat(throwable).isInstanceOf(ConfigErrorException.class).hasMessageContaining(
-        "The following tables have invalid columns selected as cursor, please select a column with a well-defined ordering with no null values as a cursor. {tableName='public.test_table_null_cursor', cursorColumnName='id', cursorSqlType=INTEGER, cause=Cursor column contains NULL value}");
+        "Invalid cursor column selected. Column must have a well-defined ordering with no null values. {tableName='public.test_table_null_cursor', cursorColumnName='id', cursorSqlType=INTEGER, cause=Cursor column contains NULL value}");
   }
 
   private ConfiguredAirbyteStream createTableWithNullValueCursor(final Database database) throws SQLException {
@@ -905,7 +905,7 @@ class PostgresSourceTest {
     final Throwable throwable = catchThrowable(() -> MoreIterators.toSet(source().read(getConfig(), catalog, null)));
     assertThat(throwable).isInstanceOf(ConfigErrorException.class)
         .hasMessageContaining(
-            "The following tables have invalid columns selected as cursor, please select a column with a well-defined ordering with no null values as a cursor. {tableName='public.test_view_null_cursor', cursorColumnName='id', cursorSqlType=INTEGER, cause=Cursor column contains NULL value}");
+            "Invalid cursor column selected. Column must have a well-defined ordering with no null values. {tableName='public.test_view_null_cursor', cursorColumnName='id', cursorSqlType=INTEGER, cause=Cursor column contains NULL value}");
   }
 
   private ConfiguredAirbyteStream createViewWithNullValueCursor(final Database database) throws SQLException {

--- a/airbyte-integrations/connectors/source-zendesk-support/unit_tests/unit_test.py
+++ b/airbyte-integrations/connectors/source-zendesk-support/unit_tests/unit_test.py
@@ -73,7 +73,7 @@ def test_check(response, status_code, check_passed):
         #     403,
         #     38,
         #     [
-        #         "An exception occurred while trying to access TicketForms stream: Forbidden. You don't have permission to access this resource.. Skipping this stream."
+        #         "An exception occurred while trying to access TicketForms stream: Forbidden. Insufficient permissions for this resource.. Skipping this stream."
         #     ],
         #     None,
         #     id="forms_inaccessible",
@@ -83,7 +83,7 @@ def test_check(response, status_code, check_passed):
         #     404,
         #     38,
         #     [
-        #         "An exception occurred while trying to access TicketForms stream: Not found. The requested resource was not found on the server.. Skipping this stream."
+        #         "An exception occurred while trying to access TicketForms stream: Requested resource not found.. Skipping this stream."
         #     ],
         #     "Not Found",
         #     id="forms_not_exists",


### PR DESCRIPTION
## Summary
- Applies Airbyte error message guidelines across Java CDK and connector sources
- Replaces vague "Something went wrong" messages with declarative, root-cause-focused error strings
- Removes embedded remediation instructions and temporal phrasing from error messages
- Updates all related test assertions

### Files changed

**Java CDK:**
- `FailureHelper.kt` (test fixture) — source/destination/check/unknown failure messages
- `AirbyteExceptionHandler.kt` — default fallback connector error
- `SshTunnel.kt` / `TunnelSession.kt` — SSH timeout message
- `InvalidCursorInfoUtil.kt` — cursor column error

**Connectors:**
- `source-facebook-marketing` — OAuth, permissions, rate limit messages
- `source-google-ads` — transient API error message
- `source-amazon-ads` — duplicate report request message
- `source-postgres` — CDC WAL retention message
- `source-mongodb-v2` — CDC oplog retention message

**Test files:** Updated assertions in 11 connector test files

## Test plan
- [ ] Java CDK tests pass with updated assertions
- [ ] Connector unit tests pass with updated error strings
- [ ] No remaining references to old error message strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)