### PR TITLE
fix(source-hubspot): use v3 properties API for CRM search streams

### DIFF
--- a/airbyte-integrations/connectors/source-hubspot/manifest.yaml
+++ b/airbyte-integrations/connectors/source-hubspot/manifest.yaml
@@ -1440,14 +1440,13 @@ definitions:
             type: SimpleRetriever
             requester:
               $ref: "#/definitions/base_requester"
-              path: "/properties/v2/{{ parameters['entity'] }}/properties"
-            decoder:
-              type: JsonDecoder
+              path: "/crm/v3/properties/{{ parameters['entity'] }}"
             record_selector:
               type: RecordSelector
               extractor:
                 type: DpathExtractor
-                field_path: []
+                field_path:
+                  - results
         request_body_json:
           limit: 200
           sorts:

--- a/airbyte-integrations/connectors/source-hubspot/unit_tests/conftest.py
+++ b/airbyte-integrations/connectors/source-hubspot/unit_tests/conftest.py
@@ -17,6 +17,21 @@ from airbyte_cdk.test.state_builder import StateBuilder
 pytest_plugins = ["airbyte_cdk.test.utils.manifest_only_fixtures"]
 
 NUMBER_OF_PROPERTIES = 2000
+
+
+def mock_v3_properties(requests_mock, entity, properties_list):
+    """Register a v3 properties mock for a CRM search entity.
+
+    CRM search streams discover properties via v3 API (/crm/v3/properties/{entity}).
+    Call this alongside any v2 property mock registration for CRM search entities.
+    """
+    requests_mock.register_uri(
+        "GET",
+        f"/crm/v3/properties/{entity}",
+        [{"json": {"results": properties_list}, "status_code": 200}],
+    )
+
+
 OBJECTS_WITH_DYNAMIC_SCHEMA = [
     "calls",
     "company",
@@ -156,18 +171,26 @@ def read_from_stream(cfg, stream: str, sync_mode, state=None, expecting_exceptio
 
 @pytest.fixture()
 def mock_dynamic_schema_requests(requests_mock):
+    properties = [
+        {
+            "name": "hs__migration_soft_delete",
+            "label": "migration_soft_delete_deprecated",
+            "description": "Describes if the goal target can be treated as deleted.",
+            "groupName": "goal_target_information",
+            "type": "enumeration",
+        }
+    ]
     for entity in OBJECTS_WITH_DYNAMIC_SCHEMA:
+        # v2 URL (used by dynamic schema loader)
         requests_mock.get(
             f"https://api.hubapi.com/properties/v2/{entity}/properties",
-            json=[
-                {
-                    "name": "hs__migration_soft_delete",
-                    "label": "migration_soft_delete_deprecated",
-                    "description": "Describes if the goal target can be treated as deleted.",
-                    "groupName": "goal_target_information",
-                    "type": "enumeration",
-                }
-            ],
+            json=properties,
+            status_code=200,
+        )
+        # v3 URL (used by CRM search streams for property discovery)
+        requests_mock.get(
+            f"https://api.hubapi.com/crm/v3/properties/{entity}",
+            json={"results": properties},
             status_code=200,
         )
 
@@ -180,12 +203,20 @@ def mock_dynamic_schema_requests_with_skip(requests_mock, object_to_skip: list):
         status_code=200,
     )
 
+    properties = [{"name": "hs__test_field", "type": "enumeration"}]
     for object_name in OBJECTS_WITH_DYNAMIC_SCHEMA:
         if object_name in object_to_skip:
             continue
+        # v2 URL (used by dynamic schema loader)
         requests_mock.get(
             f"https://api.hubapi.com/properties/v2/{object_name}/properties",
-            json=[{"name": "hs__test_field", "type": "enumeration"}],
+            json=properties,
+            status_code=200,
+        )
+        # v3 URL (used by CRM search streams for property discovery)
+        requests_mock.get(
+            f"https://api.hubapi.com/crm/v3/properties/{object_name}",
+            json={"results": properties},
             status_code=200,
         )
 

--- a/airbyte-integrations/connectors/source-hubspot/unit_tests/integrations/__init__.py
+++ b/airbyte-integrations/connectors/source-hubspot/unit_tests/integrations/__init__.py
@@ -14,7 +14,7 @@ from airbyte_cdk.test.mock_http.response_builder import FieldPath, HttpResponseB
 from airbyte_cdk.models import AirbyteStateMessage, SyncMode
 
 from .config_builder import ConfigBuilder
-from .request_builders.api import CustomObjectsRequestBuilder, OAuthRequestBuilder, PropertiesRequestBuilder, ScopesRequestBuilder
+from .request_builders.api import CrmSearchPropertiesRequestBuilder, CustomObjectsRequestBuilder, OAuthRequestBuilder, PropertiesRequestBuilder, ScopesRequestBuilder
 from .request_builders.streams import AssociationsBatchReadRequestBuilder, CRMSearchRequestBuilder, WebAnalyticsRequestBuilder
 from .response_builder.helpers import RootHttpResponseBuilder
 from .response_builder.api import ScopesResponseBuilder
@@ -129,14 +129,23 @@ class HubspotTestCase:
     @classmethod
     def mock_properties(cls, http_mocker: HttpMocker, object_type: str, properties: Dict[str, str]):
         templates = find_template("properties", __file__)
-        record_builder = lambda: RecordBuilder(copy.deepcopy(templates[0]), id_path=None, cursor_path=None)
 
-        response_builder = RootHttpResponseBuilder(templates)
+        # Mock v2 URL (used by dynamic schema loader)
+        v2_response = RootHttpResponseBuilder(copy.deepcopy(templates))
         for name, type in properties.items():
-            record = record_builder().with_field(FieldPath("name"), name).with_field(FieldPath("type"), type)
-            response_builder = response_builder.with_record(record)
+            record = RecordBuilder(copy.deepcopy(templates[0]), id_path=None, cursor_path=None)
+            record.with_field(FieldPath("name"), name).with_field(FieldPath("type"), type)
+            v2_response.with_record(record)
+        http_mocker.get(PropertiesRequestBuilder().for_entity(object_type).build(), v2_response.build())
 
-        http_mocker.get(PropertiesRequestBuilder().for_entity(object_type).build(), response_builder.build())
+        # Mock v3 URL (used by CRM search streams for property discovery)
+        v3_records = copy.deepcopy(templates)
+        for name, type in properties.items():
+            record = RecordBuilder(copy.deepcopy(templates[0]), id_path=None, cursor_path=None)
+            record.with_field(FieldPath("name"), name).with_field(FieldPath("type"), type)
+            v3_records.append(record.build())
+        v3_response = HttpResponse(json.dumps({"results": v3_records}), 200)
+        http_mocker.get(CrmSearchPropertiesRequestBuilder().for_entity(object_type).build(), v3_response)
 
     @classmethod
     def mock_response(cls, http_mocker: HttpMocker, request, responses, method: str = "get"):
@@ -149,21 +158,28 @@ class HubspotTestCase:
         entities = entities if entities is not None else OBJECTS_WITH_DYNAMIC_SCHEMA
 
         # figure out which entities are already mocked
-        existing = set()
+        existing_v2 = set()
+        existing_v3 = set()
         for entity in entities:
             for request_mock in http_mocker._get_matchers():
-                # check if dynamic stream was already mocked
-                if f"properties/v2/{entity}" in request_mock.request._parsed_url.path:
-                    existing.add(entity)
+                path = request_mock.request._parsed_url.path
+                if f"properties/v2/{entity}" in path:
+                    existing_v2.add(entity)
+                if f"crm/v3/properties/{entity}" in path:
+                    existing_v3.add(entity)
 
         templates = [{"name": "hs__test_field", "type": "enumeration"}]
-        response_builder = RootHttpResponseBuilder(templates)
 
         for entity in entities:
-            if entity in existing:
-                continue  # skip if already mocked
+            # Mock v2 URL (used by dynamic schema loader)
+            if entity not in existing_v2:
+                v2_response = RootHttpResponseBuilder(copy.deepcopy(templates))
+                http_mocker.get(PropertiesRequestBuilder().for_entity(entity).build(), v2_response.build())
 
-            http_mocker.get(PropertiesRequestBuilder().for_entity(entity).build(), response_builder.build())
+            # Mock v3 URL (used by CRM search streams for property discovery)
+            if entity not in existing_v3:
+                v3_response = HttpResponse(json.dumps({"results": copy.deepcopy(templates)}), 200)
+                http_mocker.get(CrmSearchPropertiesRequestBuilder().for_entity(entity).build(), v3_response)
 
     @classmethod
     def mock_custom_objects_streams(cls, http_mocker: HttpMocker):

--- a/airbyte-integrations/connectors/source-hubspot/unit_tests/integrations/request_builders/api.py
+++ b/airbyte-integrations/connectors/source-hubspot/unit_tests/integrations/request_builders/api.py
@@ -63,3 +63,17 @@ class PropertiesRequestBuilder(AbstractRequestBuilder):
 
     def build(self) -> HttpRequest:
         return HttpRequest(url=self.URL.format(resource=self._resource))
+
+
+class CrmSearchPropertiesRequestBuilder(AbstractRequestBuilder):
+    URL = "https://api.hubapi.com/crm/v3/properties/{resource}"
+
+    def __init__(self):
+        self._resource = None
+
+    def for_entity(self, entity):
+        self._resource = entity
+        return self
+
+    def build(self) -> HttpRequest:
+        return HttpRequest(url=self.URL.format(resource=self._resource))

--- a/airbyte-integrations/connectors/source-hubspot/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-hubspot/unit_tests/test_source.py
@@ -17,7 +17,7 @@ from airbyte_cdk.test.entrypoint_wrapper import discover
 from airbyte_cdk.test.state_builder import StateBuilder
 from airbyte_cdk.utils.datetime_helpers import ab_datetime_now
 
-from .conftest import find_stream, get_source, mock_dynamic_schema_requests_with_skip, read_from_stream
+from .conftest import find_stream, get_source, mock_dynamic_schema_requests_with_skip, mock_v3_properties, read_from_stream
 from .utils import run_read
 
 
@@ -45,8 +45,11 @@ def test_check_connection_ok(requests_mock, config):
         },
     ]
 
+    properties = [{"name": "hs__migration_soft_delete", "type": "enumeration"}]
+
     requests_mock.get("https://api.hubapi.com/crm/v3/schemas", json={}, status_code=200)
     requests_mock.register_uri("GET", "/properties/v2/contact/properties", responses)
+    requests_mock.register_uri("GET", "/crm/v3/properties/contact", [{"json": {"results": properties}, "status_code": 200}])
     requests_mock.register_uri("POST", "/crm/v3/objects/contact/search", {})
     connection_status = get_source(config).check(logger, config=config)
 
@@ -134,6 +137,7 @@ def test_check_connection_backoff_on_limit_reached(requests_mock, config):
     ]
     requests_mock.get("https://api.hubapi.com/crm/v3/schemas", json={}, status_code=200)
     requests_mock.register_uri("GET", "/properties/v2/contact/properties", prop_response)
+    mock_v3_properties(requests_mock, "contact", [{"name": "hs__migration_soft_delete", "type": "enumeration"}])
     requests_mock.register_uri("POST", "/crm/v3/objects/contact/search", responses)
     source = get_source(config)
     connection_status = source.check(logger=logger, config=config)
@@ -161,6 +165,7 @@ def test_check_connection_backoff_on_server_error(requests_mock, config):
         {"json": [], "status_code": 200},
     ]
     requests_mock.register_uri("GET", "/properties/v2/contact/properties", prop_response)
+    mock_v3_properties(requests_mock, "contact", [{"name": "hs__migration_soft_delete", "type": "enumeration"}])
     requests_mock.register_uri("POST", "/crm/v3/objects/contact/search", responses)
     source = get_source(config)
     connection_status = source.check(logger=logger, config=config)
@@ -368,6 +373,14 @@ def test_search_based_stream_should_not_attempt_to_get_more_than_10k_records(
     test_stream_url = "https://api.hubapi.com/crm/v3/objects/company/search"
     requests_mock.register_uri("POST", test_stream_url, responses)
     requests_mock.register_uri("GET", "/properties/v2/company/properties", properties_response)
+    mock_v3_properties(
+        requests_mock,
+        "company",
+        [
+            {"name": property_name, "type": "string", "updatedAt": 1571085954360, "createdAt": 1565059306048}
+            for property_name in fake_properties_list
+        ],
+    )
     requests_mock.register_uri(
         "POST",
         "/crm/v4/associations/company/contacts/batch/read",

--- a/airbyte-integrations/connectors/source-hubspot/unit_tests/test_streams.py
+++ b/airbyte-integrations/connectors/source-hubspot/unit_tests/test_streams.py
@@ -20,7 +20,7 @@ from airbyte_cdk.sources.types import Record
 from airbyte_cdk.test.entrypoint_wrapper import discover, read
 from airbyte_cdk.test.state_builder import StateBuilder
 
-from .conftest import find_stream, get_source, mock_dynamic_schema_requests_with_skip, read_from_stream
+from .conftest import find_stream, get_source, mock_dynamic_schema_requests_with_skip, mock_v3_properties, read_from_stream
 from .utils import run_read
 
 
@@ -239,6 +239,17 @@ def test_stream_read_with_legacy_field_transformation(
 
     requests_mock.register_uri(stream_retriever.requester._http_method.value, stream_url, responses)
     requests_mock.register_uri("GET", f"/properties/v2/{endpoint}/properties", properties_response)
+    mock_v3_properties(
+        requests_mock,
+        endpoint,
+        [
+            {"name": property_name, "type": "string", "updatedAt": 1571085954360, "createdAt": 1565059306048}
+            for property_name in fake_properties_list
+        ],
+    )
+
+    # Also mock v2/v3 properties for all other entities (needed by dynamic schema loader)
+    mock_dynamic_schema_requests_with_skip(requests_mock, [endpoint])
 
     # mock associations calls
     if stream_retriever.requester._http_method.value == "POST":
@@ -328,6 +339,15 @@ def test_crm_search_streams_with_no_associations(sync_mode, requests_mock, fake_
     ]
     requests_mock.register_uri("POST", endpoint_path, responses)
     requests_mock.register_uri("GET", properties_path, properties_response)
+    mock_v3_properties(
+        requests_mock,
+        "deal_split",
+        [
+            {"name": property_name, "type": "string", "updatedAt": 1571085954360, "createdAt": 1565059306048}
+            for property_name in fake_properties_list
+        ],
+    )
+    mock_dynamic_schema_requests_with_skip(requests_mock, ["deal_split"])
 
     records = run_read(stream)
     assert records
@@ -395,6 +415,15 @@ def test_crm_search_streams_requests_contain_custom_properties(requests_mock, fa
     ]
     stream._sync_mode = SyncMode.incremental
     requests_mock.register_uri("GET", properties_path, properties_response)
+    mock_v3_properties(
+        requests_mock,
+        "deal_split",
+        [
+            {"name": property_name, "type": "string", "updatedAt": 1571085954360, "createdAt": 1565059306048}
+            for property_name in fake_properties_list
+        ],
+    )
+    mock_dynamic_schema_requests_with_skip(requests_mock, ["deal_split"])
     records = run_read(stream)
 
     assert records


### PR DESCRIPTION
## What

CRM search streams (`companies`, `contacts`, `deals`, `tickets`, `leads`, `deal_splits`, `engagements_*`) fail with **403 MISSING_SCOPES** on HubSpot Enterprise accounts that have properties marked as sensitive. This is because the connector discovers properties via the v2 API, which returns sensitive properties. When those property names are passed to the CRM search endpoint, HubSpot rejects the request.

Closes: https://github.com/airbytehq/oncall/issues/11443
Based on community PR: https://github.com/airbytehq/airbyte/pull/74032

## How

Switch `PropertiesFromEndpoint` in `base_crm_search_incremental_stream` from the **v2** properties API (`/properties/v2/{entity}/properties`) to the **v3** API (`/crm/v3/properties/{entity}`), which excludes sensitive properties by default.

The `DynamicSchemaLoader` is intentionally left on v2 — it only reads property *definitions* for schema building and never passes property names to a data endpoint, so it does not trigger 403.

Test infrastructure is updated to mock both v2 (for schema loader) and v3 (for CRM search property discovery) URLs.

## Review guide

1. **`manifest.yaml` (~line 1443)** — the core fix. Only 2 functional lines changed: API path and `field_path` extractor. The `decoder` block is removed as unnecessary.
2. **`unit_tests/integrations/request_builders/api.py`** — new `CrmSearchPropertiesRequestBuilder` for the v3 URL.
3. **`unit_tests/integrations/__init__.py`** — `mock_properties` and `mock_dynamic_schema_requests` updated to register both v2 and v3 mocks.
4. **`unit_tests/conftest.py`** — new `mock_v3_properties` helper; `mock_dynamic_schema_requests` and `mock_dynamic_schema_requests_with_skip` fixtures updated to register v3 mocks.
5. **`unit_tests/test_source.py`** and **`unit_tests/test_streams.py`** — individual tests updated to register v3 property mocks where CRM search streams are exercised.

### Key things to verify
- [ ] The `mock_properties` method in `__init__.py` builds the v3 response by starting from `copy.deepcopy(templates)` and appending records — confirm this produces a valid equivalent to the v2 response
- [ ] No test was missed that exercises a CRM search stream without a v3 mock
- [ ] Version bump and changelog update may still be needed before merge

## User Impact


Users with HubSpot **Enterprise** accounts who have marked custom properties as sensitive will no longer experience 403 errors on CRM search streams. This is a backward-compatible fix — accounts without sensitive properties are unaffected since v3 returns the same non-sensitive properties as v2.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

---

**Devin session:** https://app.devin.ai/sessions/9302c45c8bc54ddc89f273ce12e27fd4  
**Requested by:** @suisuixia42
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/74069" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
