### PR TITLE
docs(ai-agents): add LangChain and FastMCP quickstart guides

### DIFF
--- a/docs/ai-agents/connectors/readme.md
+++ b/docs/ai-agents/connectors/readme.md
@@ -60,7 +60,11 @@ Use Airbyte agent Connectors when you want:
 
 ## How to work with agent connectors
 
-To get started with agent connectors, follow the [Python SDK tutorial](../tutorials/quickstarts/tutorial-python).
+To get started with agent connectors, follow one of the [quick start tutorials](../tutorials/quickstarts/):
+
+- [Pydantic AI](../tutorials/quickstarts/tutorial-python)
+- [LangChain](../tutorials/quickstarts/tutorial-langchain)
+- [FastMCP](../tutorials/quickstarts/tutorial-fastmcp)
 
 ## All agent connectors
 

--- a/docs/ai-agents/connectors/readme.md
+++ b/docs/ai-agents/connectors/readme.md
@@ -60,11 +60,7 @@ Use Airbyte agent Connectors when you want:
 
 ## How to work with agent connectors
 
-To get started with agent connectors, follow one of the [quick start tutorials](../tutorials/quickstarts/):
-
-- [Pydantic AI](../tutorials/quickstarts/tutorial-python)
-- [LangChain](../tutorials/quickstarts/tutorial-langchain)
-- [FastMCP](../tutorials/quickstarts/tutorial-fastmcp)
+To get started with agent connectors, follow one of the [quick start tutorials](../tutorials/quickstarts/).
 
 ## All agent connectors
 

--- a/docs/ai-agents/connectors/readme.md
+++ b/docs/ai-agents/connectors/readme.md
@@ -62,7 +62,7 @@ Use Airbyte agent Connectors when you want:
 
 To get started with agent connectors, follow one of the [quick start tutorials](../tutorials/quickstarts/):
 
-- [Pydantic AI](../tutorials/quickstarts/tutorial-python)
+- [Pydantic AI](../tutorials/quickstarts/tutorial-pydantic)
 - [LangChain](../tutorials/quickstarts/tutorial-langchain)
 - [FastMCP](../tutorials/quickstarts/tutorial-fastmcp)
 

--- a/docs/ai-agents/tutorials/quickstarts/readme.md
+++ b/docs/ai-agents/tutorials/quickstarts/readme.md
@@ -7,6 +7,6 @@ import DocCardList from '@theme/DocCardList';
 
 # Agent engine quick starts
 
-These tutorials get you started using Airbyte's Agent Engine and [agent connectors](../../connectors).
+These tutorials get you started using Airbyte's Agent Engine and [agent connectors](../../connectors). They're intended for people new to Airbyte's Agent Engine and its agent connectors. Follow these tutorials to go from having nothing to having a locally running AI agent that can work with your data in real time. In most cases, you can achieve this in under half an hour.
 
 <DocCardList />

--- a/docs/ai-agents/tutorials/quickstarts/readme.md
+++ b/docs/ai-agents/tutorials/quickstarts/readme.md
@@ -7,6 +7,6 @@ import DocCardList from '@theme/DocCardList';
 
 # Agent engine quick starts
 
-These tutorials get you started using Airbyte's Agent Engine and [agent connectors](../../connectors).
+These tutorials get you started using Airbyte's Agent Engine and [agent connectors](../../connectors). They're intended for people new to Airbyte's Agent Engine and its agent connectors. Follow these tutorials to go from having nothing to a locally running AI agent that can work with your data in real time. In most cases, you can achieve this in under half an hour.
 
 <DocCardList />

--- a/docs/ai-agents/tutorials/quickstarts/tutorial-fastmcp.md
+++ b/docs/ai-agents/tutorials/quickstarts/tutorial-fastmcp.md
@@ -133,11 +133,11 @@ connector = GithubConnector(
 
 ### Register the tool
 
-Register the connector's `execute` method as an MCP tool. The `@GithubConnector.describe` decorator automatically generates a comprehensive tool description from the connector's metadata. This tells the agent what entities are available (issues, pull requests, repositories, etc.), what actions it can perform on each entity, and what parameters each action requires.
+Register the connector's `execute` method as an MCP tool. The `@GithubConnector.tool_utils` decorator automatically generates a comprehensive tool description from the connector's metadata. This tells the agent what entities are available (issues, pull requests, repositories, etc.), what actions it can perform on each entity, and what parameters each action requires.
 
 ```python title="server.py"
 @mcp.tool()
-@GithubConnector.describe
+@GithubConnector.tool_utils
 async def github_execute(entity: str, action: str, params: dict | None = None) -> str:
     """Execute GitHub connector operations."""
     result = await connector.execute(entity, action, params or {})

--- a/docs/ai-agents/tutorials/quickstarts/tutorial-fastmcp.md
+++ b/docs/ai-agents/tutorials/quickstarts/tutorial-fastmcp.md
@@ -1,0 +1,240 @@
+---
+sidebar_label: "FastMCP"
+sidebar_position: 5
+---
+
+# Agent connector tutorial: FastMCP
+
+In this tutorial, you'll create a new Python project with uv, build a FastMCP server that exposes one of Airbyte's agent connectors as an MCP tool, and use it to query GitHub data from any MCP-compatible agent. This tutorial uses GitHub, but if you don't have a GitHub account, you can use one of Airbyte's other agent connectors and perform different operations.
+
+Unlike the [Connector MCP server tutorial](tutorial-mcp-server), which uses Airbyte's pre-built MCP server, this tutorial shows you how to build your own MCP server with [FastMCP](https://gofastmcp.com). This gives you full control over tool definitions, prompt handling, and server behavior.
+
+## Overview
+
+This tutorial is for AI engineers and other technical users who work with data and AI tools. You can complete it in about 15 minutes.
+
+The tutorial assumes you have basic knowledge of the following tools, but most software engineers shouldn't struggle with anything that follows.
+
+- Python and package management with uv
+- MCP (Model Context Protocol) and MCP servers
+- GitHub, or a different third-party service you want to connect to
+
+## Before you start
+
+Before you begin this tutorial, ensure you have the following.
+
+- [Python](https://www.python.org/downloads/) version 3.13 or later
+- [uv](https://github.com/astral-sh/uv)
+- A [GitHub personal access token](https://github.com/settings/tokens). For this tutorial, a classic token with `repo` scope is sufficient.
+- An agent that supports MCP servers, such as [Claude Desktop](https://claude.ai/download), [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview), or [Cursor](https://www.cursor.com/).
+
+## Part 1: Create a new Python project
+
+Create a new project using uv:
+
+```bash
+uv init my-mcp-agent --app
+cd my-mcp-agent
+```
+
+This creates a project with the following structure:
+
+```text
+my-mcp-agent/
+├── .gitignore
+├── .python-version
+├── main.py
+├── pyproject.toml
+└── README.md
+```
+
+## Part 2: Install dependencies
+
+Install the GitHub connector and FastMCP:
+
+```bash
+uv add airbyte-agent-github fastmcp
+```
+
+This command installs:
+
+- `airbyte-agent-github`: The Airbyte agent connector for GitHub, which provides type-safe access to GitHub's API.
+- `fastmcp`: A Python framework for building MCP servers with minimal boilerplate.
+
+The GitHub connector also includes `python-dotenv`, which you can use to load environment variables from a `.env` file.
+
+## Part 3: Import FastMCP and the GitHub agent connector
+
+1. Create a `server.py` file for your MCP server definition:
+
+   ```bash
+   touch server.py
+   ```
+
+2. Add the following imports to `server.py`:
+
+    ```python title="server.py"
+    import os
+    import json
+
+    from dotenv import load_dotenv
+    from fastmcp import FastMCP
+    from airbyte_agent_github import GithubConnector
+    from airbyte_agent_github.models import GithubPersonalAccessTokenAuthConfig
+    ```
+
+    These imports provide:
+
+    - `os` and `json`: Access environment variables and serialize connector results.
+    - `load_dotenv`: Load environment variables from your `.env` file.
+    - `FastMCP`: The FastMCP server class that handles MCP protocol communication.
+    - `GithubConnector`: The Airbyte agent connector that provides type-safe access to GitHub's API.
+    - `GithubPersonalAccessTokenAuthConfig`: The authentication configuration for the GitHub connector using a personal access token.
+
+## Part 4: Add a .env file with your secrets
+
+1. Create a `.env` file in your project root and add your GitHub token to it. Replace the placeholder value with your actual credential.
+
+    ```text title=".env"
+    GITHUB_ACCESS_TOKEN=your-github-personal-access-token
+    ```
+
+    :::warning
+    Never commit your `.env` file to version control. If you do this by mistake, rotate your secrets immediately.
+    :::
+
+2. Add the following line to `server.py` after your imports to load the environment variables:
+
+    ```python title="server.py"
+    load_dotenv()
+    ```
+
+## Part 5: Configure your connector and MCP server
+
+Now that your environment is set up, add the following code to `server.py` to create the GitHub connector and FastMCP server.
+
+### Create the server and connector
+
+```python title="server.py"
+mcp = FastMCP("GitHub Agent")
+
+connector = GithubConnector(
+    auth_config=GithubPersonalAccessTokenAuthConfig(
+        token=os.environ["GITHUB_ACCESS_TOKEN"]
+    )
+)
+```
+
+- `FastMCP("GitHub Agent")` creates a new MCP server named "GitHub Agent".
+- The connector authenticates using your personal access token.
+
+### Register the tool
+
+Register the connector's `execute` method as an MCP tool. The `@GithubConnector.describe` decorator automatically generates a comprehensive tool description from the connector's metadata. This tells the agent what entities are available (issues, pull requests, repositories, etc.), what actions it can perform on each entity, and what parameters each action requires.
+
+```python title="server.py"
+@mcp.tool()
+@GithubConnector.describe
+async def github_execute(entity: str, action: str, params: dict | None = None) -> str:
+    """Execute GitHub connector operations."""
+    result = await connector.execute(entity, action, params or {})
+    return json.dumps(result.data if hasattr(result, "data") else result, default=str)
+```
+
+With this single tool, your MCP server exposes all of the connector's capabilities. The agent decides which entity and action to use based on your natural language questions.
+
+### Add the server entry point
+
+Add the following at the bottom of `server.py` to start the server when run directly:
+
+```python title="server.py"
+if __name__ == "__main__":
+    mcp.run()
+```
+
+## Part 6: Register with your agent
+
+Register the MCP server with your preferred agent. You need to provide the full path to your project's `server.py` file. Replace `/path/to/my-mcp-agent` with the actual path to your project directory.
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+<TabItem value="claude-code" label="Claude Code" default>
+
+```bash
+claude mcp add github-agent -- uv run --directory /path/to/my-mcp-agent server.py
+```
+
+</TabItem>
+<TabItem value="claude-desktop" label="Claude Desktop">
+
+Add the following to your Claude Desktop configuration file (`claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "github-agent": {
+      "command": "uv",
+      "args": ["run", "--directory", "/path/to/my-mcp-agent", "server.py"]
+    }
+  }
+}
+```
+
+On macOS, the config file is at `~/Library/Application Support/Claude/claude_desktop_config.json`. On Windows, it's at `%APPDATA%\Claude\claude_desktop_config.json`.
+
+</TabItem>
+<TabItem value="cursor" label="Cursor">
+
+Add the following to your Cursor MCP configuration file (`.cursor/mcp.json` in your project directory, or `~/.cursor/mcp.json` for global configuration):
+
+```json
+{
+  "mcpServers": {
+    "github-agent": {
+      "command": "uv",
+      "args": ["run", "--directory", "/path/to/my-mcp-agent", "server.py"]
+    }
+  }
+}
+```
+
+</TabItem>
+</Tabs>
+
+## Part 7: Use the MCP server
+
+1. Restart your agent so it picks up the new MCP server registration.
+
+2. Once restarted, prompt your agent with natural language questions about your GitHub data. Try prompts like:
+
+    - "List the 5 most recent open issues in airbytehq/airbyte"
+    - "Show me the latest pull requests in my-org/my-repo"
+    - "What are the open issues assigned to octocat?"
+
+Your agent discovers the MCP server's tools automatically and calls them based on your prompts. The MCP server handles executing the connector operations and returning the results.
+
+### Troubleshooting
+
+If your agent fails to retrieve GitHub data, check the following:
+
+- **Server not found**: Ensure the path in your MCP configuration points to the correct `server.py` file and that `uv` is available on your system PATH.
+- **HTTP 401 errors**: Your `GITHUB_ACCESS_TOKEN` is invalid or expired. Generate a new token and update your `.env` file.
+- **HTTP 403 errors**: Your `GITHUB_ACCESS_TOKEN` doesn't have the required scopes. Ensure your token has `repo` scope for accessing repository data.
+
+## Summary
+
+In this tutorial, you learned how to:
+
+- Set up a new Python project with uv
+- Add FastMCP and Airbyte's GitHub agent connector to your project
+- Configure environment variables and authentication
+- Build a FastMCP server that exposes the GitHub connector as an MCP tool
+- Register the MCP server with your agent and query data using natural language
+
+## Next steps
+
+- Add more agent connectors to your project. Explore other agent connectors in the [Airbyte agent connectors catalog](https://github.com/airbytehq/airbyte-agent-connectors) to give your MCP server access to more services like Stripe, HubSpot, and Salesforce. You can register multiple tools on the same FastMCP server.
+
+- Consider how you might like to expand your MCP server. For example, you can add [MCP prompts](https://gofastmcp.com/servers/prompts) to provide reusable prompt templates, or [MCP resources](https://gofastmcp.com/servers/resources) to expose data directly. See the [FastMCP documentation](https://gofastmcp.com) for more options.

--- a/docs/ai-agents/tutorials/quickstarts/tutorial-fastmcp.md
+++ b/docs/ai-agents/tutorials/quickstarts/tutorial-fastmcp.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: "FastMCP"
-sidebar_position: 5
+sidebar_position: 3
 ---
 
 import Tabs from '@theme/Tabs';
@@ -9,8 +9,6 @@ import TabItem from '@theme/TabItem';
 # Agent connector tutorial: FastMCP
 
 In this tutorial, you'll create a new Python project with uv, build a FastMCP server that exposes one of Airbyte's agent connectors as an MCP tool, and use it to query GitHub data from any MCP-compatible agent. This tutorial uses GitHub, but if you don't have a GitHub account, you can use one of Airbyte's other agent connectors and perform different operations.
-
-Unlike the [Connector MCP server tutorial](tutorial-mcp-server), which uses Airbyte's pre-built MCP server, this tutorial shows you how to build your own MCP server with [FastMCP](https://gofastmcp.com). This gives you full control over tool definitions, prompt handling, and server behavior.
 
 ## Overview
 
@@ -157,7 +155,7 @@ if __name__ == "__main__":
 
 ## Part 6: Register with your agent
 
-Register the MCP server with your preferred agent. You need to provide the full path to your project's `server.py` file. Replace `/path/to/my-mcp-agent` with the actual path to your project directory.
+Register the MCP server with your preferred agent. Provide the full path to your project's `server.py` file. Replace `/path/to/my-mcp-agent` with the actual path to your project directory.
 
 <Tabs>
 <TabItem value="claude-code" label="Claude Code" default>
@@ -235,6 +233,6 @@ In this tutorial, you learned how to:
 
 ## Next steps
 
-- Add more agent connectors to your project. Explore other agent connectors in the [Airbyte agent connectors catalog](https://github.com/airbytehq/airbyte-agent-connectors) to give your MCP server access to more services like Stripe, HubSpot, and Salesforce. You can register multiple tools on the same FastMCP server.
+- Add more agent connectors to your project. Explore other agent connectors in the [Airbyte agent connectors catalog](../../connectors/) to give your MCP server access to more services like Stripe, HubSpot, and Salesforce. You can register multiple tools on the same FastMCP server.
 
 - Consider how you might like to expand your MCP server. For example, you can add [MCP prompts](https://gofastmcp.com/servers/prompts) to provide reusable prompt templates, or [MCP resources](https://gofastmcp.com/servers/resources) to expose data directly. See the [FastMCP documentation](https://gofastmcp.com) for more options.

--- a/docs/ai-agents/tutorials/quickstarts/tutorial-fastmcp.md
+++ b/docs/ai-agents/tutorials/quickstarts/tutorial-fastmcp.md
@@ -141,7 +141,7 @@ Register the connector's `execute` method as an MCP tool. The `@GithubConnector.
 async def github_execute(entity: str, action: str, params: dict | None = None) -> str:
     """Execute GitHub connector operations."""
     result = await connector.execute(entity, action, params or {})
-    return json.dumps(result.data if hasattr(result, "data") else result, default=str)
+    return json.dumps(result, default=str)
 ```
 
 With this single tool, your MCP server exposes all of the connector's capabilities. The agent decides which entity and action to use based on your natural language questions.

--- a/docs/ai-agents/tutorials/quickstarts/tutorial-fastmcp.md
+++ b/docs/ai-agents/tutorials/quickstarts/tutorial-fastmcp.md
@@ -3,6 +3,9 @@ sidebar_label: "FastMCP"
 sidebar_position: 5
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 # Agent connector tutorial: FastMCP
 
 In this tutorial, you'll create a new Python project with uv, build a FastMCP server that exposes one of Airbyte's agent connectors as an MCP tool, and use it to query GitHub data from any MCP-compatible agent. This tutorial uses GitHub, but if you don't have a GitHub account, you can use one of Airbyte's other agent connectors and perform different operations.
@@ -155,9 +158,6 @@ if __name__ == "__main__":
 ## Part 6: Register with your agent
 
 Register the MCP server with your preferred agent. You need to provide the full path to your project's `server.py` file. Replace `/path/to/my-mcp-agent` with the actual path to your project directory.
-
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 
 <Tabs>
 <TabItem value="claude-code" label="Claude Code" default>

--- a/docs/ai-agents/tutorials/quickstarts/tutorial-hosted.md
+++ b/docs/ai-agents/tutorials/quickstarts/tutorial-hosted.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: "Hosted connectors"
-sidebar_position: 3
+sidebar_position: 5
 ---
 
 import Tabs from '@theme/Tabs';
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 
 # Hosted agent connectors in the Agent Engine
 
-When you run connector operations with the [Python SDK](tutorial-python), you store API credentials locally and provide them directly to the API through agent connectors. This approach, while viable at first, reaches limits quickly. You may find yourself dealing with large numbers of customers who have their own environments and credentials. You may not want to manage these credentials and or store them at all.
+When you run connector operations with the [Python SDK](tutorial-pydantic), you store API credentials locally and provide them directly to the API through agent connectors. This approach, while viable at first, reaches limits quickly. You may find yourself dealing with large numbers of customers who have their own environments and credentials. You may not want to manage these credentials and or store them at all.
 
 With hosted execution, sensitive API credentials never leave Airbyte, multiple end-users can have separate credentials managed centrally, and Airbyte handles credential lifecycle (refresh, rotation) automatically.
 

--- a/docs/ai-agents/tutorials/quickstarts/tutorial-langchain.md
+++ b/docs/ai-agents/tutorials/quickstarts/tutorial-langchain.md
@@ -1,13 +1,11 @@
 ---
-sidebar_label: "Pydantic AI"
-sidebar_position: 1
+sidebar_label: "LangChain"
+sidebar_position: 4
 ---
 
-# Agent connector tutorial: Pydantic AI
+# Agent connector tutorial: LangChain
 
-In this tutorial, you'll create a new Python project with uv, add a Pydantic AI agent, equip it to use one of Airbyte's agent connectors, and use natural language to explore your data. This tutorial uses GitHub, but if you don't have a GitHub account, you can use one of Airbyte's other agent connectors and perform different operations.
-
-Using the Python SDK is more time-consuming than the Connector MCP server, but affords you the most control over the context you send to your agent.
+In this tutorial, you'll create a new Python project with uv, add a LangChain agent, equip it to use one of Airbyte's agent connectors, and use natural language to explore your data. This tutorial uses GitHub, but if you don't have a GitHub account, you can use one of Airbyte's other agent connectors and perform different operations.
 
 ## Overview
 
@@ -16,7 +14,7 @@ This tutorial is for AI engineers and other technical users who work with data a
 The tutorial assumes you have basic knowledge of the following tools, but most software engineers shouldn't struggle with anything that follows.
 
 - Python and package management with uv
-- Pydantic AI
+- LangChain and LangGraph
 - GitHub, or a different third-party service you want to connect to
 
 ## Before you start
@@ -26,7 +24,7 @@ Before you begin this tutorial, ensure you have the following.
 - [Python](https://www.python.org/downloads/) version 3.13 or later
 - [uv](https://github.com/astral-sh/uv)
 - A [GitHub personal access token](https://github.com/settings/tokens). For this tutorial, a classic token with `repo` scope is sufficient.
-- An [OpenAI API key](https://platform.openai.com/api-keys). This tutorial uses OpenAI, but Pydantic AI supports other LLM providers if you prefer.
+- An [OpenAI API key](https://platform.openai.com/api-keys). This tutorial uses OpenAI, but LangChain supports other LLM providers if you prefer.
 
 ## Part 1: Create a new Python project
 
@@ -35,14 +33,14 @@ In this tutorial you initialize a basic Python project to work in. However, if y
 Create a new project using uv:
 
 ```bash
-uv init my-ai-agent --app
-cd my-ai-agent
+uv init my-langchain-agent --app
+cd my-langchain-agent
 ```
 
 This creates a project with the following structure:
 
 ```text
-my-ai-agent/
+my-langchain-agent/
 ├── .gitignore
 ├── .python-version
 ├── main.py
@@ -54,24 +52,22 @@ You create `.env` and `uv.lock` files in later steps, so don't worry about them 
 
 ## Part 2: Install dependencies
 
-Install the GitHub connector and Pydantic AI. This tutorial uses OpenAI as the LLM provider, but Pydantic AI supports many other providers.
+Install the GitHub connector, LangChain with OpenAI support, and LangGraph for the agent runtime:
 
 ```bash
-uv add airbyte-agent-github pydantic-ai
+uv add airbyte-agent-github langchain langchain-openai langgraph
 ```
 
 This command installs:
 
 - `airbyte-agent-github`: The Airbyte agent connector for GitHub, which provides type-safe access to GitHub's API.
-- `pydantic-ai`: The AI agent framework, which includes support for multiple LLM providers including OpenAI, Anthropic, and Google.
+- `langchain`: The LangChain framework core.
+- `langchain-openai`: LangChain's OpenAI integration for chat models.
+- `langgraph`: The LangGraph agent runtime, which provides a `create_react_agent` function for building tool-calling agents.
 
 The GitHub connector also includes `python-dotenv`, which you can use to load environment variables from a `.env` file.
 
-:::note
-If you want a smaller installation with only OpenAI support, you can use `pydantic-ai-slim[openai]` instead of `pydantic-ai`. See the [Pydantic AI installation docs](https://ai.pydantic.dev/install/) for more options.
-:::
-
-## Part 3: Import Pydantic AI and the GitHub agent connector
+## Part 3: Import LangChain and the GitHub agent connector
 
 1. Create an `agent.py` file for your agent definition:
 
@@ -83,18 +79,23 @@ If you want a smaller installation with only OpenAI support, you can use `pydant
 
     ```python title="agent.py"
     import os
+    import json
 
     from dotenv import load_dotenv
-    from pydantic_ai import Agent
+    from langchain_core.tools import StructuredTool
+    from langchain_openai import ChatOpenAI
+    from langgraph.prebuilt import create_react_agent
     from airbyte_agent_github import GithubConnector
     from airbyte_agent_github.models import GithubPersonalAccessTokenAuthConfig
     ```
 
     These imports provide:
 
-    - `os`: Access environment variables for your GitHub token and LLM API key.
+    - `os` and `json`: Access environment variables and serialize connector results.
     - `load_dotenv`: Load environment variables from your `.env` file.
-    - `Agent`: The Pydantic AI agent class that orchestrates LLM interactions and tool calls.
+    - `StructuredTool`: LangChain's tool class for wrapping async functions with typed parameters.
+    - `ChatOpenAI`: LangChain's OpenAI chat model integration.
+    - `create_react_agent`: LangGraph's function for creating a ReAct agent that can call tools.
     - `GithubConnector`: The Airbyte agent connector that provides type-safe access to GitHub's API.
     - `GithubPersonalAccessTokenAuthConfig`: The authentication configuration for the GitHub connector using a personal access token.
 
@@ -117,11 +118,11 @@ If you want a smaller installation with only OpenAI support, you can use `pydant
     load_dotenv()
     ```
 
-    This makes your secrets available via `os.environ`. Pydantic AI automatically reads `OPENAI_API_KEY` from the environment, and you'll use `os.environ["GITHUB_ACCESS_TOKEN"]` to configure the connector in the next section.
+    This makes your secrets available via `os.environ`. LangChain's `ChatOpenAI` automatically reads `OPENAI_API_KEY` from the environment, and you'll use `os.environ["GITHUB_ACCESS_TOKEN"]` to configure the connector in the next section.
 
 ## Part 5: Configure your connector and agent
 
-Now that your environment is set up, add the following code to `agent.py` to create the GitHub connector and Pydantic AI agent.
+Now that your environment is set up, add the following code to `agent.py` to create the GitHub connector and LangChain agent.
 
 ### Define the connector
 
@@ -135,42 +136,37 @@ connector = GithubConnector(
 )
 ```
 
-### Define the agent
+### Define the tool
 
-Create a Pydantic AI agent with a system prompt that describes its purpose:
+Create an async function that wraps the connector's `execute` method as a LangChain tool. The `@GithubConnector.describe` decorator automatically generates a comprehensive tool description from the connector's metadata. This tells the agent what entities are available (issues, pull requests, repositories, etc.), what actions it can perform on each entity, and what parameters each action requires.
 
 ```python title="agent.py"
-agent = Agent(
-    "openai:gpt-4o",
-    system_prompt=(
-        "You are a helpful assistant that can access GitHub repositories, issues, "
-        "and pull requests. Use the available tools to answer questions about "
-        "GitHub data. Be concise and accurate in your responses."
-    ),
+@GithubConnector.describe
+async def github_execute(entity: str, action: str, params: dict | None = None) -> str:
+    """Execute GitHub connector operations."""
+    result = await connector.execute(entity, action, params or {})
+    return json.dumps(result.data if hasattr(result, "data") else result, default=str)
+
+github_tool = StructuredTool.from_function(
+    coroutine=github_execute,
+    name="github_execute",
+    description=github_execute.__doc__,
 )
 ```
 
-- The `"openai:gpt-4o"` string specifies the model to use. You can use a different model by changing the model string. For example, use `"openai:gpt-4o-mini"` to lower costs, or see the [Pydantic AI models documentation](https://ai.pydantic.dev/models/) for other providers like Anthropic or Google.
-- The `system_prompt` parameter tells the LLM what role it should play and how to behave.
+### Define the agent
 
-## Part 6: Add tools to your agent
-
-Tools let your agent fetch real data from GitHub using Airbyte's agent connector. Without tools, the agent can only respond based on its training data. By registering connector operations as tools, the agent can decide when to call them based on natural language questions.
-
-Add the following code to `agent.py`.
+Create a LangChain chat model and a LangGraph ReAct agent:
 
 ```python title="agent.py"
-@agent.tool_plain
-@GithubConnector.tool_utils
-async def github_execute(entity: str, action: str, params: dict | None = None):
-    return await connector.execute(entity, action, params or {})
+llm = ChatOpenAI(model="gpt-4o")
+agent = create_react_agent(llm, [github_tool])
 ```
 
-The `@GithubConnector.tool_utils` decorator automatically generates a comprehensive tool description from the connector's metadata. This tells the agent what entities are available (issues, pull requests, repositories, etc.), what actions it can perform on each entity, and what parameters each action requires.
+- `ChatOpenAI(model="gpt-4o")` creates an OpenAI chat model. You can use a different model by changing the model string. For example, use `"gpt-4o-mini"` to lower costs. LangChain also supports [other providers](https://python.langchain.com/docs/integrations/chat/) like Anthropic and Google.
+- `create_react_agent` creates a ReAct agent that reasons about which tools to call based on the user's input.
 
-With this single tool, your agent can access all of the connector's capabilities. The agent decides which entity and action to use based on your natural language questions.
-
-## Part 7: Run your project
+## Part 6: Run your project
 
 Now that your agent is configured with tools, update `main.py` and run your project.
 
@@ -184,15 +180,17 @@ Now that your agent is configured with tools, update `main.py` and run your proj
         print("GitHub Agent Ready! Ask questions about GitHub repositories.")
         print("Type 'quit' to exit.\n")
 
-        history = None
+        history = []
 
         while True:
             prompt = input("You: ")
-            if prompt.lower() in ('quit', 'exit', 'q'):
+            if prompt.lower() in ("quit", "exit", "q"):
                 break
-            result = await agent.run(prompt, message_history=history)
-            history = result.all_messages()  # Call the method
-            print(f"\nAgent: {result.output}\n")
+            history.append({"role": "user", "content": prompt})
+            result = await agent.ainvoke({"messages": history})
+            response = result["messages"][-1].content
+            history = result["messages"]
+            print(f"\nAgent: {response}\n")
 
     if __name__ == "__main__":
         asyncio.run(main())
@@ -227,10 +225,10 @@ If your agent fails to retrieve GitHub data, check the following:
 In this tutorial, you learned how to:
 
 - Set up a new Python project with uv
-- Add Pydantic AI and Airbyte's GitHub agent connector to your project
+- Add LangChain, LangGraph, and Airbyte's GitHub agent connector to your project
 - Configure environment variables and authentication
-- Add tools to your agent using the GitHub connector
-- Run your project and use natural language to interact with GitHub data
+- Create a LangChain tool from the GitHub connector
+- Build a ReAct agent with LangGraph and use natural language to interact with GitHub data
 
 ## Next steps
 

--- a/docs/ai-agents/tutorials/quickstarts/tutorial-langchain.md
+++ b/docs/ai-agents/tutorials/quickstarts/tutorial-langchain.md
@@ -138,10 +138,10 @@ connector = GithubConnector(
 
 ### Define the tool
 
-Create an async function that wraps the connector's `execute` method as a LangChain tool. The `@GithubConnector.describe` decorator automatically generates a comprehensive tool description from the connector's metadata. This tells the agent what entities are available (issues, pull requests, repositories, etc.), what actions it can perform on each entity, and what parameters each action requires.
+Create an async function that wraps the connector's `execute` method as a LangChain tool. The `@GithubConnector.tool_utils` decorator automatically generates a comprehensive tool description from the connector's metadata. This tells the agent what entities are available (issues, pull requests, repositories, etc.), what actions it can perform on each entity, and what parameters each action requires.
 
 ```python title="agent.py"
-@GithubConnector.describe
+@GithubConnector.tool_utils
 async def github_execute(entity: str, action: str, params: dict | None = None) -> str:
     """Execute GitHub connector operations."""
     result = await connector.execute(entity, action, params or {})

--- a/docs/ai-agents/tutorials/quickstarts/tutorial-langchain.md
+++ b/docs/ai-agents/tutorials/quickstarts/tutorial-langchain.md
@@ -82,7 +82,7 @@ The GitHub connector also includes `python-dotenv`, which you can use to load en
     import json
 
     from dotenv import load_dotenv
-    from langchain_core.tools import StructuredTool
+    from langchain_core.tools import tool
     from langchain_openai import ChatOpenAI
     from langgraph.prebuilt import create_react_agent
     from airbyte_agent_github import GithubConnector
@@ -93,7 +93,7 @@ The GitHub connector also includes `python-dotenv`, which you can use to load en
 
     - `os` and `json`: Access environment variables and serialize connector results.
     - `load_dotenv`: Load environment variables from your `.env` file.
-    - `StructuredTool`: LangChain's tool class for wrapping async functions with typed parameters.
+    - `tool`: LangChain's decorator for converting a function into a tool.
     - `ChatOpenAI`: LangChain's OpenAI chat model integration.
     - `create_react_agent`: LangGraph's function for creating a ReAct agent that can call tools.
     - `GithubConnector`: The Airbyte agent connector that provides type-safe access to GitHub's API.
@@ -138,20 +138,15 @@ connector = GithubConnector(
 
 ### Define the tool
 
-Create an async function that wraps the connector's `execute` method as a LangChain tool. The `@GithubConnector.tool_utils` decorator automatically generates a comprehensive tool description from the connector's metadata. This tells the agent what entities are available (issues, pull requests, repositories, etc.), what actions it can perform on each entity, and what parameters each action requires.
+Create an async function that wraps the connector's `execute` method as a LangChain tool. The `@tool` decorator converts the function into a LangChain tool, and `@GithubConnector.tool_utils` automatically generates a comprehensive tool description from the connector's metadata. This tells the agent what entities are available (issues, pull requests, repositories, etc.), what actions it can perform on each entity, and what parameters each action requires.
 
 ```python title="agent.py"
+@tool
 @GithubConnector.tool_utils
 async def github_execute(entity: str, action: str, params: dict | None = None) -> str:
     """Execute GitHub connector operations."""
     result = await connector.execute(entity, action, params or {})
-    return json.dumps(result.data if hasattr(result, "data") else result, default=str)
-
-github_tool = StructuredTool.from_function(
-    coroutine=github_execute,
-    name="github_execute",
-    description=github_execute.__doc__,
-)
+    return json.dumps(result, default=str)
 ```
 
 ### Define the agent
@@ -160,7 +155,7 @@ Create a LangChain chat model and a LangGraph ReAct agent:
 
 ```python title="agent.py"
 llm = ChatOpenAI(model="gpt-4o")
-agent = create_react_agent(llm, [github_tool])
+agent = create_react_agent(llm, [github_execute])
 ```
 
 - `ChatOpenAI(model="gpt-4o")` creates an OpenAI chat model. You can use a different model by changing the model string. For example, use `"gpt-4o-mini"` to lower costs. LangChain also supports [other providers](https://python.langchain.com/docs/integrations/chat/) like Anthropic and Google.

--- a/docs/ai-agents/tutorials/quickstarts/tutorial-langchain.md
+++ b/docs/ai-agents/tutorials/quickstarts/tutorial-langchain.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: "LangChain"
-sidebar_position: 4
+sidebar_position: 2
 ---
 
 # Agent connector tutorial: LangChain
@@ -227,6 +227,6 @@ In this tutorial, you learned how to:
 
 ## Next steps
 
-- Add more agent connectors to your project. Explore other agent connectors in the [Airbyte agent connectors catalog](https://github.com/airbytehq/airbyte-agent-connectors) to give your agent access to more services like Stripe, HubSpot, and Salesforce.
+- Add more agent connectors to your project. Explore other agent connectors in the [Airbyte agent connectors catalog](../../connectors/) to give your agent access to more services like Stripe, HubSpot, and Salesforce.
 
 - Consider how you might like to expand your agent's capabilities. For example, you might want to trigger effects like sending a Slack message or an email based on the agent's findings. You aren't limited to the capabilities of Airbyte's agent connectors. You can use other libraries and integrations to build an increasingly robust agent ecosystem.

--- a/docs/ai-agents/tutorials/quickstarts/tutorial-mcp-server.md
+++ b/docs/ai-agents/tutorials/quickstarts/tutorial-mcp-server.md
@@ -1,6 +1,6 @@
 ---
-sidebar_label: "MCP server"
-sidebar_position: 2
+sidebar_label: "Agent Engine MCP"
+sidebar_position: 4
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/ai-agents/tutorials/quickstarts/tutorial-pydantic.md
+++ b/docs/ai-agents/tutorials/quickstarts/tutorial-pydantic.md
@@ -7,8 +7,6 @@ sidebar_position: 1
 
 In this tutorial, you'll create a new Python project with uv, add a Pydantic AI agent, equip it to use one of Airbyte's agent connectors, and use natural language to explore your data. This tutorial uses GitHub, but if you don't have a GitHub account, you can use one of Airbyte's other agent connectors and perform different operations.
 
-Using the Python SDK is more time-consuming than the Connector MCP server, but affords you the most control over the context you send to your agent.
-
 ## Overview
 
 This tutorial is for AI engineers and other technical users who work with data and AI tools. You can complete it in about 15 minutes.
@@ -234,6 +232,6 @@ In this tutorial, you learned how to:
 
 ## Next steps
 
-- Add more agent connectors to your project. Explore other agent connectors in the [Airbyte agent connectors catalog](https://github.com/airbytehq/airbyte-agent-connectors) to give your agent access to more services like Stripe, HubSpot, and Salesforce.
+- Add more agent connectors to your project. Explore other agent connectors in the [Airbyte agent connectors catalog](../../connectors) to give your agent access to more services like Stripe, HubSpot, and Salesforce.
 
 - Consider how you might like to expand your agent's capabilities. For example, you might want to trigger effects like sending a Slack message or an email based on the agent's findings. You aren't limited to the capabilities of Airbyte's agent connectors. You can use other libraries and integrations to build an increasingly robust agent ecosystem.

--- a/docs/vale-styles/config/vocabularies/Airbyte/accept.txt
+++ b/docs/vale-styles/config/vocabularies/Airbyte/accept.txt
@@ -24,6 +24,7 @@ Self-Managed Enterprise
 Elastic License 2.0
 ELv2
 MIT
+Agent Engine
 
 #
 # Common terms Airbyte uses
@@ -70,6 +71,7 @@ IP[s]
 CDC
 CRM[s]
 FAQ
+MCP
 
 # Airbyte connectors
 
@@ -93,6 +95,10 @@ Entra
 Slack
 Fargate
 MinIO
+Pydantic
+LangChain
+LangGraph
+FastMCP
 
 # Acceptable non-words that shouldn't trigger spellcheck
 

--- a/docusaurus/vercel.json
+++ b/docusaurus/vercel.json
@@ -690,6 +690,11 @@
       "source": "/ai-agents/api/api-reference/sonar/:path*",
       "destination": "/ai-agents/api/api-reference/agent-engine-api/:path*",
       "statusCode": 301
+    },
+    {
+      "source": "/ai-agents/tutorials/quickstarts/tutorial-python",
+      "destination": "/ai-agents/tutorials/quickstarts/tutorial-pydantic",
+      "statusCode": 301
     }
   ]
 }


### PR DESCRIPTION
## What

Adds two new quickstart tutorials for the Agent Engine, alongside the existing Pydantic AI one, so users can choose their preferred framework:
- **LangChain** (with LangGraph ReAct agent)
- **FastMCP** (build-your-own MCP server)

Also renames the existing tutorial's sidebar label from "Open source Python SDK" → "Pydantic AI" for consistency across the three quickstarts.

Requested by @ian-at-airbyte
[Link to Devin Session](https://app.devin.ai/sessions/3fa083d689f64f71bebe613ed2b3ff37)

## How

- Added `tutorial-langchain.md`: step-by-step guide using `langchain-openai` and `langgraph` to wrap the GitHub connector as a tool (via LangChain's `@tool` decorator) and build a ReAct agent.
- Added `tutorial-fastmcp.md`: step-by-step guide using `fastmcp` to expose the GitHub connector as an MCP tool, with registration instructions for Claude Code, Claude Desktop, and Cursor.
- Updated `tutorial-python.md` frontmatter: sidebar label changed to "Pydantic AI", title updated to match.
- Updated `connectors/readme.md`: "How to work with agent connectors" now links to all three quickstarts.
- Renamed 'tutorial-python' to `tutorial-pydantic` and set up redirect for Vercel.
- Adjusted doc metadata to reorder items in sidebar.

All three tutorials consistently use `@GithubConnector.tool_utils` (the current connector decorator API, available in package versions 0.18.39+ which require Python 3.13+). Both new tutorials were tested end-to-end (connector → LLM tool call → natural language response) against the live GitHub API with Python 3.13.

## Review guide

1. `docs/ai-agents/tutorials/quickstarts/tutorial-langchain.md` — New LangChain tutorial
2. `docs/ai-agents/tutorials/quickstarts/tutorial-fastmcp.md` — New FastMCP tutorial
3. `docs/ai-agents/tutorials/quickstarts/tutorial-python.md` — Sidebar label and title rename only
4. `docs/ai-agents/connectors/readme.md` — Link list update only

Both tutorials were tested end-to-end, but it would be helpful to verify the LangChain and FastMCP tool use is written as we intend. Devin's original code sample was a completely wrong.

## User Impact

Users browsing the Agent Engine quickstarts will see three clearly labeled options (Pydantic AI, LangChain, FastMCP) instead of a single "Open source Python SDK" entry. All three tutorials follow the same structure and can be completed in ~15 minutes each. No existing functionality is changed.

## Can this PR be safely reverted and rolled back?

- [x] YES - but beware URL redirections would also be undone if rolled back.