### PR TITLE
feat(connectors): add source-smoke-test connector for destination regression testing

### DIFF
--- a/airbyte-integrations/connectors/source-smoke-test/README.md
+++ b/airbyte-integrations/connectors/source-smoke-test/README.md
@@ -1,0 +1,70 @@
+# Smoke Test source connector
+
+This is the repository for the Smoke Test source connector, written in Python.
+For information about how to use this connector within Airbyte, see [the documentation](https://docs.airbyte.com/integrations/sources/smoke-test).
+
+## Overview
+
+The Smoke Test source generates synthetic test data across 15 predefined scenarios designed to exercise common destination failure patterns:
+
+- **Type coverage**: basic types, timestamps, large decimals, nested JSON/arrays
+- **Null handling**: nullable columns across all types, always-null columns, null-vs-empty-vs-zero
+- **Naming edge cases**: reserved SQL words, CamelCase, dots/dashes/spaces in column names, long column names, mixed-case stream names
+- **Schema variations**: wide table (50 columns), no-primary-key stream, empty stream, single-record stream
+- **Batch sizes**: configurable large batch (default 1000 records)
+- **Unicode/special strings**: international characters, escape sequences
+
+The source also supports dynamic scenario injection via the `custom_scenarios` config field.
+
+## Configuration
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `all_fast_streams` | boolean | `true` | Include all fast (non-high-volume) predefined streams |
+| `all_slow_streams` | boolean | `false` | Include all slow (high-volume) streams such as `large_batch_stream` |
+| `scenario_filter` | array of strings | `[]` | Specific scenario names to include (unioned with boolean flags) |
+| `large_batch_record_count` | integer | `1000` | Number of records for `large_batch_stream` |
+| `custom_scenarios` | array of objects | `[]` | Additional test scenarios to inject at runtime |
+
+## Local development
+
+### Prerequisites
+
+- Python (~=3.10)
+- Poetry (~=1.7) - installation instructions [here](https://python-poetry.org/docs/#installation)
+
+### Installing the connector
+
+From this connector directory, run:
+
+```bash
+poetry install --with dev
+```
+
+### Locally running the connector
+
+```
+poetry run source-smoke-test spec
+poetry run source-smoke-test check --config secrets/config.json
+poetry run source-smoke-test discover --config secrets/config.json
+poetry run source-smoke-test read --config secrets/config.json --catalog sample_files/configured_catalog.json
+```
+
+### Running unit tests
+
+To run unit tests locally, from the connector directory run:
+
+```
+poetry run pytest unit_tests
+```
+
+### Building the docker image
+
+1. Install [`airbyte-ci`](https://github.com/airbytehq/airbyte/blob/master/airbyte-ci/connectors/pipelines/README.md)
+2. Run the following command to build the docker image:
+
+```bash
+airbyte-ci connectors --name=source-smoke-test build
+```
+
+An image will be available on your host with the tag `airbyte/source-smoke-test:dev`.

--- a/airbyte-integrations/connectors/source-smoke-test/icon.svg
+++ b/airbyte-integrations/connectors/source-smoke-test/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" fill="none">
+  <circle cx="50" cy="50" r="45" fill="#615EFF" />
+  <text x="50" y="58" text-anchor="middle" font-family="sans-serif" font-size="28" font-weight="bold" fill="white">ST</text>
+</svg>

--- a/airbyte-integrations/connectors/source-smoke-test/main.py
+++ b/airbyte-integrations/connectors/source-smoke-test/main.py
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+#
+
+
+from source_smoke_test.run import run
+
+
+if __name__ == "__main__":
+    run()

--- a/airbyte-integrations/connectors/source-smoke-test/metadata.yaml
+++ b/airbyte-integrations/connectors/source-smoke-test/metadata.yaml
@@ -1,0 +1,35 @@
+data:
+  ab_internal:
+    ql: 100
+    sl: 100
+  allowedHosts:
+    hosts: []
+  connectorBuildOptions:
+    baseImage: docker.io/airbyte/python-connector-base:4.0.2@sha256:9fdb1888c4264cf6fee473649ecb593f56f58e5d0096a87ee0b231777e2e3e73
+  connectorSubtype: api
+  connectorType: source
+  definitionId: 4745b886-d299-4a4f-b14b-4803e643159a
+  dockerImageTag: 0.1.0
+  dockerRepository: airbyte/source-smoke-test
+  documentationUrl: https://docs.airbyte.com/integrations/sources/smoke-test
+  githubIssueLabel: source-smoke-test
+  icon: icon.svg
+  license: ELv2
+  name: Smoke Test
+  registryOverrides:
+    cloud:
+      enabled: false
+    oss:
+      enabled: true
+  releaseStage: alpha
+  remoteRegistries:
+    pypi:
+      enabled: false
+      packageName: airbyte-source-smoke-test
+  supportLevel: community
+  tags:
+    - language:python
+    - cdk:python
+  connectorTestSuitesOptions:
+    - suite: unitTests
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-smoke-test/pyproject.toml
+++ b/airbyte-integrations/connectors/source-smoke-test/pyproject.toml
@@ -1,0 +1,31 @@
+[build-system]
+requires = [ "poetry-core>=1.0.0",]
+build-backend = "poetry.core.masonry.api"
+
+[tool.poetry]
+version = "0.1.0"
+name = "source-smoke-test"
+description = "Smoke test source for destination regression testing."
+authors = [ "Airbyte <contact@airbyte.io>",]
+license = "ELv2"
+readme = "README.md"
+documentation = "https://docs.airbyte.com/integrations/sources/smoke-test"
+homepage = "https://airbyte.com"
+repository = "https://github.com/airbytehq/airbyte"
+[[tool.poetry.packages]]
+include = "source_smoke_test"
+
+[tool.poetry.dependencies]
+python = ">=3.10,<3.13"
+airbyte-cdk = ">=6.61.6,<7.0"
+
+[tool.poetry.scripts]
+source-smoke-test = "source_smoke_test.run:run"
+
+[tool.poetry.group.dev.dependencies]
+pytest = ">=8.0.0"
+
+[tool.poe]
+include = [
+    "${POE_GIT_DIR}/poe-tasks/poetry-connector-tasks.toml",
+]

--- a/airbyte-integrations/connectors/source-smoke-test/source_smoke_test/__init__.py
+++ b/airbyte-integrations/connectors/source-smoke-test/source_smoke_test/__init__.py
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+#
+
+from .source import SourceSmokeTest
+
+__all__ = ["SourceSmokeTest"]

--- a/airbyte-integrations/connectors/source-smoke-test/source_smoke_test/__init__.py
+++ b/airbyte-integrations/connectors/source-smoke-test/source_smoke_test/__init__.py
@@ -4,4 +4,5 @@
 
 from .source import SourceSmokeTest
 
+
 __all__ = ["SourceSmokeTest"]

--- a/airbyte-integrations/connectors/source-smoke-test/source_smoke_test/run.py
+++ b/airbyte-integrations/connectors/source-smoke-test/source_smoke_test/run.py
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+#
+
+import sys
+
+from airbyte_cdk.entrypoint import launch
+from source_smoke_test import SourceSmokeTest
+
+
+def run():
+    source = SourceSmokeTest()
+    launch(source, sys.argv[1:])
+
+
+if __name__ == "__main__":
+    run()

--- a/airbyte-integrations/connectors/source-smoke-test/source_smoke_test/scenarios.py
+++ b/airbyte-integrations/connectors/source-smoke-test/source_smoke_test/scenarios.py
@@ -77,10 +77,7 @@ PREDEFINED_SCENARIOS: list[dict[str, Any]] = [
     },
     {
         "name": "large_decimals_and_numbers",
-        "description": (
-            "Tests handling of very large numbers, "
-            "high precision decimals, and boundary values."
-        ),
+        "description": ("Tests handling of very large numbers, high precision decimals, and boundary values."),
         "json_schema": {
             "$schema": "http://json-schema.org/draft-07/schema#",
             "type": "object",
@@ -224,10 +221,7 @@ PREDEFINED_SCENARIOS: list[dict[str, Any]] = [
     },
     {
         "name": "column_naming_edge_cases",
-        "description": (
-            "Tests special characters, casing, "
-            "and reserved words in column names."
-        ),
+        "description": ("Tests special characters, casing, and reserved words in column names."),
         "json_schema": {
             "$schema": "http://json-schema.org/draft-07/schema#",
             "type": "object",
@@ -264,10 +258,7 @@ PREDEFINED_SCENARIOS: list[dict[str, Any]] = [
     },
     {
         "name": "table_naming_edge_cases",
-        "description": (
-            "Stream with special characters in the name "
-            "to test table naming."
-        ),
+        "description": ("Stream with special characters in the name to test table naming."),
         "json_schema": {
             "$schema": "http://json-schema.org/draft-07/schema#",
             "type": "object",
@@ -322,10 +313,7 @@ PREDEFINED_SCENARIOS: list[dict[str, Any]] = [
     },
     {
         "name": "empty_stream",
-        "description": (
-            "A stream that emits zero records, "
-            "testing empty dataset handling."
-        ),
+        "description": ("A stream that emits zero records, testing empty dataset handling."),
         "json_schema": {
             "$schema": "http://json-schema.org/draft-07/schema#",
             "type": "object",
@@ -355,10 +343,7 @@ PREDEFINED_SCENARIOS: list[dict[str, Any]] = [
     },
     {
         "name": "large_batch_stream",
-        "description": (
-            "A stream that generates a configurable "
-            "number of records for batch testing."
-        ),
+        "description": ("A stream that generates a configurable number of records for batch testing."),
         "json_schema": {
             "$schema": "http://json-schema.org/draft-07/schema#",
             "type": "object",
@@ -376,10 +361,7 @@ PREDEFINED_SCENARIOS: list[dict[str, Any]] = [
     },
     {
         "name": "unicode_and_special_strings",
-        "description": (
-            "Tests unicode characters, emoji, escape "
-            "sequences, and special string values."
-        ),
+        "description": ("Tests unicode characters, emoji, escape sequences, and special string values."),
         "json_schema": {
             "$schema": "http://json-schema.org/draft-07/schema#",
             "type": "object",
@@ -415,10 +397,7 @@ PREDEFINED_SCENARIOS: list[dict[str, Any]] = [
     },
     {
         "name": "schema_with_no_primary_key",
-        "description": (
-            "A stream without a primary key, "
-            "testing append-only behavior."
-        ),
+        "description": ("A stream without a primary key, testing append-only behavior."),
         "json_schema": {
             "$schema": "http://json-schema.org/draft-07/schema#",
             "type": "object",
@@ -441,10 +420,7 @@ PREDEFINED_SCENARIOS: list[dict[str, Any]] = [
     },
     {
         "name": "long_column_names",
-        "description": (
-            "Tests handling of very long column names "
-            "that may exceed database limits."
-        ),
+        "description": ("Tests handling of very long column names that may exceed database limits."),
         "json_schema": {
             "$schema": "http://json-schema.org/draft-07/schema#",
             "type": "object",

--- a/airbyte-integrations/connectors/source-smoke-test/source_smoke_test/scenarios.py
+++ b/airbyte-integrations/connectors/source-smoke-test/source_smoke_test/scenarios.py
@@ -1,0 +1,508 @@
+#
+# Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+#
+"""Predefined smoke test scenarios for destination regression testing.
+
+Each scenario defines a stream name, JSON schema, optional primary key,
+and either inline records or a record generator reference.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+
+_DEFAULT_LARGE_BATCH_COUNT = 1000
+
+HIGH_VOLUME_SCENARIO_NAMES: set[str] = {
+    "large_batch_stream",
+}
+
+PREDEFINED_SCENARIOS: list[dict[str, Any]] = [
+    {
+        "name": "basic_types",
+        "description": "Covers fundamental column types: string, integer, number, boolean.",
+        "json_schema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "properties": {
+                "id": {"type": "integer"},
+                "name": {"type": "string"},
+                "amount": {"type": "number"},
+                "is_active": {"type": "boolean"},
+            },
+        },
+        "primary_key": [["id"]],
+        "records": [
+            {"id": 1, "name": "Alice", "amount": 100.50, "is_active": True},
+            {"id": 2, "name": "Bob", "amount": 0.0, "is_active": False},
+            {"id": 3, "name": "", "amount": -99.99, "is_active": True},
+        ],
+    },
+    {
+        "name": "timestamp_types",
+        "description": "Covers date and timestamp formats including ISO 8601 variations.",
+        "json_schema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "properties": {
+                "id": {"type": "integer"},
+                "created_date": {"type": "string", "format": "date"},
+                "updated_at": {"type": "string", "format": "date-time"},
+                "epoch_seconds": {"type": "integer"},
+            },
+        },
+        "primary_key": [["id"]],
+        "records": [
+            {
+                "id": 1,
+                "created_date": "2024-01-15",
+                "updated_at": "2024-01-15T10:30:00Z",
+                "epoch_seconds": 1705312200,
+            },
+            {
+                "id": 2,
+                "created_date": "1970-01-01",
+                "updated_at": "1970-01-01T00:00:00+00:00",
+                "epoch_seconds": 0,
+            },
+            {
+                "id": 3,
+                "created_date": "2099-12-31",
+                "updated_at": "2099-12-31T23:59:59.999999Z",
+                "epoch_seconds": 4102444799,
+            },
+        ],
+    },
+    {
+        "name": "large_decimals_and_numbers",
+        "description": (
+            "Tests handling of very large numbers, "
+            "high precision decimals, and boundary values."
+        ),
+        "json_schema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "properties": {
+                "id": {"type": "integer"},
+                "big_integer": {"type": "integer"},
+                "precise_decimal": {"type": "number"},
+                "small_decimal": {"type": "number"},
+            },
+        },
+        "primary_key": [["id"]],
+        "records": [
+            {
+                "id": 1,
+                "big_integer": 9999999999999999,
+                "precise_decimal": math.pi,
+                "small_decimal": 0.000001,
+            },
+            {
+                "id": 2,
+                "big_integer": -9999999999999999,
+                "precise_decimal": -0.1,
+                "small_decimal": 1e-10,
+            },
+            {
+                "id": 3,
+                "big_integer": 0,
+                "precise_decimal": 99999999.99999999,
+                "small_decimal": 0.0,
+            },
+        ],
+    },
+    {
+        "name": "nested_json_objects",
+        "description": "Tests nested object and array handling in destination columns.",
+        "json_schema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "properties": {
+                "id": {"type": "integer"},
+                "metadata": {
+                    "type": "object",
+                    "properties": {
+                        "source": {"type": "string"},
+                        "tags": {"type": "array", "items": {"type": "string"}},
+                    },
+                },
+                "nested_deep": {
+                    "type": "object",
+                    "properties": {
+                        "level1": {
+                            "type": "object",
+                            "properties": {
+                                "level2": {
+                                    "type": "object",
+                                    "properties": {
+                                        "value": {"type": "string"},
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+                "items_array": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "sku": {"type": "string"},
+                            "qty": {"type": "integer"},
+                        },
+                    },
+                },
+            },
+        },
+        "primary_key": [["id"]],
+        "records": [
+            {
+                "id": 1,
+                "metadata": {"source": "api", "tags": ["a", "b", "c"]},
+                "nested_deep": {"level1": {"level2": {"value": "deep"}}},
+                "items_array": [{"sku": "ABC", "qty": 10}],
+            },
+            {
+                "id": 2,
+                "metadata": {"source": "manual", "tags": []},
+                "nested_deep": {"level1": {"level2": {"value": ""}}},
+                "items_array": [],
+            },
+        ],
+    },
+    {
+        "name": "null_handling",
+        "description": "Tests null values across all column types and patterns.",
+        "json_schema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "properties": {
+                "id": {"type": "integer"},
+                "nullable_string": {"type": ["null", "string"]},
+                "nullable_integer": {"type": ["null", "integer"]},
+                "nullable_number": {"type": ["null", "number"]},
+                "nullable_boolean": {"type": ["null", "boolean"]},
+                "nullable_object": {
+                    "type": ["null", "object"],
+                    "properties": {"key": {"type": "string"}},
+                },
+                "always_null": {"type": ["null", "string"]},
+            },
+        },
+        "primary_key": [["id"]],
+        "records": [
+            {
+                "id": 1,
+                "nullable_string": "present",
+                "nullable_integer": 42,
+                "nullable_number": math.pi,
+                "nullable_boolean": True,
+                "nullable_object": {"key": "val"},
+                "always_null": None,
+            },
+            {
+                "id": 2,
+                "nullable_string": None,
+                "nullable_integer": None,
+                "nullable_number": None,
+                "nullable_boolean": None,
+                "nullable_object": None,
+                "always_null": None,
+            },
+            {
+                "id": 3,
+                "nullable_string": "",
+                "nullable_integer": 0,
+                "nullable_number": 0.0,
+                "nullable_boolean": False,
+                "nullable_object": {},
+                "always_null": None,
+            },
+        ],
+    },
+    {
+        "name": "column_naming_edge_cases",
+        "description": (
+            "Tests special characters, casing, "
+            "and reserved words in column names."
+        ),
+        "json_schema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "properties": {
+                "id": {"type": "integer"},
+                "CamelCaseColumn": {"type": "string"},
+                "ALLCAPS": {"type": "string"},
+                "snake_case_column": {"type": "string"},
+                "column-with-dashes": {"type": "string"},
+                "column.with.dots": {"type": "string"},
+                "column with spaces": {"type": "string"},
+                "select": {"type": "string"},
+                "from": {"type": "string"},
+                "order": {"type": "string"},
+                "group": {"type": "string"},
+            },
+        },
+        "primary_key": [["id"]],
+        "records": [
+            {
+                "id": 1,
+                "CamelCaseColumn": "camel",
+                "ALLCAPS": "caps",
+                "snake_case_column": "snake",
+                "column-with-dashes": "dashes",
+                "column.with.dots": "dots",
+                "column with spaces": "spaces",
+                "select": "reserved_select",
+                "from": "reserved_from",
+                "order": "reserved_order",
+                "group": "reserved_group",
+            },
+        ],
+    },
+    {
+        "name": "table_naming_edge_cases",
+        "description": (
+            "Stream with special characters in the name "
+            "to test table naming."
+        ),
+        "json_schema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "properties": {
+                "id": {"type": "integer"},
+                "value": {"type": "string"},
+            },
+        },
+        "primary_key": [["id"]],
+        "records": [
+            {"id": 1, "value": "table_name_test"},
+        ],
+    },
+    {
+        "name": "CamelCaseStreamName",
+        "description": "Stream with CamelCase name to test case handling.",
+        "json_schema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "properties": {
+                "id": {"type": "integer"},
+                "value": {"type": "string"},
+            },
+        },
+        "primary_key": [["id"]],
+        "records": [
+            {"id": 1, "value": "camel_case_stream_test"},
+        ],
+    },
+    {
+        "name": "wide_table_50_columns",
+        "description": "Tests a wide table with 50 columns.",
+        "json_schema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "properties": {
+                "id": {"type": "integer"},
+                **{f"col_{i:03d}": {"type": ["null", "string"]} for i in range(1, 50)},
+            },
+        },
+        "primary_key": [["id"]],
+        "records": [
+            {
+                "id": 1,
+                **{f"col_{i:03d}": f"val_{i}" for i in range(1, 50)},
+            },
+            {
+                "id": 2,
+                **{f"col_{i:03d}": None for i in range(1, 50)},
+            },
+        ],
+    },
+    {
+        "name": "empty_stream",
+        "description": (
+            "A stream that emits zero records, "
+            "testing empty dataset handling."
+        ),
+        "json_schema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "properties": {
+                "id": {"type": "integer"},
+                "value": {"type": "string"},
+            },
+        },
+        "primary_key": [["id"]],
+        "records": [],
+    },
+    {
+        "name": "single_record_stream",
+        "description": "A stream with exactly one record.",
+        "json_schema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "properties": {
+                "id": {"type": "integer"},
+                "value": {"type": "string"},
+            },
+        },
+        "primary_key": [["id"]],
+        "records": [
+            {"id": 1, "value": "only_record"},
+        ],
+    },
+    {
+        "name": "large_batch_stream",
+        "description": (
+            "A stream that generates a configurable "
+            "number of records for batch testing."
+        ),
+        "json_schema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "properties": {
+                "id": {"type": "integer"},
+                "name": {"type": "string"},
+                "value": {"type": "number"},
+                "category": {"type": "string"},
+            },
+        },
+        "primary_key": [["id"]],
+        "record_count": _DEFAULT_LARGE_BATCH_COUNT,
+        "record_generator": "large_batch",
+        "high_volume": True,
+    },
+    {
+        "name": "unicode_and_special_strings",
+        "description": (
+            "Tests unicode characters, emoji, escape "
+            "sequences, and special string values."
+        ),
+        "json_schema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "properties": {
+                "id": {"type": "integer"},
+                "unicode_text": {"type": "string"},
+                "special_chars": {"type": "string"},
+            },
+        },
+        "primary_key": [["id"]],
+        "records": [
+            {
+                "id": 1,
+                "unicode_text": "Hello World",
+                "special_chars": "line1\nline2\ttab",
+            },
+            {
+                "id": 2,
+                "unicode_text": "Caf\u00e9 na\u00efve r\u00e9sum\u00e9",
+                "special_chars": 'quote"inside',
+            },
+            {
+                "id": 3,
+                "unicode_text": "\u4f60\u597d\u4e16\u754c",
+                "special_chars": "back\\slash",
+            },
+            {
+                "id": 4,
+                "unicode_text": "\u0410\u0411\u0412\u0413",
+                "special_chars": "",
+            },
+        ],
+    },
+    {
+        "name": "schema_with_no_primary_key",
+        "description": (
+            "A stream without a primary key, "
+            "testing append-only behavior."
+        ),
+        "json_schema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "properties": {
+                "event_id": {"type": "string"},
+                "event_type": {"type": "string"},
+                "payload": {"type": "string"},
+            },
+        },
+        "primary_key": None,
+        "records": [
+            {"event_id": "evt_001", "event_type": "click", "payload": "{}"},
+            {"event_id": "evt_001", "event_type": "click", "payload": "{}"},
+            {
+                "event_id": "evt_002",
+                "event_type": "view",
+                "payload": '{"page": "home"}',
+            },
+        ],
+    },
+    {
+        "name": "long_column_names",
+        "description": (
+            "Tests handling of very long column names "
+            "that may exceed database limits."
+        ),
+        "json_schema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "properties": {
+                "id": {"type": "integer"},
+                "a_very_long_column_name_that_exceeds"
+                "_typical_database_limits_and_should_be"
+                "_truncated_or_handled_gracefully_by"
+                "_the_destination": {
+                    "type": "string",
+                },
+                "another_extremely_verbose_column_name"
+                "_designed_to_test_the_absolute_maximum"
+                "_length_that_any_reasonable_database"
+                "_would_support": {
+                    "type": "string",
+                },
+            },
+        },
+        "primary_key": [["id"]],
+        "records": [
+            {
+                "id": 1,
+                "a_very_long_column_name_that_exceeds"
+                "_typical_database_limits_and_should_be"
+                "_truncated_or_handled_gracefully_by"
+                "_the_destination": "long_col_1",
+                "another_extremely_verbose_column_name"
+                "_designed_to_test_the_absolute_maximum"
+                "_length_that_any_reasonable_database"
+                "_would_support": "long_col_2",
+            },
+        ],
+    },
+]
+
+
+def generate_large_batch_records(
+    scenario: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Generate records for the large_batch_stream scenario."""
+    count = scenario.get("record_count", _DEFAULT_LARGE_BATCH_COUNT)
+    categories = ["cat_a", "cat_b", "cat_c", "cat_d", "cat_e"]
+    return [
+        {
+            "id": i,
+            "name": f"record_{i:06d}",
+            "value": float(i) * 1.1,
+            "category": categories[i % len(categories)],
+        }
+        for i in range(1, count + 1)
+    ]
+
+
+def get_scenario_records(
+    scenario: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Get records for a scenario, using generator if specified."""
+    if scenario.get("record_generator") == "large_batch":
+        return generate_large_batch_records(scenario)
+    return scenario.get("records", [])

--- a/airbyte-integrations/connectors/source-smoke-test/source_smoke_test/source.py
+++ b/airbyte-integrations/connectors/source-smoke-test/source_smoke_test/source.py
@@ -1,0 +1,319 @@
+#
+# Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+#
+"""Smoke test source for destination regression testing.
+
+This source generates synthetic test data covering common edge cases
+that break destinations: type variations, null handling, naming edge cases,
+schema variations, and batch size variations.
+
+Predefined scenarios are always available. Additional scenarios can be
+injected dynamically via the ``custom_scenarios`` config field.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import TYPE_CHECKING, Any
+
+from airbyte_cdk.models import (
+    AirbyteCatalog,
+    AirbyteConnectionStatus,
+    AirbyteMessage,
+    AirbyteRecordMessage,
+    AirbyteStream,
+    ConfiguredAirbyteCatalog,
+    ConnectorSpecification,
+    Status,
+    SyncMode,
+    Type,
+)
+from airbyte_cdk.sources.source import Source
+
+from source_smoke_test.scenarios import (
+    _DEFAULT_LARGE_BATCH_COUNT,
+    PREDEFINED_SCENARIOS,
+    get_scenario_records,
+)
+
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping
+
+
+logger = logging.getLogger("airbyte")
+
+
+def _build_streams_from_scenarios(
+    scenarios: list[dict[str, Any]],
+) -> list[AirbyteStream]:
+    """Build AirbyteStream objects from scenario definitions."""
+    return [
+        AirbyteStream(
+            name=scenario["name"],
+            json_schema=scenario["json_schema"],
+            supported_sync_modes=[SyncMode.full_refresh],
+            source_defined_cursor=False,
+            source_defined_primary_key=scenario.get("primary_key"),
+        )
+        for scenario in scenarios
+    ]
+
+
+class SourceSmokeTest(Source):
+    """Smoke test source for destination regression testing.
+
+    Generates synthetic data across predefined scenarios that cover
+    common destination failure patterns. Supports dynamic injection
+    of additional scenarios via the ``custom_scenarios`` config field.
+    """
+
+    def spec(
+        self,
+        logger: logging.Logger,
+    ) -> ConnectorSpecification:
+        """Return the connector specification."""
+        return ConnectorSpecification(
+            documentationUrl="https://docs.airbyte.com/integrations/sources/smoke-test",
+            connectionSpecification={
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "title": "Smoke Test Source Spec",
+                "type": "object",
+                "required": [],
+                "properties": {
+                    "custom_scenarios": {
+                        "type": "array",
+                        "title": "Custom Test Scenarios",
+                        "description": (
+                            "Additional test scenarios to inject "
+                            "at runtime. Each scenario defines a "
+                            "stream name, JSON schema, and records."
+                        ),
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "name",
+                                "json_schema",
+                                "records",
+                            ],
+                            "properties": {
+                                "name": {
+                                    "type": "string",
+                                    "description": "Stream name for this scenario.",
+                                },
+                                "description": {
+                                    "type": "string",
+                                    "description": "Human-readable description of this scenario.",
+                                },
+                                "json_schema": {
+                                    "type": "object",
+                                    "description": "JSON schema for the stream.",
+                                },
+                                "records": {
+                                    "type": "array",
+                                    "description": "Records to emit for this stream.",
+                                    "items": {"type": "object"},
+                                },
+                                "primary_key": {
+                                    "type": ["array", "null"],
+                                    "description": (
+                                        "Primary key definition "
+                                        "(list of key paths) "
+                                        "or null."
+                                    ),
+                                    "items": {
+                                        "type": "array",
+                                        "items": {"type": "string"},
+                                    },
+                                },
+                            },
+                        },
+                        "default": [],
+                    },
+                    "large_batch_record_count": {
+                        "type": "integer",
+                        "title": "Large Batch Record Count",
+                        "description": (
+                            "Number of records to generate for "
+                            "the large_batch_stream scenario. "
+                            "Set to 0 to skip this stream."
+                        ),
+                        "default": 1000,
+                    },
+                    "all_fast_streams": {
+                        "type": "boolean",
+                        "title": "All Fast Streams",
+                        "description": (
+                            "Include all fast (non-high-volume) "
+                            "predefined streams."
+                        ),
+                        "default": True,
+                    },
+                    "all_slow_streams": {
+                        "type": "boolean",
+                        "title": "All Slow Streams",
+                        "description": (
+                            "Include all slow (high-volume) streams "
+                            "such as large_batch_stream. These are "
+                            "excluded by default to avoid incurring "
+                            "the cost of large record sets."
+                        ),
+                        "default": False,
+                    },
+                    "scenario_filter": {
+                        "type": "array",
+                        "title": "Scenario Filter",
+                        "description": (
+                            "Specific scenario names to include. "
+                            "These are unioned with the boolean-driven "
+                            "sets (deduped). If omitted or empty, "
+                            "only the boolean flags control selection."
+                        ),
+                        "items": {"type": "string"},
+                        "default": [],
+                    },
+                },
+            },
+        )
+
+    def _get_all_scenarios(
+        self,
+        config: Mapping[str, Any],
+    ) -> list[dict[str, Any]]:
+        """Combine predefined and custom scenarios.
+
+        Selection logic:
+        1. Boolean flags control groups: ``all_fast_streams``
+           (default true) enables non-high-volume scenarios,
+           ``all_slow_streams`` (default false) enables
+           high-volume scenarios.
+        2. ``scenario_filter`` names are unioned with the boolean sets.
+        3. Custom scenarios are always included.
+        4. The final list is deduplicated by name.
+        """
+        include_default = config.get("all_fast_streams", True)
+        include_high_volume = config.get("all_slow_streams", False)
+        scenario_filter: list[str] = config.get("scenario_filter", [])
+        explicit_names: set[str] = set(scenario_filter)
+
+        large_batch_count = config.get(
+            "large_batch_record_count",
+            _DEFAULT_LARGE_BATCH_COUNT,
+        )
+
+        scenarios: list[dict[str, Any]] = []
+        seen_names: set[str] = set()
+
+        for scenario in PREDEFINED_SCENARIOS:
+            name = scenario["name"]
+            is_high_volume = scenario.get("high_volume", False)
+
+            included_by_flag = (include_high_volume and is_high_volume) or (
+                include_default and not is_high_volume
+            )
+            if not included_by_flag and name not in explicit_names:
+                continue
+
+            s = dict(scenario)
+            if name == "large_batch_stream" and large_batch_count != _DEFAULT_LARGE_BATCH_COUNT:
+                s["record_count"] = large_batch_count
+
+            if name not in seen_names:
+                scenarios.append(s)
+                seen_names.add(name)
+
+        custom = config.get("custom_scenarios", [])
+        if custom:
+            for cs in custom:
+                name = cs.get("name", "")
+                if not name or not cs.get("json_schema"):
+                    continue
+                if name not in seen_names:
+                    scenarios.append(
+                        {
+                            "name": name,
+                            "description": cs.get(
+                                "description",
+                                "Custom injected scenario",
+                            ),
+                            "json_schema": cs["json_schema"],
+                            "primary_key": cs.get("primary_key"),
+                            "records": cs.get("records", []),
+                        }
+                    )
+                    seen_names.add(name)
+
+        return scenarios
+
+    def check(
+        self,
+        logger: logging.Logger,
+        config: Mapping[str, Any],
+    ) -> AirbyteConnectionStatus:
+        """Validate the configuration."""
+        custom = config.get("custom_scenarios", [])
+        for i, scenario in enumerate(custom):
+            if not scenario.get("name"):
+                return AirbyteConnectionStatus(
+                    status=Status.FAILED,
+                    message=f"Custom scenario at index {i} is missing 'name'.",
+                )
+            if not scenario.get("json_schema"):
+                return AirbyteConnectionStatus(
+                    status=Status.FAILED,
+                    message=f"Custom scenario '{scenario['name']}' is missing 'json_schema'.",
+                )
+
+        scenarios = self._get_all_scenarios(config)
+        if not scenarios:
+            return AirbyteConnectionStatus(
+                status=Status.FAILED,
+                message="No scenarios available. Check scenario_filter config.",
+            )
+
+        logger.info(f"Smoke test source check passed with {len(scenarios)} scenarios.")
+        return AirbyteConnectionStatus(status=Status.SUCCEEDED)
+
+    def discover(
+        self,
+        logger: logging.Logger,
+        config: Mapping[str, Any],
+    ) -> AirbyteCatalog:
+        """Return the catalog with all test scenario streams."""
+        scenarios = self._get_all_scenarios(config)
+        streams = _build_streams_from_scenarios(scenarios)
+        logger.info(f"Discovered {len(streams)} smoke test streams.")
+        return AirbyteCatalog(streams=streams)
+
+    def read(
+        self,
+        logger: logging.Logger,
+        config: Mapping[str, Any],
+        catalog: ConfiguredAirbyteCatalog,
+        state: list[Any] | None = None,
+    ) -> Iterable[AirbyteMessage]:
+        """Read records from selected smoke test streams."""
+        selected_streams = {stream.stream.name for stream in catalog.streams}
+        scenarios = self._get_all_scenarios(config)
+        scenario_map = {s["name"]: s for s in scenarios}
+        now_ms = int(time.time() * 1000)
+
+        for stream_name in selected_streams:
+            scenario = scenario_map.get(stream_name)
+            if not scenario:
+                logger.warning(f"Stream '{stream_name}' not found in scenarios, skipping.")
+                continue
+
+            records = get_scenario_records(scenario)
+            logger.info(f"Emitting {len(records)} records for stream '{stream_name}'.")
+
+            for record in records:
+                yield AirbyteMessage(
+                    type=Type.RECORD,
+                    record=AirbyteRecordMessage(
+                        stream=stream_name,
+                        data=record,
+                        emitted_at=now_ms,
+                    ),
+                )

--- a/airbyte-integrations/connectors/source-smoke-test/source_smoke_test/source.py
+++ b/airbyte-integrations/connectors/source-smoke-test/source_smoke_test/source.py
@@ -30,7 +30,6 @@ from airbyte_cdk.models import (
     Type,
 )
 from airbyte_cdk.sources.source import Source
-
 from source_smoke_test.scenarios import (
     _DEFAULT_LARGE_BATCH_COUNT,
     PREDEFINED_SCENARIOS,
@@ -86,9 +85,7 @@ class SourceSmokeTest(Source):
                         "type": "array",
                         "title": "Custom Test Scenarios",
                         "description": (
-                            "Additional test scenarios to inject "
-                            "at runtime. Each scenario defines a "
-                            "stream name, JSON schema, and records."
+                            "Additional test scenarios to inject at runtime. Each scenario defines a stream name, JSON schema, and records."
                         ),
                         "items": {
                             "type": "object",
@@ -117,11 +114,7 @@ class SourceSmokeTest(Source):
                                 },
                                 "primary_key": {
                                     "type": ["array", "null"],
-                                    "description": (
-                                        "Primary key definition "
-                                        "(list of key paths) "
-                                        "or null."
-                                    ),
+                                    "description": ("Primary key definition (list of key paths) or null."),
                                     "items": {
                                         "type": "array",
                                         "items": {"type": "string"},
@@ -134,20 +127,13 @@ class SourceSmokeTest(Source):
                     "large_batch_record_count": {
                         "type": "integer",
                         "title": "Large Batch Record Count",
-                        "description": (
-                            "Number of records to generate for "
-                            "the large_batch_stream scenario. "
-                            "Set to 0 to skip this stream."
-                        ),
+                        "description": ("Number of records to generate for the large_batch_stream scenario. Set to 0 to skip this stream."),
                         "default": 1000,
                     },
                     "all_fast_streams": {
                         "type": "boolean",
                         "title": "All Fast Streams",
-                        "description": (
-                            "Include all fast (non-high-volume) "
-                            "predefined streams."
-                        ),
+                        "description": ("Include all fast (non-high-volume) predefined streams."),
                         "default": True,
                     },
                     "all_slow_streams": {
@@ -209,9 +195,7 @@ class SourceSmokeTest(Source):
             name = scenario["name"]
             is_high_volume = scenario.get("high_volume", False)
 
-            included_by_flag = (include_high_volume and is_high_volume) or (
-                include_default and not is_high_volume
-            )
+            included_by_flag = (include_high_volume and is_high_volume) or (include_default and not is_high_volume)
             if not included_by_flag and name not in explicit_names:
                 continue
 


### PR DESCRIPTION
## What

Adds a new **`source-smoke-test`** connector that generates synthetic data across 15 predefined scenarios designed to exercise common destination failure patterns. This is the monorepo counterpart to the PyAirbyte implementation in [airbytehq/PyAirbyte#982](https://github.com/airbytehq/PyAirbyte/pull/982).

Closes: https://github.com/airbytehq/PyAirbyte/issues/981

## How

Self-contained Python CDK-based source connector with:
- `source.py` — `SourceSmokeTest` class implementing `spec`, `check`, `discover`, `read`
- `scenarios.py` — 15 predefined scenario definitions covering type variations, null handling, naming edge cases, schema variations, batch sizes, and unicode strings
- Config-driven stream selection via `all_fast_streams` (default true) and `all_slow_streams` (default false) boolean flags, plus an explicit `scenario_filter` list
- Dynamic scenario injection via `custom_scenarios` config field
- Standard connector scaffolding: `metadata.yaml`, `pyproject.toml`, `main.py`, `README.md`, `icon.svg`

## Review guide

**Start here — these are the files that matter:**

1. `source_smoke_test/source.py` — Core connector logic. Key areas:
   - `_get_all_scenarios()` (line ~190): scenario selection/filtering logic combining boolean flags + explicit filter + custom scenarios
   - `check()`: validates custom scenario structure before calling `_get_all_scenarios`
   - `read()`: emits records from selected streams

2. `source_smoke_test/scenarios.py` — All 15 predefined scenario definitions. Large file but straightforward data declarations. The `large_batch_stream` scenario uses a generator function rather than inline records.

3. `metadata.yaml` — Registry configuration. Note: `cloud.enabled: false`, `oss.enabled: true`, `releaseStage: alpha`.

**Things that warrant reviewer attention:**

- **Code is duplicated** from PyAirbyte PR #982. Reviewer should decide if maintaining two copies is acceptable or if this connector should depend on PyAirbyte directly.
- **`HIGH_VOLUME_SCENARIO_NAMES`** is exported from `scenarios.py` but never imported by `source.py` (which checks `scenario.get("high_volume", False)` directly instead).
- **`definitionId: 4745b886-d299-4a4f-b14b-4803e643159a`** is randomly generated — verify no conflict and that this is the intended permanent ID.
- **No `poetry.lock`** — other connectors include one, though CI passes without it.
- **No sample config or configured catalog files** — README references paths that don't exist (`secrets/config.json`, `sample_files/configured_catalog.json`).

## User Impact

Adds a new alpha-stage OSS source connector. No impact on existing connectors or users. The connector generates deterministic test data with no external dependencies.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Requested by: @aaronsteers
[Devin session](https://app.devin.ai/sessions/02ea317be9054bcba5e48a6ed1622620)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/74058" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
