### PR TITLE
fix(source-xero): resolve JsonDecoder generator decode and refactor manifest

### DIFF
--- a/airbyte-integrations/connectors/source-xero/components.py
+++ b/airbyte-integrations/connectors/source-xero/components.py
@@ -5,7 +5,7 @@
 import re
 from dataclasses import InitVar, dataclass, field
 from datetime import date, datetime, time, timedelta, timezone
-from typing import Any, Dict, List, Mapping, Union
+from typing import Any, Dict, Iterable, List, Mapping, Union
 
 import dpath.util
 import requests
@@ -83,8 +83,7 @@ class CustomExtractor(RecordExtractor):
             if isinstance(self.field_path[path_index], str):
                 self.field_path[path_index] = InterpolatedString.create(self.field_path[path_index], parameters=parameters)
 
-    def extract_records(self, response: requests.Response) -> List[Mapping[str, Any]]:
-        all_records: List[Mapping[str, Any]] = []
+    def extract_records(self, response: requests.Response) -> Iterable[Mapping[str, Any]]:
         for response_body in self.decoder.decode(response):
             if len(self.field_path) == 0:
                 extracted = response_body
@@ -98,7 +97,6 @@ class CustomExtractor(RecordExtractor):
             ParseDates.convert_dates(extracted)
 
             if isinstance(extracted, list):
-                all_records.extend(extracted)
+                yield from extracted
             elif extracted:
-                all_records.append(extracted)
-        return all_records
+                yield extracted

--- a/airbyte-integrations/connectors/source-xero/components.py
+++ b/airbyte-integrations/connectors/source-xero/components.py
@@ -3,7 +3,7 @@
 #
 
 import re
-from dataclasses import InitVar, dataclass
+from dataclasses import InitVar, dataclass, field
 from datetime import date, datetime, time, timedelta, timezone
 from typing import Any, Dict, List, Mapping, Union
 
@@ -76,7 +76,7 @@ class CustomExtractor(RecordExtractor):
     field_path: List[Union[InterpolatedString, str]]
     config: Config
     parameters: InitVar[Mapping[str, Any]]
-    decoder: Decoder = JsonDecoder(parameters={})
+    decoder: Decoder = field(default_factory=lambda: JsonDecoder(parameters={}))
 
     def __post_init__(self, parameters: Mapping[str, Any]):
         for path_index in range(len(self.field_path)):
@@ -84,7 +84,8 @@ class CustomExtractor(RecordExtractor):
                 self.field_path[path_index] = InterpolatedString.create(self.field_path[path_index], parameters=parameters)
 
     def extract_records(self, response: requests.Response) -> List[Mapping[str, Any]]:
-        response_body = self.decoder.decode(response)
+        decoded = self.decoder.decode(response)
+        response_body = decoded if isinstance(decoded, Mapping) else next(decoded)
         if len(self.field_path) == 0:
             extracted = response_body
         else:

--- a/airbyte-integrations/connectors/source-xero/components.py
+++ b/airbyte-integrations/connectors/source-xero/components.py
@@ -84,22 +84,21 @@ class CustomExtractor(RecordExtractor):
                 self.field_path[path_index] = InterpolatedString.create(self.field_path[path_index], parameters=parameters)
 
     def extract_records(self, response: requests.Response) -> List[Mapping[str, Any]]:
-        decoded = self.decoder.decode(response)
-        response_body = decoded if isinstance(decoded, Mapping) else next(decoded)
-        if len(self.field_path) == 0:
-            extracted = response_body
-        else:
-            path = [path.eval(self.config) for path in self.field_path]
-            if "*" in path:
-                extracted = dpath.util.values(response_body, path)
+        all_records: List[Mapping[str, Any]] = []
+        for response_body in self.decoder.decode(response):
+            if len(self.field_path) == 0:
+                extracted = response_body
             else:
-                extracted = dpath.util.get(response_body, path, default=[])
+                path = [path.eval(self.config) for path in self.field_path]
+                if "*" in path:
+                    extracted = dpath.util.values(response_body, path)
+                else:
+                    extracted = dpath.util.get(response_body, path, default=[])
 
-        ParseDates.convert_dates(extracted)
+            ParseDates.convert_dates(extracted)
 
-        if isinstance(extracted, list):
-            return extracted
-        elif extracted:
-            return [extracted]
-        else:
-            return []
+            if isinstance(extracted, list):
+                all_records.extend(extracted)
+            elif extracted:
+                all_records.append(extracted)
+        return all_records

--- a/airbyte-integrations/connectors/source-xero/components.py
+++ b/airbyte-integrations/connectors/source-xero/components.py
@@ -5,7 +5,7 @@
 import re
 from dataclasses import InitVar, dataclass, field
 from datetime import date, datetime, time, timedelta, timezone
-from typing import Any, Dict, Iterable, List, Mapping, Union
+from typing import Any, Iterable, List, Mapping, Union
 
 import dpath.util
 import requests

--- a/airbyte-integrations/connectors/source-xero/manifest.yaml
+++ b/airbyte-integrations/connectors/source-xero/manifest.yaml
@@ -14,1603 +14,403 @@ definitions:
       name: bank_transactions
       primary_key:
         - BankTransactionID
+      $parameters:
+        path: "BankTransactions"
+        records_field: "BankTransactions"
       retriever:
-        type: SimpleRetriever
-        requester:
-          $ref: "#/definitions/base_requester"
-          path: /BankTransactions
-          http_method: GET
-          request_headers:
-            Accept: application/json
-            Xero-Tenant-Id: "{{ config['tenant_id'] }}"
-          error_handler:
-            type: CompositeErrorHandler
-            error_handlers:
-              - type: DefaultErrorHandler
-                backoff_strategies:
-                  - type: ConstantBackoffStrategy
-                    backoff_time_in_seconds: 30
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: FAIL
-                    http_codes:
-                      - 401
-                    error_message: >-
-                      Failed to authorize request. Please update your access
-                      token to continue using the source.
-              - type: DefaultErrorHandler
-                backoff_strategies:
-                  - type: ConstantBackoffStrategy
-                    backoff_time_in_seconds: 30
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: IGNORE
-                    http_codes:
-                      - 403
-              - type: DefaultErrorHandler
-                backoff_strategies:
-                  - type: ConstantBackoffStrategy
-                    backoff_time_in_seconds: 30
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: RETRY
-                    http_codes:
-                      - 429
-        record_selector:
-          type: RecordSelector
-          extractor:
-            type: CustomRecordExtractor
-            class_name: source_declarative_manifest.components.CustomExtractor
-            field_path:
-              - BankTransactions
-          record_filter:
-            type: RecordFilter
-            condition: "{{ record['UpdatedDateUTC'] >= stream_interval['start_time'] }}"
-        paginator:
-          type: DefaultPaginator
-          page_token_option:
-            type: RequestOption
-            inject_into: request_parameter
-            field_name: page
-          page_size_option:
-            type: RequestOption
-            field_name: page_size
-            inject_into: request_parameter
-          pagination_strategy:
-            type: PageIncrement
-            page_size: 100
+        $ref: "#/definitions/base_retriever"
       incremental_sync:
-        type: DatetimeBasedCursor
-        cursor_field: UpdatedDateUTC
-        cursor_datetime_formats:
-          - "%Y-%m-%dT%H:%M:%S%z"
-        datetime_format: "%Y-%m-%dT%H:%M:%S%z"
-        start_datetime:
-          type: MinMaxDatetime
-          datetime: "{{ config[\"start_date\"] }}"
-          datetime_format: "%Y-%m-%dT%H:%M:%SZ"
-        end_datetime:
-          type: MinMaxDatetime
-          datetime: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%S%z') }}"
-          datetime_format: "%Y-%m-%dT%H:%M:%S%z"
+        $ref: "#/definitions/base_incremental_sync"
       schema_loader:
         type: InlineSchemaLoader
         schema:
           $ref: "#/schemas/bank_transactions"
+
     contacts:
       type: DeclarativeStream
       name: contacts
       primary_key:
         - ContactID
+      $parameters:
+        path: "Contacts"
+        records_field: "Contacts"
       retriever:
-        type: SimpleRetriever
-        requester:
-          $ref: "#/definitions/base_requester"
-          path: /Contacts
-          http_method: GET
-          request_headers:
-            Accept: application/json
-            Xero-Tenant-Id: "{{ config['tenant_id'] }}"
-          error_handler:
-            type: CompositeErrorHandler
-            error_handlers:
-              - type: DefaultErrorHandler
-                backoff_strategies:
-                  - type: ConstantBackoffStrategy
-                    backoff_time_in_seconds: 30
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: FAIL
-                    http_codes:
-                      - 401
-                    error_message: >-
-                      Failed to authorize request. Please update your access
-                      token to continue using the source.
-              - type: DefaultErrorHandler
-                backoff_strategies:
-                  - type: ConstantBackoffStrategy
-                    backoff_time_in_seconds: 30
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: IGNORE
-                    http_codes:
-                      - 403
-              - type: DefaultErrorHandler
-                backoff_strategies:
-                  - type: ConstantBackoffStrategy
-                    backoff_time_in_seconds: 30
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: RETRY
-                    http_codes:
-                      - 429
-        record_selector:
-          type: RecordSelector
-          extractor:
-            type: CustomRecordExtractor
-            class_name: source_declarative_manifest.components.CustomExtractor
-            field_path:
-              - Contacts
-          record_filter:
-            type: RecordFilter
-            condition: "{{ record['UpdatedDateUTC'] >= stream_interval['start_time'] }}"
-        paginator:
-          type: DefaultPaginator
-          page_token_option:
-            type: RequestOption
-            inject_into: request_parameter
-            field_name: page
-          page_size_option:
-            type: RequestOption
-            field_name: page_size
-            inject_into: request_parameter
-          pagination_strategy:
-            type: PageIncrement
-            page_size: 100
+        $ref: "#/definitions/base_retriever"
       incremental_sync:
-        type: DatetimeBasedCursor
-        cursor_field: UpdatedDateUTC
-        cursor_datetime_formats:
-          - "%Y-%m-%dT%H:%M:%S%z"
-        datetime_format: "%Y-%m-%dT%H:%M:%S%z"
-        start_datetime:
-          type: MinMaxDatetime
-          datetime: "{{ config[\"start_date\"] }}"
-          datetime_format: "%Y-%m-%dT%H:%M:%SZ"
-        end_datetime:
-          type: MinMaxDatetime
-          datetime: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%S%z') }}"
-          datetime_format: "%Y-%m-%dT%H:%M:%S%z"
+        $ref: "#/definitions/base_incremental_sync"
       schema_loader:
         type: InlineSchemaLoader
         schema:
           $ref: "#/schemas/contacts"
+
     credit_notes:
       type: DeclarativeStream
       name: credit_notes
       primary_key:
         - CreditNoteID
+      $parameters:
+        path: "CreditNotes"
+        records_field: "CreditNotes"
       retriever:
-        type: SimpleRetriever
-        requester:
-          $ref: "#/definitions/base_requester"
-          path: /CreditNotes
-          http_method: GET
-          request_headers:
-            Accept: application/json
-            Xero-Tenant-Id: "{{ config['tenant_id'] }}"
-          error_handler:
-            type: CompositeErrorHandler
-            error_handlers:
-              - type: DefaultErrorHandler
-                backoff_strategies:
-                  - type: ConstantBackoffStrategy
-                    backoff_time_in_seconds: 30
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: FAIL
-                    http_codes:
-                      - 401
-                    error_message: >-
-                      Failed to authorize request. Please update your access
-                      token to continue using the source.
-              - type: DefaultErrorHandler
-                backoff_strategies:
-                  - type: ConstantBackoffStrategy
-                    backoff_time_in_seconds: 30
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: IGNORE
-                    http_codes:
-                      - 403
-              - type: DefaultErrorHandler
-                backoff_strategies:
-                  - type: ConstantBackoffStrategy
-                    backoff_time_in_seconds: 30
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: RETRY
-                    http_codes:
-                      - 429
-        record_selector:
-          type: RecordSelector
-          extractor:
-            type: CustomRecordExtractor
-            class_name: source_declarative_manifest.components.CustomExtractor
-            field_path:
-              - CreditNotes
-          record_filter:
-            type: RecordFilter
-            condition: "{{ record['UpdatedDateUTC'] >= stream_interval['start_time'] }}"
-        paginator:
-          type: DefaultPaginator
-          page_token_option:
-            type: RequestOption
-            inject_into: request_parameter
-            field_name: page
-          page_size_option:
-            type: RequestOption
-            field_name: page_size
-            inject_into: request_parameter
-          pagination_strategy:
-            type: PageIncrement
-            page_size: 100
+        $ref: "#/definitions/base_retriever"
       incremental_sync:
-        type: DatetimeBasedCursor
-        cursor_field: UpdatedDateUTC
-        cursor_datetime_formats:
-          - "%Y-%m-%dT%H:%M:%S%z"
-        datetime_format: "%Y-%m-%dT%H:%M:%S%z"
-        start_datetime:
-          type: MinMaxDatetime
-          datetime: "{{ config[\"start_date\"] }}"
-          datetime_format: "%Y-%m-%dT%H:%M:%SZ"
-        end_datetime:
-          type: MinMaxDatetime
-          datetime: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%S%z') }}"
-          datetime_format: "%Y-%m-%dT%H:%M:%S%z"
+        $ref: "#/definitions/base_incremental_sync"
       schema_loader:
         type: InlineSchemaLoader
         schema:
           $ref: "#/schemas/credit_notes"
+
     invoices:
       type: DeclarativeStream
       name: invoices
       primary_key:
         - InvoiceID
+      $parameters:
+        path: "Invoices"
+        records_field: "Invoices"
       retriever:
-        type: SimpleRetriever
-        requester:
-          $ref: "#/definitions/base_requester"
-          path: /Invoices
-          http_method: GET
-          request_headers:
-            Accept: application/json
-            Xero-Tenant-Id: "{{ config['tenant_id'] }}"
-          error_handler:
-            type: CompositeErrorHandler
-            error_handlers:
-              - type: DefaultErrorHandler
-                backoff_strategies:
-                  - type: ConstantBackoffStrategy
-                    backoff_time_in_seconds: 30
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: FAIL
-                    http_codes:
-                      - 401
-                    error_message: >-
-                      Failed to authorize request. Please update your access
-                      token to continue using the source.
-              - type: DefaultErrorHandler
-                backoff_strategies:
-                  - type: ConstantBackoffStrategy
-                    backoff_time_in_seconds: 30
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: IGNORE
-                    http_codes:
-                      - 403
-              - type: DefaultErrorHandler
-                backoff_strategies:
-                  - type: ConstantBackoffStrategy
-                    backoff_time_in_seconds: 30
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: RETRY
-                    http_codes:
-                      - 429
-        record_selector:
-          type: RecordSelector
-          extractor:
-            type: CustomRecordExtractor
-            class_name: source_declarative_manifest.components.CustomExtractor
-            field_path:
-              - Invoices
-          record_filter:
-            type: RecordFilter
-            condition: "{{ record['UpdatedDateUTC'] >= stream_interval['start_time'] }}"
-        paginator:
-          type: DefaultPaginator
-          page_token_option:
-            type: RequestOption
-            inject_into: request_parameter
-            field_name: page
-          page_size_option:
-            type: RequestOption
-            field_name: page_size
-            inject_into: request_parameter
-          pagination_strategy:
-            type: PageIncrement
-            page_size: 100
+        $ref: "#/definitions/base_retriever"
       incremental_sync:
-        type: DatetimeBasedCursor
-        cursor_field: UpdatedDateUTC
-        cursor_datetime_formats:
-          - "%Y-%m-%dT%H:%M:%S%z"
-        datetime_format: "%Y-%m-%dT%H:%M:%S%z"
-        start_datetime:
-          type: MinMaxDatetime
-          datetime: "{{ config[\"start_date\"] }}"
-          datetime_format: "%Y-%m-%dT%H:%M:%SZ"
-        end_datetime:
-          type: MinMaxDatetime
-          datetime: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%S%z') }}"
-          datetime_format: "%Y-%m-%dT%H:%M:%S%z"
+        $ref: "#/definitions/base_incremental_sync"
       schema_loader:
         type: InlineSchemaLoader
         schema:
           $ref: "#/schemas/invoices"
+
     manual_journals:
       type: DeclarativeStream
       name: manual_journals
       primary_key:
         - ManualJournalID
+      $parameters:
+        path: "ManualJournals"
+        records_field: "ManualJournals"
       retriever:
-        type: SimpleRetriever
-        requester:
-          $ref: "#/definitions/base_requester"
-          path: /ManualJournals
-          http_method: GET
-          request_headers:
-            Accept: application/json
-            Xero-Tenant-Id: "{{ config['tenant_id'] }}"
-          error_handler:
-            type: CompositeErrorHandler
-            error_handlers:
-              - type: DefaultErrorHandler
-                backoff_strategies:
-                  - type: ConstantBackoffStrategy
-                    backoff_time_in_seconds: 30
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: FAIL
-                    http_codes:
-                      - 401
-                    error_message: >-
-                      Failed to authorize request. Please update your access
-                      token to continue using the source.
-              - type: DefaultErrorHandler
-                backoff_strategies:
-                  - type: ConstantBackoffStrategy
-                    backoff_time_in_seconds: 30
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: IGNORE
-                    http_codes:
-                      - 403
-              - type: DefaultErrorHandler
-                backoff_strategies:
-                  - type: ConstantBackoffStrategy
-                    backoff_time_in_seconds: 30
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: RETRY
-                    http_codes:
-                      - 429
-        record_selector:
-          type: RecordSelector
-          extractor:
-            type: CustomRecordExtractor
-            class_name: source_declarative_manifest.components.CustomExtractor
-            field_path:
-              - ManualJournals
-          record_filter:
-            type: RecordFilter
-            condition: "{{ record['UpdatedDateUTC'] >= stream_interval['start_time'] }}"
-        paginator:
-          type: DefaultPaginator
-          page_token_option:
-            type: RequestOption
-            inject_into: request_parameter
-            field_name: page
-          page_size_option:
-            type: RequestOption
-            field_name: page_size
-            inject_into: request_parameter
-          pagination_strategy:
-            type: PageIncrement
-            page_size: 100
+        $ref: "#/definitions/base_retriever"
       incremental_sync:
-        type: DatetimeBasedCursor
-        cursor_field: UpdatedDateUTC
-        cursor_datetime_formats:
-          - "%Y-%m-%dT%H:%M:%S%z"
-        datetime_format: "%Y-%m-%dT%H:%M:%S%z"
-        start_datetime:
-          type: MinMaxDatetime
-          datetime: "{{ config[\"start_date\"] }}"
-          datetime_format: "%Y-%m-%dT%H:%M:%SZ"
-        end_datetime:
-          type: MinMaxDatetime
-          datetime: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%S%z') }}"
-          datetime_format: "%Y-%m-%dT%H:%M:%S%z"
+        $ref: "#/definitions/base_incremental_sync"
       schema_loader:
         type: InlineSchemaLoader
         schema:
           $ref: "#/schemas/manual_journals"
+
     overpayments:
       type: DeclarativeStream
       name: overpayments
       primary_key:
         - OverpaymentID
+      $parameters:
+        path: "Overpayments"
+        records_field: "Overpayments"
       retriever:
-        type: SimpleRetriever
-        requester:
-          $ref: "#/definitions/base_requester"
-          path: /Overpayments
-          http_method: GET
-          request_headers:
-            Accept: application/json
-            Xero-Tenant-Id: "{{ config['tenant_id'] }}"
-          error_handler:
-            type: CompositeErrorHandler
-            error_handlers:
-              - type: DefaultErrorHandler
-                backoff_strategies:
-                  - type: ConstantBackoffStrategy
-                    backoff_time_in_seconds: 30
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: FAIL
-                    http_codes:
-                      - 401
-                    error_message: >-
-                      Failed to authorize request. Please update your access
-                      token to continue using the source.
-              - type: DefaultErrorHandler
-                backoff_strategies:
-                  - type: ConstantBackoffStrategy
-                    backoff_time_in_seconds: 30
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: IGNORE
-                    http_codes:
-                      - 403
-              - type: DefaultErrorHandler
-                backoff_strategies:
-                  - type: ConstantBackoffStrategy
-                    backoff_time_in_seconds: 30
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: RETRY
-                    http_codes:
-                      - 429
-        record_selector:
-          type: RecordSelector
-          extractor:
-            type: CustomRecordExtractor
-            class_name: source_declarative_manifest.components.CustomExtractor
-            field_path:
-              - Overpayments
-          record_filter:
-            type: RecordFilter
-            condition: "{{ record['UpdatedDateUTC'] >= stream_interval['start_time'] }}"
-        paginator:
-          type: DefaultPaginator
-          page_token_option:
-            type: RequestOption
-            inject_into: request_parameter
-            field_name: page
-          page_size_option:
-            type: RequestOption
-            field_name: page_size
-            inject_into: request_parameter
-          pagination_strategy:
-            type: PageIncrement
-            page_size: 100
+        $ref: "#/definitions/base_retriever"
       incremental_sync:
-        type: DatetimeBasedCursor
-        cursor_field: UpdatedDateUTC
-        cursor_datetime_formats:
-          - "%Y-%m-%dT%H:%M:%S%z"
-        datetime_format: "%Y-%m-%dT%H:%M:%S%z"
-        start_datetime:
-          type: MinMaxDatetime
-          datetime: "{{ config[\"start_date\"] }}"
-          datetime_format: "%Y-%m-%dT%H:%M:%SZ"
-        end_datetime:
-          type: MinMaxDatetime
-          datetime: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%S%z') }}"
-          datetime_format: "%Y-%m-%dT%H:%M:%S%z"
+        $ref: "#/definitions/base_incremental_sync"
       schema_loader:
         type: InlineSchemaLoader
         schema:
           $ref: "#/schemas/overpayments"
+
     prepayments:
       type: DeclarativeStream
       name: prepayments
       primary_key:
         - PrepaymentID
+      $parameters:
+        path: "Prepayments"
+        records_field: "Prepayments"
       retriever:
-        type: SimpleRetriever
-        requester:
-          $ref: "#/definitions/base_requester"
-          path: /Prepayments
-          http_method: GET
-          request_headers:
-            Accept: application/json
-            Xero-Tenant-Id: "{{ config['tenant_id'] }}"
-          error_handler:
-            type: CompositeErrorHandler
-            error_handlers:
-              - type: DefaultErrorHandler
-                backoff_strategies:
-                  - type: ConstantBackoffStrategy
-                    backoff_time_in_seconds: 30
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: FAIL
-                    http_codes:
-                      - 401
-                    error_message: >-
-                      Failed to authorize request. Please update your access
-                      token to continue using the source.
-              - type: DefaultErrorHandler
-                backoff_strategies:
-                  - type: ConstantBackoffStrategy
-                    backoff_time_in_seconds: 30
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: IGNORE
-                    http_codes:
-                      - 403
-              - type: DefaultErrorHandler
-                backoff_strategies:
-                  - type: ConstantBackoffStrategy
-                    backoff_time_in_seconds: 30
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: RETRY
-                    http_codes:
-                      - 429
-        record_selector:
-          type: RecordSelector
-          extractor:
-            type: CustomRecordExtractor
-            class_name: source_declarative_manifest.components.CustomExtractor
-            field_path:
-              - Prepayments
-          record_filter:
-            type: RecordFilter
-            condition: "{{ record['UpdatedDateUTC'] >= stream_interval['start_time'] }}"
-        paginator:
-          type: DefaultPaginator
-          page_token_option:
-            type: RequestOption
-            inject_into: request_parameter
-            field_name: page
-          page_size_option:
-            type: RequestOption
-            field_name: page_size
-            inject_into: request_parameter
-          pagination_strategy:
-            type: PageIncrement
-            page_size: 100
+        $ref: "#/definitions/base_retriever"
       incremental_sync:
-        type: DatetimeBasedCursor
-        cursor_field: UpdatedDateUTC
-        cursor_datetime_formats:
-          - "%Y-%m-%dT%H:%M:%S%z"
-        datetime_format: "%Y-%m-%dT%H:%M:%S%z"
-        start_datetime:
-          type: MinMaxDatetime
-          datetime: "{{ config[\"start_date\"] }}"
-          datetime_format: "%Y-%m-%dT%H:%M:%SZ"
-        end_datetime:
-          type: MinMaxDatetime
-          datetime: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%S%z') }}"
-          datetime_format: "%Y-%m-%dT%H:%M:%S%z"
+        $ref: "#/definitions/base_incremental_sync"
       schema_loader:
         type: InlineSchemaLoader
         schema:
           $ref: "#/schemas/prepayments"
+
     purchase_orders:
       type: DeclarativeStream
       name: purchase_orders
       primary_key:
         - PurchaseOrderID
+      $parameters:
+        path: "PurchaseOrders"
+        records_field: "PurchaseOrders"
       retriever:
-        type: SimpleRetriever
-        requester:
-          $ref: "#/definitions/base_requester"
-          path: /PurchaseOrders
-          http_method: GET
-          request_headers:
-            Accept: application/json
-            Xero-Tenant-Id: "{{ config['tenant_id'] }}"
-          error_handler:
-            type: CompositeErrorHandler
-            error_handlers:
-              - type: DefaultErrorHandler
-                backoff_strategies:
-                  - type: ConstantBackoffStrategy
-                    backoff_time_in_seconds: 30
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: FAIL
-                    http_codes:
-                      - 401
-                    error_message: >-
-                      Failed to authorize request. Please update your access
-                      token to continue using the source.
-              - type: DefaultErrorHandler
-                backoff_strategies:
-                  - type: ConstantBackoffStrategy
-                    backoff_time_in_seconds: 30
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: IGNORE
-                    http_codes:
-                      - 403
-              - type: DefaultErrorHandler
-                backoff_strategies:
-                  - type: ConstantBackoffStrategy
-                    backoff_time_in_seconds: 30
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: RETRY
-                    http_codes:
-                      - 429
-        record_selector:
-          type: RecordSelector
-          extractor:
-            type: CustomRecordExtractor
-            class_name: source_declarative_manifest.components.CustomExtractor
-            field_path:
-              - PurchaseOrders
-          record_filter:
-            type: RecordFilter
-            condition: "{{ record['UpdatedDateUTC'] >= stream_interval['start_time'] }}"
-        paginator:
-          type: DefaultPaginator
-          page_token_option:
-            type: RequestOption
-            inject_into: request_parameter
-            field_name: page
-          page_size_option:
-            type: RequestOption
-            field_name: page_size
-            inject_into: request_parameter
-          pagination_strategy:
-            type: PageIncrement
-            page_size: 100
+        $ref: "#/definitions/base_retriever"
       incremental_sync:
-        type: DatetimeBasedCursor
-        cursor_field: UpdatedDateUTC
-        cursor_datetime_formats:
-          - "%Y-%m-%dT%H:%M:%S%z"
-        datetime_format: "%Y-%m-%dT%H:%M:%S%z"
-        start_datetime:
-          type: MinMaxDatetime
-          datetime: "{{ config[\"start_date\"] }}"
-          datetime_format: "%Y-%m-%dT%H:%M:%SZ"
-        end_datetime:
-          type: MinMaxDatetime
-          datetime: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%S%z') }}"
-          datetime_format: "%Y-%m-%dT%H:%M:%S%z"
+        $ref: "#/definitions/base_incremental_sync"
       schema_loader:
         type: InlineSchemaLoader
         schema:
           $ref: "#/schemas/purchase_orders"
+
     accounts:
       type: DeclarativeStream
       name: accounts
       primary_key:
         - AccountID
+      $parameters:
+        path: "Accounts"
+        records_field: "Accounts"
       retriever:
-        type: SimpleRetriever
-        requester:
-          $ref: "#/definitions/base_requester"
-          path: /Accounts
-          http_method: GET
-          request_headers:
-            Accept: application/json
-            Xero-Tenant-Id: "{{ config['tenant_id'] }}"
-          error_handler:
-            type: CompositeErrorHandler
-            error_handlers:
-              - type: DefaultErrorHandler
-                backoff_strategies:
-                  - type: ConstantBackoffStrategy
-                    backoff_time_in_seconds: 30
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: FAIL
-                    http_codes:
-                      - 401
-                    error_message: >-
-                      Failed to authorize request. Please update your access
-                      token to continue using the source.
-              - type: DefaultErrorHandler
-                backoff_strategies:
-                  - type: ConstantBackoffStrategy
-                    backoff_time_in_seconds: 30
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: IGNORE
-                    http_codes:
-                      - 403
-              - type: DefaultErrorHandler
-                backoff_strategies:
-                  - type: ConstantBackoffStrategy
-                    backoff_time_in_seconds: 30
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: RETRY
-                    http_codes:
-                      - 429
-        record_selector:
-          type: RecordSelector
-          extractor:
-            type: CustomRecordExtractor
-            class_name: source_declarative_manifest.components.CustomExtractor
-            field_path:
-              - Accounts
-          record_filter:
-            type: RecordFilter
-            condition: "{{ record['UpdatedDateUTC'] >= stream_interval['start_time'] }}"
+        $ref: "#/definitions/base_retriever"
       incremental_sync:
-        type: DatetimeBasedCursor
-        cursor_field: UpdatedDateUTC
-        cursor_datetime_formats:
-          - "%Y-%m-%dT%H:%M:%S%z"
-        datetime_format: "%Y-%m-%dT%H:%M:%S%z"
-        start_datetime:
-          type: MinMaxDatetime
-          datetime: "{{ config[\"start_date\"] }}"
-          datetime_format: "%Y-%m-%dT%H:%M:%SZ"
-        end_datetime:
-          type: MinMaxDatetime
-          datetime: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%S%z') }}"
-          datetime_format: "%Y-%m-%dT%H:%M:%S%z"
+        $ref: "#/definitions/base_incremental_sync"
       schema_loader:
         type: InlineSchemaLoader
         schema:
           $ref: "#/schemas/accounts"
+
     bank_transfers:
       type: DeclarativeStream
       name: bank_transfers
       primary_key:
         - BankTransferID
+      $parameters:
+        path: "BankTransfers"
+        records_field: "BankTransfers"
+        cursor_field: "CreatedDateUTC"
       retriever:
-        type: SimpleRetriever
-        requester:
-          $ref: "#/definitions/base_requester"
-          path: /BankTransfers
-          http_method: GET
-          request_headers:
-            Accept: application/json
-            Xero-Tenant-Id: "{{ config['tenant_id'] }}"
-          error_handler:
-            type: CompositeErrorHandler
-            error_handlers:
-              - type: DefaultErrorHandler
-                backoff_strategies:
-                  - type: ConstantBackoffStrategy
-                    backoff_time_in_seconds: 30
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: FAIL
-                    http_codes:
-                      - 401
-                    error_message: >-
-                      Failed to authorize request. Please update your access
-                      token to continue using the source.
-              - type: DefaultErrorHandler
-                backoff_strategies:
-                  - type: ConstantBackoffStrategy
-                    backoff_time_in_seconds: 30
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: IGNORE
-                    http_codes:
-                      - 403
-              - type: DefaultErrorHandler
-                backoff_strategies:
-                  - type: ConstantBackoffStrategy
-                    backoff_time_in_seconds: 30
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: RETRY
-                    http_codes:
-                      - 429
-        record_selector:
-          type: RecordSelector
-          extractor:
-            type: CustomRecordExtractor
-            class_name: source_declarative_manifest.components.CustomExtractor
-            field_path:
-              - BankTransfers
-          record_filter:
-            type: RecordFilter
-            condition: "{{ record['CreatedDateUTC'] >= stream_interval['start_time'] }}"
-        paginator:
-          type: DefaultPaginator
-          page_token_option:
-            type: RequestOption
-            inject_into: request_parameter
-            field_name: page
-          page_size_option:
-            type: RequestOption
-            field_name: page_size
-            inject_into: request_parameter
-          pagination_strategy:
-            type: PageIncrement
-            page_size: 100
+        $ref: "#/definitions/base_retriever"
       incremental_sync:
-        type: DatetimeBasedCursor
-        cursor_field: CreatedDateUTC
-        cursor_datetime_formats:
-          - "%Y-%m-%dT%H:%M:%S%z"
-        datetime_format: "%Y-%m-%dT%H:%M:%S%z"
-        start_datetime:
-          type: MinMaxDatetime
-          datetime: "{{ config[\"start_date\"] }}"
-          datetime_format: "%Y-%m-%dT%H:%M:%SZ"
-        end_datetime:
-          type: MinMaxDatetime
-          datetime: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%S%z') }}"
-          datetime_format: "%Y-%m-%dT%H:%M:%S%z"
+        $ref: "#/definitions/base_incremental_sync"
       schema_loader:
         type: InlineSchemaLoader
         schema:
           $ref: "#/schemas/bank_transfers"
+
     employees:
       type: DeclarativeStream
       name: employees
       primary_key:
         - EmployeeID
+      $parameters:
+        path: "Employees"
+        records_field: "Employees"
       retriever:
-        type: SimpleRetriever
-        requester:
-          $ref: "#/definitions/base_requester"
-          path: /Employees
-          http_method: GET
-          request_headers:
-            Accept: application/json
-            Xero-Tenant-Id: "{{ config['tenant_id'] }}"
-          error_handler:
-            type: CompositeErrorHandler
-            error_handlers:
-              - type: DefaultErrorHandler
-                backoff_strategies:
-                  - type: ConstantBackoffStrategy
-                    backoff_time_in_seconds: 30
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: FAIL
-                    http_codes:
-                      - 401
-                    error_message: >-
-                      Failed to authorize request. Please update your access
-                      token to continue using the source.
-              - type: DefaultErrorHandler
-                backoff_strategies:
-                  - type: ConstantBackoffStrategy
-                    backoff_time_in_seconds: 30
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: IGNORE
-                    http_codes:
-                      - 403
-              - type: DefaultErrorHandler
-                backoff_strategies:
-                  - type: ConstantBackoffStrategy
-                    backoff_time_in_seconds: 30
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: RETRY
-                    http_codes:
-                      - 429
-        record_selector:
-          type: RecordSelector
-          extractor:
-            type: CustomRecordExtractor
-            class_name: source_declarative_manifest.components.CustomExtractor
-            field_path:
-              - Employees
-          record_filter:
-            type: RecordFilter
-            condition: "{{ record['UpdatedDateUTC'] >= stream_interval['start_time'] }}"
-        paginator:
-          type: DefaultPaginator
-          page_token_option:
-            type: RequestOption
-            inject_into: request_parameter
-            field_name: page
-          page_size_option:
-            type: RequestOption
-            field_name: page_size
-            inject_into: request_parameter
-          pagination_strategy:
-            type: PageIncrement
-            page_size: 100
+        $ref: "#/definitions/base_retriever"
       incremental_sync:
-        type: DatetimeBasedCursor
-        cursor_field: UpdatedDateUTC
-        cursor_datetime_formats:
-          - "%Y-%m-%dT%H:%M:%S%z"
-        datetime_format: "%Y-%m-%dT%H:%M:%S%z"
-        start_datetime:
-          type: MinMaxDatetime
-          datetime: "{{ config[\"start_date\"] }}"
-          datetime_format: "%Y-%m-%dT%H:%M:%SZ"
-        end_datetime:
-          type: MinMaxDatetime
-          datetime: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%S%z') }}"
-          datetime_format: "%Y-%m-%dT%H:%M:%S%z"
+        $ref: "#/definitions/base_incremental_sync"
       schema_loader:
         type: InlineSchemaLoader
         schema:
           $ref: "#/schemas/employees"
+
     items:
       type: DeclarativeStream
       name: items
       primary_key:
         - ItemID
+      $parameters:
+        path: "Items"
+        records_field: "Items"
       retriever:
-        type: SimpleRetriever
-        requester:
-          $ref: "#/definitions/base_requester"
-          path: /Items
-          http_method: GET
-          request_headers:
-            Accept: application/json
-            Xero-Tenant-Id: "{{ config['tenant_id'] }}"
-          error_handler:
-            type: CompositeErrorHandler
-            error_handlers:
-              - type: DefaultErrorHandler
-                backoff_strategies:
-                  - type: ConstantBackoffStrategy
-                    backoff_time_in_seconds: 30
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: FAIL
-                    http_codes:
-                      - 401
-                    error_message: >-
-                      Failed to authorize request. Please update your access
-                      token to continue using the source.
-              - type: DefaultErrorHandler
-                backoff_strategies:
-                  - type: ConstantBackoffStrategy
-                    backoff_time_in_seconds: 30
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: IGNORE
-                    http_codes:
-                      - 403
-              - type: DefaultErrorHandler
-                backoff_strategies:
-                  - type: ConstantBackoffStrategy
-                    backoff_time_in_seconds: 30
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: RETRY
-                    http_codes:
-                      - 429
-        record_selector:
-          type: RecordSelector
-          extractor:
-            type: CustomRecordExtractor
-            class_name: source_declarative_manifest.components.CustomExtractor
-            field_path:
-              - Items
-          record_filter:
-            type: RecordFilter
-            condition: "{{ record['UpdatedDateUTC'] >= stream_interval['start_time'] }}"
+        $ref: "#/definitions/base_retriever"
       incremental_sync:
-        type: DatetimeBasedCursor
-        cursor_field: UpdatedDateUTC
-        cursor_datetime_formats:
-          - "%Y-%m-%dT%H:%M:%S%z"
-        datetime_format: "%Y-%m-%dT%H:%M:%S%z"
-        start_datetime:
-          type: MinMaxDatetime
-          datetime: "{{ config[\"start_date\"] }}"
-          datetime_format: "%Y-%m-%dT%H:%M:%SZ"
-        end_datetime:
-          type: MinMaxDatetime
-          datetime: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%S%z') }}"
-          datetime_format: "%Y-%m-%dT%H:%M:%S%z"
+        $ref: "#/definitions/base_incremental_sync"
       schema_loader:
         type: InlineSchemaLoader
         schema:
           $ref: "#/schemas/items"
+
     payments:
       type: DeclarativeStream
       name: payments
       primary_key:
         - PaymentID
+      $parameters:
+        path: "Payments"
+        records_field: "Payments"
       retriever:
-        type: SimpleRetriever
-        requester:
-          $ref: "#/definitions/base_requester"
-          path: /Payments
-          http_method: GET
-          request_headers:
-            Accept: application/json
-            Xero-Tenant-Id: "{{ config['tenant_id'] }}"
-          error_handler:
-            type: CompositeErrorHandler
-            error_handlers:
-              - type: DefaultErrorHandler
-                backoff_strategies:
-                  - type: ConstantBackoffStrategy
-                    backoff_time_in_seconds: 30
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: FAIL
-                    http_codes:
-                      - 401
-                    error_message: >-
-                      Failed to authorize request. Please update your access
-                      token to continue using the source.
-              - type: DefaultErrorHandler
-                backoff_strategies:
-                  - type: ConstantBackoffStrategy
-                    backoff_time_in_seconds: 30
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: IGNORE
-                    http_codes:
-                      - 403
-              - type: DefaultErrorHandler
-                backoff_strategies:
-                  - type: ConstantBackoffStrategy
-                    backoff_time_in_seconds: 30
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: RETRY
-                    http_codes:
-                      - 429
-        record_selector:
-          type: RecordSelector
-          extractor:
-            type: CustomRecordExtractor
-            class_name: source_declarative_manifest.components.CustomExtractor
-            field_path:
-              - Payments
-          record_filter:
-            type: RecordFilter
-            condition: "{{ record['UpdatedDateUTC'] >= stream_interval['start_time'] }}"
-        paginator:
-          type: DefaultPaginator
-          page_token_option:
-            type: RequestOption
-            inject_into: request_parameter
-            field_name: page
-          page_size_option:
-            type: RequestOption
-            field_name: page_size
-            inject_into: request_parameter
-          pagination_strategy:
-            type: PageIncrement
-            page_size: 100
+        $ref: "#/definitions/base_retriever"
       incremental_sync:
-        type: DatetimeBasedCursor
-        cursor_field: UpdatedDateUTC
-        cursor_datetime_formats:
-          - "%Y-%m-%dT%H:%M:%S%z"
-        datetime_format: "%Y-%m-%dT%H:%M:%S%z"
-        start_datetime:
-          type: MinMaxDatetime
-          datetime: "{{ config[\"start_date\"] }}"
-          datetime_format: "%Y-%m-%dT%H:%M:%SZ"
-        end_datetime:
-          type: MinMaxDatetime
-          datetime: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%S%z') }}"
-          datetime_format: "%Y-%m-%dT%H:%M:%S%z"
+        $ref: "#/definitions/base_incremental_sync"
       schema_loader:
         type: InlineSchemaLoader
         schema:
           $ref: "#/schemas/payments"
+
     users:
       type: DeclarativeStream
       name: users
       primary_key:
         - UserID
+      $parameters:
+        path: "Users"
+        records_field: "Users"
       retriever:
-        type: SimpleRetriever
-        requester:
-          $ref: "#/definitions/base_requester"
-          path: /Users
-          http_method: GET
-          request_headers:
-            Accept: application/json
-            Xero-Tenant-Id: "{{ config['tenant_id'] }}"
-          error_handler:
-            type: CompositeErrorHandler
-            error_handlers:
-              - type: DefaultErrorHandler
-                backoff_strategies:
-                  - type: ConstantBackoffStrategy
-                    backoff_time_in_seconds: 30
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: FAIL
-                    http_codes:
-                      - 401
-                    error_message: >-
-                      Failed to authorize request. Please update your access
-                      token to continue using the source.
-              - type: DefaultErrorHandler
-                backoff_strategies:
-                  - type: ConstantBackoffStrategy
-                    backoff_time_in_seconds: 30
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: IGNORE
-                    http_codes:
-                      - 403
-              - type: DefaultErrorHandler
-                backoff_strategies:
-                  - type: ConstantBackoffStrategy
-                    backoff_time_in_seconds: 30
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: RETRY
-                    http_codes:
-                      - 429
-        record_selector:
-          type: RecordSelector
-          extractor:
-            type: CustomRecordExtractor
-            class_name: source_declarative_manifest.components.CustomExtractor
-            field_path:
-              - Users
-          record_filter:
-            type: RecordFilter
-            condition: "{{ record['UpdatedDateUTC'] >= stream_interval['start_time'] }}"
+        $ref: "#/definitions/base_retriever"
       incremental_sync:
-        type: DatetimeBasedCursor
-        cursor_field: UpdatedDateUTC
-        cursor_datetime_formats:
-          - "%Y-%m-%dT%H:%M:%S%z"
-        datetime_format: "%Y-%m-%dT%H:%M:%S%z"
-        start_datetime:
-          type: MinMaxDatetime
-          datetime: "{{ config[\"start_date\"] }}"
-          datetime_format: "%Y-%m-%dT%H:%M:%SZ"
-        end_datetime:
-          type: MinMaxDatetime
-          datetime: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%S%z') }}"
-          datetime_format: "%Y-%m-%dT%H:%M:%S%z"
+        $ref: "#/definitions/base_incremental_sync"
       schema_loader:
         type: InlineSchemaLoader
         schema:
           $ref: "#/schemas/users"
+
     branding_themes:
       type: DeclarativeStream
       name: branding_themes
       primary_key:
         - BrandingThemeID
+      $parameters:
+        path: "BrandingThemes"
+        records_field: "BrandingThemes"
       retriever:
-        type: SimpleRetriever
-        requester:
-          $ref: "#/definitions/base_requester"
-          path: /BrandingThemes
-          http_method: GET
-          request_headers:
-            Accept: application/json
-            Xero-Tenant-Id: "{{ config['tenant_id'] }}"
-          error_handler:
-            type: CompositeErrorHandler
-            error_handlers:
-              - type: DefaultErrorHandler
-                backoff_strategies:
-                  - type: ConstantBackoffStrategy
-                    backoff_time_in_seconds: 30
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: FAIL
-                    http_codes:
-                      - 401
-                    error_message: >-
-                      Failed to authorize request. Please update your access
-                      token to continue using the source.
-              - type: DefaultErrorHandler
-                backoff_strategies:
-                  - type: ConstantBackoffStrategy
-                    backoff_time_in_seconds: 30
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: IGNORE
-                    http_codes:
-                      - 403
-              - type: DefaultErrorHandler
-                backoff_strategies:
-                  - type: ConstantBackoffStrategy
-                    backoff_time_in_seconds: 30
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: RETRY
-                    http_codes:
-                      - 429
-        record_selector:
-          type: RecordSelector
-          extractor:
-            type: CustomRecordExtractor
-            class_name: source_declarative_manifest.components.CustomExtractor
-            field_path:
-              - BrandingThemes
+        $ref: "#/definitions/base_retriever"
       schema_loader:
         type: InlineSchemaLoader
         schema:
           $ref: "#/schemas/branding_themes"
+
     contact_groups:
       type: DeclarativeStream
       name: contact_groups
       primary_key:
         - ContactGroupID
+      $parameters:
+        path: "ContactGroups"
+        records_field: "ContactGroups"
       retriever:
-        type: SimpleRetriever
-        requester:
-          $ref: "#/definitions/base_requester"
-          path: /ContactGroups
-          http_method: GET
-          request_headers:
-            Accept: application/json
-            Xero-Tenant-Id: "{{ config['tenant_id'] }}"
-          error_handler:
-            type: CompositeErrorHandler
-            error_handlers:
-              - type: DefaultErrorHandler
-                backoff_strategies:
-                  - type: ConstantBackoffStrategy
-                    backoff_time_in_seconds: 30
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: FAIL
-                    http_codes:
-                      - 401
-                    error_message: >-
-                      Failed to authorize request. Please update your access
-                      token to continue using the source.
-              - type: DefaultErrorHandler
-                backoff_strategies:
-                  - type: ConstantBackoffStrategy
-                    backoff_time_in_seconds: 30
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: IGNORE
-                    http_codes:
-                      - 403
-              - type: DefaultErrorHandler
-                backoff_strategies:
-                  - type: ConstantBackoffStrategy
-                    backoff_time_in_seconds: 30
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: RETRY
-                    http_codes:
-                      - 429
-        record_selector:
-          type: RecordSelector
-          extractor:
-            type: CustomRecordExtractor
-            class_name: source_declarative_manifest.components.CustomExtractor
-            field_path:
-              - ContactGroups
+        $ref: "#/definitions/base_retriever"
       schema_loader:
         type: InlineSchemaLoader
         schema:
           $ref: "#/schemas/contact_groups"
+
     currencies:
       type: DeclarativeStream
       name: currencies
       primary_key:
         - Code
+      $parameters:
+        path: "Currencies"
+        records_field: "Currencies"
       retriever:
-        type: SimpleRetriever
-        requester:
-          $ref: "#/definitions/base_requester"
-          path: /Currencies
-          http_method: GET
-          request_headers:
-            Accept: application/json
-            Xero-Tenant-Id: "{{ config['tenant_id'] }}"
-          error_handler:
-            type: CompositeErrorHandler
-            error_handlers:
-              - type: DefaultErrorHandler
-                backoff_strategies:
-                  - type: ConstantBackoffStrategy
-                    backoff_time_in_seconds: 30
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: FAIL
-                    http_codes:
-                      - 401
-                    error_message: >-
-                      Failed to authorize request. Please update your access
-                      token to continue using the source.
-              - type: DefaultErrorHandler
-                backoff_strategies:
-                  - type: ConstantBackoffStrategy
-                    backoff_time_in_seconds: 30
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: IGNORE
-                    http_codes:
-                      - 403
-              - type: DefaultErrorHandler
-                backoff_strategies:
-                  - type: ConstantBackoffStrategy
-                    backoff_time_in_seconds: 30
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: RETRY
-                    http_codes:
-                      - 429
-        record_selector:
-          type: RecordSelector
-          extractor:
-            type: CustomRecordExtractor
-            class_name: source_declarative_manifest.components.CustomExtractor
-            field_path:
-              - Currencies
+        $ref: "#/definitions/base_retriever"
       schema_loader:
         type: InlineSchemaLoader
         schema:
           $ref: "#/schemas/currencies"
+
     organisations:
       type: DeclarativeStream
       name: organisations
       primary_key:
         - OrganisationID
+      $parameters:
+        path: "Organisation"
+        records_field: "Organisations"
       retriever:
-        type: SimpleRetriever
-        requester:
-          $ref: "#/definitions/base_requester"
-          path: /Organisation
-          http_method: GET
-          request_headers:
-            Accept: application/json
-            Xero-Tenant-Id: "{{ config['tenant_id'] }}"
-          error_handler:
-            type: CompositeErrorHandler
-            error_handlers:
-              - type: DefaultErrorHandler
-                backoff_strategies:
-                  - type: ConstantBackoffStrategy
-                    backoff_time_in_seconds: 30
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: FAIL
-                    http_codes:
-                      - 401
-                    error_message: >-
-                      Failed to authorize request. Please update your access
-                      token to continue using the source.
-              - type: DefaultErrorHandler
-                backoff_strategies:
-                  - type: ConstantBackoffStrategy
-                    backoff_time_in_seconds: 30
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: IGNORE
-                    http_codes:
-                      - 403
-              - type: DefaultErrorHandler
-                backoff_strategies:
-                  - type: ConstantBackoffStrategy
-                    backoff_time_in_seconds: 30
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: RETRY
-                    http_codes:
-                      - 429
-        record_selector:
-          type: RecordSelector
-          extractor:
-            type: CustomRecordExtractor
-            class_name: source_declarative_manifest.components.CustomExtractor
-            field_path:
-              - Organisations
+        $ref: "#/definitions/base_retriever"
       schema_loader:
         type: InlineSchemaLoader
         schema:
           $ref: "#/schemas/organisations"
+
     repeating_invoices:
       type: DeclarativeStream
       name: repeating_invoices
       primary_key:
         - RepeatingInvoiceID
+      $parameters:
+        path: "RepeatingInvoices"
+        records_field: "RepeatingInvoices"
       retriever:
-        type: SimpleRetriever
-        requester:
-          $ref: "#/definitions/base_requester"
-          path: /RepeatingInvoices
-          http_method: GET
-          request_headers:
-            Accept: application/json
-            Xero-Tenant-Id: "{{ config['tenant_id'] }}"
-          error_handler:
-            type: CompositeErrorHandler
-            error_handlers:
-              - type: DefaultErrorHandler
-                backoff_strategies:
-                  - type: ConstantBackoffStrategy
-                    backoff_time_in_seconds: 30
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: FAIL
-                    http_codes:
-                      - 401
-                    error_message: >-
-                      Failed to authorize request. Please update your access
-                      token to continue using the source.
-              - type: DefaultErrorHandler
-                backoff_strategies:
-                  - type: ConstantBackoffStrategy
-                    backoff_time_in_seconds: 30
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: IGNORE
-                    http_codes:
-                      - 403
-              - type: DefaultErrorHandler
-                backoff_strategies:
-                  - type: ConstantBackoffStrategy
-                    backoff_time_in_seconds: 30
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: RETRY
-                    http_codes:
-                      - 429
-        record_selector:
-          type: RecordSelector
-          extractor:
-            type: CustomRecordExtractor
-            class_name: source_declarative_manifest.components.CustomExtractor
-            field_path:
-              - RepeatingInvoices
+        $ref: "#/definitions/base_retriever"
       schema_loader:
         type: InlineSchemaLoader
         schema:
           $ref: "#/schemas/repeating_invoices"
+
     tax_rates:
       type: DeclarativeStream
       name: tax_rates
       primary_key:
         - Name
+      $parameters:
+        path: "TaxRates"
+        records_field: "TaxRates"
       retriever:
-        type: SimpleRetriever
-        requester:
-          $ref: "#/definitions/base_requester"
-          path: /TaxRates
-          http_method: GET
-          request_headers:
-            Accept: application/json
-            Xero-Tenant-Id: "{{ config['tenant_id'] }}"
-          error_handler:
-            type: CompositeErrorHandler
-            error_handlers:
-              - type: DefaultErrorHandler
-                backoff_strategies:
-                  - type: ConstantBackoffStrategy
-                    backoff_time_in_seconds: 30
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: FAIL
-                    http_codes:
-                      - 401
-                    error_message: >-
-                      Failed to authorize request. Please update your access
-                      token to continue using the source.
-              - type: DefaultErrorHandler
-                backoff_strategies:
-                  - type: ConstantBackoffStrategy
-                    backoff_time_in_seconds: 30
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: IGNORE
-                    http_codes:
-                      - 403
-              - type: DefaultErrorHandler
-                backoff_strategies:
-                  - type: ConstantBackoffStrategy
-                    backoff_time_in_seconds: 30
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: RETRY
-                    http_codes:
-                      - 429
-        record_selector:
-          type: RecordSelector
-          extractor:
-            type: CustomRecordExtractor
-            class_name: source_declarative_manifest.components.CustomExtractor
-            field_path:
-              - TaxRates
+        $ref: "#/definitions/base_retriever"
       schema_loader:
         type: InlineSchemaLoader
         schema:
           $ref: "#/schemas/tax_rates"
+
     tracking_categories:
       type: DeclarativeStream
       name: tracking_categories
       primary_key:
         - TrackingCategoryID
+      $parameters:
+        path: "TrackingCategories"
+        records_field: "TrackingCategories"
       retriever:
-        type: SimpleRetriever
-        requester:
-          $ref: "#/definitions/base_requester"
-          path: /TrackingCategories
-          http_method: GET
-          request_headers:
-            Accept: application/json
-            Xero-Tenant-Id: "{{ config['tenant_id'] }}"
-          error_handler:
-            type: CompositeErrorHandler
-            error_handlers:
-              - type: DefaultErrorHandler
-                backoff_strategies:
-                  - type: ConstantBackoffStrategy
-                    backoff_time_in_seconds: 30
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: FAIL
-                    http_codes:
-                      - 401
-                    error_message: >-
-                      Failed to authorize request. Please update your access
-                      token to continue using the source.
-              - type: DefaultErrorHandler
-                backoff_strategies:
-                  - type: ConstantBackoffStrategy
-                    backoff_time_in_seconds: 30
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: IGNORE
-                    http_codes:
-                      - 403
-              - type: DefaultErrorHandler
-                backoff_strategies:
-                  - type: ConstantBackoffStrategy
-                    backoff_time_in_seconds: 30
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: RETRY
-                    http_codes:
-                      - 429
-        record_selector:
-          type: RecordSelector
-          extractor:
-            type: CustomRecordExtractor
-            class_name: source_declarative_manifest.components.CustomExtractor
-            field_path:
-              - TrackingCategories
+        $ref: "#/definitions/base_retriever"
       schema_loader:
         type: InlineSchemaLoader
         schema:
           $ref: "#/schemas/tracking_categories"
+
+  base_incremental_sync:
+    type: DatetimeBasedCursor
+    cursor_field: "{{ parameters.get('cursor_field', 'UpdatedDateUTC') }}"
+    # Inject Xero server-side filter
+    start_time_option:
+      type: RequestOption
+      inject_into: header
+      field_name: If-Modified-Since
+    datetime_format: "%Y-%m-%dT%H:%M:%S"
+    cursor_datetime_formats:
+      - "%Y-%m-%dT%H:%M:%S%z"
+      - "%Y-%m-%dT%H:%M:%SZ"
+      - "%Y-%m-%dT%H:%M:%S.%f%z"
+      - "%Y-%m-%dT%H:%M:%S.%fZ"
+    start_datetime:
+      type: MinMaxDatetime
+      datetime: "{{ config['start_date'] }}"
+      datetime_format: "%Y-%m-%dT%H:%M:%SZ"
+    end_datetime:
+      type: MinMaxDatetime
+      datetime: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"
+      datetime_format: "%Y-%m-%dT%H:%M:%SZ"
+
+  base_retriever:
+    type: SimpleRetriever
+    requester:
+      $ref: "#/definitions/base_requester"
+      path: "{{ parameters.path }}"
+      http_method: GET
+    paginator:
+      type: DefaultPaginator
+      page_token_option:
+        type: RequestOption
+        inject_into: request_parameter
+        field_name: page
+      page_size_option:
+        type: RequestOption
+        field_name: pageSize
+        inject_into: request_parameter
+      pagination_strategy:
+        type: PageIncrement
+        page_size: 1000
+        start_from_page: 1
+        inject_on_first_request: true
+    record_selector:
+      type: RecordSelector
+      extractor:
+        type: CustomRecordExtractor
+        class_name: source_declarative_manifest.components.CustomExtractor
+        field_path:
+          - "{{ parameters['records_field'] }}"
+
   base_requester:
     type: HttpRequester
     url_base: https://api.xero.com/api.xro/2.0/
+    request_headers:
+      Accept: application/json
+      Xero-Tenant-Id: "{{ config['tenant_id'] }}"
     authenticator:
       type: SelectiveAuthenticator
       authenticators:
@@ -1629,7 +429,9 @@ definitions:
             - accounting.settings.read
             - accounting.contacts.read
             - accounting.attachments.read
-            - assets.read files.read projects.read
+            - assets.read
+            - files.read
+            - projects.read
             - openid
           client_id: "{{ config['credentials']['client_id'] }}"
           grant_type: client_credentials
@@ -1641,6 +443,39 @@ definitions:
       authenticator_selection_path:
         - credentials
         - auth_type
+    error_handler:
+      type: CompositeErrorHandler
+      error_handlers:
+        - type: DefaultErrorHandler
+          backoff_strategies:
+            - type: ConstantBackoffStrategy
+              backoff_time_in_seconds: 30
+          response_filters:
+            - type: HttpResponseFilter
+              action: FAIL
+              http_codes: [401]
+              error_message: "Failed to authorize request"
+        - type: DefaultErrorHandler
+          response_filters:
+            - type: HttpResponseFilter
+              action: IGNORE
+              http_codes: [403]
+        # Stop immediately if Daily Limit reached
+        - type: DefaultErrorHandler
+          response_filters:
+            - type: HttpResponseFilter
+              action: FAIL
+              http_codes: [429]
+              error_message: "daily limit"
+        # Retry standard rate limits (e.g. 60/min)
+        - type: DefaultErrorHandler
+          backoff_strategies:
+            - type: ExponentialBackoffStrategy
+              factor: 2
+          response_filters:
+            - type: HttpResponseFilter
+              action: RETRY
+              http_codes: [429]
 
 streams:
   - $ref: "#/definitions/streams/bank_transactions"

--- a/airbyte-integrations/connectors/source-xero/metadata.yaml
+++ b/airbyte-integrations/connectors/source-xero/metadata.yaml
@@ -31,7 +31,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 6fd1e833-dd6e-45ec-a727-ab917c5be892
-  dockerImageTag: 2.1.4
+  dockerImageTag: 2.1.5
   dockerRepository: airbyte/source-xero
   githubIssueLabel: source-xero
   icon: xero.svg

--- a/airbyte-integrations/connectors/source-xero/metadata.yaml
+++ b/airbyte-integrations/connectors/source-xero/metadata.yaml
@@ -49,15 +49,13 @@ data:
     ql: 300
   connectorTestSuitesOptions:
     - suite: unitTests
-    # Disabling acceptance tests
-    # No/Low Airbyte Cloud Usage
-    # - suite: acceptanceTests
-    #   testSecrets:
-    #     - name: SECRET_SOURCE-XERO__CREDS
-    #       fileName: config.json
-    #       secretStore:
-    #         type: GSM
-    #         alias: airbyte-connector-testing-secret-store
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-XERO__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
   externalDocumentationUrls:
     - title: Xero API reference
       url: https://developer.xero.com/documentation/

--- a/airbyte-integrations/connectors/source-xero/metadata.yaml
+++ b/airbyte-integrations/connectors/source-xero/metadata.yaml
@@ -49,13 +49,15 @@ data:
     ql: 300
   connectorTestSuitesOptions:
     - suite: unitTests
-    - suite: acceptanceTests
-      testSecrets:
-        - name: SECRET_SOURCE-XERO__CREDS
-          fileName: config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
+    # Disabling acceptance tests
+    # No/Low Airbyte Cloud Usage
+    # - suite: acceptanceTests
+    #   testSecrets:
+    #     - name: SECRET_SOURCE-XERO__CREDS
+    #       fileName: config.json
+    #       secretStore:
+    #         type: GSM
+    #         alias: airbyte-connector-testing-secret-store
   externalDocumentationUrls:
     - title: Xero API reference
       url: https://developer.xero.com/documentation/

--- a/airbyte-integrations/connectors/source-xero/unit_tests/pyproject.toml
+++ b/airbyte-integrations/connectors/source-xero/unit_tests/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "source-xero-tests"
-version = "2.1.0"
+version = "2.1.5"
 description = "Unit tests for source-xero"
 authors = ["Airbyte <contact@airbyte.io>"]
 

--- a/docs/integrations/sources/xero.md
+++ b/docs/integrations/sources/xero.md
@@ -121,6 +121,7 @@ If you are upgrading from a previous version of the connector, please refer to t
 
 | Version | Date       | Pull Request                                             | Subject                                                   |
 |:--------|:-----------|:---------------------------------------------------------|:----------------------------------------------------------|
+| 2.1.5 | 2026-02-25 | [71340](https://github.com/airbytehq/airbyte/pull/71340) | Resolve the generator returned from JsonDecoder into dictionary |
 | 2.1.4 | 2025-03-01 | [55142](https://github.com/airbytehq/airbyte/pull/55142) | Update dependencies |
 | 2.1.3 | 2025-02-22 | [54526](https://github.com/airbytehq/airbyte/pull/54526) | Update dependencies |
 | 2.1.2 | 2025-02-15 | [54042](https://github.com/airbytehq/airbyte/pull/54042) | Update dependencies |


### PR DESCRIPTION
## What
Fixes `source-xero` record extraction when `JsonDecoder.decode()` returns a generator, and refactors the connector manifest to DRY up stream definitions and utilize the `If-Modified-Since` header for server-side incremental filtering.

This PR is intended as a re-introduction of the fix described in https://github.com/airbytehq/airbyte/pull/71340 (the original PR no longer contains the code change), plus a manifest refactor from the same contributor.

## How
### JsonDecoder fix (`components.py`)
- Update `CustomExtractor.extract_records` to iterate over the generator returned by `self.decoder.decode(response)` using a `for` loop, collecting all extracted records across yielded bodies.
- Fix a Python 3.11 dataclass issue by switching `decoder` to use `default_factory` (avoids a mutable default).

### Manifest refactor (`manifest.yaml`)
- Extract shared `base_retriever`, `base_incremental_sync`, and common `base_requester` config (headers, error handling) to eliminate per-stream duplication (~1200 lines removed).
- Add `If-Modified-Since` header injection via `start_time_option` for server-side incremental filtering, replacing client-side `record_filter` conditions.
- Use `$parameters` (`path`, `records_field`) on each stream for DRY retriever/selector configuration.
- Fix OAuth scopes list (previously `assets.read files.read projects.read` on a single line → properly separated).
- Move error handling into `base_requester` with differentiated 429 handling: FAIL for daily limit, exponential backoff RETRY for standard rate limits.
- Increase page size from 100 to 1000.

### Version & changelog
- Bump connector patch version (`2.1.4` → `2.1.5`) and add a changelog entry.

## Review guide
1. `airbyte-integrations/connectors/source-xero/components.py`
   - `CustomExtractor.decoder` dataclass default → `field(default_factory=...)`
   - `CustomExtractor.extract_records` now iterates over `self.decoder.decode(response)` with a `for` loop, accumulating records into `all_records`
2. `airbyte-integrations/connectors/source-xero/manifest.yaml` — major refactor:
   - New `base_retriever`, `base_incremental_sync` shared definitions
   - `base_requester` now includes `request_headers`, `error_handler`
   - All streams now use `$ref` to shared definitions + `$parameters`
   - `If-Modified-Since` header replaces client-side `record_filter`
3. `airbyte-integrations/connectors/source-xero/metadata.yaml` — version bump only
4. `docs/integrations/sources/xero.md` — changelog entry
5. `airbyte-integrations/connectors/source-xero/unit_tests/pyproject.toml` — test project version alignment

### ⚠️ Items for human reviewer
- **Server-side filtering**: Verify all Xero endpoints properly support the `If-Modified-Since` header for incremental syncs. The refactor removes client-side `record_filter` conditions in favor of this header.
- **Pagination**: Page size increased from 100 to 1000. Confirm this is within Xero API limits and doesn't trigger rate limiting issues.
- **Error handling**: 401 errors now FAIL immediately (previously RETRY in upstream). 429 errors differentiate between daily limit (FAIL) and standard rate limits (RETRY with exponential backoff).
- **Shared definitions**: All streams now share the same retriever/error handling/pagination. Verify this is appropriate for all Xero endpoints.
- **Test coverage**: Acceptance tests are **not** enabled for this connector (intentionally disabled upstream due to low Airbyte Cloud usage), so the fix is only covered by unit tests in CI. Unit test coverage is minimal (1 test).

## Updates since last revision
- Replaced `next(decoded)` / `isinstance(decoded, Mapping)` approach with a `for` loop over the generator, per reviewer feedback. This properly handles all yielded items and avoids the `StopIteration` risk.
- Cherry-picked manifest refactor commit from https://github.com/airbytehq/airbyte/commit/bcf54ce8284cdd4f4b4b2a9c78b7e3f77fe0593b (requested by user).

## User Impact
Users of the Xero source connector should no longer see empty syncs / missing records due to decoded API responses being a generator instead of a concrete mapping. Incremental syncs will now use server-side filtering via `If-Modified-Since` header, which should improve performance.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌

---
Requested by: @DanyloGL  
[Devin session](https://app.devin.ai/sessions/01d639b5326549db8678de58852b776d)