### PR TITLE
docs(source-hubspot): add BEHAVIOR.md documenting unique connector behaviors and CLAUDE.md

### DIFF
--- a/airbyte-integrations/connectors/source-hubspot/BEHAVIOR.md
+++ b/airbyte-integrations/connectors/source-hubspot/BEHAVIOR.md
@@ -1,0 +1,273 @@
+# source-hubspot: Unique Connector Behaviors
+
+This document describes non-obvious, connector-specific behaviors in `source-hubspot` that deviate from
+standard declarative connector patterns. Read this before making changes to the connector.
+
+---
+
+## 1. HubspotAssociationsExtractor: Hidden API Calls Inside Record Extraction
+
+**Files:** `components.py` (`HubspotAssociationsExtractor`, `build_associations_retriever`), `manifest.yaml` (`base_crm_search_incremental_stream`)
+
+The CRM search streams (contacts, companies, deals, tickets, leads, engagements_*, deal_splits) use
+`HubspotAssociationsExtractor` as their record extractor. This extractor does **not** simply parse the
+HTTP response -- it makes **additional batch POST requests** to the HubSpot Associations v4 API
+(`/crm/v4/associations/{entity}/{association}/batch/read`) for every page of results.
+
+**Why this matters:**
+- Each page of CRM search results triggers N additional API calls (one per association type per batch).
+  For example, the `deals` stream fetches associations for `companies`, `contacts`, and `line_items`,
+  so every page of deal results triggers 3 additional API calls.
+- The `build_associations_retriever()` function in `components.py` manually constructs a full
+  `SimpleRetriever` with its own `SelectiveAuthenticator`, `HttpRequester`, error handler, and
+  `ListPartitionRouter` -- all in Python code rather than YAML. This is because the low-code framework
+  does not support instantiating a `SimpleRetriever` outside of a `DeclarativeStream` context.
+- If you add a new association to a stream's `associations` list, you are adding an extra API call per
+  page of results. Consider rate limit impact.
+- The associations retriever sends record IDs in the POST body via `extra_fields` on the `StreamSlice`,
+  which is an unusual data-passing pattern.
+
+---
+
+## 2. EngagementsHttpRequester: Dual-Endpoint Selection at Runtime
+
+**Files:** `components.py` (`EngagementsHttpRequester`), `manifest.yaml` (`engagements_stream`)
+
+The `engagements` stream dynamically chooses between two completely different API endpoints at runtime:
+
+- **Recent Engagements API** (`/engagements/v1/engagements/recent/modified`): Used when the start
+  date/state is within the last 29 days **AND** the total record count is <= 10,000.
+- **All Engagements API** (`/engagements/v1/engagements/paged`): Used in all other cases.
+
+**Why this matters:**
+- On the first request, `should_use_recent_api()` makes a **probe request** to the Recent API to check
+  the `total` field in the response. This is an extra API call that happens before any data is fetched.
+- The Recent API has a hard cap of 10,000 most recently updated records. If exceeded, the connector
+  silently falls back to the All API, which returns everything but requires client-side incremental
+  filtering (`is_client_side_incremental: true`).
+- The page size is set to 250 (All API max), but if the Recent API is selected, HubSpot silently
+  clamps it to 100.
+- The decision is cached for the entire sync via `_use_recent_api`, so it cannot switch mid-sync.
+- The stream uses a single slice from start_date to now (no step/windowing), which is required for the
+  dual-endpoint logic to work. Do not add `step` to the incremental sync config.
+
+---
+
+## 3. HubspotCRMSearchPaginationStrategy: 10,000-Result Limit Workaround
+
+**Files:** `components.py` (`HubspotCRMSearchPaginationStrategy`), `manifest.yaml` (`base_crm_search_incremental_stream`)
+
+HubSpot's `/search` API has a hard limit of 10,000 total results per query. Attempting to paginate
+beyond 10,000 returns a 400 error. This custom pagination strategy works around the limit by:
+
+1. Tracking the current offset (`after`) and detecting when it approaches 10,000.
+2. When the limit is reached, resetting `after` to 0 and adding an `id` filter using the last
+   record's `hs_object_id + 1` to start a new query window.
+3. The CRM search request body includes a `sorts` clause ordering by `hs_object_id ASCENDING` and a
+   filter `hs_object_id >= {id}` to support this reset mechanism.
+
+**Why this matters:**
+- The pagination token is a dict (`{"after": N}` or `{"after": N, "id": M}`), not a simple cursor
+  string. Code that inspects or manipulates page tokens must handle both shapes.
+- The search request body in the manifest references `next_page_token['next_page_token'].get('id', 0)`
+  and `next_page_token['next_page_token']['after']`, which is tightly coupled to this strategy.
+- This applies to all streams inheriting from `base_crm_search_incremental_stream`.
+
+---
+
+## 4. StateDelegatingStream for Custom Objects
+
+**Files:** `manifest.yaml` (`dynamic_streams` section)
+
+Custom HubSpot objects use `DynamicDeclarativeStream` with `StateDelegatingStream` to select between
+two completely different stream implementations based on whether incoming stream state exists:
+
+- **No state (full refresh):** Uses `GET /crm/v3/objects/{entity}` with property chunking and
+  `GroupByKeyMergeStrategy` to merge chunked responses by `id`.
+- **Has state (incremental):** Uses `POST /crm/v3/objects/{entity}/search` with the CRM search
+  pagination strategy and date range filters.
+
+**Why this matters:**
+- The two sub-streams have different requesters, paginators, and record selectors. Changes to one do
+  not automatically apply to the other.
+- The `HttpComponentsResolver` fetches custom object schemas from `/crm/v3/schemas` and dynamically
+  injects the object name, entity identifier, and property list into both sub-stream templates via
+  `components_mapping`.
+- The `fullyQualifiedName` is used as the entity path parameter (e.g., `p_{name}` if
+  `fullyQualifiedName` is not available), which differs from standard CRM objects.
+- Custom objects use `HubspotCustomObjectsSchemaLoader` to generate schemas from the properties
+  returned by the components resolver, rather than the `DynamicSchemaLoader` used by standard streams.
+
+---
+
+## 5. Property Chunking with Character-Based Limits
+
+**Files:** `manifest.yaml` (multiple streams)
+
+Many streams use `PropertyChunking` to split property requests into chunks with a **15,000 character
+limit** (not a count limit). This is used in:
+
+- Property history streams (companies, contacts, deals) -- properties sent as URL query parameters via
+  `QueryProperties` + `propertiesWithHistory`
+- Archived streams (deals_archived) -- properties sent as URL query parameters with
+  `GroupByKeyMergeStrategy` to merge chunked responses by `id`
+- Forms stream -- same pattern as archived streams
+- Custom objects (full refresh sub-stream) -- same pattern as archived streams
+- Base CRM object streams (goals, products, line_items) -- properties sent as URL query parameters
+
+**Why this matters:**
+- The 15,000 character limit exists because HubSpot's API (and intermediary proxies) have URL length
+  restrictions. Properties are fetched dynamically from `/properties/v2/{entity}/properties`.
+- Streams that use chunking with `record_merge_strategy: GroupByKeyMergeStrategy` make multiple API
+  requests per page and merge results client-side. This multiplies API call volume proportionally to
+  the number of property chunks.
+- The CRM search streams (`base_crm_search_incremental_stream`) handle properties differently: they
+  use `fetch_properties_from_endpoint` on the requester, which sends all properties in the POST body
+  rather than URL params, avoiding the URL length issue.
+
+---
+
+## 6. NewtoLegacyFieldTransformation: Dynamic V2-to-Legacy Field Mapping
+
+**Files:** `components.py` (`NewtoLegacyFieldTransformation`), `manifest.yaml` (contacts, deals, deals_archived streams)
+
+HubSpot renamed fields between API versions (v1 -> v2). This transformation dynamically maps new field
+names back to their legacy equivalents to prevent breaking existing syncs. The mapping is prefix-based
+and applies to dynamically-named fields:
+
+- `hs_v2_date_entered_{stage_id}` -> `hs_date_entered_{stage_id}`
+- `hs_v2_date_exited_{stage_id}` -> `hs_date_exited_{stage_id}`
+- `hs_v2_latest_time_in_{stage_id}` -> `hs_time_in_{stage_id}`
+- For contacts: `hs_v2_date_entered_{stage_id}` -> `hs_lifecyclestage_{stage_id}_date`
+
+**Why this matters:**
+- The `{stage_id}` portion is user-generated (deal pipeline stages, lifecycle stages), so the
+  transformation cannot use static field lists -- it must pattern-match at runtime.
+- The contacts stream has a special case: `hs_lifecyclestage_` mappings append `_date` to the
+  transformed field name if not already present.
+- This transformation applies to both records and schemas (via `deals_archived_schema_loader` and
+  dynamic schema loaders for contacts/deals).
+
+---
+
+## 7. AddFieldsFromEndpointTransformation: Per-Record API Enrichment
+
+**Files:** `components.py` (`AddFieldsFromEndpointTransformation`, `MarketingEmailStatisticsTransformation`), `manifest.yaml` (campaigns, marketing_emails streams)
+
+Two streams make **additional API calls during record transformation** to enrich each record:
+
+- **Campaigns:** For every campaign record, makes a GET request to
+  `/email/public/v1/campaigns/{id}` to fetch full campaign details and merges them into the record.
+- **Marketing Emails:** For every email record, makes a GET request to
+  `/marketing/v3/emails/{emailId}/statistics` to fetch email statistics and merges them into the
+  record.
+
+**Why this matters:**
+- This means these streams make 1 additional API call per record (not per page). For large datasets,
+  this can result in thousands of extra API calls.
+- The `MarketingEmailStatisticsTransformation` has error handling that logs warnings but doesn't fail
+  the sync if statistics are unavailable for individual emails. The campaigns transformation does not
+  have this safety net.
+
+---
+
+## 8. HubspotPropertyHistoryExtractor: Flattening Versioned Properties into Records
+
+**Files:** `components.py` (`HubspotPropertyHistoryExtractor`), `manifest.yaml` (companies/contacts/deals property history streams)
+
+Property history streams yield **one record per property version change**, not one record per entity.
+The extractor iterates over `propertiesWithHistory` in each API response entity and yields individual
+records for each historical version of each property.
+
+**Why this matters:**
+- A single API entity (e.g., one contact) can produce dozens or hundreds of records if it has many
+  property changes over time.
+- The extractor explicitly skips `hs_lastmodifieddate` history to avoid redundant records (every
+  property change also updates `lastmodifieddate`, which would double the output).
+- Primary keys are composite: `(entity_id, property_name, timestamp)`.
+- The contacts property history stream applies field renaming transformations to convert v3 camelCase
+  fields back to v1 kebab-case (e.g., `sourceId` -> `source-id`) for backwards compatibility.
+- These streams use `is_client_side_incremental: true` with a cursor on `timestamp`, and support a
+  legacy `%ms` (millisecond string) state format via `MigrateEmptyStringState`.
+
+---
+
+## 9. EntitySchemaNormalization: HubSpot-Specific Type Coercion
+
+**Files:** `components.py` (`EntitySchemaNormalization`)
+
+Custom schema normalization handles several HubSpot API quirks:
+
+- **Empty strings:** Converted to `None` for non-string field types (HubSpot returns `""` instead of
+  `null` for empty fields).
+- **Numeric strings:** Cast to `int` if the string is purely numeric, otherwise `float`. This prevents
+  numeric IDs from being cast to floats. Handles non-castable values gracefully (e.g.,
+  `"3092727991;3881228353"` for a field typed as `number`) by logging and returning the original.
+- **Boolean strings:** `"true"`/`"false"` converted to actual booleans.
+- **Datetime parsing:** Attempts seconds-precision parsing first, then milliseconds. Handles float
+  timestamp strings by truncating the decimal before parsing. Returns original value on parse failure
+  rather than raising an error.
+
+---
+
+## 10. Authentication: 401 Retry and Dual Auth Support
+
+**Files:** `manifest.yaml` (error handlers, authenticator definitions)
+
+- **401 Retry:** The error handler retries on HTTP 401 (authentication expired). This is unusual --
+  most connectors fail on 401. This exists because HubSpot OAuth access tokens can expire mid-sync,
+  and the `OAuthAuthenticator` will transparently refresh the token on retry.
+- **530 Cloudflare Error:** The connector handles HTTP 530 (Cloudflare Origin DNS Error) as a FAIL
+  with a credentials-related message, because HubSpot returns this status when the API token format
+  is incorrect.
+- **SelectiveAuthenticator:** Supports two auth methods selected by `credentials.credentials_title`:
+  `"OAuth Credentials"` (OAuthAuthenticator with client_id/client_secret/refresh_token) and
+  `"Private App Credentials"` (BearerAuthenticator with a static access token).
+- **Standard OAuth behavior:** HubSpot uses a standard OAuth 2.0 flow with long-lived refresh tokens.
+  The token refresh endpoint is `/oauth/v1/token`. Unlike connectors such as source-airtable (which
+  has short-lived refresh tokens) or source-gong (which requires updating the source config after
+  token exchange), HubSpot's refresh tokens do not expire and do not require special handling.
+
+---
+
+## 11. API Rate Budget: Differentiated Rate Limits
+
+**Files:** `manifest.yaml` (`api_budget` section)
+
+The connector implements two separate rate limit policies:
+
+- **CRM Search endpoints** (`POST /crm/v3/objects/*/search`): 5 requests/second, 300 requests/minute.
+- **All other endpoints:** 10 requests/second, 100 requests per 10 seconds.
+
+HubSpot accounts are limited to 110 requests per 10 seconds overall. The error handler uses dual
+backoff: first `Retry-After` header, then exponential backoff as fallback (HubSpot does not always
+include `Retry-After` on 429 responses).
+
+---
+
+## 12. MigrateEmptyStringState: Legacy State Handling
+
+**Files:** `components.py` (`MigrateEmptyStringState`), `manifest.yaml` (most incremental streams)
+
+Almost every incremental stream uses `MigrateEmptyStringState` to handle a legacy issue where previous
+connector versions stored empty strings (`""`) as cursor values in stream state. The migration replaces
+empty string state with the configured `start_date` (or the default `2006-06-01T00:00:00.000Z`).
+
+Some streams also specify a `cursor_format` (e.g., `"%ms"`) to convert the start_date into the
+appropriate format for that stream's cursor field.
+
+---
+
+## 13. Mixed Datetime Formats Across Streams
+
+The connector handles multiple datetime formats because HubSpot's API is inconsistent across endpoints:
+
+- `%ms` -- Millisecond Unix timestamps (used by legacy v1 endpoints: engagements, campaigns,
+  deal_pipelines, workflows, email_events, subscription_changes, form_submissions)
+- `%Y-%m-%dT%H:%M:%S.%fZ` -- ISO 8601 with millisecond precision (used by v3 CRM endpoints)
+- `%Y-%m-%dT%H:%M:%SZ` -- ISO 8601 without fractional seconds
+- `%Y-%m-%dT%H:%M:%S%z` -- ISO 8601 with timezone offset
+
+Most streams list multiple `cursor_datetime_formats` to handle both current API responses and legacy
+state values. The contacts property history stream explicitly notes: "Previous version of Hubspot
+stored state as a millisecond string for some reason."

--- a/airbyte-integrations/connectors/source-hubspot/BEHAVIOR.md
+++ b/airbyte-integrations/connectors/source-hubspot/BEHAVIOR.md
@@ -1,83 +1,93 @@
 # source-hubspot: Unique Connector Behaviors
 
-This document describes non-obvious, connector-specific behaviors in `source-hubspot` that deviate from
-standard declarative connector patterns. Read this before making changes to the connector.
+This document describes the biggest non-obvious gotchas in `source-hubspot` that deviate from standard
+declarative connector patterns. Read this before making changes to the connector.
 
 ---
 
 ## 1. HubspotAssociationsExtractor: Hidden API Calls Inside Record Extraction
-
-**Files:** `components.py` (`HubspotAssociationsExtractor`, `build_associations_retriever`), `manifest.yaml` (`base_crm_search_incremental_stream`)
 
 The CRM search streams (contacts, companies, deals, tickets, leads, engagements_*, deal_splits) use
 `HubspotAssociationsExtractor` as their record extractor. This extractor does **not** simply parse the
 HTTP response -- it makes **additional batch POST requests** to the HubSpot Associations v4 API
 (`/crm/v4/associations/{entity}/{association}/batch/read`) for every page of results.
 
+HubSpot's CRM v3 Search API does not return association data inline with object records. To get
+associations (e.g., which contacts are linked to a deal), you must make separate calls to the
+Associations v4 batch read endpoint, passing in the record IDs from the primary response. This is a
+fundamental limitation of HubSpot's API design -- there is no way to include association data in a
+single search request.
+
 **Why this matters:**
-- Each page of CRM search results triggers N additional API calls (one per association type per batch).
-  For example, the `deals` stream fetches associations for `companies`, `contacts`, and `line_items`,
-  so every page of deal results triggers 3 additional API calls.
-- The `build_associations_retriever()` function in `components.py` manually constructs a full
-  `SimpleRetriever` with its own `SelectiveAuthenticator`, `HttpRequester`, error handler, and
-  `ListPartitionRouter` -- all in Python code rather than YAML. This is because the low-code framework
-  does not support instantiating a `SimpleRetriever` outside of a `DeclarativeStream` context.
-- If you add a new association to a stream's `associations` list, you are adding an extra API call per
-  page of results. Consider rate limit impact.
-- The associations retriever sends record IDs in the POST body via `extra_fields` on the `StreamSlice`,
-  which is an unusual data-passing pattern.
+- Each page of CRM search results triggers N additional API calls (one per association type). For
+  example, the `deals` stream fetches associations for `companies`, `contacts`, and `line_items`, so
+  every page of deal results triggers 3 extra API calls.
+- The `build_associations_retriever()` function manually constructs a full `SimpleRetriever` with its
+  own `SelectiveAuthenticator`, `HttpRequester`, error handler, and `ListPartitionRouter` entirely in
+  Python code. This is because the low-code framework does not support instantiating a
+  `SimpleRetriever` outside of a `DeclarativeStream` context.
+- Adding a new association to a stream's `associations` list adds an extra API call per page. Consider
+  rate limit impact.
 
 ---
 
 ## 2. EngagementsHttpRequester: Dual-Endpoint Selection at Runtime
 
-**Files:** `components.py` (`EngagementsHttpRequester`), `manifest.yaml` (`engagements_stream`)
-
-The `engagements` stream dynamically chooses between two completely different API endpoints at runtime:
+The `engagements` stream dynamically chooses between two completely different HubSpot API endpoints at
+runtime:
 
 - **Recent Engagements API** (`/engagements/v1/engagements/recent/modified`): Used when the start
   date/state is within the last 29 days **AND** the total record count is <= 10,000.
 - **All Engagements API** (`/engagements/v1/engagements/paged`): Used in all other cases.
 
+Both are HubSpot legacy v1 endpoints. The Recent API is optimized for low-volume recent changes but
+has a hard cap of 10,000 records and only covers the last 30 days. The All API has no such limits but
+returns every engagement ever created, requiring client-side filtering. HubSpot does not offer a single
+v1 endpoint that efficiently handles both cases, which is why the connector implements this switching
+logic.
+
 **Why this matters:**
 - On the first request, `should_use_recent_api()` makes a **probe request** to the Recent API to check
-  the `total` field in the response. This is an extra API call that happens before any data is fetched.
-- The Recent API has a hard cap of 10,000 most recently updated records. If exceeded, the connector
-  silently falls back to the All API, which returns everything but requires client-side incremental
-  filtering (`is_client_side_incremental: true`).
-- The page size is set to 250 (All API max), but if the Recent API is selected, HubSpot silently
-  clamps it to 100.
-- The decision is cached for the entire sync via `_use_recent_api`, so it cannot switch mid-sync.
-- The stream uses a single slice from start_date to now (no step/windowing), which is required for the
-  dual-endpoint logic to work. Do not add `step` to the incremental sync config.
+  the `total` field in the response. This is an extra API call before any data is fetched.
+- The Recent API silently clamps page size to 100 even though the stream requests 250 (the All API
+  max).
+- The decision is cached for the entire sync, so it cannot switch mid-sync.
+- The stream uses a single slice from start_date to now (no step/windowing), which is required for
+  the dual-endpoint logic to work. **Do not add `step` to the incremental sync config.**
 
 ---
 
 ## 3. HubspotCRMSearchPaginationStrategy: 10,000-Result Limit Workaround
 
-**Files:** `components.py` (`HubspotCRMSearchPaginationStrategy`), `manifest.yaml` (`base_crm_search_incremental_stream`)
+HubSpot's CRM Search API (`POST /crm/v3/objects/{entity}/search`) enforces a hard limit of 10,000
+total results per query. This is documented in
+[HubSpot's API reference](https://developers.hubspot.com/docs/api/crm/search): attempting to page
+beyond offset 10,000 returns a 400 error. The limit applies per-query, not per-account -- you can
+issue multiple queries with different filters to access more data.
 
-HubSpot's `/search` API has a hard limit of 10,000 total results per query. Attempting to paginate
-beyond 10,000 returns a 400 error. This custom pagination strategy works around the limit by:
+The custom pagination strategy works around this by:
 
 1. Tracking the current offset (`after`) and detecting when it approaches 10,000.
 2. When the limit is reached, resetting `after` to 0 and adding an `id` filter using the last
-   record's `hs_object_id + 1` to start a new query window.
+   record's `hs_object_id + 1` to effectively start a new query window.
 3. The CRM search request body includes a `sorts` clause ordering by `hs_object_id ASCENDING` and a
-   filter `hs_object_id >= {id}` to support this reset mechanism.
+   filter `hs_object_id >= {id}` to ensure deterministic ordering and seamless continuation.
+
+This is necessary because HubSpot's search endpoint was designed for filtered discovery, not bulk
+export. The 10,000 limit is intentional on HubSpot's side and cannot be increased.
 
 **Why this matters:**
 - The pagination token is a dict (`{"after": N}` or `{"after": N, "id": M}`), not a simple cursor
   string. Code that inspects or manipulates page tokens must handle both shapes.
 - The search request body in the manifest references `next_page_token['next_page_token'].get('id', 0)`
   and `next_page_token['next_page_token']['after']`, which is tightly coupled to this strategy.
-- This applies to all streams inheriting from `base_crm_search_incremental_stream`.
+- This applies to all streams inheriting from `base_crm_search_incremental_stream` (contacts,
+  companies, deals, tickets, leads, engagements_calls/emails/meetings/notes/tasks, deal_splits) as
+  well as the incremental sub-stream for custom objects.
 
 ---
 
 ## 4. StateDelegatingStream for Custom Objects
-
-**Files:** `manifest.yaml` (`dynamic_streams` section)
 
 Custom HubSpot objects use `DynamicDeclarativeStream` with `StateDelegatingStream` to select between
 two completely different stream implementations based on whether incoming stream state exists:
@@ -87,187 +97,126 @@ two completely different stream implementations based on whether incoming stream
 - **Has state (incremental):** Uses `POST /crm/v3/objects/{entity}/search` with the CRM search
   pagination strategy and date range filters.
 
+This split exists because HubSpot's CRM Search API requires filter parameters that depend on knowing a
+cursor position (i.e., state). On first sync with no state, it is more reliable to use the simpler
+list endpoint which returns all objects without needing filter constraints. The search endpoint is more
+efficient for incremental syncs because it supports `lastmodifieddate` filters, avoiding full scans.
+
 **Why this matters:**
 - The two sub-streams have different requesters, paginators, and record selectors. Changes to one do
   not automatically apply to the other.
 - The `HttpComponentsResolver` fetches custom object schemas from `/crm/v3/schemas` and dynamically
-  injects the object name, entity identifier, and property list into both sub-stream templates via
-  `components_mapping`.
-- The `fullyQualifiedName` is used as the entity path parameter (e.g., `p_{name}` if
-  `fullyQualifiedName` is not available), which differs from standard CRM objects.
-- Custom objects use `HubspotCustomObjectsSchemaLoader` to generate schemas from the properties
-  returned by the components resolver, rather than the `DynamicSchemaLoader` used by standard streams.
+  injects the object name, entity identifier, and property list into both sub-stream templates.
 
 ---
 
 ## 5. Property Chunking with Character-Based Limits
 
-**Files:** `manifest.yaml` (multiple streams)
-
 Many streams use `PropertyChunking` to split property requests into chunks with a **15,000 character
-limit** (not a count limit). This is used in:
+limit** (not a count limit). This affects property history streams (companies, contacts, deals),
+archived streams, forms, custom objects, and base CRM object streams (goals, products, line_items).
 
-- Property history streams (companies, contacts, deals) -- properties sent as URL query parameters via
-  `QueryProperties` + `propertiesWithHistory`
-- Archived streams (deals_archived) -- properties sent as URL query parameters with
-  `GroupByKeyMergeStrategy` to merge chunked responses by `id`
-- Forms stream -- same pattern as archived streams
-- Custom objects (full refresh sub-stream) -- same pattern as archived streams
-- Base CRM object streams (goals, products, line_items) -- properties sent as URL query parameters
+HubSpot's CRM v3 list endpoints accept property names as query parameters (e.g.,
+`?properties=name,email,phone,...`). Because HubSpot accounts can have hundreds of custom properties
+with long names, the resulting URL can exceed HTTP URL length limits imposed by HubSpot's
+infrastructure and intermediary proxies. HubSpot does not document a specific URL length limit, but
+the connector uses a 15,000 character threshold as a conservative safe maximum based on observed
+failures. Properties are fetched dynamically from `/properties/v2/{entity}/properties` and then split
+into character-bounded chunks.
 
 **Why this matters:**
-- The 15,000 character limit exists because HubSpot's API (and intermediary proxies) have URL length
-  restrictions. Properties are fetched dynamically from `/properties/v2/{entity}/properties`.
-- Streams that use chunking with `record_merge_strategy: GroupByKeyMergeStrategy` make multiple API
-  requests per page and merge results client-side. This multiplies API call volume proportionally to
-  the number of property chunks.
-- The CRM search streams (`base_crm_search_incremental_stream`) handle properties differently: they
-  use `fetch_properties_from_endpoint` on the requester, which sends all properties in the POST body
-  rather than URL params, avoiding the URL length issue.
+- Streams that use chunking with `record_merge_strategy: GroupByKeyMergeStrategy` make **multiple API
+  requests per page** and merge results client-side by record `id`. This multiplies API call volume
+  proportionally to the number of property chunks. An account with many custom properties will consume
+  significantly more API quota.
+- The CRM search streams handle properties differently: they send all properties in the POST request
+  body rather than URL params, avoiding the URL length issue entirely. This is why search streams do
+  not need property chunking.
+- If you're adding a stream that uses HubSpot's CRM list endpoints (GET), you likely need property
+  chunking. If you're using search endpoints (POST), you don't.
 
 ---
 
-## 6. NewtoLegacyFieldTransformation: Dynamic V2-to-Legacy Field Mapping
-
-**Files:** `components.py` (`NewtoLegacyFieldTransformation`), `manifest.yaml` (contacts, deals, deals_archived streams)
-
-HubSpot renamed fields between API versions (v1 -> v2). This transformation dynamically maps new field
-names back to their legacy equivalents to prevent breaking existing syncs. The mapping is prefix-based
-and applies to dynamically-named fields:
-
-- `hs_v2_date_entered_{stage_id}` -> `hs_date_entered_{stage_id}`
-- `hs_v2_date_exited_{stage_id}` -> `hs_date_exited_{stage_id}`
-- `hs_v2_latest_time_in_{stage_id}` -> `hs_time_in_{stage_id}`
-- For contacts: `hs_v2_date_entered_{stage_id}` -> `hs_lifecyclestage_{stage_id}_date`
-
-**Why this matters:**
-- The `{stage_id}` portion is user-generated (deal pipeline stages, lifecycle stages), so the
-  transformation cannot use static field lists -- it must pattern-match at runtime.
-- The contacts stream has a special case: `hs_lifecyclestage_` mappings append `_date` to the
-  transformed field name if not already present.
-- This transformation applies to both records and schemas (via `deals_archived_schema_loader` and
-  dynamic schema loaders for contacts/deals).
-
----
-
-## 7. AddFieldsFromEndpointTransformation: Per-Record API Enrichment
-
-**Files:** `components.py` (`AddFieldsFromEndpointTransformation`, `MarketingEmailStatisticsTransformation`), `manifest.yaml` (campaigns, marketing_emails streams)
+## 6. Per-Record API Enrichment (Campaigns and Marketing Emails)
 
 Two streams make **additional API calls during record transformation** to enrich each record:
 
-- **Campaigns:** For every campaign record, makes a GET request to
-  `/email/public/v1/campaigns/{id}` to fetch full campaign details and merges them into the record.
-- **Marketing Emails:** For every email record, makes a GET request to
-  `/marketing/v3/emails/{emailId}/statistics` to fetch email statistics and merges them into the
-  record.
+- **Campaigns:** HubSpot's campaign list endpoint (`/email/public/v1/campaigns`) only returns a
+  summary with `id`, `appId`, `appName`, and `lastUpdatedTime`. To get full campaign details
+  (subject, counters, etc.), the connector makes a separate GET request to
+  `/email/public/v1/campaigns/{id}` for each record. This is a limitation of HubSpot's email campaign
+  API which has no "list with full details" endpoint.
+- **Marketing Emails:** HubSpot's v3 email API separates content data and performance statistics into
+  different endpoints. For every email record, the connector makes a GET request to
+  `/marketing/v3/emails/{emailId}/statistics` to fetch performance metrics.
 
 **Why this matters:**
-- This means these streams make 1 additional API call per record (not per page). For large datasets,
-  this can result in thousands of extra API calls.
-- The `MarketingEmailStatisticsTransformation` has error handling that logs warnings but doesn't fail
-  the sync if statistics are unavailable for individual emails. The campaigns transformation does not
-  have this safety net.
+- These streams make **1 additional API call per record** (not per page). For large datasets, this
+  results in thousands of extra API calls and is the most API-intensive pattern in the connector.
+- The marketing emails enrichment has error handling that logs warnings but doesn't fail the sync if
+  statistics are unavailable. The campaigns enrichment does not have this safety net.
 
 ---
 
-## 8. HubspotPropertyHistoryExtractor: Flattening Versioned Properties into Records
+## 7. Mixed Datetime Formats Across Streams
 
-**Files:** `components.py` (`HubspotPropertyHistoryExtractor`), `manifest.yaml` (companies/contacts/deals property history streams)
+HubSpot's API uses inconsistent datetime formats across different endpoint versions:
 
-Property history streams yield **one record per property version change**, not one record per entity.
-The extractor iterates over `propertiesWithHistory` in each API response entity and yields individual
-records for each historical version of each property.
+- **Legacy v1 endpoints** (engagements, campaigns, deal_pipelines, workflows, email_events,
+  subscription_changes, form_submissions) return **millisecond Unix timestamps** (e.g.,
+  `1672531200000`). The connector uses the `%ms` format string for these.
+- **CRM v3 endpoints** (contacts, companies, deals, tickets, etc.) return **ISO 8601 strings** with
+  varying precision:
+  - `%Y-%m-%dT%H:%M:%S.%fZ` (with milliseconds, e.g., `2023-01-01T00:00:00.000Z`)
+  - `%Y-%m-%dT%H:%M:%SZ` (without fractional seconds)
+  - `%Y-%m-%dT%H:%M:%S%z` (with timezone offset)
+
+This inconsistency stems from HubSpot's gradual API evolution -- v1 endpoints were designed around
+Unix timestamps, while v3 adopted ISO 8601. HubSpot has not standardized across versions and the v1
+endpoints are still actively used for resources not yet available in v3.
+
+Additionally, previous versions of the connector stored state values as millisecond strings even for
+streams that now use ISO 8601. Most streams list multiple `cursor_datetime_formats` to handle both
+current API responses and legacy state values. The `MigrateEmptyStringState` migration (used by nearly
+every incremental stream) also handles a legacy bug where previous connector versions stored empty
+strings as cursor values.
 
 **Why this matters:**
-- A single API entity (e.g., one contact) can produce dozens or hundreds of records if it has many
-  property changes over time.
-- The extractor explicitly skips `hs_lastmodifieddate` history to avoid redundant records (every
-  property change also updates `lastmodifieddate`, which would double the output).
-- Primary keys are composite: `(entity_id, property_name, timestamp)`.
-- The contacts property history stream applies field renaming transformations to convert v3 camelCase
-  fields back to v1 kebab-case (e.g., `sourceId` -> `source-id`) for backwards compatibility.
-- These streams use `is_client_side_incremental: true` with a cursor on `timestamp`, and support a
-  legacy `%ms` (millisecond string) state format via `MigrateEmptyStringState`.
+- When adding a new stream, you must check which datetime format the HubSpot endpoint actually returns
+  and configure `cursor_datetime_formats` accordingly. Getting this wrong will cause silent data loss
+  or sync failures.
 
 ---
 
-## 9. EntitySchemaNormalization: HubSpot-Specific Type Coercion
+## 8. Authentication: 401 Retry
 
-**Files:** `components.py` (`EntitySchemaNormalization`)
+The error handler retries on HTTP 401 (authentication expired). This is unusual -- most connectors
+fail immediately on 401. HubSpot OAuth access tokens have a 30-minute lifetime, and for long-running
+syncs the token can expire mid-sync. The `OAuthAuthenticator` transparently refreshes the token on
+retry, making this seamless. Without this retry, any sync lasting longer than 30 minutes would fail
+partway through.
 
-Custom schema normalization handles several HubSpot API quirks:
+The connector also handles HTTP 530 (Cloudflare Origin DNS Error) as a credentials failure. HubSpot
+returns this non-standard status code when the API token format is incorrect, rather than a standard
+401 or 403.
 
-- **Empty strings:** Converted to `None` for non-string field types (HubSpot returns `""` instead of
-  `null` for empty fields).
-- **Numeric strings:** Cast to `int` if the string is purely numeric, otherwise `float`. This prevents
-  numeric IDs from being cast to floats. Handles non-castable values gracefully (e.g.,
-  `"3092727991;3881228353"` for a field typed as `number`) by logging and returning the original.
-- **Boolean strings:** `"true"`/`"false"` converted to actual booleans.
-- **Datetime parsing:** Attempts seconds-precision parsing first, then milliseconds. Handles float
-  timestamp strings by truncating the decimal before parsing. Returns original value on parse failure
-  rather than raising an error.
-
----
-
-## 10. Authentication: 401 Retry and Dual Auth Support
-
-**Files:** `manifest.yaml` (error handlers, authenticator definitions)
-
-- **401 Retry:** The error handler retries on HTTP 401 (authentication expired). This is unusual --
-  most connectors fail on 401. This exists because HubSpot OAuth access tokens can expire mid-sync,
-  and the `OAuthAuthenticator` will transparently refresh the token on retry.
-- **530 Cloudflare Error:** The connector handles HTTP 530 (Cloudflare Origin DNS Error) as a FAIL
-  with a credentials-related message, because HubSpot returns this status when the API token format
-  is incorrect.
-- **SelectiveAuthenticator:** Supports two auth methods selected by `credentials.credentials_title`:
-  `"OAuth Credentials"` (OAuthAuthenticator with client_id/client_secret/refresh_token) and
-  `"Private App Credentials"` (BearerAuthenticator with a static access token).
-- **Standard OAuth behavior:** HubSpot uses a standard OAuth 2.0 flow with long-lived refresh tokens.
-  The token refresh endpoint is `/oauth/v1/token`. Unlike connectors such as source-airtable (which
-  has short-lived refresh tokens) or source-gong (which requires updating the source config after
-  token exchange), HubSpot's refresh tokens do not expire and do not require special handling.
+HubSpot uses standard OAuth 2.0 with long-lived refresh tokens via `/oauth/v1/token`. Unlike
+source-airtable (short-lived refresh tokens) or source-gong (requires config update after token
+exchange), HubSpot's refresh tokens do not expire and do not require special handling.
 
 ---
 
-## 11. API Rate Budget: Differentiated Rate Limits
+## 9. API Rate Budget: Differentiated Rate Limits
 
-**Files:** `manifest.yaml` (`api_budget` section)
-
-The connector implements two separate rate limit policies:
+HubSpot enforces different rate limits depending on the API category. The connector models this with
+two separate rate limit policies:
 
 - **CRM Search endpoints** (`POST /crm/v3/objects/*/search`): 5 requests/second, 300 requests/minute.
-- **All other endpoints:** 10 requests/second, 100 requests per 10 seconds.
+  [HubSpot documents this](https://developers.hubspot.com/docs/api/crm/search) as a stricter limit
+  specifically for search operations.
+- **All other endpoints:** 10 requests/second, 100 requests per 10 seconds. HubSpot's general limit
+  for OAuth apps is 110 requests per 10 seconds.
 
-HubSpot accounts are limited to 110 requests per 10 seconds overall. The error handler uses dual
-backoff: first `Retry-After` header, then exponential backoff as fallback (HubSpot does not always
-include `Retry-After` on 429 responses).
-
----
-
-## 12. MigrateEmptyStringState: Legacy State Handling
-
-**Files:** `components.py` (`MigrateEmptyStringState`), `manifest.yaml` (most incremental streams)
-
-Almost every incremental stream uses `MigrateEmptyStringState` to handle a legacy issue where previous
-connector versions stored empty strings (`""`) as cursor values in stream state. The migration replaces
-empty string state with the configured `start_date` (or the default `2006-06-01T00:00:00.000Z`).
-
-Some streams also specify a `cursor_format` (e.g., `"%ms"`) to convert the start_date into the
-appropriate format for that stream's cursor field.
-
----
-
-## 13. Mixed Datetime Formats Across Streams
-
-The connector handles multiple datetime formats because HubSpot's API is inconsistent across endpoints:
-
-- `%ms` -- Millisecond Unix timestamps (used by legacy v1 endpoints: engagements, campaigns,
-  deal_pipelines, workflows, email_events, subscription_changes, form_submissions)
-- `%Y-%m-%dT%H:%M:%S.%fZ` -- ISO 8601 with millisecond precision (used by v3 CRM endpoints)
-- `%Y-%m-%dT%H:%M:%SZ` -- ISO 8601 without fractional seconds
-- `%Y-%m-%dT%H:%M:%S%z` -- ISO 8601 with timezone offset
-
-Most streams list multiple `cursor_datetime_formats` to handle both current API responses and legacy
-state values. The contacts property history stream explicitly notes: "Previous version of Hubspot
-stored state as a millisecond string for some reason."
+The error handler uses dual backoff on 429 responses: first the `Retry-After` header, then exponential
+backoff as fallback. This dual approach is necessary because HubSpot does not always include the
+`Retry-After` header on 429 responses.

--- a/airbyte-integrations/connectors/source-hubspot/BEHAVIOR.md
+++ b/airbyte-integrations/connectors/source-hubspot/BEHAVIOR.md
@@ -18,16 +18,7 @@ Associations v4 batch read endpoint, passing in the record IDs from the primary 
 fundamental limitation of HubSpot's API design -- there is no way to include association data in a
 single search request.
 
-**Why this matters:**
-- Each page of CRM search results triggers N additional API calls (one per association type). For
-  example, the `deals` stream fetches associations for `companies`, `contacts`, and `line_items`, so
-  every page of deal results triggers 3 extra API calls.
-- The `build_associations_retriever()` function manually constructs a full `SimpleRetriever` with its
-  own `SelectiveAuthenticator`, `HttpRequester`, error handler, and `ListPartitionRouter` entirely in
-  Python code. This is because the low-code framework does not support instantiating a
-  `SimpleRetriever` outside of a `DeclarativeStream` context.
-- Adding a new association to a stream's `associations` list adds an extra API call per page. Consider
-  rate limit impact.
+**Why this matters:** Each page of CRM search results silently triggers N additional API calls -- one per association type configured on that stream. For example, the `deals` stream fetches associations for companies, contacts, and line items, so every single page of deals costs 4 HTTP requests total (1 search + 3 association batches). Adding a new association to a stream's config quietly increases API usage across every page of every sync.
 
 ---
 
@@ -46,14 +37,7 @@ returns every engagement ever created, requiring client-side filtering. HubSpot 
 v1 endpoint that efficiently handles both cases, which is why the connector implements this switching
 logic.
 
-**Why this matters:**
-- On the first request, `should_use_recent_api()` makes a **probe request** to the Recent API to check
-  the `total` field in the response. This is an extra API call before any data is fetched.
-- The Recent API silently clamps page size to 100 even though the stream requests 250 (the All API
-  max).
-- The decision is cached for the entire sync, so it cannot switch mid-sync.
-- The stream uses a single slice from start_date to now (no step/windowing), which is required for
-  the dual-endpoint logic to work. **Do not add `step` to the incremental sync config.**
+**Why this matters:** The connector makes a hidden probe request at the start of every sync to decide which endpoint to use, and that decision is locked in for the entire sync. The two endpoints have different page size limits (100 vs 250) and different data coverage (30-day window vs all-time). **Do not add `step` to the incremental sync config** -- the dual-endpoint logic requires a single slice from start_date to now.
 
 ---
 
@@ -76,14 +60,7 @@ The custom pagination strategy works around this by:
 This is necessary because HubSpot's search endpoint was designed for filtered discovery, not bulk
 export. The 10,000 limit is intentional on HubSpot's side and cannot be increased.
 
-**Why this matters:**
-- The pagination token is a dict (`{"after": N}` or `{"after": N, "id": M}`), not a simple cursor
-  string. Code that inspects or manipulates page tokens must handle both shapes.
-- The search request body in the manifest references `next_page_token['next_page_token'].get('id', 0)`
-  and `next_page_token['next_page_token']['after']`, which is tightly coupled to this strategy.
-- This applies to all streams inheriting from `base_crm_search_incremental_stream` (contacts,
-  companies, deals, tickets, leads, engagements_calls/emails/meetings/notes/tasks, deal_splits) as
-  well as the incremental sub-stream for custom objects.
+**Why this matters:** Without this workaround, any CRM object type with more than 10,000 modified records since the last sync would silently stop paginating and miss data. The pagination token is a dict with two possible shapes (`{"after": N}` or `{"after": N, "id": M}`), not a simple cursor string, so any code touching page tokens must handle both. This affects all CRM search streams: contacts, companies, deals, tickets, leads, all engagement subtypes, deal_splits, and custom objects.
 
 ---
 
@@ -102,11 +79,7 @@ cursor position (i.e., state). On first sync with no state, it is more reliable 
 list endpoint which returns all objects without needing filter constraints. The search endpoint is more
 efficient for incremental syncs because it supports `lastmodifieddate` filters, avoiding full scans.
 
-**Why this matters:**
-- The two sub-streams have different requesters, paginators, and record selectors. Changes to one do
-  not automatically apply to the other.
-- The `HttpComponentsResolver` fetches custom object schemas from `/crm/v3/schemas` and dynamically
-  injects the object name, entity identifier, and property list into both sub-stream templates.
+**Why this matters:** These are two completely independent stream implementations that happen to share a name. They have different requesters, paginators, and record selectors, so a fix applied to one sub-stream will not carry over to the other. If you change how custom objects sync, you need to verify both the full-refresh and incremental paths separately.
 
 ---
 
@@ -124,16 +97,7 @@ the connector uses a 15,000 character threshold as a conservative safe maximum b
 failures. Properties are fetched dynamically from `/properties/v2/{entity}/properties` and then split
 into character-bounded chunks.
 
-**Why this matters:**
-- Streams that use chunking with `record_merge_strategy: GroupByKeyMergeStrategy` make **multiple API
-  requests per page** and merge results client-side by record `id`. This multiplies API call volume
-  proportionally to the number of property chunks. An account with many custom properties will consume
-  significantly more API quota.
-- The CRM search streams handle properties differently: they send all properties in the POST request
-  body rather than URL params, avoiding the URL length issue entirely. This is why search streams do
-  not need property chunking.
-- If you're adding a stream that uses HubSpot's CRM list endpoints (GET), you likely need property
-  chunking. If you're using search endpoints (POST), you don't.
+**Why this matters:** This means what looks like a single page of 100 records may actually require N parallel HTTP requests behind the scenes (one per property chunk), all stitched together before being emitted. If a user adds many custom properties to their HubSpot objects, the number of HTTP calls per page silently multiplies. CRM search streams (POST) send properties in the request body and don't need chunking -- only GET-based list endpoints are affected.
 
 ---
 
@@ -150,11 +114,7 @@ Two streams make **additional API calls during record transformation** to enrich
   different endpoints. For every email record, the connector makes a GET request to
   `/marketing/v3/emails/{emailId}/statistics` to fetch performance metrics.
 
-**Why this matters:**
-- These streams make **1 additional API call per record** (not per page). For large datasets, this
-  results in thousands of extra API calls and is the most API-intensive pattern in the connector.
-- The marketing emails enrichment has error handling that logs warnings but doesn't fail the sync if
-  statistics are unavailable. The campaigns enrichment does not have this safety net.
+**Why this matters:** Unlike the association extractor (which batches per page), these enrichments make one extra HTTP call per individual record. A sync of 50,000 campaigns means 50,000 additional API calls on top of the pagination calls. This is the most API-intensive pattern in the connector and the most likely to hit rate limits on large accounts.
 
 ---
 
@@ -181,10 +141,7 @@ current API responses and legacy state values. The `MigrateEmptyStringState` mig
 every incremental stream) also handles a legacy bug where previous connector versions stored empty
 strings as cursor values.
 
-**Why this matters:**
-- When adding a new stream, you must check which datetime format the HubSpot endpoint actually returns
-  and configure `cursor_datetime_formats` accordingly. Getting this wrong will cause silent data loss
-  or sync failures.
+**Why this matters:** If you add a new stream and configure the wrong datetime format, cursor comparisons will silently break -- either skipping records or re-syncing everything on every run. Most streams list multiple `cursor_datetime_formats` to handle both current API responses and legacy state values from older connector versions.
 
 ---
 

--- a/airbyte-integrations/connectors/source-hubspot/CLAUDE.md
+++ b/airbyte-integrations/connectors/source-hubspot/CLAUDE.md
@@ -1,0 +1,28 @@
+# source-hubspot
+
+## Overview
+
+HubSpot CRM source connector using the declarative (low-code) framework with extensive custom Python
+components in `components.py`. The connector syncs data from HubSpot's CRM, marketing, and engagement
+APIs.
+
+## Key Files
+
+- `manifest.yaml` -- Declarative stream definitions, authentication, pagination, error handling, and
+  schemas (~7600 lines).
+- `components.py` -- Custom Python components for behaviors that cannot be expressed in YAML alone.
+- `BEHAVIOR.md` -- **Read this first.** Documents all non-obvious connector-specific behaviors
+  including hidden API calls during extraction, dual-endpoint selection, pagination workarounds, and
+  property chunking. Understanding these behaviors is critical before making changes.
+
+## Important Patterns
+
+- CRM search streams make additional association API calls inside the record extractor. See
+  `BEHAVIOR.md` section 1.
+- The engagements stream dynamically selects between two different API endpoints. See `BEHAVIOR.md`
+  section 2.
+- Pagination resets at 10,000 results for search endpoints. See `BEHAVIOR.md` section 3.
+- Custom objects use `StateDelegatingStream` with two different sub-stream implementations. See
+  `BEHAVIOR.md` section 4.
+- Many streams use character-based property chunking (15,000 char limit). See `BEHAVIOR.md` section 5.
+- Authentication retries on 401 to handle mid-sync token expiration. See `BEHAVIOR.md` section 10.

--- a/airbyte-integrations/connectors/source-hubspot/CLAUDE.md
+++ b/airbyte-integrations/connectors/source-hubspot/CLAUDE.md
@@ -25,4 +25,4 @@ APIs.
 - Custom objects use `StateDelegatingStream` with two different sub-stream implementations. See
   `BEHAVIOR.md` section 4.
 - Many streams use character-based property chunking (15,000 char limit). See `BEHAVIOR.md` section 5.
-- Authentication retries on 401 to handle mid-sync token expiration. See `BEHAVIOR.md` section 10.
+- Authentication retries on 401 to handle mid-sync token expiration. See `BEHAVIOR.md` section 8.


### PR DESCRIPTION
## What

Adds documentation for non-obvious, connector-specific behaviors in `source-hubspot` that deviate from standard declarative connector patterns. These docs are intended to be read by engineers (and AI agents) before making changes to this connector.

Requested by @brianjlai.

## How

Two new files added:

- **`BEHAVIOR.md`** — Documents the 9 biggest gotchas, each with HubSpot API context explaining *why* the behavior exists:
  1. Hidden API calls inside `HubspotAssociationsExtractor` (per-page batch association fetches via Associations v4 API)
  2. Dual-endpoint selection in the engagements stream (Recent vs. All API, with probe request)
  3. 10,000-result pagination workaround for CRM Search (ID-based query windowing)
  4. `StateDelegatingStream` for custom objects (full refresh vs. incremental sub-streams)
  5. Character-based property chunking (15,000 char limit due to URL length constraints)
  6. Per-record API enrichment (campaigns and marketing emails — 1 extra call per record)
  7. Mixed datetime formats across v1 (millisecond timestamps) and v3 (ISO 8601) endpoints
  8. Authentication: 401 retry for mid-sync token expiration, 530 Cloudflare handling, standard OAuth
  9. Differentiated API rate budgets (stricter limits for CRM Search)

- **`CLAUDE.md`** — Brief overview pointing to `BEHAVIOR.md` and listing key files and the most important patterns to be aware of.

### Revision history

1. Trimmed from 13 sections to 9 per reviewer feedback:
   - Removed sections on record transformations (field mapping, property history flattening, schema normalization, legacy state migration) as these are not "big gotchas" and are already self-documented in code
   - Added more HubSpot API context to remaining sections (e.g., why the 10k search limit exists, why property chunking uses character limits, HubSpot's API version evolution for datetime formats)
   - Removed per-section `**Files:**` references as clunky — nearly everything lives in `manifest.yaml` or `components.py`
   - Added links to HubSpot's API reference where relevant

2. Rewrote all "Why this matters" summaries to be more concise and human-readable — each is now a single focused paragraph explaining the practical impact rather than a bullet list of implementation details.

## Review guide

1. `BEHAVIOR.md` — Main deliverable. Each section documents a specific behavior with a concise "why this matters" summary. Verify accuracy of behavioral claims against `components.py` and `manifest.yaml`.
2. `CLAUDE.md` — Short pointer file. Verify it adequately references the important patterns.

**Key items to verify:**
- [ ] Section 8 claims HubSpot OAuth access tokens have a 30-minute lifetime and refresh tokens are long-lived (unlike source-airtable or source-gong). Confirm this matches production experience.
- [ ] Section 2 warns against adding `step` to the engagements incremental sync config. Confirm this constraint is accurate.
- [ ] Section 3 claims HubSpot's 10k search limit is per-query and cannot be increased. Verify against [HubSpot docs](https://developers.hubspot.com/docs/api/crm/search).
- [ ] Confirm the 9 retained behaviors represent the most important gotchas — no critical ones missed, no non-critical ones included.
- [ ] Verify the concise "Why this matters" summaries don't lose important nuance from the fuller explanations above them in each section.

## User Impact

No user impact — documentation only. These files help engineers and AI agents understand non-obvious connector behaviors before making changes.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

[Link to Devin run](https://app.devin.ai/sessions/5abb4107d5364d37bc5aceebee32beaf)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/74046" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
