### PR TITLE
ci: Disable auto-merge when new commits are pushed to a PR

### DIFF
--- a/.github/workflows/disable-auto-merge-on-push.yml
+++ b/.github/workflows/disable-auto-merge-on-push.yml
@@ -19,7 +19,36 @@ jobs:
         run: |
           REPO="${{ github.repository }}"
           PR_NUMBER="${{ github.event.pull_request.number }}"
+          PR_AUTHOR="${{ github.event.pull_request.user.login }}"
 
+          # Exception 1: Skip if PR author is a bot
+          if [[ "$PR_AUTHOR" == *"[bot]"* ]] || [[ "$PR_AUTHOR" == *"-bot"* ]]; then
+            echo "PR author '$PR_AUTHOR' is a bot. Skipping."
+            exit 0
+          fi
+
+          # Exception 2: Skip if PR has an auto-merge label
+          LABELS=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json labels --jq '.labels[].name')
+          for LABEL in $LABELS; do
+            if [[ "$LABEL" == *"auto-merge"* ]]; then
+              echo "PR has auto-merge label '$LABEL'. Skipping."
+              exit 0
+            fi
+          done
+
+          # Exception 3: Skip if PR was never in draft status (non-draft from creation)
+          # A PR that skipped draft status is presumed to have auto-merge set intentionally.
+          if [[ "${{ github.event.pull_request.draft }}" != "true" ]]; then
+            # Check the timeline for draft events to see if it was ever a draft
+            WAS_DRAFT=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/timeline" --paginate \
+              --jq '[.[] | select(.event == "convert_to_draft" or .event == "ready_for_review")] | length > 0')
+            if [[ "$WAS_DRAFT" != "true" ]]; then
+              echo "PR was never in draft status. Skipping."
+              exit 0
+            fi
+          fi
+
+          # Check if auto-merge is actually enabled
           AUTO_MERGE_ENABLED=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json autoMergeRequest --jq '.autoMergeRequest != null')
 
           if [[ "$AUTO_MERGE_ENABLED" != "true" ]]; then

--- a/.github/workflows/disable-auto-merge-on-push.yml
+++ b/.github/workflows/disable-auto-merge-on-push.yml
@@ -1,0 +1,34 @@
+name: Disable Auto-Merge on New Commits
+
+on:
+  pull_request_target:
+    types:
+      - synchronize
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  disable-auto-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check and disable auto-merge
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          REPO="${{ github.repository }}"
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+
+          AUTO_MERGE_ENABLED=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json autoMergeRequest --jq '.autoMergeRequest != null')
+
+          if [[ "$AUTO_MERGE_ENABLED" != "true" ]]; then
+            echo "Auto-merge is not enabled. Nothing to do."
+            exit 0
+          fi
+
+          echo "Auto-merge is enabled. Disabling due to new commits."
+          gh pr merge "$PR_NUMBER" --repo "$REPO" --disable-auto
+
+          gh pr comment "$PR_NUMBER" --repo "$REPO" --body \
+            "Auto-merge has been disabled because new commits were pushed to this PR. Please re-enable auto-merge manually after reviewing the new changes."


### PR DESCRIPTION
## What

Addresses a race condition where auto-merge can cause PRs to merge after new commits are pushed (e.g., from automated review bots) without human re-review. See [Slack thread](https://airbytehq-team.slack.com/archives/C09U4Q6A9BK/p1772050928479969) for context.

This PR adds a lightweight workflow that automatically disables auto-merge whenever new commits are pushed to a PR, requiring the author to manually re-enable it after reviewing the new changes.

Being added to `sonar`, `airbyte`, and `airbyte-enterprise` via parallel PRs.

## How

A new GitHub Actions workflow triggers on `pull_request_target` → `synchronize` (fires when commits are pushed to a PR). It:
1. Checks three exception conditions (see below) — if any match, the workflow exits early without disabling auto-merge
2. Checks if auto-merge is currently enabled on the PR via `gh pr view --json autoMergeRequest`
3. If enabled, disables it via `gh pr merge --disable-auto`
4. Posts a comment explaining that auto-merge was disabled and needs to be manually re-enabled

**Exceptions — auto-merge is NOT disabled when:**
- **Bot authors**: PR author login contains `[bot]` or ends with `-bot`
- **Auto-merge labels**: PR has any label containing `auto-merge` (e.g., `low-risk-auto-merge`, `auto-merge`)
- **Never-draft PRs**: PR was created directly (never went through draft status), checked via the issue timeline API for `convert_to_draft` / `ready_for_review` events

Uses `pull_request_target` (not `pull_request`) because the workflow needs write permissions to disable auto-merge and comment. This is safe since **no code from the PR branch is checked out or executed**.

## Review guide

1. `.github/workflows/disable-auto-merge-on-push.yml` — the entire change is this single file

**Things to verify:**
- The `pull_request_target` trigger is appropriate here (we need write access but don't execute PR code)
- The bot detection uses glob matching on the author login (`*[bot]*` and `*-bot*`). The `-bot` suffix check could theoretically match a human username ending in `-bot` — verify this is an acceptable trade-off
- The auto-merge label check uses `*auto-merge*` glob — any label containing that substring will match. Confirm this is broad enough (and not too broad) for each repo's label conventions
- The never-draft check calls `gh api repos/{repo}/issues/{pr}/timeline --paginate` — verify this doesn't hit rate limits or permission issues in practice
- There is an inherent race condition: if CI is already green and auto-merge fires before this workflow completes, the PR could still merge. This workflow reduces but doesn't eliminate the window
- Each push to a qualifying PR with auto-merge enabled will produce a new comment. Rapid successive pushes could create multiple comments

## User Impact

When a contributor pushes new commits to a PR that has auto-merge enabled, auto-merge will be automatically disabled and a comment will notify them. They must manually re-enable auto-merge after reviewing the new changes. This prevents unreviewed commits from being merged automatically.

**No impact** on PRs authored by bots, PRs with auto-merge labels, or PRs that were never in draft status — these are presumed to have auto-merge set intentionally.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Link to Devin run: https://app.devin.ai/sessions/71843ea98d6a4481988b1c4d8dfdbf5d
Requested by: @aaronsteers