### PR TITLE
chore: bump extract cdk base version to pick up CVE fix.

### DIFF
--- a/airbyte-cdk/bulk/core/extract/build.gradle
+++ b/airbyte-cdk/bulk/core/extract/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    api "io.airbyte.bulk-cdk:bulk-cdk-core-base:1.0.0"
+    api "io.airbyte.bulk-cdk:bulk-cdk-core-base:1.0.1"
     implementation 'org.apache.commons:commons-lang3:3.17.0'
     implementation 'hu.webarticum:tree-printer:3.2.1'
 

--- a/airbyte-cdk/bulk/core/extract/changelog.md
+++ b/airbyte-cdk/bulk/core/extract/changelog.md
@@ -9,6 +9,7 @@ The Extract CDK provides functionality for source connectors including schema di
 
 | Version | Date       | Pull Request | Subject                                                                                                                                                           |
 |---------|------------|--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1.0.1   | 2026-02-24 | | Bump bulk-cdk-core-base to 1.0.1 to pick up CVE fixes (CVE-2021-47621, CVE-2022-36944). |
 | 1.0.0   | 2026-02-02 | [#72376](https://github.com/airbytehq/airbyte/pull/72376) | Initial independent release of bulk-cdk-core-extract. Separate versioning for extract package begins. |
 
 </details>

--- a/airbyte-cdk/bulk/core/extract/version.properties
+++ b/airbyte-cdk/bulk/core/extract/version.properties
@@ -1,1 +1,1 @@
-version=1.0.0
+version=1.0.1


### PR DESCRIPTION
## What
Bump `bulk-cdk-core-base` dependency to 1.0.1 in the extract CDK to pick up transitive dependency CVE fixes.
## Why
base 1.0.1 patches CVE-2021-47621 (classgraph, XXE) and CVE-2022-36944 (scala-library, deserialization gadget chain) in transitive deps from `mbknor-jackson-jsonschema`.
## How
Bump `bulk-cdk-core-base` version in `build.gradle`, bump package version, and add changelog entry. 

## Next Steps
- Bump `cdkVersion` in `gradle.properties` for affected connectors to pick up the new CDK

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._