### PR TITLE
docs(docker-images): scrub stale content, clarify DockerHub opt-in publishing

### DIFF
--- a/docker-images/README.md
+++ b/docker-images/README.md
@@ -76,21 +76,9 @@ Here are some convenient commands:
 
 Note:
 
-- While connectors are being migrating from `airbyte-ci` to the new Dockerfile images here in this directory, some connectors will build using the legacy `airbyte-ci` method and some will build using the new `Dockerfile`-based method.
 - _This is the preferred and recommended method of building Docker files for all JVM-based connectors._
 - By default, this builds an image matching your local architecture (`arm64` on M-series Macs).
 
-### `airbyte-ci`-based Image Builds
-
-We are in the process of phasing this out, but for now it is still the official method of building connector images:
-
-`airbyte-ci connectors --connector-name=source-foo build`
-
-Note:
-
-- This method is _not_ using the Dockerfile images in this directory. Instead it is using custom Dagger code, which is currently at its end-of-life (EOL) and will no longer be supported going forward.
-- You need to be careful about which platform(s) you are building for in this method. Use `--help` for info on how to build `arm64` images vs `amd64` images, etc.
-- This is not guaranteed to work for JVM connectors that have migrated over to the new gradle flow. Gradle commands are recommended instead.
 ### `airbyte-cdk`-based Builds
 
 This new method is faster, easier to type, and builds using the Dockerfiles in this directory, using the connector directory that is active:
@@ -101,13 +89,13 @@ airbyte-cdk image build
 ```
 
 Note:
-- Until `airybte-ci` is phased out, the images created this way will not exactly match the ones that would be built by the connector publish flow.
+
 - This method will automatically build arm64 and amd64 images - defaulting your `dev` image to `arm64` (since Mac M-series laptops are standard at Airbyte), while still providing an `amd64` based image, which you will need if uploading to `amd64`-based Platform instances.
-- All connector types are supported using this method, since the code is only thin wrapper around the `Dockerfile`-based build process.
+- All connector types are supported using this method, since the code is only a thin wrapper around the `Dockerfile`-based build process.
 
 ## GitHub Actions Workflow for Building and Publishing Images
 
-A GitHub Actions workflow is now available for manually building and publishing connector base images:
+A GitHub Actions workflow is available for manually building and publishing connector base images. **This workflow is manual-only (`workflow_dispatch`) and does not run automatically on merge to `master`.** Publishing to DockerHub requires explicit opt-in (see below).
 
 ### Using the Workflow
 
@@ -118,17 +106,30 @@ A GitHub Actions workflow is now available for manually building and publishing 
    - **Image Type**: `base` (currently only base images are supported)
    - **Tag or Version Number**: The tag to apply to the image (e.g., `dev-test` or `2.0.2`)
    - **Repository Root**: Choose between:
-     - `docker.io/airbyte` for production images
-     - `ghcr.io/airbytehq` for testing
-   - **Dry Run**: If enabled, builds the image but doesn't publish it
-   - **Require Security Check**: If enabled, fails the workflow if HIGH/CRITICAL vulnerabilities are found
+     - `ghcr.io/airbytehq` for testing (this is the **default**)
+     - `docker.io/airbyte` for production images on DockerHub
+   - **Dry Run**: If enabled, builds the image but doesn't publish it (**enabled by default**)
+   - **Require Security Check**: If enabled, fails the workflow if HIGH/CRITICAL vulnerabilities are found (enabled by default)
+
+### Publishing to DockerHub
+
+> **DockerHub publishing is opt-in.** The workflow defaults are intentionally safe: images are sent to GHCR with dry-run enabled. To actually publish a production image to DockerHub, you must change **both** of the following:
+>
+> 1. Set **Repository Root** to `docker.io/airbyte`
+> 2. Uncheck **Dry Run**
+>
+> The `docker.io/airbyte` option requires a GitHub Environment approval (`hub.docker.com/r/airbyte`), providing an additional safeguard.
+
+### Automated CI Testing (Pull Requests)
+
+A separate workflow ([Dockerfile Tests](https://github.com/airbytehq/airbyte/actions/workflows/docker-connector-base-image-tests.yml)) runs automatically on pull requests that modify Dockerfiles in this directory. It builds and tests images against GHCR but **does not publish to DockerHub**.
 
 ### Key Features
 
 - **Multi-Architecture Support**: Builds images for both `linux/amd64` and `linux/arm64` architectures
 - **Vulnerability Scanning**: Automatically scans images for security vulnerabilities
 - **Registry Options**: Supports publishing to either DockerHub or GitHub Container Registry
-- **Dry-Run Mode**: Test builds without publishing
+- **Dry-Run Mode**: Test builds without publishing (default)
 
 ## Common Build Args
 


### PR DESCRIPTION
## What

Tidies up the `docker-images/README.md` to remove stale `airbyte-ci` references and make it explicit that publishing to DockerHub is a manual, opt-in process that does not happen automatically on merge to `master`.

Requested by @aaronsteers.
[Link to Devin run](https://app.devin.ai/sessions/eeae89d3bfc144c69e59ebb4b443ecbd)

## How

1. **Removed the `airbyte-ci`-based Image Builds section** — it was already documented as EOL/phasing-out and no workflows reference it. Also removed the related migration note under Gradle builds and the "`airbyte-ci` parity" caveat under `airbyte-cdk` builds.
2. **Added a "Publishing to DockerHub" callout** — a blockquote clearly stating the two settings a user must explicitly change (Repository Root → `docker.io/airbyte` **and** uncheck Dry Run) to publish to DockerHub.
3. **Annotated workflow defaults** — GHCR is now listed first and marked as the default; Dry Run is noted as enabled by default.
4. **Added "Automated CI Testing" subsection** — documents the separate PR-triggered Dockerfile Tests workflow and clarifies it does not publish to DockerHub.
5. **Minor prose fixes** — typo fix ("thin" → "a thin"), removed stale "now available" phrasing.

## Review guide

1. `docker-images/README.md` — single file, all changes are documentation.

Key items for reviewer attention:
- **Lines 96-98**: Verify the bolded statement that the workflow does not auto-run on merge to `master` is accurate (confirmed: the workflow trigger is `workflow_dispatch` only).
- **Lines 114-121**: Verify the DockerHub opt-in callout accurately reflects the workflow's default inputs and the GitHub Environment approval gate.
- **Removal of `airbyte-ci` section**: Confirm `airbyte-ci` is sufficiently deprecated that removing the section is appropriate rather than just marking it deprecated.

## User Impact

Developers reading the README will have clearer, non-stale guidance on how to build and publish Docker images, with an explicit callout that DockerHub publishing requires manual opt-in.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/74018" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
