### PR TITLE
chore(source-stripe): lower default num_workers from 25 to 10

### DIFF
--- a/airbyte-integrations/connectors/source-stripe/manifest.yaml
+++ b/airbyte-integrations/connectors/source-stripe/manifest.yaml
@@ -1921,7 +1921,7 @@ spec:
         title: Number of concurrent workers
         minimum: 2
         maximum: 100
-        default: 25
+        default: 10
         examples: [ 2, 3, 4]
         description: >-
           The number of worker thread to use for the sync.
@@ -1946,12 +1946,12 @@ spec:
               - type: AddedFieldDefinition
                 path: ["num_workers"]
                 value: "2"
-            condition: "{{ config.get('num_workers', 25) == 1 }}"
+            condition: "{{ config.get('num_workers', 10) == 1 }}"
 # Concurrency level controls how many partition slices are processed in parallel.
 # Each worker handles a different time slice, preventing overlap.
 concurrency_level:
   type: ConcurrencyLevel
-  default_concurrency: "{{ config.get('num_workers', 4 if 'sk_test_' in config['client_secret'] else 25) }}"
+  default_concurrency: "{{ config.get('num_workers', 4 if 'sk_test_' in config['client_secret'] else 10) }}"
   max_concurrency: 100
 
 api_budget:


### PR DESCRIPTION
## What

Lowers the default `num_workers` (concurrent workers) for the Stripe source connector from 25 to 10 for production API keys. The previous default of 25 was observed to consistently trigger Stripe API rate limiting on live connections.

This was identified through a week-long monitoring exercise on a production connection: 25 and 20 workers both caused repeated sync failures due to rate limiting, while 10 workers synced reliably. Incremental testing from 10→14 workers all succeeded on incremental syncs, but since Stripe uses `StateDelegatingStream`, the initial full-refresh sync is more concurrency-intensive and 10 was the first value that passed cleanly.

## How

Three locations in `manifest.yaml` updated to change the production default from 25 to 10:

1. **Spec default** (line 1924): The user-facing default shown in the UI
2. **Config migration condition** (line 1949): Fallback value in a migration that converts `num_workers=1` to `2`. Functionally unchanged since neither 25 nor 10 equals 1, but updated for consistency.
3. **Runtime concurrency level** (line 1954): The actual fallback used when `num_workers` is not explicitly configured. Test/sandbox keys still default to 4.

## Review guide

1. `airbyte-integrations/connectors/source-stripe/manifest.yaml` — all three changes are in close proximity (lines 1919–1954)
   - **Most important**: Line 1954 (`default_concurrency`) — this is the runtime behavior change
   - Line 1924 (`default: 10`) — UI/spec default
   - Line 1949 — consistency change only, no behavioral impact

**Key questions for reviewer:**
- Is lowering the default for *all* production Stripe users appropriate, or should this be scoped differently?
- Should this include a version bump to trigger a connector release?
- Existing connections with `num_workers` explicitly set are unaffected; only connections relying on the default will see a change.

## User Impact

- **New connections**: Will default to 10 concurrent workers instead of 25, reducing likelihood of rate limiting at the cost of potentially slower syncs.
- **Existing connections with explicit `num_workers`**: No impact — their configured value is preserved.
- **Existing connections using the default**: Will drop from 25 to 10 workers on next sync after this version is deployed, which should reduce rate-limit failures.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Link to Devin run: https://app.devin.ai/sessions/1194ea9a614a4ad992a36c89471eddd8
Requested by: @agarctfi