### PR TITLE
Declare the postgres ObjectFieldType as protobuf aware for supplying …

### DIFF
--- a/airbyte-integrations/connectors/source-postgres/src/main/kotlin/io/airbyte/integrations/source/postgres/operations/types/ObjectFieldTypes.kt
+++ b/airbyte-integrations/connectors/source-postgres/src/main/kotlin/io/airbyte/integrations/source/postgres/operations/types/ObjectFieldTypes.kt
@@ -11,6 +11,7 @@ import io.airbyte.cdk.data.JsonCodec
 import io.airbyte.cdk.data.LeafAirbyteSchemaType
 import io.airbyte.cdk.jdbc.JdbcAccessor
 import io.airbyte.cdk.jdbc.SymmetricJdbcFieldType
+import io.airbyte.cdk.output.sockets.ProtobufAwareCustomConnectorJsonCodec
 import io.airbyte.cdk.util.Jsons
 import java.sql.PreparedStatement
 import java.sql.ResultSet
@@ -41,7 +42,7 @@ class ObjectAccessor<T : PGobject>(val kClass: KClass<T>) : JdbcAccessor<T> {
     }
 }
 
-class ObjectCodec<T : PGobject>() : JsonCodec<T> {
+class ObjectCodec<T : PGobject>() : ProtobufAwareCustomConnectorJsonCodec<T> {
     override fun encode(decoded: T): JsonNode {
         return TextNode(decoded.value)
     }
@@ -49,6 +50,9 @@ class ObjectCodec<T : PGobject>() : JsonCodec<T> {
     override fun decode(encoded: JsonNode): T {
         return Jsons.readValue(encoded.asText(), object : TypeReference<T>() {})
     }
+
+    override fun valueForProtobufEncoding(v: T): Any? =
+        encode(v).asText()
 }
 
 // These need to be defined at compile time to avoid issues with type erasure


### PR DESCRIPTION
Similarly to HstoreFieldType, declare ObjectCodec used in ObjectFieldType as a protobuf ProtobufAwareCustomConnectorJsonCodec type so it can provide the correct native type (String) for protobuf encoding in speed mode.