### PR TITLE
docs: use HTTPS for Airbyte Cloud API reference link

### DIFF
--- a/docs/release_notes/december_2022.md
+++ b/docs/release_notes/december_2022.md
@@ -14,7 +14,7 @@ This page includes new features and improvements to the Airbyte Cloud and Airbyt
 - Added the auto-detect schema changes option to the Connection Replication UI, which allows you to choose whether Airbyte ignores or disables the connection when it detects a non-breaking schema change in the source. [#19734](https://github.com/airbytehq/airbyte/pull/19734)
 - Added stream table configuration windows for Destination namespace and Stream name, which allow you to choose how the data is stored and edit the names and prefixes of tables in the destination. [#19713](https://github.com/airbytehq/airbyte/pull/19713)
 - Added the AWS Secret Manager to Airbyte Open Source as an option for storing secrets. [#19690](https://github.com/airbytehq/airbyte/pull/19690)
-- Added the [Airbyte Cloud API](http://reference.airbyte.com/) in alpha, which allows you to programmatically control Airbyte Cloud through an API.
+- Added the [Airbyte Cloud API](https://reference.airbyte.com/) in alpha, which allows you to programmatically control Airbyte Cloud through an API.
 
 ### Improvements
 


### PR DESCRIPTION
## What
Updates an external documentation link in the December 2022 release notes to use the canonical HTTPS endpoint.


## How
Verified that `http://reference.airbyte.com` permanently redirects to HTTPS and updated the link to avoid unnecessary redirects.


## Review guide
1. docs/release_notes/december_2022.md

## User Impact
No functional impact. Improves documentation accuracy and security.


## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
