### PR TITLE
feat(source-intercom): add concurrency_level=4 for tuning rollout

### DIFF
--- a/airbyte-integrations/connectors/source-intercom/manifest.yaml
+++ b/airbyte-integrations/connectors/source-intercom/manifest.yaml
@@ -811,6 +811,16 @@ streams:
   - $ref: "#/definitions/streams/company_segments"
   - $ref: "#/definitions/streams/tickets"
 
+# Concurrency tuning for source-intercom.
+# Intercom's lowest-tier rate limit is 1000 req/min (~17 req/s).
+# Starting concurrency = max(floor(17/4), 2) = 4.
+# The custom ErrorHandlerWithRateLimiter already provides proactive backoff
+# based on X-RateLimit-Remaining headers.
+concurrency_level:
+  type: ConcurrencyLevel
+  default_concurrency: 4
+  max_concurrency: 25
+
 spec:
   type: Spec
   connection_specification:

--- a/airbyte-integrations/connectors/source-intercom/metadata.yaml
+++ b/airbyte-integrations/connectors/source-intercom/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: d8313939-3782-41b0-be29-b3ca20d8dd3a
-  dockerImageTag: 0.13.18
+  dockerImageTag: 0.13.19-rc.1
   dockerRepository: airbyte/source-intercom
   documentationUrl: https://docs.airbyte.com/integrations/sources/intercom
   externalDocumentationUrls:
@@ -43,7 +43,7 @@ data:
   releaseStage: generally_available
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
   suggestedStreams:
     streams:
       - conversations

--- a/docs/integrations/sources/intercom.md
+++ b/docs/integrations/sources/intercom.md
@@ -124,6 +124,7 @@ Because these streams must read all records on every sync, syncing Companies and
 
 | Version      | Date       | Pull Request                                             | Subject                                                                                                                              |
 |:-------------|:-----------|:---------------------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------|
+| 0.13.19-rc.1 | 2026-04-06 | [74067](https://github.com/airbytehq/airbyte/pull/74067) | Add concurrency_level with default_concurrency=4 for progressive rollout tuning |
 | 0.13.18 | 2026-03-31 | [75899](https://github.com/airbytehq/airbyte/pull/75899) | Update CDK to 7.15.0 |
 | 0.13.17 | 2026-03-30 | [75575](https://github.com/airbytehq/airbyte/pull/75575) | Add `oauth_connector_input_specification` for declarative OAuth |
 | 0.13.16 | 2026-03-24 | [75419](https://github.com/airbytehq/airbyte/pull/75419) | Promote 0.13.16-rc.6 to GA — includes CDK 7.13.0 upgrade, block_simultaneous_read for companies, rate limiter fix, step size/end_datetime for incremental streams, and heartbeat timeout bump |


### PR DESCRIPTION
## What

Adds a `concurrency_level` block to the Intercom source connector with a hardcoded `default_concurrency` of 4, up from the CDK default of 2. This is the starting point for a progressive concurrency tuning rollout ([airbytehq/airbyte-internal-issues#15309](https://github.com/airbytehq/airbyte-internal-issues/issues/15309), epic: [airbytehq/airbyte-internal-issues#15262](https://github.com/airbytehq/airbyte-internal-issues/issues/15262)).

The starting concurrency of 4 is derived from Intercom's lowest-tier rate limit: 1000 req/min ≈ 17 req/s → `max(floor(17/4), 2) = 4`.

## How

1. Added a `concurrency_level` block to `manifest.yaml` with `default_concurrency: 4` and `max_concurrency: 25`
2. Version bumped to `0.13.19-rc.1`
3. Enabled `enableProgressiveRollout: true` in `metadata.yaml`

No spec changes, no Python code changes, no HTTPAPIBudget added (budget is deferred to Phase 2 of the tuning playbook if needed).

## Updates since last revision

- **Rebased on latest master** (current stable is 0.13.18; old PR was based on 0.13.16-rc.3 which is now obsolete)
- **Switched from config-driven to hardcoded concurrency**: Replaced `"{{ config.get('num_workers', 2) }}"` with a hardcoded `default_concurrency: 4`. The config-driven `num_workers` spec field has been removed. Hardcoding simplifies the rollout — concurrency will be tuned via the progressive rollout playbook (adjusting the value in manifest.yaml and publishing new RCs) rather than per-connection config.
- **Version is now 0.13.19-rc.1** (next RC after current stable 0.13.18)

## Review guide

1. `manifest.yaml` — adds the `concurrency_level` block between `streams` and `spec` (lines 814–822)
2. `metadata.yaml` — version bump to `0.13.19-rc.1` and `enableProgressiveRollout: true`
3. Worth reviewing alongside `components.py` (unchanged) — the custom `IntercomRateLimiter` sleeps per-thread based on shared rate limit headers. At concurrency=4 (up from 2), multiple threads may read stale remaining-capacity values. The CDK's default retry/backoff should handle resulting 429s.
4. `conversation_parts` and `companies` streams use `DefaultErrorHandler` (no proactive rate limiting) — they rely solely on 429 retry/backoff and will be the most aggressive under higher concurrency.

### Suggested human review checklist
- [ ] Verify that `default_concurrency: 4` is appropriate given Intercom's lowest-tier rate limit (1000 req/min ≈ 17 req/s)
- [ ] Confirm `max_concurrency: 25` is a safe upper bound
- [ ] Consider whether the proactive rate limiter in `components.py` needs adjustment for 4 concurrent threads vs 2
- [ ] Confirm no HTTPAPIBudget is needed at concurrency=4 (budget addition is deferred to Phase 2)

## User Impact

- Syncs will use 4 concurrent threads instead of 2, which should improve throughput for substream-heavy syncs (especially `conversation_parts`)
- This is an RC version — it will only be deployed to a subset of Tier 2 connections via progressive rollout, not to all users
- The existing `ErrorHandlerWithRateLimiter` provides proactive backoff; users may see slightly more 429 retry cycles but net throughput should be higher
- No user-facing configuration changes

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/7b0ff56c8dd04a7caf67ae5fe7a87510
Requested by: @sophiecuiy
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/74067" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
