### PR TITLE
chore: bump transitive deps with CVEs in unmaintained json schema lib.

### DIFF
--- a/airbyte-cdk/bulk/core/base/build.gradle.kts
+++ b/airbyte-cdk/bulk/core/base/build.gradle.kts
@@ -62,6 +62,14 @@ dependencies {
     api("com.fasterxml.jackson.core:jackson-databind")
     api("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
     api("com.kjetland:mbknor-jackson-jsonschema_2.13:1.0.39")
+    constraints {
+        api("org.scala-lang:scala-library:2.13.9") {
+            because("override transitive dep from mbknor-jackson-jsonschema — CVE-2022-36944 (deserialization gadget chain)")
+        }
+        api("io.github.classgraph:classgraph:4.8.112") {
+            because("override transitive dep from mbknor-jackson-jsonschema — CVE-2021-47621 (XXE)")
+        }
+    }
     api("io.airbyte.airbyte-protocol:protocol-models:0.19.0") {
         exclude(group="com.google.guava", module="guava")
         exclude(group="com.google.api-client")

--- a/airbyte-cdk/bulk/core/base/changelog.md
+++ b/airbyte-cdk/bulk/core/base/changelog.md
@@ -1,3 +1,7 @@
+## Version 1.0.1
+
+Bump transitive deps with CVEs in unmaintained json schema lib (mbknor-jackson-jsonschema): upgrade classgraph to 4.8.112 (CVE-2021-47621, XXE) and scala-library to 2.13.9 (CVE-2022-36944, deserialization gadget chain).
+
 ## Version 1.0.0
 
 Initial independent release of bulk-cdk-core-base.

--- a/airbyte-cdk/bulk/core/base/version.properties
+++ b/airbyte-cdk/bulk/core/base/version.properties
@@ -1,1 +1,1 @@
-version=1.0.0
+version=1.0.1


### PR DESCRIPTION
## What
Bump transitive dependencies of `mbknor-jackson-jsonschema` in `bulk-cdk-core-base`: `classgraph` 4.8.21 → 4.8.112 and `scala-library` 2.13.1 → 2.13.9.

## Why
Both old versions have known CVEs: `classgraph` has CVE-2021-47621 (XXE, moderate) and `scala-library` has CVE-2022-36944 (deserialization gadget chain, critical 9.8).
## How
Added Gradle dependency `constraints` in `bulk-cdk-core-base/build.gradle.kts` to override the transitive versions pulled in by the unmaintained `mbknor-jackson-jsonschema` library to their minimum patched versions.
## Next Steps
- Bump `bulk-cdk-core-extract` and `bulk-cdk-core-load` to pick up the new `bulk-cdk-core-base:1.0.1` dependency (currently both pin `1.0.0` in their `build.gradle`)
- Publish new extract/load versions
- Bump `cdkVersion` in `gradle.properties` for affected connectors to pick up the new CDK
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/74014" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
