### PR TITLE
chore: bump CDK to 1.0.2 and base image to 2.0.4 for CVE patches

### DIFF
--- a/airbyte-integrations/connectors/destination-snowflake/gradle.properties
+++ b/airbyte-integrations/connectors/destination-snowflake/gradle.properties
@@ -1,3 +1,3 @@
 testExecutionConcurrency=-1
-cdkVersion=0.2.8
+cdkVersion=1.0.2
 JunitMethodExecutionTimeout=10m

--- a/airbyte-integrations/connectors/destination-snowflake/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-snowflake/metadata.yaml
@@ -6,7 +6,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 424892c4-daac-4491-b35d-c6688ba547ba
-  dockerImageTag: 4.0.37
+  dockerImageTag: 4.0.38
   dockerRepository: airbyte/destination-snowflake
   documentationUrl: https://docs.airbyte.com/integrations/destinations/snowflake
   githubIssueLabel: destination-snowflake
@@ -23,7 +23,7 @@ data:
         - SOCKET
         - STDIO
   connectorBuildOptions:
-    baseImage: docker.io/airbyte/java-connector-base:2.0.3@sha256:119b8506bca069bbc8357a275936c7e2b0994e6947b81f1bf8d6ce9e16db7d47
+    baseImage: docker.io/airbyte/java-connector-base:2.0.4@sha256:5f343797cfcf021ca98ba9bdf5970ef66cbf6222d8cc17b0d61d13860a5bcc2b
   registryOverrides:
     cloud:
       enabled: true

--- a/docs/integrations/destinations/snowflake.md
+++ b/docs/integrations/destinations/snowflake.md
@@ -260,6 +260,7 @@ desired namespace.
 
 | Version         | Date       | Pull Request                                                 | Subject                                                                                                                                                                                |
 |:----------------|:-----------|:-------------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 4.0.38 | 2026-02-25 | | Upgrade CDK to 1.0.2 and base image to 2.0.4 for CVE patches |
 | 4.0.37          | 2026-02-04 | [72854](https://github.com/airbytehq/airbyte/pull/72854) | Internal interface changes                                                                                                                                                                 |
 | 4.0.36 | 2026-01-29 | [72417](https://github.com/airbytehq/airbyte/pull/72417) | Handle exception in countTable correctly                                                                                                                                                            |
 | 4.0.35 | 2026-01-26 | [72295](https://github.com/airbytehq/airbyte/pull/72295) | Upgrade CDK to 0.2.0                                                                                                                                                                                |


### PR DESCRIPTION
## What
Bump bulk CDK to 1.0.2 and Java base image to 2.0.4 to pick up CVE patches in transitive dependencies.

## How
Patch-bump `cdkVersion` in `gradle.properties`
Update `baseImage` and `dockerImageTag` in `metadata.yaml`