### PR TITLE
feat: wire upgradeCdk and auto-upgrade workflow to split CDK versions

### DIFF
--- a/.github/workflows/auto-upgrade-certified-connectors-cdk.yml
+++ b/.github/workflows/auto-upgrade-certified-connectors-cdk.yml
@@ -86,9 +86,11 @@ jobs:
         run: |
           set -euo pipefail
           ./gradlew :airbyte-integrations:connectors:${{ matrix.connector }}:upgradeCdk
-          # --quiet disables all of gradle's normal logging, so we only get the CDK version number
+          # --quiet disables all of gradle's normal logging, so we only get the value
           new_cdk_version=$(./gradlew :airbyte-integrations:connectors:${{ matrix.connector }}:getCdkVersion --quiet)
+          cdk_core_type=$(./gradlew :airbyte-integrations:connectors:${{ matrix.connector }}:getCdkCoreType --quiet)
           echo "new_cdk_version=$new_cdk_version" >> $GITHUB_OUTPUT
+          echo "cdk_core_type=$cdk_core_type" >> $GITHUB_OUTPUT
 
       - name: Check for changes
         id: check-changes
@@ -120,7 +122,7 @@ jobs:
           commit-message: "chore: upgrade bulk CDK for ${{ matrix.connector }}"
           branch: "auto-upgrade-jvm-bulk-cdk/${{ steps.upgrade-cdk.outputs.new_cdk_version }}/${{ matrix.connector }}"
           delete-branch: true
-          title: "chore: upgrade ${{ matrix.connector }} to bulk CDK ${{ steps.upgrade-cdk.outputs.new_cdk_version }}"
+          title: "chore: upgrade ${{ matrix.connector }} to bulk CDK ${{ steps.upgrade-cdk.outputs.cdk_core_type }} ${{ steps.upgrade-cdk.outputs.new_cdk_version }}"
           body: |
             Upgrade Bulk CDK version for `${{ matrix.connector }}`
 
@@ -145,7 +147,7 @@ jobs:
             "${{ matrix.connector }}" \
             "${{ steps.bump-version.outputs.new_version }}" \
             "${{ steps.create-pr.outputs.pull-request-number }}" \
-            "Upgrade to Bulk CDK ${{ steps.upgrade-cdk.outputs.new_cdk_version }}."
+            "Upgrade to Bulk CDK ${{ steps.upgrade-cdk.outputs.cdk_core_type }} ${{ steps.upgrade-cdk.outputs.new_cdk_version }}."
 
           # Commit and push the changelog changes
           branch_name="${{ steps.create-pr.outputs.pull-request-branch }}"

--- a/buildSrc/src/main/groovy/airbyte-bulk-connector.gradle
+++ b/buildSrc/src/main/groovy/airbyte-bulk-connector.gradle
@@ -330,12 +330,30 @@ class AirbyteBulkConnectorPlugin implements Plugin<Project> {
             }
         }
 
+        project.tasks.register('getCdkCoreType') {
+            description = 'Gets the CDK core type (extract or load) used by the connector'
+            group = 'airbyte-bulk-connector'
+
+            doLast {
+                println extension.core
+            }
+        }
+
         project.tasks.register('upgradeCdk', BumpConnectorCdkVersion)
+
+        // Wire the extension's core type to the upgradeCdk task after the build script is evaluated,
+        // since the connector sets `core = "extract"` or `core = "load"` in its build.gradle.
+        project.afterEvaluate {
+            project.tasks.named('upgradeCdk').configure { task ->
+                task.core = extension.core
+            }
+        }
     }
 }
 
 class BumpConnectorCdkVersion extends DefaultTask {
     private String targetVersion = null
+    String core // 'extract' or 'load', set by the plugin from the extension
 
     BumpConnectorCdkVersion() {
         description = 'Bump the bulk CDK version number'
@@ -350,7 +368,7 @@ class BumpConnectorCdkVersion extends DefaultTask {
     @TaskAction
     void bumpVersion() {
         if (targetVersion == null) {
-            targetVersion = getLocalCdkVersion(project)
+            targetVersion = getLocalCdkVersion(project, core)
             println "No version specified, upgrading to local CDK version: $targetVersion"
         } else {
             println "Version specified, using the provided CDK versionn: $targetVersion"
@@ -359,8 +377,15 @@ class BumpConnectorCdkVersion extends DefaultTask {
         updateCdkVersion(project, targetVersion)
     }
 
-    private static String getLocalCdkVersion(Project project) throws IOException {
-        File versionPropsFile = new File(project.rootDir, 'airbyte-cdk/bulk/version.properties')
+    private static String getLocalCdkVersion(Project project, String core) throws IOException {
+        if (core == null) {
+            throw new IllegalStateException(
+                "Cannot determine CDK version: connector's 'core' type is not set. " +
+                "Ensure the connector's build.gradle sets airbyteBulkConnector { core = 'extract' } or { core = 'load' }."
+            )
+        }
+
+        File versionPropsFile = new File(project.rootDir, "airbyte-cdk/bulk/core/${core}/version.properties")
         if (!versionPropsFile.exists()) {
             throw new FileNotFoundException("CDK version file not found: ${versionPropsFile.absolutePath}")
         }
@@ -376,7 +401,7 @@ class BumpConnectorCdkVersion extends DefaultTask {
             throw new IllegalStateException("'version' property is empty in ${versionPropsFile.absolutePath}")
         }
 
-        project.logger.info("Found local CDK version from version.properties: ${localVersion}")
+        project.logger.info("Found local CDK ${core} version from version.properties: ${localVersion}")
         return localVersion
     }
 

--- a/connector-writer/destination/implementation-reference.md
+++ b/connector-writer/destination/implementation-reference.md
@@ -1107,7 +1107,10 @@ cdkVersion=0.1.76  # Update to new version
 ### Check Latest CDK Version
 
 ```bash
-cat airbyte-cdk/bulk/version.properties
+# For destinations (load):
+cat airbyte-cdk/bulk/core/load/version.properties
+# For sources (extract):
+cat airbyte-cdk/bulk/core/extract/version.properties
 ```
 
 ---

--- a/connector-writer/destination/step-by-step/1-getting-started.md
+++ b/connector-writer/destination/step-by-step/1-getting-started.md
@@ -40,8 +40,8 @@ mkdir write/load write/transform
 
 ```properties
 # Pin to latest stable Bulk CDK version
-# Check airbyte-cdk/bulk/version.properties for latest
-cdkVersion=0.1.76
+# Check airbyte-cdk/bulk/core/load/version.properties for latest (destinations use 'load')
+cdkVersion=1.0.2
 ```
 
 **IMPORTANT:** Always use a pinned version for production connectors.


### PR DESCRIPTION
## Summary

- Fix `upgradeCdk` task to read the correct split version file (`core/extract/version.properties` or `core/load/version.properties`) based on the connector's `core` type
- Add `getCdkCoreType` task so workflows can query whether a connector uses extract or load
- Update auto-upgrade workflow to include component name (extract/load) in PR titles and changelog entries
- Update connector-writer docs to reference split version files

## How it works

The `BumpConnectorCdkVersion` task now has a `core` property that gets wired from the `AirbyteBulkConnectorExtension` via `afterEvaluate`. When `upgradeCdk` runs without an explicit `--cdkVersion`, it reads the version from `airbyte-cdk/bulk/core/{extract|load}/version.properties` based on the connector's core type.

## Depends on

Stacked on #74122 (cleanup PR that removes the old unified version machinery).

## Test plan

- [ ] `./gradlew :airbyte-integrations:connectors:destination-snowflake:upgradeCdk` picks up load version (1.0.2)
- [ ] `./gradlew :airbyte-integrations:connectors:source-mysql:upgradeCdk` picks up extract version (1.0.1)
- [ ] `./gradlew :airbyte-integrations:connectors:destination-snowflake:getCdkCoreType --quiet` prints `load`
- [ ] `./gradlew :airbyte-integrations:connectors:source-mysql:getCdkCoreType --quiet` prints `extract`

🤖 Generated with [Claude Code](https://claude.com/claude-code)