### PR TITLE
feat(source-salesloft): add API budget and periodic state checkpointing

### DIFF
--- a/airbyte-integrations/connectors/source-salesloft/manifest.yaml
+++ b/airbyte-integrations/connectors/source-salesloft/manifest.yaml
@@ -1619,6 +1619,24 @@ definitions:
           type: BearerAuthenticator
           api_token: "{{ config['credentials']['api_key'] }}"
 
+# Salesloft API rate limit: 600 cost per minute (team-level).
+# Default cost per request is 1, but requests with high page numbers cost more:
+#   Page 101-150: 3 points, Page 151-250: 8 points, Page 251-500: 10 points, Page 501+: 30 points
+# We use a FixedWindowCallRatePolicy so the x-ratelimit-remaining-minute response header
+# dynamically adjusts the remaining budget each minute. When high-page requests consume
+# more points per call, the API reports fewer remaining points and the connector
+# automatically throttles to stay within the budget.
+# See: https://developers.salesloft.com/docs/platform/api-basics/rate-limits/
+api_budget:
+  type: HTTPAPIBudget
+  policies:
+    - type: FixedWindowCallRatePolicy
+      period: PT1M
+      call_limit: 600
+      matchers: []
+  ratelimit_remaining_header: x-ratelimit-remaining-minute
+  status_codes_for_ratelimit_hit: [429]
+
 streams:
   - $ref: "#/definitions/streams/users"
   - $ref: "#/definitions/streams/account_tiers"

--- a/airbyte-integrations/connectors/source-salesloft/manifest.yaml
+++ b/airbyte-integrations/connectors/source-salesloft/manifest.yaml
@@ -631,6 +631,8 @@ definitions:
           type: MinMaxDatetime
           datetime: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"
           datetime_format: "%Y-%m-%dT%H:%M:%SZ"
+        step: P30D
+        cursor_granularity: PT1S
       schema_loader:
         type: InlineSchemaLoader
         schema:
@@ -695,6 +697,8 @@ definitions:
           type: MinMaxDatetime
           datetime: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"
           datetime_format: "%Y-%m-%dT%H:%M:%SZ"
+        step: P30D
+        cursor_granularity: PT1S
       schema_loader:
         type: InlineSchemaLoader
         schema:
@@ -759,6 +763,8 @@ definitions:
           type: MinMaxDatetime
           datetime: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"
           datetime_format: "%Y-%m-%dT%H:%M:%SZ"
+        step: P30D
+        cursor_granularity: PT1S
       schema_loader:
         type: InlineSchemaLoader
         schema:
@@ -823,6 +829,8 @@ definitions:
           type: MinMaxDatetime
           datetime: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"
           datetime_format: "%Y-%m-%dT%H:%M:%SZ"
+        step: P30D
+        cursor_granularity: PT1S
       schema_loader:
         type: InlineSchemaLoader
         schema:
@@ -900,6 +908,8 @@ definitions:
           type: MinMaxDatetime
           datetime: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"
           datetime_format: "%Y-%m-%dT%H:%M:%SZ"
+        step: P30D
+        cursor_granularity: PT1S
       schema_loader:
         type: InlineSchemaLoader
         schema:
@@ -964,6 +974,8 @@ definitions:
           type: MinMaxDatetime
           datetime: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"
           datetime_format: "%Y-%m-%dT%H:%M:%SZ"
+        step: P30D
+        cursor_granularity: PT1S
       schema_loader:
         type: InlineSchemaLoader
         schema:
@@ -1028,6 +1040,8 @@ definitions:
           type: MinMaxDatetime
           datetime: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"
           datetime_format: "%Y-%m-%dT%H:%M:%SZ"
+        step: P30D
+        cursor_granularity: PT1S
       schema_loader:
         type: InlineSchemaLoader
         schema:
@@ -1092,6 +1106,8 @@ definitions:
           type: MinMaxDatetime
           datetime: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"
           datetime_format: "%Y-%m-%dT%H:%M:%SZ"
+        step: P30D
+        cursor_granularity: PT1S
       schema_loader:
         type: InlineSchemaLoader
         schema:
@@ -1156,6 +1172,8 @@ definitions:
           type: MinMaxDatetime
           datetime: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"
           datetime_format: "%Y-%m-%dT%H:%M:%SZ"
+        step: P30D
+        cursor_granularity: PT1S
       schema_loader:
         type: InlineSchemaLoader
         schema:
@@ -1220,6 +1238,8 @@ definitions:
           type: MinMaxDatetime
           datetime: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"
           datetime_format: "%Y-%m-%dT%H:%M:%SZ"
+        step: P30D
+        cursor_granularity: PT1S
       schema_loader:
         type: InlineSchemaLoader
         schema:
@@ -1284,6 +1304,8 @@ definitions:
           type: MinMaxDatetime
           datetime: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"
           datetime_format: "%Y-%m-%dT%H:%M:%SZ"
+        step: P30D
+        cursor_granularity: PT1S
       schema_loader:
         type: InlineSchemaLoader
         schema:
@@ -1348,6 +1370,8 @@ definitions:
           type: MinMaxDatetime
           datetime: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"
           datetime_format: "%Y-%m-%dT%H:%M:%SZ"
+        step: P30D
+        cursor_granularity: PT1S
       schema_loader:
         type: InlineSchemaLoader
         schema:
@@ -1412,6 +1436,8 @@ definitions:
           type: MinMaxDatetime
           datetime: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"
           datetime_format: "%Y-%m-%dT%H:%M:%SZ"
+        step: P30D
+        cursor_granularity: PT1S
       schema_loader:
         type: InlineSchemaLoader
         schema:
@@ -1476,6 +1502,8 @@ definitions:
           type: MinMaxDatetime
           datetime: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"
           datetime_format: "%Y-%m-%dT%H:%M:%SZ"
+        step: P30D
+        cursor_granularity: PT1S
       schema_loader:
         type: InlineSchemaLoader
         schema:
@@ -1593,6 +1621,8 @@ definitions:
           type: MinMaxDatetime
           datetime: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"
           datetime_format: "%Y-%m-%dT%H:%M:%SZ"
+        step: P30D
+        cursor_granularity: PT1S
       schema_loader:
         type: InlineSchemaLoader
         schema:

--- a/airbyte-integrations/connectors/source-salesloft/metadata.yaml
+++ b/airbyte-integrations/connectors/source-salesloft/metadata.yaml
@@ -22,7 +22,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 41991d12-d4b5-439e-afd0-260a31d4c53f
-  dockerImageTag: 1.5.2
+  dockerImageTag: 1.5.3
   dockerRepository: airbyte/source-salesloft
   githubIssueLabel: source-salesloft
   icon: icon.svg

--- a/airbyte-integrations/connectors/source-salesloft/metadata.yaml
+++ b/airbyte-integrations/connectors/source-salesloft/metadata.yaml
@@ -18,7 +18,7 @@ data:
     # Please update to the latest version of the connector base image.
     # https://hub.docker.com/r/airbyte/python-connector-base
     # Please use the full address with sha256 hash to guarantee build reproducibility.
-    baseImage: docker.io/airbyte/source-declarative-manifest:5.15.0@sha256:09a84e0622f36393077332faf11cc239e77083fae5fa500592c049dca25888a7
+    baseImage: docker.io/airbyte/source-declarative-manifest:7.10.1@sha256:bd69f6b52bdd92ce06c30786d67546427b828ffb553363c8950b2816c552d6e0
   connectorSubtype: api
   connectorType: source
   definitionId: 41991d12-d4b5-439e-afd0-260a31d4c53f

--- a/docs/integrations/sources/salesloft.md
+++ b/docs/integrations/sources/salesloft.md
@@ -106,6 +106,7 @@ Salesloft has the [rate limits](hhttps://developers.salesloft.com/api.html#!/Top
 
 | Version | Date       | Pull Request                                             | Subject                                                        |
 | :------ | :--------- | :------------------------------------------------------- | :------------------------------------------------------------- |
+| 1.5.3 | 2026-02-26 | [74061](https://github.com/airbytehq/airbyte/pull/74061) | Add API budget to respect Salesloft 600 cost/minute rate limit with dynamic response header tracking |
 | 1.5.2 | 2025-03-24 | [56365](https://github.com/airbytehq/airbyte/pull/56365) | Correct data types for email_scoped_fields |
 | 1.5.1 | 2025-03-16 | [55779](https://github.com/airbytehq/airbyte/pull/55779) | Adding missing columns too emails_scoped_fields stream |
 | 1.5.0 | 2025-03-06 | [55229](https://github.com/airbytehq/airbyte/pull/55229) | Add emails_scoped_fields stream. Remove body and subject fields from email stream |

--- a/docs/integrations/sources/salesloft.md
+++ b/docs/integrations/sources/salesloft.md
@@ -106,7 +106,7 @@ Salesloft has the [rate limits](hhttps://developers.salesloft.com/api.html#!/Top
 
 | Version | Date       | Pull Request                                             | Subject                                                        |
 | :------ | :--------- | :------------------------------------------------------- | :------------------------------------------------------------- |
-| 1.5.3 | 2026-02-26 | [74061](https://github.com/airbytehq/airbyte/pull/74061) | Add API budget to respect Salesloft 600 cost/minute rate limit with dynamic response header tracking |
+| 1.5.3 | 2026-02-26 | [74061](https://github.com/airbytehq/airbyte/pull/74061) | Add API budget for rate limiting and 30-day time-window slicing for periodic state checkpointing |
 | 1.5.2 | 2025-03-24 | [56365](https://github.com/airbytehq/airbyte/pull/56365) | Correct data types for email_scoped_fields |
 | 1.5.1 | 2025-03-16 | [55779](https://github.com/airbytehq/airbyte/pull/55779) | Adding missing columns too emails_scoped_fields stream |
 | 1.5.0 | 2025-03-06 | [55229](https://github.com/airbytehq/airbyte/pull/55229) | Add emails_scoped_fields stream. Remove body and subject fields from email stream |


### PR DESCRIPTION
## What

Addresses rate limit failures on the Salesloft connector during large incremental syncs (e.g., `people` stream). Salesloft uses a cost-based rate limit of **600 cost per minute**, where requests to high page numbers have escalating costs (up to 30 points per request at page 501+). Without proactive rate limiting, the connector exhausts its budget and gets throttled by repeated 429 responses.

Additionally, adds **30-day time-window slicing** (`step: P30D`) to all 15 incremental streams that support server-side time filtering. Previously, each stream fetched the entire time range as a single slice, meaning state was only emitted after the stream finished reading — a sync failure after 140k records meant restarting from scratch. Now, state is checkpointed after each 30-day window completes. As a bonus, page numbers reset to 1 for each window, keeping pages well below the 501+ threshold where Salesloft charges 30 points per request.

Also updates the base image from `source-declarative-manifest:5.15.0` to `7.10.1` — the old base image lacked the `airbyte` user required by the manifest-only Dockerfile, which caused all preview publishes to fail with `unable to find user airbyte: no matching entries in passwd file`.

Reference: [Salesloft Rate Limits documentation](https://developers.salesloft.com/docs/platform/api-basics/rate-limits/)

## How

### 1. API Budget (`HTTPAPIBudget`)

Adds an `HTTPAPIBudget` with a `FixedWindowCallRatePolicy` to the connector's `manifest.yaml`:

- **Global policy**: 600 calls per 1-minute fixed window, matching Salesloft's 600 cost/minute budget (at default cost of 1 per request).
- **Dynamic feedback**: Reads the `x-ratelimit-remaining-minute` response header after each request. The `FixedWindowCallRatePolicy` adjusts its internal counter downward when the API reports fewer remaining points than expected — this is how the connector adapts to high-cost pages (e.g., page 501+ costs 30 points, so the header drops by 30 instead of 1).
- **429 handling**: Recognizes HTTP 429 as a rate limit hit, setting remaining calls to 0 and blocking until the window resets.

### 2. Time-window slicing (`step` + `cursor_granularity`)

Adds `step: P30D` and `cursor_granularity: PT1S` to all 15 incremental streams that use `updated_at[gte]`/`updated_at[lte]` server-side filtering. This breaks the full time range into 30-day windows, with state emitted after each window completes.

- **Excluded stream**: `call_data_records` — this stream has no `start_time_option`/`end_time_option`/`end_datetime`, so it does not support server-side time-range filtering and cannot be sliced.

### 3. Base image update

Updates the base image in `metadata.yaml` from `5.15.0` to `7.10.1` to fix the Docker build/publish pipeline.

## Review guide

1. `airbyte-integrations/connectors/source-salesloft/manifest.yaml`:
   - The `api_budget` block is added between the `base_requester` definition and the `streams` list.
   - `step: P30D` and `cursor_granularity: PT1S` are added to each of the 15 `incremental_sync` blocks that have `end_datetime`.
2. `airbyte-integrations/connectors/source-salesloft/metadata.yaml` — version bump `1.5.2` → `1.5.3`, base image update `5.15.0` → `7.10.1`.
3. `docs/integrations/sources/salesloft.md` — changelog entry for `1.5.3`.

**Key things to verify:**
- The `FixedWindowCallRatePolicy` is chosen over `MovingWindowCallRatePolicy` because `FixedWindowCallRatePolicy.update()` reacts to decreasing `available_calls` from the response header, while `MovingWindowCallRatePolicy.update()` only acts when `available_calls == 0`. This is important for Salesloft's cost-based model where a single request can consume 30 points.
- `matchers: []` — an empty matcher list means the policy applies to **all** requests to this API. This is intentional since Salesloft's rate limit is a single team-level budget shared across all endpoints.
- `ratelimit_reset_header` is intentionally omitted (falls back to CDK default `"ratelimit-reset"`). Salesloft doesn't provide this header, so it will return `None` and the policy uses its own internal window timing.
- The base image jump from `5.15.0` → `7.10.1` is large. Verify that `api_budget` / `HTTPAPIBudget` / `FixedWindowCallRatePolicy` are supported by the CDK version bundled in `7.10.1` (they should be — these features were added well before `7.x`).

**Human review checklist:**
- [ ] Confirm `matchers: []` is correctly interpreted as "match all requests" by the CDK (not "match nothing").
- [ ] Confirm `FixedWindowCallRatePolicy` correctly self-adjusts when `x-ratelimit-remaining-minute` reports a larger drop than expected (e.g., 30-point page cost).
- [ ] Confirm the CDK default `ratelimit_reset_header: "ratelimit-reset"` gracefully returns `None` when Salesloft doesn't send that header.
- [ ] Verify `step: P30D` with `cursor_granularity: PT1S` correctly slices time ranges into 30-day windows without data gaps or duplicates at window boundaries.
- [ ] Verify `call_data_records` exclusion is correct — this stream has no `start_time_option`/`end_time_option`, so it cannot be sliced.
- [ ] Verify no breaking behavioral changes were introduced by the large base image upgrade (`5.15.0` → `7.10.1`). The preview publish workflow succeeded, which is a good signal.

## User Impact

- Syncs involving large page counts (especially the `people` stream) will no longer be cancelled due to rate limit exhaustion.
- The connector will proactively throttle requests to stay within budget, which may result in slightly slower but **reliable** syncs that complete without errors.
- **Incremental syncs now checkpoint progress every 30 days** — if a sync fails after processing 60 days of data, it will resume from day 60 instead of restarting from scratch.
- Page numbers reset to 1 for each 30-day window, keeping pages below the 501+ threshold where Salesloft charges 30 points per request.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Reverting removes the rate limiting, time-window slicing, and returns to base image `5.15.0`, restoring the connector to its previous behavior. No data model or configuration changes.

---

**Updates since last revision:**
- Updated base image from `source-declarative-manifest:5.15.0` to `7.10.1` to fix Docker publish failures (old image lacked the `airbyte` user).
- Added `step: P30D` and `cursor_granularity: PT1S` to 15 incremental streams for periodic state checkpointing.
- Updated changelog entry to reflect both rate limiting and state checkpointing changes.
- Preview publish workflow succeeded: https://github.com/airbytehq/airbyte/actions/runs/22675736306
- Docker image published: `airbyte/source-salesloft:1.5.3-preview.1b92bb8`

---

Link to Devin Session: https://app.devin.ai/sessions/da6428ce2f054e8d9618a24eb270973b  
Requested by: @vai-airbyte
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/74061" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->