### PR TITLE
fix(source-wikipedia-pageviews): country should not be required for per-article stream

### DIFF
--- a/airbyte-integrations/connectors/source-wikipedia-pageviews/manifest.yaml
+++ b/airbyte-integrations/connectors/source-wikipedia-pageviews/manifest.yaml
@@ -239,7 +239,6 @@ spec:
       - access
       - agent
       - article
-      - country
       - end
       - project
       - start

--- a/airbyte-integrations/connectors/source-wikipedia-pageviews/metadata.yaml
+++ b/airbyte-integrations/connectors/source-wikipedia-pageviews/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 87c58f70-6f7a-4f70-aba5-bab1a458f5ba
-  dockerImageTag: 0.2.22
+  dockerImageTag: 0.2.23
   dockerRepository: airbyte/source-wikipedia-pageviews
   githubIssueLabel: source-wikipedia-pageviews
   icon: wikipedia-pageviews.svg

--- a/docs/integrations/sources/wikipedia-pageviews.md
+++ b/docs/integrations/sources/wikipedia-pageviews.md
@@ -53,6 +53,7 @@ The Wikipedia Pageviews source connector supports the following [sync modes](htt
 
 | Version | Date       | Pull Request                                              | Subject        |
 | :------ | :--------- | :-------------------------------------------------------- | :------------- |
+| 0.2.23 | 2025-03-27 | [74119](https://github.com/airbytehq/airbyte/pull/74119) | Make `country` optional (unused in streams) |
 | 0.2.22 | 2025-05-24 | [60778](https://github.com/airbytehq/airbyte/pull/60778) | Update dependencies |
 | 0.2.21 | 2025-05-10 | [59940](https://github.com/airbytehq/airbyte/pull/59940) | Update dependencies |
 | 0.2.20 | 2025-05-04 | [58919](https://github.com/airbytehq/airbyte/pull/58919) | Update dependencies |


### PR DESCRIPTION

## What
Removes an unused configuration field from the source-wikipedia-pageviews connector specification. The country field was marked as required in the connector spec but is not used by any stream, including per-article or top, leading to unnecessary configuration friction.

## How
- Removed country from the required list in the connector spec
- Left the stream definitions unchanged, as no runtime behavior depends on this field

## Review guide
1. airbyte-integrations/connectors/source-wikipedia-pageviews/manifest.yaml
     spec.connection_specification.required

## User Impact
- Users no longer need to provide an unused country value when configuring the connector
- Cleaner, more accurate connector configuration
- No impact on data sync behavior or output

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
