### PR TITLE
docs(destination-bigquery): expand troubleshooting section for write failures

### DIFF
--- a/docs/integrations/destinations/bigquery.md
+++ b/docs/integrations/destinations/bigquery.md
@@ -210,6 +210,8 @@ If your sync fails with `BigQueryException: 400 Bad Request` and the message
     configured.
   - Try reducing the **Google BigQuery Client Chunk Size** from the default 15 MiB to a
     smaller value (for example, 5 MiB).
+  - Try reducing concurrent syncs to your BigQuery instance or table. Contention is a
+    possible contributing factor.
 
 ### Load job timeouts
 

--- a/docs/integrations/destinations/bigquery.md
+++ b/docs/integrations/destinations/bigquery.md
@@ -195,22 +195,6 @@ The HMAC key is wrong.
 - Make sure the HMAC key is created for the BigQuery service account, and the service account has
   permission to access the GCS bucket and path.
 
-### "Socket file not created" timeout
-
-If your sync fails with an error containing `Socket file ... not created after 900000 ms`,
-the Airbyte platform was unable to set up an internal data channel before the connector
-timed out. This is not caused by your BigQuery configuration or credentials.
-
-- **Retry the sync.** The issue is often transient, caused by temporary resource pressure, and resolves
-  on the next attempt.
-- **Stagger concurrent syncs.** Running many connections to the same destination at the same
-  time increases the chance of this error. Spacing out sync schedules can help.
-- **Airbyte Cloud:** If the error persists after retrying, contact
-  [Airbyte Support](https://support.airbyte.com) with the connection ID and job ID.
-- **Self-managed:** Make sure your Airbyte platform is up to date. Check
-  the worker or pod logs for out-of-memory events or container restarts around the time of
-  the failure.
-
 ### HTTP 400 "Request had invalid euc header" during upload
 
 If your sync fails with `BigQueryException: 400 Bad Request` and the message
@@ -227,26 +211,14 @@ If your sync fails with `BigQueryException: 400 Bad Request` and the message
   - Try reducing the **Google BigQuery Client Chunk Size** from the default 15 MiB to a
     smaller value (for example, 5 MiB).
 
-### Broken pipe errors
-
-If your sync fails with a `Broken pipe` error on the destination side:
-
-- This is a transport-level error caused by a network interruption between the Airbyte worker
-  and the BigQuery API.
-- **Reduce chunk size:** In the connector settings, decrease the **Google BigQuery Client Chunk
-  Size** to 5 MiB or less. Smaller uploads complete faster and are less susceptible to
-  connection timeouts.
-- **Check network infrastructure:** Firewalls, NAT gateways, and cloud load balancers may
-  terminate idle or long-lived connections. Ensure outbound HTTPS to `*.googleapis.com` is not
-  subject to aggressive idle timeouts.
-- **Retry the sync.** Broken pipe errors are typically transient.
-
 ### Load job timeouts
 
 If your sync fails with `Fail to complete a load job in big query`:
 
 - BigQuery load jobs have a 30-minute wait timeout. Very large batches or high BigQuery queue
   contention can exceed this limit.
+- Running concurrent syncs that load into the same BigQuery table is not supported and can
+  also trigger this timeout.
 - Try reducing the volume per sync by using incremental sync mode or reducing the number of
   streams per connection.
 

--- a/docs/integrations/destinations/bigquery.md
+++ b/docs/integrations/destinations/bigquery.md
@@ -220,7 +220,7 @@ If your sync fails with `BigQueryException: 400 Bad Request` and the message
 - **Retry the sync.** In most cases the error resolves on the next attempt.
 - If the error recurs on every sync, the underlying causes can be complex. Google does not
   publicly document this specific error. The following steps may help narrow the issue:
-  - If you Self-manage Airbyte, check whether a proxy, VPN, or firewall is modifying HTTP
+  - If you self-manage Airbyte, check whether a proxy, VPN, or firewall is modifying HTTP
     headers on requests to `bigquery.googleapis.com`.
   - Verify the service account key has not been rotated or revoked since the connection was
     configured.

--- a/docs/integrations/destinations/bigquery.md
+++ b/docs/integrations/destinations/bigquery.md
@@ -178,7 +178,9 @@ namespace with `n` for converted namespaces.
 | OBJECT                              | JSON          |
 | ARRAY                               | JSON          |
 
-## Troubleshooting permission issues
+## Troubleshooting
+
+### Permission errors
 
 The service account does not have the proper permissions.
 
@@ -192,6 +194,61 @@ The HMAC key is wrong.
 
 - Make sure the HMAC key is created for the BigQuery service account, and the service account has
   permission to access the GCS bucket and path.
+
+### "Socket file not created" timeout
+
+_Applies to connector version 3.0.7 and later (socket data-channel mode)._
+
+If your sync fails with an error containing `Socket file ... not created after 900000 ms`:
+
+- This indicates the Airbyte platform sidecar did not create the inter-process communication
+  channel in time. The connector itself is not at fault.
+- **Self-hosted deployments:** Verify the platform version supports socket-mode destinations.
+  Check worker pod logs for sidecar startup failures or OOM events.
+- **Running multiple connections to the same destination simultaneously** can cause resource
+  contention. Try staggering connection schedules.
+- If the error persists, contact [Airbyte Support](https://support.airbyte.com) with the full
+  destination logs.
+
+### HTTP 400 "Request had invalid euc header" during upload
+
+If your sync fails with `BigQueryException: 400 Bad Request` and the message
+`Request had invalid euc header`:
+
+- This is a transient error from the Google BigQuery resumable-upload API. The upload session
+  was invalidated mid-stream.
+- **Retry the sync.** In most cases the error resolves on the next attempt.
+- If the error recurs on every sync:
+  - Check whether a proxy, VPN, or firewall is modifying HTTP headers on requests to
+    `bigquery.googleapis.com`.
+  - Verify the service account key has not been rotated or revoked since the connection was
+    configured.
+  - Try reducing the **Google BigQuery Client Chunk Size** from the default 15 MiB to a
+    smaller value (for example, 5 MiB). Smaller chunks reduce the window for session
+    corruption.
+
+### Broken pipe errors
+
+If your sync fails with a `Broken pipe` error on the destination side:
+
+- This is a transport-level error caused by a network interruption between the Airbyte worker
+  and the BigQuery API.
+- **Reduce chunk size:** In the connector settings, decrease the **Google BigQuery Client Chunk
+  Size** to 5 MiB or less. Smaller uploads complete faster and are less susceptible to
+  connection timeouts.
+- **Check network infrastructure:** Firewalls, NAT gateways, and cloud load balancers may
+  terminate idle or long-lived connections. Ensure outbound HTTPS to `*.googleapis.com` is not
+  subject to aggressive idle timeouts.
+- **Retry the sync.** Broken pipe errors are typically transient.
+
+### Load job timeouts
+
+If your sync fails with `Fail to complete a load job in big query`:
+
+- BigQuery load jobs have a 30-minute wait timeout. Very large batches or high BigQuery queue
+  contention can exceed this limit.
+- Try reducing the volume per sync by using incremental sync mode or reducing the number of
+  streams per connection.
 
 ## Tutorials
 

--- a/docs/integrations/destinations/bigquery.md
+++ b/docs/integrations/destinations/bigquery.md
@@ -216,17 +216,16 @@ timed out. This is not caused by your BigQuery configuration or credentials.
 If your sync fails with `BigQueryException: 400 Bad Request` and the message
 `Request had invalid euc header`:
 
-- This is a transient error from the Google BigQuery resumable-upload API. The upload session
-  was invalidated mid-stream.
+- This error originates from the Google BigQuery resumable-upload API. It is usually transient.
 - **Retry the sync.** In most cases the error resolves on the next attempt.
-- If the error recurs on every sync:
-  - If you Self-manage Airbyte, check whether a proxy, VPN, or firewall is modifying HTTP headers on requests to
-    `bigquery.googleapis.com`.
+- If the error recurs on every sync, the underlying causes can be complex. Google does not
+  publicly document this specific error. The following steps may help narrow the issue:
+  - If you Self-manage Airbyte, check whether a proxy, VPN, or firewall is modifying HTTP
+    headers on requests to `bigquery.googleapis.com`.
   - Verify the service account key has not been rotated or revoked since the connection was
     configured.
   - Try reducing the **Google BigQuery Client Chunk Size** from the default 15 MiB to a
-    smaller value (for example, 5 MiB). Smaller chunks reduce the window for session
-    corruption.
+    smaller value (for example, 5 MiB).
 
 ### Broken pipe errors
 

--- a/docs/integrations/destinations/bigquery.md
+++ b/docs/integrations/destinations/bigquery.md
@@ -218,7 +218,8 @@ If your sync fails with `Fail to complete a load job in big query`:
 - BigQuery load jobs have a 30-minute wait timeout. Very large batches or high BigQuery queue
   contention can exceed this limit.
 - Running concurrent syncs that load into the same BigQuery table is not supported and can
-  also trigger this timeout.
+  also trigger this timeout. See [Stream uniqueness](https://docs.airbyte.com/platform/using-airbyte/configuring-schema#stream-uniqueness)
+  for details.
 - Try reducing the volume per sync by using incremental sync mode or reducing the number of
   streams per connection.
 

--- a/docs/integrations/destinations/bigquery.md
+++ b/docs/integrations/destinations/bigquery.md
@@ -197,18 +197,19 @@ The HMAC key is wrong.
 
 ### "Socket file not created" timeout
 
-_Applies to connector version 3.0.7 and later (socket data-channel mode)._
+If your sync fails with an error containing `Socket file ... not created after 900000 ms`,
+the Airbyte platform was unable to set up an internal data channel before the connector
+timed out. This is not caused by your BigQuery configuration or credentials.
 
-If your sync fails with an error containing `Socket file ... not created after 900000 ms`:
-
-- This indicates the Airbyte platform sidecar did not create the inter-process communication
-  channel in time. The connector itself is not at fault.
-- **Self-hosted deployments:** Verify the platform version supports socket-mode destinations.
-  Check worker pod logs for sidecar startup failures or OOM events.
-- **Running multiple connections to the same destination simultaneously** can cause resource
-  contention. Try staggering connection schedules.
-- If the error persists, contact [Airbyte Support](https://support.airbyte.com) with the full
-  destination logs.
+- **Retry the sync.** The issue is often caused by temporary resource pressure and resolves
+  on the next attempt.
+- **Stagger concurrent syncs.** Running many connections to the same destination at the same
+  time increases the chance of this error. Spacing out sync schedules can help.
+- **Airbyte Cloud:** If the error persists after retrying, contact
+  [Airbyte Support](https://support.airbyte.com) with the connection ID and job ID.
+- **Self-hosted (OSS / Enterprise):** Make sure your Airbyte platform is up to date. Check
+  the worker or pod logs for out-of-memory events or container restarts around the time of
+  the failure.
 
 ### HTTP 400 "Request had invalid euc header" during upload
 

--- a/docs/integrations/destinations/bigquery.md
+++ b/docs/integrations/destinations/bigquery.md
@@ -201,13 +201,13 @@ If your sync fails with an error containing `Socket file ... not created after 9
 the Airbyte platform was unable to set up an internal data channel before the connector
 timed out. This is not caused by your BigQuery configuration or credentials.
 
-- **Retry the sync.** The issue is often caused by temporary resource pressure and resolves
+- **Retry the sync.** The issue is often transient, caused by temporary resource pressure, and resolves
   on the next attempt.
 - **Stagger concurrent syncs.** Running many connections to the same destination at the same
   time increases the chance of this error. Spacing out sync schedules can help.
 - **Airbyte Cloud:** If the error persists after retrying, contact
   [Airbyte Support](https://support.airbyte.com) with the connection ID and job ID.
-- **Self-hosted (OSS / Enterprise):** Make sure your Airbyte platform is up to date. Check
+- **Self-managed:** Make sure your Airbyte platform is up to date. Check
   the worker or pod logs for out-of-memory events or container restarts around the time of
   the failure.
 
@@ -220,7 +220,7 @@ If your sync fails with `BigQueryException: 400 Bad Request` and the message
   was invalidated mid-stream.
 - **Retry the sync.** In most cases the error resolves on the next attempt.
 - If the error recurs on every sync:
-  - Check whether a proxy, VPN, or firewall is modifying HTTP headers on requests to
+  - If you Self-manage Airbyte, check whether a proxy, VPN, or firewall is modifying HTTP headers on requests to
     `bigquery.googleapis.com`.
   - Verify the service account key has not been rotated or revoked since the connection was
     configured.


### PR DESCRIPTION
## What

The BigQuery destination troubleshooting documentation only covered permission and HMAC-key errors. Users encountering common write-failure scenarios (HTTP 400 upload errors, load job timeouts) had no guidance, leading to poor chatbot coverage and unanswered support questions.

This was identified via a [Kapa.ai coverage-gap analysis](https://app.kapa.ai/114210e3-270b-430b-9723-6ece2bcd9a62/coverage-gaps/clusters/46c73d1a-557f-41cb-b88f-e0e6341dfe12) of user conversations.

## How

Expands the existing `## Troubleshooting permission issues` section into a broader `## Troubleshooting` section with subsections for:

1. **Permission errors** — existing content, moved under a subheading
2. **HTTP 400 "Request had invalid euc header"** — transient BigQuery resumable-upload session error; acknowledges that Google does not publicly document this error and frames mitigation steps accordingly
3. **Load job timeouts** — 30-minute wait timeout on BigQuery load jobs, including a note that concurrent syncs to the same table (unsupported) can also trigger this

Two originally proposed sections — "Socket file not created" timeout and "Broken pipe errors" — were removed during review after @tryangul clarified these are generic platform-level errors (bad release / source container crash), not BigQuery-specific. A tracking issue was created at [airbyte-internal-issues#15917](https://github.com/airbytehq/airbyte-internal-issues/issues/15917) to centralize generic platform troubleshooting docs.

## Review guide

1. `docs/integrations/destinations/bigquery.md` — single file changed

Key items for review:
- **Anchor breakage:** The heading rename from `## Troubleshooting permission issues` → `## Troubleshooting` / `### Permission errors` changes the URL anchor. Verify no internal docs link to `#troubleshooting-permission-issues`.
- **"euc header" characterization:** Described as usually transient, with an explicit note that Google does not publicly document it. The mitigation steps (proxy check, key rotation, chunk size reduction) are reasonable inferences from code analysis (`BigqueryBatchStandardInsertLoader.kt`, `BigQueryUtils.kt`) but not confirmed against production support data.
- **Concurrent syncs note:** The load-job section mentions concurrent syncs to the same BQ table as unsupported — confirm this matches actual connector behavior.

### Suggested human review checklist

- [ ] Verify no existing docs or in-app links reference `#troubleshooting-permission-issues`
- [ ] Confirm the "euc header" mitigation steps (proxy/VPN check, chunk size reduction) are reasonable advice for users
- [ ] Confirm the 30-minute load-job timeout value is still current in `BigQueryUtils.kt`

## User Impact

Users encountering BigQuery write failures now have documented troubleshooting steps instead of relying solely on support or community forums.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Link to Devin run: https://app.devin.ai/sessions/b7a79ba7bae14745801247e9fe775f35
Requested by: @ian-at-airbyte