### PR TITLE
chore(source-stripe): Bump CDK to 7.8.1.post51.dev22586905043

### DIFF
--- a/airbyte-integrations/connectors/source-stripe/metadata.yaml
+++ b/airbyte-integrations/connectors/source-stripe/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: e094cb9a-26de-4645-8761-65c0c425d1de
-  dockerImageTag: 5.15.21-rc.2
+  dockerImageTag: 5.15.21-rc.3
   dockerRepository: airbyte/source-stripe
   documentationUrl: https://docs.airbyte.com/integrations/sources/stripe
   erdUrl: https://dbdocs.io/airbyteio/source-stripe?view=relationships

--- a/airbyte-integrations/connectors/source-stripe/metadata.yaml
+++ b/airbyte-integrations/connectors/source-stripe/metadata.yaml
@@ -6,7 +6,7 @@ data:
     hosts:
       - api.stripe.com
   connectorBuildOptions:
-    baseImage: docker.io/airbyte/source-declarative-manifest:7.8.1.post50.dev22418146992@sha256:87d5005c063294752aa3f5d2392dec131f1c60966da6da6a80dfba60d055bdaa
+    baseImage: docker.io/airbyte/source-declarative-manifest:7.8.1.post51.dev22586905043@sha256:77fc14088398f2f61b06e2f2f88cc6746732ada1835f42877a80070dcff82a76
   connectorSubtype: api
   connectorType: source
   definitionId: e094cb9a-26de-4645-8761-65c0c425d1de

--- a/docs/integrations/sources/stripe.md
+++ b/docs/integrations/sources/stripe.md
@@ -291,6 +291,7 @@ Each record is marked with `is_deleted` flag when the appropriate event happens 
 
 | Version     | Date       | Pull Request                                                 | Subject                                                                                                                                                                                                                       |
 |:------------|:-----------|:-------------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 5.15.21-rc.3 | 2026-03-02 | [74132](https://github.com/airbytehq/airbyte/pull/74132) | Fix cursor age validation to clear state before constructing full refresh stream, ensuring true full refresh from start_date |
 | 5.15.21-rc.2 | 2026-02-25 | [74051](https://github.com/airbytehq/airbyte/pull/74051) | Fix sync failure when unselected parent streams have stale cursor state during cursor age validation |
 | 5.15.21-rc.1 | 2026-02-25 | [73646](https://github.com/airbytehq/airbyte/pull/73646) | Add cursor age validation for StateDelegatingStream streams to prevent data loss when initial sync fails mid-way |
 | 5.15.20 | 2026-02-24 | [73944](https://github.com/airbytehq/airbyte/pull/73944) | Update dependencies |


### PR DESCRIPTION
## What

Bumps the `source-declarative-manifest` base image for the Stripe connector to pick up the cursor age validation fix from [airbytehq/airbyte-python-cdk#890](https://github.com/airbytehq/airbyte-python-cdk/pull/890).

That CDK PR fixes a temporal ordering bug in `StateDelegatingStream`: when cursor age validation detected a stale cursor, the `full_refresh_stream` was constructed **before** clearing state, so its cursor inherited the old stale position instead of starting from `start_date`. The fix clears state first, then constructs the stream.

## How

- Update `connectorBuildOptions.baseImage` in `metadata.yaml` from `7.8.1.post50.dev22418146992` to `7.8.1.post51.dev22586905043` with the corresponding sha256 digest.
- Bump `dockerImageTag` from `5.15.21-rc.2` to `5.15.21-rc.3`.
- Add changelog entry in `docs/integrations/sources/stripe.md`.

## Review guide

1. `airbyte-integrations/connectors/source-stripe/metadata.yaml` — verify the base image tag, sha256 digest, and version bump are correct.
2. `docs/integrations/sources/stripe.md` — verify the new changelog row for `5.15.21-rc.3`.

**Note:** This is a **pre-release** CDK version (`.dev` suffix). The upstream CDK PR ([airbytehq/airbyte-python-cdk#890](https://github.com/airbytehq/airbyte-python-cdk/pull/890)) should be reviewed in parallel.

## User Impact

No user-facing changes from this PR alone. This enables testing of the CDK fix which ensures that when the Stripe connector detects a cursor older than the 30-day event retention period, it correctly performs a true full refresh from `start_date` rather than starting from the stale cursor position.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Link to Devin session: https://app.devin.ai/sessions/782b85a317204e3c833c3ecc3bc02f1e
Requested by: @agarctfi
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/74132" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
