### PR TITLE
fix(source-hubspot): add clear_http_cache fixture and mock_v3_properties helper to conftest.py

### DIFF
--- a/airbyte-integrations/connectors/source-hubspot/unit_tests/conftest.py
+++ b/airbyte-integrations/connectors/source-hubspot/unit_tests/conftest.py
@@ -6,6 +6,7 @@ import sys
 from pathlib import Path
 
 import pytest
+import requests_cache
 
 from airbyte_cdk.models import ConfiguredAirbyteCatalog
 from airbyte_cdk.sources.declarative.yaml_declarative_source import YamlDeclarativeSource
@@ -150,6 +151,21 @@ def patch_time(mocker):
     mocker.patch("time.sleep")
 
 
+@pytest.fixture(autouse=True)
+def clear_http_cache():
+    """Clear the shared in-memory SQLite HTTP cache between tests.
+
+    The CDK's HttpClient uses requests_cache with 'file::memory:?cache=shared' when
+    use_cache=True (e.g. for the fetch_properties_from_endpoint retriever). This creates
+    a process-wide shared SQLite database that persists across test functions in the same
+    pytest session. Cached HTTP responses bypass requests_mock entirely, causing tests that
+    depend on specific mocked property responses to receive stale data from earlier tests.
+    Clearing it before each test guarantees every test starts with a clean HTTP cache.
+    """
+    requests_cache.SQLiteCache("file::memory:?cache=shared").clear()
+    yield
+
+
 def read_from_stream(cfg, stream: str, sync_mode, state=None, expecting_exception: bool = False) -> EntrypointOutput:
     return read(get_source(cfg, state), cfg, CatalogBuilder().with_stream(stream, sync_mode).build(), state, expecting_exception)
 
@@ -170,6 +186,24 @@ def mock_dynamic_schema_requests(requests_mock):
             ],
             status_code=200,
         )
+
+
+def mock_v3_properties(requests_mock, entity):
+    requests_mock.get(
+        f"https://api.hubapi.com/crm/v3/properties/{entity}",
+        json={
+            "results": [
+                {
+                    "name": "hs__migration_soft_delete",
+                    "label": "migration_soft_delete_deprecated",
+                    "description": "Describes if the goal target can be treated as deleted.",
+                    "groupName": "goal_target_information",
+                    "type": "enumeration",
+                }
+            ]
+        },
+        status_code=200,
+    )
 
 
 def mock_dynamic_schema_requests_with_skip(requests_mock, object_to_skip: list):


### PR DESCRIPTION
## What

Adds test infrastructure to `source-hubspot` unit tests to support the v2→v3 properties API migration in [#74032](https://github.com/airbytehq/airbyte/pull/74032). Specifically addresses an issue where the CDK's shared in-memory HTTP cache (`requests_cache` with `file::memory:?cache=shared`) persists across test functions, causing cached responses to bypass `requests_mock` and leak stale data between tests.

## How

Three changes to `conftest.py`:

1. **`import requests_cache`** — New import to support cache clearing.
2. **`clear_http_cache` fixture (`autouse=True`)** — Clears the CDK's shared in-memory SQLite HTTP cache before each test, preventing cross-test cache pollution.
3. **`mock_v3_properties` helper function** — Registers a `requests_mock` GET handler for the v3 properties endpoint (`https://api.hubapi.com/crm/v3/properties/{entity}`) with the v3 response format (`{"results": [...]}`). This is a helper for tests that need to mock the v3 API (used by `PropertiesFromEndpoint` after the manifest change in #74032).

## Review guide

1. `airbyte-integrations/connectors/source-hubspot/unit_tests/conftest.py` — Only file changed.

**Key items for review:**
- Confirm `requests_cache` is already available as a dependency in the test environment (it's a transitive dep of `airbyte-cdk`). If not, this will break all test imports.
- `clear_http_cache` is `autouse=True`, meaning it runs for **every** test. Verify this doesn't introduce issues for tests that don't use HTTP caching.
- `mock_v3_properties` is currently **unused** — it's prep infrastructure for #74032. No existing tests call it yet.

## User Impact

No user-facing impact. This is a test-only change that improves test isolation and adds mock infrastructure.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

---

Requested by: @suisuixia42
[Link to Devin run](https://app.devin.ai/sessions/164328db78174da39d921888439bf910)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/74096" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
