### PR TITLE
fix(source-stripe): prevent balance_transactions boundary duplicate records

### DIFF
--- a/airbyte-integrations/connectors/source-stripe/manifest.yaml
+++ b/airbyte-integrations/connectors/source-stripe/manifest.yaml
@@ -291,6 +291,12 @@ definitions:
         name: shipping_rates
     balance_transactions:
       $ref: "#/definitions/created_stream"
+      retriever:
+        $ref: "#/definitions/base_retriever"
+        $parameters:
+          path: balance_transactions
+          record_filter:
+            condition: "{{ record.get('created', 0) | int > (stream_state.get('created', 0) | int) }}"
       schema_loader:
         type: InlineSchemaLoader
         schema:


### PR DESCRIPTION
## What

Addresses duplicate `balance_transactions` records reported in [airbytehq/oncall#10479](https://github.com/airbytehq/oncall/issues/10479). The CDK's `DatetimeBasedCursor.should_be_synced` uses inclusive lower bounds (`start <= record <= end`), causing records at exactly the saved cursor timestamp to be re-emitted on every subsequent incremental sync. For `balance_transactions` (immutable records using `cursor_field: created`), this results in boundary duplicates accumulating in append-mode destinations.

## How

Adds a `RecordFilter` to the `balance_transactions` stream definition in `manifest.yaml`. The filter condition excludes records whose `created` timestamp is equal to the cursor value stored in `stream_state`:

```jinja
{{ record.get('created', 0) | int > (stream_state.get('created', 0) | int) }}
```

- On first sync (empty state): `stream_state.get('created', 0)` → `0`, all records pass.
- On subsequent syncs: records with `created > cursor` pass; records at exactly the cursor value are excluded.

This follows the existing `record_filter` pattern already used in the Stripe manifest (e.g., `external_account_cards`, `external_account_bank_accounts`).

## Review guide

1. `manifest.yaml` — the only file changed. The filter is added via `$parameters` on an overridden `retriever`, following the same propagation pattern used by `external_account_cards` at line ~1037.

**Key things to verify:**
- ⚠️ **Same-timestamp data loss risk**: If multiple balance transactions share the exact same `created` timestamp (e.g., a charge and its fee created in the same second), and that timestamp is the cursor value, *all* of them are excluded on the next sync — even ones not previously synced. Is this an acceptable tradeoff vs. guaranteed duplicates?
- ⚠️ **`stream_state` in concurrent execution**: This filter depends on `stream_state` being correctly populated when the `RecordFilter` runs. In the `ConcurrentCursor` path (used in production), verify that `stream_state` reflects the initial cursor value and not an updated mid-sync value.
- ⚠️ **No tests**: There are no unit tests for this filter behavior.
- **Scope**: This only fixes `balance_transactions`. The same boundary duplicate issue applies to other `created_stream` streams (`shipping_rates`, `events`, `files`, `file_links`) and all `StateDelegatingStream` incremental paths. Intentional scoping per user request — but worth discussing whether to apply broadly.

## User Impact

Users running `balance_transactions` in Incremental Append mode will no longer see boundary duplicate records on each sync. There is a small theoretical risk of missing records if multiple balance transactions share the exact same `created` second as the cursor boundary.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚


Reverting restores the previous behavior (boundary duplicates). No schema changes, no state format changes.

---

**Link to Devin run:** https://app.devin.ai/sessions/6961f0c0b4864a6987f7469c0d94d2e5  
**Requested by:** @sophiecuiy