### PR TITLE
docs: add BEHAVIOR.md and CLAUDE.md for 27 certified source connectors

### DIFF
--- a/airbyte-integrations/connectors/source-airtable/BEHAVIOR.md
+++ b/airbyte-integrations/connectors/source-airtable/BEHAVIOR.md
@@ -1,0 +1,7 @@
+# source-airtable: Unique Behaviors
+
+## 1. Single-Use Rotating Refresh Tokens
+
+Airtable's OAuth implementation issues single-use refresh tokens. Every time an access token is refreshed, the old refresh token is invalidated and a new one is returned. The connector uses `refresh_token_updater` to persist the new refresh token back to the connection configuration after each token exchange.
+
+**Why this matters:** If a token refresh succeeds but the new refresh token fails to persist (e.g., due to a crash or network issue between the exchange and the config update), the connection becomes permanently broken and requires re-authentication. Standard OAuth connectors can retry with the same refresh token, but Airtable cannot.

--- a/airbyte-integrations/connectors/source-airtable/CLAUDE.md
+++ b/airbyte-integrations/connectors/source-airtable/CLAUDE.md
@@ -1,0 +1,5 @@
+# source-airtable
+
+## Unique Behaviors
+See [BEHAVIOR.md](./BEHAVIOR.md) for documented unique behaviors:
+1. Single-use rotating refresh tokens

--- a/airbyte-integrations/connectors/source-amazon-ads/BEHAVIOR.md
+++ b/airbyte-integrations/connectors/source-amazon-ads/BEHAVIOR.md
@@ -1,0 +1,15 @@
+# source-amazon-ads: Unique Behaviors
+
+## 1. Async Report Generation with Polling and Download
+
+Report streams use the `AsyncRetriever` pattern instead of standard REST pagination. The connector creates a report via POST, polls a separate endpoint for the report's completion status, and then downloads the finished report from a URL provided in the polling response. This three-phase workflow (create → poll → download) means report streams have fundamentally different timing characteristics than standard entity streams: each report slice involves multiple sequential HTTP requests with wait intervals between polls.
+
+The connector enforces a configurable `max_concurrent_async_job_count` (default 10) to limit how many reports are being generated simultaneously across all streams.
+
+**Why this matters:** Report streams cannot be treated like standard paginated streams. They require polling intervals, have separate error handlers for creation vs. polling phases, and can take minutes to complete per slice. If you add a new report stream, you must configure all three phases (creation requester, polling requester, download requester) and their respective error handlers independently.
+
+## 2. HTTP 425 (Too Early) for Duplicate Report Requests
+
+When a user syncs the same report type with different time granularities simultaneously (e.g., daily and monthly versions of the same report), Amazon detects these as duplicate requests and returns HTTP 425. The connector treats this as a config error because the only fix is to either use separate sources for different granularities or set the number of concurrent workers to 2 for sequential processing.
+
+**Why this matters:** HTTP 425 is extremely rare in REST APIs and is not handled by default error handlers. If you see a config error mentioning "duplicate report requests," it is not a credential or permission issue — it is a concurrency conflict that requires changing the source configuration or splitting into separate connections.

--- a/airbyte-integrations/connectors/source-amazon-ads/CLAUDE.md
+++ b/airbyte-integrations/connectors/source-amazon-ads/CLAUDE.md
@@ -1,0 +1,6 @@
+# source-amazon-ads
+
+## Key Documentation
+- See `BEHAVIOR.md` for unique connector behaviors including:
+  1. Async report generation with three-phase create/poll/download workflow
+  2. HTTP 425 (Too Early) for duplicate concurrent report requests

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/BEHAVIOR.md
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/BEHAVIOR.md
@@ -19,3 +19,75 @@ When Amazon SP API returns a 403 with a message indicating the access token has 
 The custom backoff strategy computes wait time as the reciprocal of the `Retry-After` header value (i.e., `1 / header_value`) instead of using the header value directly. This is because Amazon's `x-amzn-RateLimit-Limit` header returns requests-per-second, not seconds-to-wait.
 
 **Why this matters:** If you see a `Retry-After` value of 0.5, the connector waits 2 seconds (1/0.5), not 0.5 seconds. This inverted interpretation is specific to Amazon's rate limit header semantics and would produce incorrect wait times if applied to other APIs.
+
+## 4. Regression Tests Will Not Run for This Connector
+
+The OAuth token refresh flow fails when running "locally" or via regression tests due to an issue in the CDK's [`abstract_oauth.py` refresh method](https://github.com/airbytehq/airbyte-python-cdk/blob/9ec30dc780ffc44ef132aee7c728bbc23c77afca/airbyte_cdk/sources/streams/http/requests_native_auth/abstract_oauth.py#L195). This is **only** an issue in local/regression test environments, not in Cloud.
+
+**Alternate testing process:**
+1. Create a dev image of the connector branch
+2. Set up a new source on a Cloud test account using integration test credentials
+3. Set up a destination as `dev/null` — verify source setup succeeds and first sync completes
+4. Pin customer actor IDs to the dev image and verify that existing customer syncs continue to run without issues
+
+**PRs for this connector should be rolled out via progressive rollouts** while this local testing limitation exists.
+
+**Why this matters:** You cannot rely on regression tests or local runs to validate changes to this connector. The only reliable way to test is through Cloud with a dev image. Skipping the Cloud-based testing process risks shipping broken changes that won't be caught until production.
+
+## 5. Standard Tests Will Not Pass for All Streams
+
+The test `test_basic_read['config' Test Scenario]` fails for `GET_VENDOR_FORECASTING_RETAIL_REPORT` and `GET_VENDOR_FORECASTING_FRESH_REPORT` due to sandbox account permissions:
+
+> `Report type 56300 does not support account ID of type class com.amazon.partner.account.id.MerchantAccountId.`
+
+This error has been returning since at least v4.4.7 of the connector (before these streams were migrated to low-code). This should be resolved once Standard Tests can bypass specific streams — an upcoming update expected in the next few weeks.
+
+## 6. Known Stream Failures in Testing
+
+The following streams have known failures when running against test/sandbox credentials. These are **not** connector bugs — they are limitations of the test account or sandbox environment.
+
+### Permission Errors (403 Forbidden)
+
+| Stream | Failure Reason |
+|--------|---------------|
+| VendorDirectFulfillmentShipping | `Forbidden. You don't have permission to access this resource.` |
+| VendorOrders | `Forbidden. You don't have permission to access this resource.` (repeated 5 times) |
+| GET_FLAT_FILE_ACTIONABLE_ORDER_DATA_SHIPPING | `Access to the resource is forbidden` (403 from POST request to SP-API) |
+| GET_ORDER_REPORT_DATA_SHIPPING | `Access to the resource is forbidden` (403 from POST request to SP-API) |
+
+### Timeout Errors
+
+| Stream | Failure Reason |
+|--------|---------------|
+| GET_FBA_STORAGE_FEE_CHARGES_DATA | `Job timed out for slice 2023-09-01 to 2023-09-30` |
+| GET_LEDGER_DETAIL_VIEW_DATA | `Job timed out for slice 2023-09-01 to 2023-09-30` |
+| GET_LEDGER_SUMMARY_VIEW_DATA | `Job timed out for slice 2023-09-01 to 2023-09-30` |
+| GET_FBA_FULFILLMENT_CUSTOMER_RETURNS_DATA | `Job timed out for slice 2023-09-01 to 2023-09-30` |
+| GET_AFN_INVENTORY_DATA_BY_COUNTRY | `Job timed out for slice 2023-09-01 to 2023-09-30` |
+| GET_FBA_INVENTORY_PLANNING_DATA | `Job timed out for slice 2023-09-01 to 2023-09-30` |
+| GET_FLAT_FILE_ARCHIVED_ORDERS_DATA_BY_ORDER_DATE | `Job timed out for slice 2023-09-01 to 2023-09-30` |
+| GET_STRANDED_INVENTORY_UI_DATA | `Job timed out for slice 2023-09-01 to 2023-09-30` |
+
+### Job Failed to Complete
+
+| Stream | Failure Reason |
+|--------|---------------|
+| GET_AMAZON_FULFILLED_SHIPMENTS_DATA_GENERAL | `Job failed for slice 2023-09-01 to 2023-09-30` |
+| GET_FBA_FULFILLMENT_REMOVAL_ORDER_DETAIL_DATA | `Job failed for slice 2023-09-01 to 2023-09-30` |
+| GET_FBA_REIMBURSEMENTS_DATA | `Job failed for slice 2023-09-01 to 2023-09-30` |
+| GET_SELLER_FEEDBACK_DATA | `Job failed to start` |
+| GET_FBA_SNS_PERFORMANCE_DATA | `Job failed for slice 2023-09-01 to 2023-09-30` |
+| GET_FBA_SNS_FORECAST_DATA | `Job failed for slice 2023-09-01 to 2023-09-30` |
+| GET_FBA_MYI_UNSUPPRESSED_INVENTORY_DATA | `Job failed for slice 2023-09-01 to 2023-09-30` |
+| GET_FBA_FULFILLMENT_CUSTOMER_SHIPMENT_PROMOTION_DATA | `Job failed for slice 2023-09-01 to 2023-09-30` |
+| GET_FBA_ESTIMATED_FBA_FEES_TXT_DATA | `Job failed for slice 2023-09-01 to 2023-09-30` |
+| GET_FBA_FULFILLMENT_CUSTOMER_SHIPMENT_REPLACEMENT_DATA | `Job failed for slice 2023-09-01 to 2023-09-30` |
+| GET_FBA_FULFILLMENT_REMOVAL_SHIPMENT_DETAIL_DATA | `Job failed for slice 2023-09-01 to 2023-09-30` |
+| GET_VENDOR_FORECASTING_FRESH_REPORT | `Job failed to start` |
+| GET_VENDOR_FORECASTING_RETAIL_REPORT | `Job failed to start` |
+
+### Invalid Input
+
+| Stream | Failure Reason |
+|--------|---------------|
+| GET_V2_SETTLEMENT_REPORT_DATA_FLAT_FILE | `RequestedFromDate 2023-09-30T00:00:00.000Z is more than 90 days old` (400 InvalidInput) |

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/BEHAVIOR.md
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/BEHAVIOR.md
@@ -1,0 +1,21 @@
+# source-amazon-seller-partner: Unique Behaviors
+
+## 1. Report Responses Are Gzip-Compressed CSV, XML, or JSON (Not Standard REST)
+
+Amazon SP API report streams do not return standard JSON REST responses. Instead, reports are fetched as gzip-compressed files that may contain CSV, XML, or JSON data depending on the report type. The connector uses three custom decoders (`GzipCsvDecoder`, `GzipXmlDecoder`, `GzipJsonDecoder`) to handle each format.
+
+For CSV reports, the column headers can be localized per marketplace. For example, seller feedback reports return different column names depending on the seller's marketplace ID, and some marketplaces use different date formats in their CSV output.
+
+**Why this matters:** A single connector handles three fundamentally different response formats behind the scenes. Adding a new report stream requires knowing which format that report uses and selecting the correct decoder. CSV reports may also need marketplace-specific date parsing logic.
+
+## 2. Reactive Token Invalidation on 403 Errors
+
+When Amazon SP API returns a 403 with a message indicating the access token has expired, the connector's custom authenticator (`AmazonSPOauthAuthenticator`) forcibly invalidates the current token by setting its expiry date to the Unix epoch. This is triggered by a custom backoff strategy (`AmazonSellerPartnerWaitTimeFromHeaderBackoffStrategy`) that detects the 403, calls the authenticator's `invalidate_token()` method via a module-level global reference, and then retries the request with a freshly refreshed token.
+
+**Why this matters:** Token invalidation happens through a global module-level variable linking the backoff strategy to the authenticator instance, which is unusual. If this global reference breaks (e.g., due to refactoring), 403 token-expired errors will not trigger token refresh and will instead fail permanently.
+
+## 3. Reciprocal Retry-After Header for Backoff
+
+The custom backoff strategy computes wait time as the reciprocal of the `Retry-After` header value (i.e., `1 / header_value`) instead of using the header value directly. This is because Amazon's `x-amzn-RateLimit-Limit` header returns requests-per-second, not seconds-to-wait.
+
+**Why this matters:** If you see a `Retry-After` value of 0.5, the connector waits 2 seconds (1/0.5), not 0.5 seconds. This inverted interpretation is specific to Amazon's rate limit header semantics and would produce incorrect wait times if applied to other APIs.

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/CLAUDE.md
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/CLAUDE.md
@@ -1,0 +1,7 @@
+# source-amazon-seller-partner
+
+## Key Documentation
+- See `BEHAVIOR.md` for unique connector behaviors including:
+  1. Gzip-compressed report responses in CSV, XML, or JSON formats
+  2. Reactive token invalidation on 403 errors via global module reference
+  3. Reciprocal Retry-After header interpretation for backoff timing

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/CLAUDE.md
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/CLAUDE.md
@@ -5,3 +5,6 @@
   1. Gzip-compressed report responses in CSV, XML, or JSON formats
   2. Reactive token invalidation on 403 errors via global module reference
   3. Reciprocal Retry-After header interpretation for backoff timing
+  4. Regression tests will not run locally — must test via Cloud dev image + progressive rollout
+  5. Standard tests fail for vendor forecasting streams (sandbox permission issue since v4.4.7)
+  6. Known stream failures in testing — permission errors, timeouts, job failures, invalid input (see tables in BEHAVIOR.md)

--- a/airbyte-integrations/connectors/source-amplitude/BEHAVIOR.md
+++ b/airbyte-integrations/connectors/source-amplitude/BEHAVIOR.md
@@ -1,0 +1,15 @@
+# source-amplitude: Unique Behaviors
+
+## 1. Matrix-Style API Response Extraction
+
+Amplitude's Dashboard REST API (Average Session Length, Active Users) does not return records as individual objects. Instead, it returns parallel arrays: `xValues` contains dates and `series` contains nested value arrays. The connector uses custom extractors (`AverageSessionLengthRecordExtractor`, `ActiveUsersRecordExtractor`) to zip these arrays together and construct individual records.
+
+For Active Users specifically, the `series` field is a 2D matrix (one row per metric label like "1 Day Active", "7 Day Active"), and the extractor transposes this matrix with `zip(*series)` before pairing with dates.
+
+**Why this matters:** What looks like a single API response actually requires matrix transposition and array zipping to produce usable records. Adding a new analytics stream that uses this response format requires a custom extractor rather than a standard DpathExtractor.
+
+## 2. Hard Export Size Limit with Timeout Fallback
+
+Amplitude's API enforces a 4GB export size limit, returning HTTP 400 when exceeded. Additionally, large data volumes can trigger HTTP 504 timeouts. Amplitude's own documentation recommends using their Amazon S3 destination for large exports instead of the REST API. The connector surfaces these as config errors with guidance to shorten the `request_time_range` interval.
+
+**Why this matters:** Syncs that work fine for small date ranges can suddenly fail when the date range grows large enough to exceed 4GB or trigger a timeout, with no way to resume from where it left off within that range.

--- a/airbyte-integrations/connectors/source-amplitude/CLAUDE.md
+++ b/airbyte-integrations/connectors/source-amplitude/CLAUDE.md
@@ -1,0 +1,6 @@
+# source-amplitude
+
+## Unique Behaviors
+See [BEHAVIOR.md](./BEHAVIOR.md) for documented unique behaviors:
+1. Matrix-style API response extraction (xValues/series zipping)
+2. Hard 4GB export size limit with timeout fallback

--- a/airbyte-integrations/connectors/source-bing-ads/BEHAVIOR.md
+++ b/airbyte-integrations/connectors/source-bing-ads/BEHAVIOR.md
@@ -1,0 +1,13 @@
+# source-bing-ads: Unique Behaviors
+
+## 1. Duplicate Records from Predicate-Based Filtering
+
+When the connector is configured with `account_names` predicates (e.g., filter accounts containing "Airbyte" AND accounts containing "Plumbing"), a single account matching multiple predicates will be returned once per matching predicate. The `DuplicatedRecordsFilter` component deduplicates these by tracking seen record IDs and only emitting each record once.
+
+**Why this matters:** Without this filter, users with multiple account name predicates would see duplicate records in their destination. The deduplication only activates when predicates are configured, so it is invisible during testing without predicates.
+
+## 2. Bulk Report Downloads May Arrive Uncompressed Despite Gzip Content-Type
+
+Bing Ads bulk report streams download files from Azure Blob Storage URLs. These files are expected to be gzip-compressed CSV, but the `BingAdsGzipCsvDecoder` includes fallback logic to handle cases where the file arrives uncompressed despite the expected gzip format. The decoder attempts gzip decompression first and falls back to reading the raw content if decompression fails.
+
+**Why this matters:** If you assume all bulk downloads are properly gzip-compressed, you will encounter intermittent failures. Azure Blob Storage does not always apply compression consistently, so the decoder must handle both compressed and uncompressed responses for the same stream.

--- a/airbyte-integrations/connectors/source-bing-ads/CLAUDE.md
+++ b/airbyte-integrations/connectors/source-bing-ads/CLAUDE.md
@@ -1,0 +1,6 @@
+# source-bing-ads
+
+## Key Documentation
+- See `BEHAVIOR.md` for unique connector behaviors including:
+  1. Duplicate records from predicate-based account filtering
+  2. Bulk report downloads that may arrive uncompressed despite gzip expectation

--- a/airbyte-integrations/connectors/source-chargebee/BEHAVIOR.md
+++ b/airbyte-integrations/connectors/source-chargebee/BEHAVIOR.md
@@ -1,0 +1,7 @@
+# source-chargebee: Unique Behaviors
+
+## 1. Product Catalog Version-Gated Streams
+
+Chargebee has two incompatible Product Catalog versions (1.0 and 2.0), and many streams only work with one version. When a stream is requested against the wrong Product Catalog version, the API returns a response with `api_error_code: configuration_incompatible`. The connector silently ignores these responses via a predicate-based error filter rather than failing the sync.
+
+**Why this matters:** A Chargebee account on Product Catalog 2.0 will silently produce zero records for streams that only exist in Product Catalog 1.0 (like `addon`), and vice versa. There is no upfront validation of which catalog version the account uses, so streams quietly return empty rather than raising an error explaining the incompatibility.

--- a/airbyte-integrations/connectors/source-chargebee/CLAUDE.md
+++ b/airbyte-integrations/connectors/source-chargebee/CLAUDE.md
@@ -1,0 +1,5 @@
+# source-chargebee
+
+## Unique Behaviors
+See [BEHAVIOR.md](./BEHAVIOR.md) for documented unique behaviors:
+1. Product Catalog version-gated streams (silently ignored via `configuration_incompatible`)

--- a/airbyte-integrations/connectors/source-gitlab/BEHAVIOR.md
+++ b/airbyte-integrations/connectors/source-gitlab/BEHAVIOR.md
@@ -1,0 +1,7 @@
+# source-gitlab: Unique Behaviors
+
+## 1. Single-Use Rotating Refresh Tokens
+
+GitLab's OAuth implementation issues single-use refresh tokens. Every time an access token is refreshed, the old refresh token is invalidated and a new one is returned. The connector uses `refresh_token_updater` to persist the new refresh token back to the connection configuration after each token exchange.
+
+**Why this matters:** If a token refresh succeeds but the new refresh token fails to persist (e.g., due to a crash or network issue between the exchange and the config update), the connection becomes permanently broken and requires re-authentication. Standard OAuth connectors can retry with the same refresh token, but GitLab cannot.

--- a/airbyte-integrations/connectors/source-gitlab/CLAUDE.md
+++ b/airbyte-integrations/connectors/source-gitlab/CLAUDE.md
@@ -1,0 +1,5 @@
+# source-gitlab
+
+## Unique Behaviors
+See [BEHAVIOR.md](./BEHAVIOR.md) for documented unique behaviors:
+1. Single-use rotating refresh tokens

--- a/airbyte-integrations/connectors/source-google-analytics-data-api/BEHAVIOR.md
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/BEHAVIOR.md
@@ -1,5 +1,11 @@
 # source-google-analytics-data-api: Unique Behaviors
 
+## Important: Naming Convention — GA4 vs Universal Analytics
+
+This connector is **Google Analytics 4 (GA4)** with package name `source-google-analytics-data-api`. It is very commonly confused with the legacy connector **Google Analytics (Universal Analytics)** with package name `source-google-analytics-v4`.
+
+The "GA4" identifier in the modern Google Analytics connector and the legacy Universal Analytics API being on "v4" often causes these to be mixed up. Now that the legacy Universal Analytics API was fully deprecated on **July 1, 2024**, no development work will ever be done in the `source-google-analytics-v4` package again. All work should be done in `source-google-analytics-data-api` from now on.
+
 ## 1. Positional Key-Value Array Extraction
 
 GA4's RunReport API returns dimension and metric headers separately from their values. Each row contains `dimensionValues` and `metricValues` as flat arrays of objects (e.g., `[{"value": "20231001"}, {"value": "organic"}]`), not as key-value pairs. The connector uses `KeyValueExtractor` to zip the header names with the flat value stream, chunking by the number of keys to reconstruct individual records.
@@ -57,3 +63,11 @@ When a custom report includes a `cohortSpec` with `enabled: "true"`, the manifes
 This means cohort reports are always full-refresh with no incremental support, and their request body structure is fundamentally different from non-cohort reports.
 
 **Why this matters:** The same stream template produces two structurally different API requests depending on whether cohorts are enabled. Testing or modifying cohort behavior requires tracing through all the `{% if cohort %}` conditionals scattered across multiple component mappings to understand the full impact.
+
+## 6. Rate Limit Quota Cannot Be Self-Service Increased
+
+Most Google APIs allow quota increases through the [API & Services dashboard on GCP](https://console.cloud.google.com/apis/dashboard?project=prod-ab-cloud-proj). However, the Google Analytics Data API is **not** one of them — the quota cannot be self-service increased from the GCP console.
+
+If rate-limited requests increase and a higher quota is needed, you must reach out to the DoIT contact (via Ralph or Davin) to request a quota increase on our behalf.
+
+**Why this matters:** Unlike most Google connectors where rate limit issues can be resolved by bumping quotas in the GCP console, GA4 rate limit issues require an external escalation through DoIT. This means rate limit problems cannot be quickly self-resolved and require coordination with external parties.

--- a/airbyte-integrations/connectors/source-google-analytics-data-api/BEHAVIOR.md
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/BEHAVIOR.md
@@ -7,3 +7,53 @@ GA4's RunReport API returns dimension and metric headers separately from their v
 Similarly, `CombinedExtractor` merges records from separate sub-extractors (one for dimensions, one for metrics) by zipping them together, so each final record contains both dimension and metric fields.
 
 **Why this matters:** Unlike most APIs that return records as self-describing objects, GA4 returns positional data that only makes sense when paired with the separately-returned header definitions. Any change to the dimensions or metrics requested will shift all value positions, and the extraction logic must correctly chunk the flat value array by key count.
+
+## 2. Two-Level Jinja Interpolation in Component Mappings
+
+The manifest's `components_mapping` section uses two distinct levels of Jinja interpolation that execute at different times:
+
+1. **Template-level interpolation** resolves `components_values` during stream template building (e.g., `{{ components_values["metrics"] }}` expands into the actual metric list from the config).
+2. **Runtime interpolation** resolves `stream_slice`, `config`, and `response` during sync execution (e.g., `{{ stream_slice.start_time }}`).
+
+To prevent the second level from being evaluated during template building (when `stream_slice` doesn't exist yet), the manifest wraps runtime expressions in `{% raw %}...{% endraw %}` blocks. For example:
+```
+value: "{% raw %}{{ stream_slice.start_time or config.get('date_ranges_start_date', day_delta(-730, '%Y-%m-%d')) }}{% endraw %}"
+```
+
+The schema filter condition goes even further, using string concatenation with `~` to inject template-level values into a runtime expression:
+```
+{{ '{{ record.keys() | list | first in ' ~ (components_values["metrics"] | tojson) ~ ' }}' }}
+```
+
+**Why this matters:** Editing any interpolation in the `components_mapping` section requires understanding which level of interpolation applies. Forgetting a `{% raw %}` wrapper will cause a template build failure when the runtime variable doesn't exist yet. Conversely, wrapping a `components_values` reference in `{% raw %}` will leave it unresolved, producing broken requests.
+
+## 3. Fully Dynamic Stream Construction from Config
+
+Every stream in this connector is generated dynamically via `ConfigComponentsResolver`. There are no statically-defined streams in the manifest — only a `google_analytics_stream_template` that serves as a blueprint. The resolver takes user-defined custom reports (dimensions, metrics, optional pivots, cohorts, dimension filters) and the list of property IDs, then uses 12+ `ComponentMappingDefinition` entries to override nearly every part of the template:
+
+- The API path switches between `:runReport` and `:runPivotReport` based on whether pivots are configured
+- Pagination is conditionally disabled (`NoPagination`) for pivot reports since the GA4 API doesn't support pagination on pivot queries
+- The incremental sync cursor is auto-detected by scanning dimensions for date-like fields (`date`, `yearWeek`, `yearMonth`, `year`), with the first match becoming the cursor field
+- Stream naming follows a backward-compatible convention: the first property ID uses the plain report name, while additional property IDs get a `Property<id>` suffix (e.g., `devices` vs `devicesProperty5729978930`)
+- The schema is constructed at build time by fetching metadata from the GA4 API and filtering it against the requested metrics, then adding dimension fields via schema transformations
+
+**Why this matters:** There is no single place in the manifest that shows what a given stream looks like at runtime. To understand the final shape of a stream, you must mentally execute the 12+ component mappings against the user's config. Adding a new feature (e.g., a new report parameter) requires adding a mapping entry and understanding how it interacts with all the conditional branches.
+
+## 4. DimensionFilter Config Transformation
+
+The connector uses a custom `DimensionFilterConfigTransformation` component to reshape dimension filter definitions from the user-facing config format into the format required by the GA4 RunReport API. This is performed as a record transformation at sync time, not as a config migration.
+
+The transformation handles four filter types (`andGroup`, `orGroup`, `notExpression`, `filter`) and four sub-filter types (`stringFilter`, `inListFilter`, `numericFilter`, `betweenFilter`), each with different structural requirements. For example, `matchType` and `operation` fields arrive as single-element arrays from the config UI and must be unwrapped to plain strings.
+
+**Why this matters:** The config schema for dimension filters looks nothing like the API request schema. If you need to add a new filter type or modify existing filter behavior, changes must be made in the `DimensionFilterConfigTransformation` component rather than in the manifest's request body interpolation, because the interpolation simply passes through the already-transformed result.
+
+## 5. Cohort Reports Disable Date Ranges and Incremental Sync
+
+When a custom report includes a `cohortSpec` with `enabled: "true"`, the manifest's interpolation conditionally:
+- Replaces `dateRanges` in the request body with a `cohortSpec` block
+- Omits the `startDate` and `endDate` fields from record transformations and schema transformations
+- Skips adding the `DatetimeBasedCursor` incremental sync component entirely
+
+This means cohort reports are always full-refresh with no incremental support, and their request body structure is fundamentally different from non-cohort reports.
+
+**Why this matters:** The same stream template produces two structurally different API requests depending on whether cohorts are enabled. Testing or modifying cohort behavior requires tracing through all the `{% if cohort %}` conditionals scattered across multiple component mappings to understand the full impact.

--- a/airbyte-integrations/connectors/source-google-analytics-data-api/BEHAVIOR.md
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/BEHAVIOR.md
@@ -1,0 +1,9 @@
+# source-google-analytics-data-api: Unique Behaviors
+
+## 1. Positional Key-Value Array Extraction
+
+GA4's RunReport API returns dimension and metric headers separately from their values. Each row contains `dimensionValues` and `metricValues` as flat arrays of objects (e.g., `[{"value": "20231001"}, {"value": "organic"}]`), not as key-value pairs. The connector uses `KeyValueExtractor` to zip the header names with the flat value stream, chunking by the number of keys to reconstruct individual records.
+
+Similarly, `CombinedExtractor` merges records from separate sub-extractors (one for dimensions, one for metrics) by zipping them together, so each final record contains both dimension and metric fields.
+
+**Why this matters:** Unlike most APIs that return records as self-describing objects, GA4 returns positional data that only makes sense when paired with the separately-returned header definitions. Any change to the dimensions or metrics requested will shift all value positions, and the extraction logic must correctly chunk the flat value array by key count.

--- a/airbyte-integrations/connectors/source-google-analytics-data-api/CLAUDE.md
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/CLAUDE.md
@@ -1,5 +1,8 @@
 # source-google-analytics-data-api
 
+## Important
+This is **Google Analytics 4 (GA4)** (`source-google-analytics-data-api`), NOT the deprecated Universal Analytics (`source-google-analytics-v4`). All work goes here.
+
 ## Unique Behaviors
 See [BEHAVIOR.md](./BEHAVIOR.md) for documented unique behaviors:
 1. Positional key-value array extraction (headers and values returned separately)
@@ -7,3 +10,4 @@ See [BEHAVIOR.md](./BEHAVIOR.md) for documented unique behaviors:
 3. Fully dynamic stream construction from config (12+ ComponentMappingDefinitions, no static streams)
 4. DimensionFilter config transformation (config schema differs from API request schema)
 5. Cohort reports disable date ranges and incremental sync
+6. Rate limit quota cannot be self-service increased — requires DoIT escalation (via Ralph or Davin)

--- a/airbyte-integrations/connectors/source-google-analytics-data-api/CLAUDE.md
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/CLAUDE.md
@@ -3,3 +3,7 @@
 ## Unique Behaviors
 See [BEHAVIOR.md](./BEHAVIOR.md) for documented unique behaviors:
 1. Positional key-value array extraction (headers and values returned separately)
+2. Two-level Jinja interpolation in component mappings (`{% raw %}` for runtime vs template-level)
+3. Fully dynamic stream construction from config (12+ ComponentMappingDefinitions, no static streams)
+4. DimensionFilter config transformation (config schema differs from API request schema)
+5. Cohort reports disable date ranges and incremental sync

--- a/airbyte-integrations/connectors/source-google-analytics-data-api/CLAUDE.md
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/CLAUDE.md
@@ -1,0 +1,5 @@
+# source-google-analytics-data-api
+
+## Unique Behaviors
+See [BEHAVIOR.md](./BEHAVIOR.md) for documented unique behaviors:
+1. Positional key-value array extraction (headers and values returned separately)

--- a/airbyte-integrations/connectors/source-google-search-console/BEHAVIOR.md
+++ b/airbyte-integrations/connectors/source-google-search-console/BEHAVIOR.md
@@ -5,26 +5,7 @@ from standard declarative connector patterns. Read this before making changes to
 
 ---
 
-## 1. Two-Level Nested Substream State Migration
-
-Search Analytics streams are partitioned by two dimensions: `site_url` and `search_type`. The legacy
-state format stored cursors in a two-level nested structure
-(`{ "https://example.com/": { "web": { "date": "2025-05-25" } } }`), but the current declarative
-framework's `LegacyToPerPartitionStateMigration` only handles one level of nesting.
-
-The custom `NestedSubstreamStateMigration` handles this two-level migration by iterating over
-site URLs as the outer key and search types as the inner key, converting each combination into a
-per-partition state entry.
-
-**Why this matters:** If this migration is removed or broken, any connection that was created before the
-migration to the declarative framework will lose its cursor positions and re-sync all historical data
-from scratch. The migration also intentionally discards the legacy global cursor value because the
-previous Python implementation saved an unreliable "last seen partition" value rather than a true global
-maximum.
-
----
-
-## 2. POST-Based Search Analytics with Keys Array Response Format
+## 1. POST-Based Search Analytics with Keys Array Response Format
 
 All Search Analytics streams use POST requests to `/searchAnalytics/query` rather than GET requests.
 Google's Search Console API returns dimension values as a positional `keys` array in each row (e.g.,
@@ -44,43 +25,7 @@ values will appear in the device field and vice versa).
 
 ---
 
-## 3. Custom Reports with Dynamic Schema Generation
-
-Users can define custom search analytics reports in their config under `custom_reports_array`, selecting
-any combination of dimensions (country, date, device, page, query). These are rendered as
-`DynamicDeclarativeStream` instances. The `CustomReportSchemaLoader` generates a JSON schema at runtime
-based on which dimensions the user selected, mapping each dimension to its schema type using a static
-`DIMENSION_TO_PROPERTY_SCHEMA_MAP`.
-
-The `date` dimension is always force-included (even if not specified by the user) because it serves as
-the incremental sync cursor field.
-
-**Why this matters:** The schema for custom report streams is not static -- it is computed at runtime
-from the user's config. If you add a new possible dimension to the Search Console connector, you must
-also add its schema mapping to `DIMENSION_TO_PROPERTY_SCHEMA_MAP` in `CustomReportSchemaLoader`, or
-custom reports using that dimension will produce records with untyped fields.
-
----
-
-## 4. Dual Authentication: OAuth vs Service Account (JWT)
-
-The connector supports two completely different authentication flows via `SelectiveAuthenticator`:
-- **OAuth (`Client`):** Standard Google OAuth 2.0 with refresh tokens
-- **Service Account (`Service`):** JWT-based authentication using
-  `JwtProfileAssertionOAuthAuthenticator` with RS256 signing, a 3600-second token duration, and the
-  `webmasters.readonly` scope
-
-The service account flow parses the `service_account_info` JSON string from the config to extract the
-private key, client email, and token URI at runtime.
-
-**Why this matters:** These are two fundamentally different auth mechanisms that share nothing beyond the
-`SelectiveAuthenticator` switch. The Service Account path involves JWT construction, RS256 signing, and
-profile assertion -- if you modify the OAuth flow, the Service Account flow is unaffected and vice
-versa. Testing one auth type does not validate the other.
-
----
-
-## 5. Configurable Rate Limits with Low Default Quotas
+## 2. Configurable Rate Limits with Low Default Quotas
 
 Google Search Console has three layers of rate limits: per-site (1,200 req/min max), per-user
 (1,200 req/min max), and per-project (40,000 req/min max). However, most new or unbilled Google Cloud
@@ -97,7 +42,7 @@ Google Cloud Console quota and adjust `requests_per_minute` accordingly. The con
 
 ---
 
-## 6. AggregationType Override for Compatibility
+## 3. AggregationType Override for Compatibility
 
 Some Google Search Console implementations return a 400 error for certain `aggregationType` values
 (`byPage`, `byProperty`). This is customer-specific and depends on how their Search Console property is
@@ -111,33 +56,3 @@ enable this setting.
 uses `byPage` or `search_analytics_site_report_by_site` which uses `byProperty`) will fail with a 400
 error for some customers. The error looks like a connector bug but is actually a Google API limitation
 based on the customer's property type. This config option is the escape hatch.
-
----
-
-## 7. Config Migration from String to Array Format
-
-The connector migrates the legacy `custom_reports` config (a JSON string) to the current
-`custom_reports_array` format (a native array) via `ConfigNormalizationRules`. The migration uses Jinja
-interpolation which automatically infers the datatype, so no explicit JSON parsing is needed.
-
-After migration, the config is validated against a schema that enforces required fields (`name`,
-`dimensions`) and valid dimension enum values (`country`, `date`, `device`, `page`, `query`).
-
-**Why this matters:** If you modify the custom reports config structure, you must ensure the migration
-still works for connections created with the old string-based format. The validation runs after
-migration, so invalid legacy configs will surface validation errors rather than silently producing
-broken streams.
-
----
-
-## 8. Search Appearance Keyword Streams as Substreams
-
-The `search_analytics_keyword_*` streams are substreams of a parent `search_appearances` stream. The
-parent stream fetches the list of search appearances (rich result types like AMP, FAQ, etc.) for each
-site URL and search type combination. Each keyword stream then makes filtered API calls using
-`dimensionFilterGroups` to get analytics data for each specific search appearance type.
-
-**Why this matters:** The keyword streams generate one API call per search appearance type per site URL
-per search type per date slice. If a site has many search appearance types, the number of API calls
-multiplies rapidly. These streams also do not use `NestedSubstreamStateMigration` because they were
-added after the migration to the declarative framework.

--- a/airbyte-integrations/connectors/source-google-search-console/BEHAVIOR.md
+++ b/airbyte-integrations/connectors/source-google-search-console/BEHAVIOR.md
@@ -1,0 +1,143 @@
+# source-google-search-console: Unique Connector Behaviors
+
+This document describes the biggest non-obvious gotchas in `source-google-search-console` that deviate
+from standard declarative connector patterns. Read this before making changes to the connector.
+
+---
+
+## 1. Two-Level Nested Substream State Migration
+
+Search Analytics streams are partitioned by two dimensions: `site_url` and `search_type`. The legacy
+state format stored cursors in a two-level nested structure
+(`{ "https://example.com/": { "web": { "date": "2025-05-25" } } }`), but the current declarative
+framework's `LegacyToPerPartitionStateMigration` only handles one level of nesting.
+
+The custom `NestedSubstreamStateMigration` handles this two-level migration by iterating over
+site URLs as the outer key and search types as the inner key, converting each combination into a
+per-partition state entry.
+
+**Why this matters:** If this migration is removed or broken, any connection that was created before the
+migration to the declarative framework will lose its cursor positions and re-sync all historical data
+from scratch. The migration also intentionally discards the legacy global cursor value because the
+previous Python implementation saved an unreliable "last seen partition" value rather than a true global
+maximum.
+
+---
+
+## 2. POST-Based Search Analytics with Keys Array Response Format
+
+All Search Analytics streams use POST requests to `/searchAnalytics/query` rather than GET requests.
+Google's Search Console API returns dimension values as a positional `keys` array in each row (e.g.,
+`{"keys": ["2025-01-01", "US", "DESKTOP"], "clicks": 42}`) rather than as named fields. The connector
+must map each position in the `keys` array back to its corresponding dimension name using
+`AddFields` transformations.
+
+For built-in streams, this mapping is hardcoded (e.g., `record['keys'][0]` -> `date`,
+`record['keys'][1]` -> `country`). For custom report streams, the
+`CustomReportExtractDimensionsFromKeys` component handles this dynamically based on the dimensions
+configured in the user's custom report.
+
+**Why this matters:** The order of dimensions in the API request body determines the order of values in
+the `keys` array response. If you reorder the `dimensions` list in a stream's request body without
+updating the corresponding `AddFields` transformations, fields will be silently swapped (e.g., country
+values will appear in the device field and vice versa).
+
+---
+
+## 3. Custom Reports with Dynamic Schema Generation
+
+Users can define custom search analytics reports in their config under `custom_reports_array`, selecting
+any combination of dimensions (country, date, device, page, query). These are rendered as
+`DynamicDeclarativeStream` instances. The `CustomReportSchemaLoader` generates a JSON schema at runtime
+based on which dimensions the user selected, mapping each dimension to its schema type using a static
+`DIMENSION_TO_PROPERTY_SCHEMA_MAP`.
+
+The `date` dimension is always force-included (even if not specified by the user) because it serves as
+the incremental sync cursor field.
+
+**Why this matters:** The schema for custom report streams is not static -- it is computed at runtime
+from the user's config. If you add a new possible dimension to the Search Console connector, you must
+also add its schema mapping to `DIMENSION_TO_PROPERTY_SCHEMA_MAP` in `CustomReportSchemaLoader`, or
+custom reports using that dimension will produce records with untyped fields.
+
+---
+
+## 4. Dual Authentication: OAuth vs Service Account (JWT)
+
+The connector supports two completely different authentication flows via `SelectiveAuthenticator`:
+- **OAuth (`Client`):** Standard Google OAuth 2.0 with refresh tokens
+- **Service Account (`Service`):** JWT-based authentication using
+  `JwtProfileAssertionOAuthAuthenticator` with RS256 signing, a 3600-second token duration, and the
+  `webmasters.readonly` scope
+
+The service account flow parses the `service_account_info` JSON string from the config to extract the
+private key, client email, and token URI at runtime.
+
+**Why this matters:** These are two fundamentally different auth mechanisms that share nothing beyond the
+`SelectiveAuthenticator` switch. The Service Account path involves JWT construction, RS256 signing, and
+profile assertion -- if you modify the OAuth flow, the Service Account flow is unaffected and vice
+versa. Testing one auth type does not validate the other.
+
+---
+
+## 5. Configurable Rate Limits with Low Default Quotas
+
+Google Search Console has three layers of rate limits: per-site (1,200 req/min max), per-user
+(1,200 req/min max), and per-project (40,000 req/min max). However, most new or unbilled Google Cloud
+projects start with a quota of only 60 requests per minute, far below the documented maximum.
+
+The connector exposes a `requests_per_minute` config option (default: 1200) and injects it into the
+`api_budget` policy. The error handler specifically matches the string `"Search Analytics QPS quota
+exceeded"` to classify rate limit errors, using a 60-second constant backoff.
+
+**Why this matters:** The default rate limit of 1200 RPM will immediately cause rate limiting for most
+new Google Cloud projects. If customers report 429 errors, the first thing to check is their actual
+Google Cloud Console quota and adjust `requests_per_minute` accordingly. The connector also has a
+`num_workers` config (default: 3, max: 50) that controls concurrency.
+
+---
+
+## 6. AggregationType Override for Compatibility
+
+Some Google Search Console implementations return a 400 error for certain `aggregationType` values
+(`byPage`, `byProperty`). This is customer-specific and depends on how their Search Console property is
+configured. The connector provides an `always_use_aggregation_type_auto` boolean config that, when
+enabled, overrides all stream-specific `aggregationType` values to `auto`.
+
+The error handler explicitly matches HTTP 400 responses and surfaces a message telling the user to
+enable this setting.
+
+**Why this matters:** Without this override, certain streams (like `search_analytics_page_report` which
+uses `byPage` or `search_analytics_site_report_by_site` which uses `byProperty`) will fail with a 400
+error for some customers. The error looks like a connector bug but is actually a Google API limitation
+based on the customer's property type. This config option is the escape hatch.
+
+---
+
+## 7. Config Migration from String to Array Format
+
+The connector migrates the legacy `custom_reports` config (a JSON string) to the current
+`custom_reports_array` format (a native array) via `ConfigNormalizationRules`. The migration uses Jinja
+interpolation which automatically infers the datatype, so no explicit JSON parsing is needed.
+
+After migration, the config is validated against a schema that enforces required fields (`name`,
+`dimensions`) and valid dimension enum values (`country`, `date`, `device`, `page`, `query`).
+
+**Why this matters:** If you modify the custom reports config structure, you must ensure the migration
+still works for connections created with the old string-based format. The validation runs after
+migration, so invalid legacy configs will surface validation errors rather than silently producing
+broken streams.
+
+---
+
+## 8. Search Appearance Keyword Streams as Substreams
+
+The `search_analytics_keyword_*` streams are substreams of a parent `search_appearances` stream. The
+parent stream fetches the list of search appearances (rich result types like AMP, FAQ, etc.) for each
+site URL and search type combination. Each keyword stream then makes filtered API calls using
+`dimensionFilterGroups` to get analytics data for each specific search appearance type.
+
+**Why this matters:** The keyword streams generate one API call per search appearance type per site URL
+per search type per date slice. If a site has many search appearance types, the number of API calls
+multiplies rapidly. These streams also do not use `NestedSubstreamStateMigration` because they were
+added after the migration to the declarative framework.

--- a/airbyte-integrations/connectors/source-google-search-console/CLAUDE.md
+++ b/airbyte-integrations/connectors/source-google-search-console/CLAUDE.md
@@ -1,0 +1,16 @@
+# source-google-search-console
+
+Google Search Console API source connector built on the declarative framework with custom Python
+components for state migration, dimension extraction, and schema generation.
+
+## Key Behavior Documentation
+
+See [BEHAVIOR.md](BEHAVIOR.md) for the most important non-obvious gotchas in this connector, including:
+- Two-level nested substream state migration for site_url + search_type partitions
+- POST-based Search Analytics with positional keys array that must be mapped to dimension names
+- Custom reports with dynamic schema generation based on user-selected dimensions
+- Dual authentication (OAuth vs Service Account JWT) with completely separate code paths
+- Configurable rate limits where most new projects default far below the connector's limit
+- AggregationType override config for customers whose properties reject certain aggregation types
+- Config migration from legacy string format to array format for custom reports
+- Search appearance keyword streams implemented as substreams that multiply API calls

--- a/airbyte-integrations/connectors/source-google-search-console/CLAUDE.md
+++ b/airbyte-integrations/connectors/source-google-search-console/CLAUDE.md
@@ -6,11 +6,6 @@ components for state migration, dimension extraction, and schema generation.
 ## Key Behavior Documentation
 
 See [BEHAVIOR.md](BEHAVIOR.md) for the most important non-obvious gotchas in this connector, including:
-- Two-level nested substream state migration for site_url + search_type partitions
 - POST-based Search Analytics with positional keys array that must be mapped to dimension names
-- Custom reports with dynamic schema generation based on user-selected dimensions
-- Dual authentication (OAuth vs Service Account JWT) with completely separate code paths
 - Configurable rate limits where most new projects default far below the connector's limit
 - AggregationType override config for customers whose properties reject certain aggregation types
-- Config migration from legacy string format to array format for custom reports
-- Search appearance keyword streams implemented as substreams that multiply API calls

--- a/airbyte-integrations/connectors/source-google-sheets/BEHAVIOR.md
+++ b/airbyte-integrations/connectors/source-google-sheets/BEHAVIOR.md
@@ -1,0 +1,15 @@
+# source-google-sheets: Unique Behaviors
+
+## 1. Schema Derived from Row 1 with Positional Value Matching
+
+Google Sheets has no formal schema. The connector derives each stream's schema by reading row 1 of each sheet as column headers. All subsequent rows are matched to these headers by cell position, not by any key in the data. If row 1 has headers `["Name", "Age", "City"]`, then the third cell in every data row is assumed to be "City" regardless of its actual content.
+
+Duplicate headers are automatically deduplicated by appending the column letter (e.g., two columns named "Name" become "Name_A1" and "Name_C1"). Empty header cells terminate header parsing by default, but when `read_empty_header_columns` is enabled, empty headers get generated names like "column_C".
+
+**Why this matters:** The schema is entirely user-controlled via spreadsheet headers and can change between syncs if someone edits row 1. A renamed or reordered column silently shifts which data maps to which field, potentially corrupting downstream data without any error being raised. The positional matching also means that a row with fewer cells than headers will simply have missing fields rather than misaligned data.
+
+## 2. Batch Row Fetching with Per-Request Timeout Constraint
+
+Large sheets are fetched in configurable row batches (default 1,000,000 rows per batch) via `RangePartitionRouter`. Each batch is a separate Google Sheets API request. Google enforces a 180-second per-request timeout, so wide sheets (many columns) with large batch sizes may hit this limit before all rows in the batch are returned.
+
+**Why this matters:** A sheet with many columns may need a smaller `batch_size` to avoid 180-second timeouts, even if the total row count is modest. The default of 1M rows assumes relatively narrow sheets, and there is no automatic fallback if a batch times out.

--- a/airbyte-integrations/connectors/source-google-sheets/CLAUDE.md
+++ b/airbyte-integrations/connectors/source-google-sheets/CLAUDE.md
@@ -1,0 +1,6 @@
+# source-google-sheets
+
+## Unique Behaviors
+See [BEHAVIOR.md](./BEHAVIOR.md) for documented unique behaviors:
+1. Schema derived from row 1 with positional value matching and header deduplication
+2. Batch row fetching with per-request 180-second timeout constraint

--- a/airbyte-integrations/connectors/source-harvest/BEHAVIOR.md
+++ b/airbyte-integrations/connectors/source-harvest/BEHAVIOR.md
@@ -1,0 +1,99 @@
+# source-harvest: Unique Connector Behaviors
+
+This document describes the biggest non-obvious gotchas in `source-harvest` that deviate from standard
+declarative connector patterns. Read this before making changes to the connector.
+
+---
+
+## 1. Harvest-Account-Id Header Required on Every Request
+
+Every API request to Harvest requires a `Harvest-Account-Id` header containing the customer's account
+ID. This is not part of authentication -- it is a separate routing header that Harvest uses to identify
+which account's data to return. The header is injected on every stream's requester via
+`request_headers: Harvest-Account-Id: "{{ config['account_id'] }}"`.
+
+**Why this matters:** If you add a new stream and forget the `Harvest-Account-Id` header, the API will
+return a 404 or data from the wrong account context. This header must be present on every single
+request, even though it looks like it should be part of the authenticator. It is separate from auth
+because a single OAuth token can have access to multiple Harvest accounts.
+
+---
+
+## 2. Link-Based Cursor Pagination
+
+Harvest uses a non-standard pagination approach where the next page URL is embedded in the response
+body under `links.next` rather than using standard offset/page parameters or response headers. The
+paginator is configured as `CursorPagination` with `RequestPath` as the page token option, meaning the
+entire next-page URL from `response.links.next` replaces the request path on subsequent pages.
+
+**Why this matters:** This is not offset-based or token-based pagination in the usual sense. The
+`cursor_value` extracts a full URL from `response.get("links", {}).get("next", {})`, and the
+`stop_condition` checks for its absence. If you try to switch to `OffsetIncrement` or standard cursor
+pagination, it will break because Harvest's API does not support `page` or `offset` parameters on most
+endpoints.
+
+---
+
+## 3. Graceful Degradation on 401/403/404
+
+Every stream in source-harvest uses a `CompositeErrorHandler` that **ignores** (rather than fails on)
+HTTP 401, 403, and 404 responses. This means if a user's credentials lack permission to access a
+specific stream, or the account ID is incorrect for a particular resource, that stream silently produces
+zero records instead of failing the entire sync.
+
+**Why this matters:** This is an intentional design choice because Harvest's permission model is
+granular -- a user may have access to time entries but not invoices, for example. However, it also means
+that misconfigured credentials or an incorrect account ID will not produce an error; the sync will
+succeed with empty streams, which can be confusing to diagnose.
+
+---
+
+## 4. Report Streams Use Date-Range Slicing with Different Cursor Format
+
+The report streams (expenses_categories, expenses_clients, expenses_projects, expenses_team,
+project_budget, time_clients, time_projects, time_tasks, time_team, uninvoiced) use a fundamentally
+different incremental sync pattern than the entity streams. Entity streams use `updated_since` with
+ISO 8601 format (`%Y-%m-%dT%H:%M:%SZ`), while report streams use `from`/`to` date parameters with a
+compact date format (`%Y%m%d`) and 365-day steps.
+
+Report streams also inject `from` and `to` as `stream_partition.start_time` and
+`stream_partition.end_time` into each record via `AddFields` transformations, since the API response
+does not include the date range in the data itself.
+
+**Why this matters:** Entity streams and report streams have incompatible cursor formats and pagination
+patterns. If you copy an entity stream's incremental sync config to a report stream (or vice versa),
+the date filtering will silently break. Report streams cursor on `to` (end of range), not `updated_at`.
+
+---
+
+## 5. WaitTimeFromHeader Backoff Strategy
+
+Harvest's API returns a `Retry-After` header on rate-limited responses, and the connector uses
+`WaitTimeFromHeader` as its primary backoff strategy rather than exponential backoff. This is the first
+handler in the `CompositeErrorHandler` chain, meaning it takes precedence over the 401/403/404 IGNORE
+handlers.
+
+Harvest documents a rate limit of 100 requests per 15 seconds per token
+(https://help.getharvest.com/api-v2/introduction/overview/general/#rate-limiting).
+
+**Why this matters:** The `Retry-After` header tells the connector exactly how long to wait, so the
+connector will pause for precisely the time Harvest specifies. If you add a second backoff strategy
+(like `ExponentialBackoffStrategy`), make sure it comes after `WaitTimeFromHeader` in the chain so the
+API-specified wait time is honored first.
+
+---
+
+## 6. Substream Patterns for Messages, Payments, and Rates
+
+Several streams are implemented as substreams that partition by parent entity ID:
+- `estimate_messages` partitions by estimate ID
+- `invoice_messages` and `invoice_payments` partition by invoice ID
+- `project_assignments` and `billable_rates`/`cost_rates` partition by user or project ID
+
+Each substream injects the parent ID into records via `AddFields` transformations (e.g.,
+`parent_id: "{{stream_partition.id}}"`).
+
+**Why this matters:** These substreams make one API call per parent entity, so the total number of
+requests scales linearly with the number of parent records. A Harvest account with 10,000 invoices will
+generate 10,000 additional API calls just for `invoice_messages`. Combined with the `Retry-After`
+backoff, large accounts may experience very slow syncs for substreams.

--- a/airbyte-integrations/connectors/source-harvest/BEHAVIOR.md
+++ b/airbyte-integrations/connectors/source-harvest/BEHAVIOR.md
@@ -5,36 +5,7 @@ declarative connector patterns. Read this before making changes to the connector
 
 ---
 
-## 1. Harvest-Account-Id Header Required on Every Request
-
-Every API request to Harvest requires a `Harvest-Account-Id` header containing the customer's account
-ID. This is not part of authentication -- it is a separate routing header that Harvest uses to identify
-which account's data to return. The header is injected on every stream's requester via
-`request_headers: Harvest-Account-Id: "{{ config['account_id'] }}"`.
-
-**Why this matters:** If you add a new stream and forget the `Harvest-Account-Id` header, the API will
-return a 404 or data from the wrong account context. This header must be present on every single
-request, even though it looks like it should be part of the authenticator. It is separate from auth
-because a single OAuth token can have access to multiple Harvest accounts.
-
----
-
-## 2. Link-Based Cursor Pagination
-
-Harvest uses a non-standard pagination approach where the next page URL is embedded in the response
-body under `links.next` rather than using standard offset/page parameters or response headers. The
-paginator is configured as `CursorPagination` with `RequestPath` as the page token option, meaning the
-entire next-page URL from `response.links.next` replaces the request path on subsequent pages.
-
-**Why this matters:** This is not offset-based or token-based pagination in the usual sense. The
-`cursor_value` extracts a full URL from `response.get("links", {}).get("next", {})`, and the
-`stop_condition` checks for its absence. If you try to switch to `OffsetIncrement` or standard cursor
-pagination, it will break because Harvest's API does not support `page` or `offset` parameters on most
-endpoints.
-
----
-
-## 3. Graceful Degradation on 401/403/404
+## 1. Graceful Degradation on 401/403/404
 
 Every stream in source-harvest uses a `CompositeErrorHandler` that **ignores** (rather than fails on)
 HTTP 401, 403, and 404 responses. This means if a user's credentials lack permission to access a
@@ -48,7 +19,7 @@ succeed with empty streams, which can be confusing to diagnose.
 
 ---
 
-## 4. Report Streams Use Date-Range Slicing with Different Cursor Format
+## 2. Report Streams Use Date-Range Slicing with Different Cursor Format
 
 The report streams (expenses_categories, expenses_clients, expenses_projects, expenses_team,
 project_budget, time_clients, time_projects, time_tasks, time_team, uninvoiced) use a fundamentally
@@ -63,37 +34,3 @@ does not include the date range in the data itself.
 **Why this matters:** Entity streams and report streams have incompatible cursor formats and pagination
 patterns. If you copy an entity stream's incremental sync config to a report stream (or vice versa),
 the date filtering will silently break. Report streams cursor on `to` (end of range), not `updated_at`.
-
----
-
-## 5. WaitTimeFromHeader Backoff Strategy
-
-Harvest's API returns a `Retry-After` header on rate-limited responses, and the connector uses
-`WaitTimeFromHeader` as its primary backoff strategy rather than exponential backoff. This is the first
-handler in the `CompositeErrorHandler` chain, meaning it takes precedence over the 401/403/404 IGNORE
-handlers.
-
-Harvest documents a rate limit of 100 requests per 15 seconds per token
-(https://help.getharvest.com/api-v2/introduction/overview/general/#rate-limiting).
-
-**Why this matters:** The `Retry-After` header tells the connector exactly how long to wait, so the
-connector will pause for precisely the time Harvest specifies. If you add a second backoff strategy
-(like `ExponentialBackoffStrategy`), make sure it comes after `WaitTimeFromHeader` in the chain so the
-API-specified wait time is honored first.
-
----
-
-## 6. Substream Patterns for Messages, Payments, and Rates
-
-Several streams are implemented as substreams that partition by parent entity ID:
-- `estimate_messages` partitions by estimate ID
-- `invoice_messages` and `invoice_payments` partition by invoice ID
-- `project_assignments` and `billable_rates`/`cost_rates` partition by user or project ID
-
-Each substream injects the parent ID into records via `AddFields` transformations (e.g.,
-`parent_id: "{{stream_partition.id}}"`).
-
-**Why this matters:** These substreams make one API call per parent entity, so the total number of
-requests scales linearly with the number of parent records. A Harvest account with 10,000 invoices will
-generate 10,000 additional API calls just for `invoice_messages`. Combined with the `Retry-After`
-backoff, large accounts may experience very slow syncs for substreams.

--- a/airbyte-integrations/connectors/source-harvest/CLAUDE.md
+++ b/airbyte-integrations/connectors/source-harvest/CLAUDE.md
@@ -1,0 +1,14 @@
+# source-harvest
+
+Harvest time tracking API source connector built entirely on the declarative framework (no custom Python
+components).
+
+## Key Behavior Documentation
+
+See [BEHAVIOR.md](BEHAVIOR.md) for the most important non-obvious gotchas in this connector, including:
+- Harvest-Account-Id header required on every request (separate from authentication)
+- Link-based cursor pagination using full URLs from response body
+- Graceful degradation that silently ignores 401/403/404 errors per stream
+- Report streams use date-range slicing with a different cursor format than entity streams
+- WaitTimeFromHeader backoff strategy that honors Harvest's Retry-After header
+- Substream patterns that scale API calls linearly with parent entity count

--- a/airbyte-integrations/connectors/source-harvest/CLAUDE.md
+++ b/airbyte-integrations/connectors/source-harvest/CLAUDE.md
@@ -6,9 +6,5 @@ components).
 ## Key Behavior Documentation
 
 See [BEHAVIOR.md](BEHAVIOR.md) for the most important non-obvious gotchas in this connector, including:
-- Harvest-Account-Id header required on every request (separate from authentication)
-- Link-based cursor pagination using full URLs from response body
 - Graceful degradation that silently ignores 401/403/404 errors per stream
 - Report streams use date-range slicing with a different cursor format than entity streams
-- WaitTimeFromHeader backoff strategy that honors Harvest's Retry-After header
-- Substream patterns that scale API calls linearly with parent entity count

--- a/airbyte-integrations/connectors/source-instagram/BEHAVIOR.md
+++ b/airbyte-integrations/connectors/source-instagram/BEHAVIOR.md
@@ -5,3 +5,11 @@
 When syncing media records that have children (carousel posts), the `InstagramMediaChildrenTransformation` makes an additional API call for EACH child media ID during record transformation. A carousel post with 10 slides triggers 10 separate HTTP requests to the `/media` endpoint to fetch detailed information (media_type, media_url, timestamp, etc.) for each child.
 
 **Why this matters:** What appears to be a simple media stream read can silently multiply into many additional API calls proportional to the number of carousel slides across all media records. This directly impacts sync duration and rate limit consumption, and the additional calls are invisible from the manifest configuration.
+
+## 2. Access Token Generation for CAT Tests
+
+The easiest way to generate a new access token for CAT tests is through an Airbyte Cloud connection for the Instagram connector. During the OAuth authentication flow, enable browser developer tools, log in to the Instagram test account from LastPass (`[Source-Instagram] Integration test account`), and monitor requests in the Network tab. Look for the `complete_oauth` POST request — the response body contains the access token you need.
+
+After copying the access token, update the credentials in Google Secret Manager (secret: `SECRET_SOURCE-INSTAGRAM__CREDS`).
+
+**Why this matters:** Instagram access tokens are short-lived and there is no simple CLI or API-only way to refresh them for testing. Without this workflow, engineers waste time trying to figure out how to get a working token for local reads or CAT test runs.

--- a/airbyte-integrations/connectors/source-instagram/BEHAVIOR.md
+++ b/airbyte-integrations/connectors/source-instagram/BEHAVIOR.md
@@ -1,0 +1,7 @@
+# source-instagram: Unique Behaviors
+
+## 1. Hidden Per-Record API Calls for Carousel Media Children
+
+When syncing media records that have children (carousel posts), the `InstagramMediaChildrenTransformation` makes an additional API call for EACH child media ID during record transformation. A carousel post with 10 slides triggers 10 separate HTTP requests to the `/media` endpoint to fetch detailed information (media_type, media_url, timestamp, etc.) for each child.
+
+**Why this matters:** What appears to be a simple media stream read can silently multiply into many additional API calls proportional to the number of carousel slides across all media records. This directly impacts sync duration and rate limit consumption, and the additional calls are invisible from the manifest configuration.

--- a/airbyte-integrations/connectors/source-instagram/CLAUDE.md
+++ b/airbyte-integrations/connectors/source-instagram/CLAUDE.md
@@ -1,0 +1,5 @@
+# source-instagram
+
+## Key Documentation
+- See `BEHAVIOR.md` for unique connector behaviors including:
+  1. Hidden per-record API calls for carousel media children during transformation

--- a/airbyte-integrations/connectors/source-instagram/CLAUDE.md
+++ b/airbyte-integrations/connectors/source-instagram/CLAUDE.md
@@ -3,3 +3,4 @@
 ## Key Documentation
 - See `BEHAVIOR.md` for unique connector behaviors including:
   1. Hidden per-record API calls for carousel media children during transformation
+  2. Access token generation for CAT tests (OAuth flow via Airbyte Cloud + DevTools)

--- a/airbyte-integrations/connectors/source-intercom/BEHAVIOR.md
+++ b/airbyte-integrations/connectors/source-intercom/BEHAVIOR.md
@@ -7,3 +7,13 @@ The connector uses a custom `ErrorHandlerWithRateLimiter` that wraps the standar
 The sleep duration scales dynamically: 10ms when load is low (>50% capacity remaining), 1.5 seconds at medium load, and 8 seconds when remaining capacity drops below 10%. If headers are unavailable, it defaults to a 1-second hold.
 
 **Why this matters:** The connector intentionally throttles itself even when not rate-limited, trading sync speed for stability. This means syncs will always be slower than the raw API rate limit would allow, and the slowdown increases as rate limit capacity decreases during a sync. This is not a bug but a deliberate design choice that may look like unnecessary latency if you are not aware of it.
+
+## 2. Companies Scroll API — Single Active Scroll Constraint
+
+The `companies` stream uses Intercom's Scroll API (`companies/scroll`) instead of standard cursor pagination. Intercom enforces a hard constraint: **only one scroll can be active per workspace at a time**. If a second scroll request is made while one is already in progress, the API returns HTTP 400. The connector treats this as a `transient_error` with the message: "Scroll already exists for this workspace. Please ensure you do not have multiple syncs running at the same time."
+
+This constraint also applies to any substream that uses `companies` as a parent — specifically `company_segments` and `company_attributes`. Since these streams depend on iterating over company records, they inherit the single-scroll limitation. Running two syncs that involve any combination of companies, company_segments, or company_attributes against the same Intercom workspace simultaneously will cause one to fail.
+
+Additionally, on HTTP 500 the connector uses `RESET_PAGINATION` to restart the scroll from the beginning, meaning a transient server error can cause the entire companies stream to re-read all data.
+
+**Why this matters:** Unlike standard paginated streams where multiple readers can paginate independently, the scroll API is a workspace-level singleton. This makes it impossible to run parallel syncs or test syncs against the same Intercom workspace if any of them include the companies stream or its dependents.

--- a/airbyte-integrations/connectors/source-intercom/BEHAVIOR.md
+++ b/airbyte-integrations/connectors/source-intercom/BEHAVIOR.md
@@ -1,0 +1,9 @@
+# source-intercom: Unique Behaviors
+
+## 1. Proactive Rate Limiting Before Every Request
+
+The connector uses a custom `ErrorHandlerWithRateLimiter` that wraps the standard error handler with a decorator-based rate limiter. Unlike typical backoff strategies that only activate after hitting a rate limit, this limiter adds a sleep BEFORE every single API request based on the ratio of remaining requests to the total rate limit capacity (from `X-RateLimit-Remaining` and `X-RateLimit-Limit` headers).
+
+The sleep duration scales dynamically: 10ms when load is low (>50% capacity remaining), 1.5 seconds at medium load, and 8 seconds when remaining capacity drops below 10%. If headers are unavailable, it defaults to a 1-second hold.
+
+**Why this matters:** The connector intentionally throttles itself even when not rate-limited, trading sync speed for stability. This means syncs will always be slower than the raw API rate limit would allow, and the slowdown increases as rate limit capacity decreases during a sync. This is not a bug but a deliberate design choice that may look like unnecessary latency if you are not aware of it.

--- a/airbyte-integrations/connectors/source-intercom/CLAUDE.md
+++ b/airbyte-integrations/connectors/source-intercom/CLAUDE.md
@@ -1,0 +1,5 @@
+# source-intercom
+
+## Key Documentation
+- See `BEHAVIOR.md` for unique connector behaviors including:
+  1. Proactive rate limiting that throttles every request based on remaining capacity headers

--- a/airbyte-integrations/connectors/source-intercom/CLAUDE.md
+++ b/airbyte-integrations/connectors/source-intercom/CLAUDE.md
@@ -3,3 +3,4 @@
 ## Key Documentation
 - See `BEHAVIOR.md` for unique connector behaviors including:
   1. Proactive rate limiting that throttles every request based on remaining capacity headers
+  2. Companies Scroll API single active scroll constraint (blocks parallel syncs and substreams)

--- a/airbyte-integrations/connectors/source-jira/BEHAVIOR.md
+++ b/airbyte-integrations/connectors/source-jira/BEHAVIOR.md
@@ -1,0 +1,9 @@
+# source-jira: Unique Behaviors
+
+## 1. Global Silent 400 Error Ignoring
+
+The base error handler for source-jira silently ignores ALL HTTP 400 (Bad Request) responses across every stream. This means any malformed request, invalid JQL query, unsupported field, or missing parameter will produce zero records for that request rather than raising an error.
+
+Many individual streams add additional IGNORE rules for 403 and 404, meaning permission errors and missing resources are also silently skipped.
+
+**Why this matters:** If a Jira instance changes its configuration (e.g., disabling a feature or changing field availability), affected streams will silently return fewer or zero records instead of alerting the user. Debugging missing data requires checking API responses directly, as the connector intentionally suppresses these errors to handle the wide variation in Jira instance configurations.

--- a/airbyte-integrations/connectors/source-jira/CLAUDE.md
+++ b/airbyte-integrations/connectors/source-jira/CLAUDE.md
@@ -1,0 +1,5 @@
+# source-jira
+
+## Unique Behaviors
+See [BEHAVIOR.md](./BEHAVIOR.md) for documented unique behaviors:
+1. Global silent 400 error ignoring across all streams

--- a/airbyte-integrations/connectors/source-klaviyo/BEHAVIOR.md
+++ b/airbyte-integrations/connectors/source-klaviyo/BEHAVIOR.md
@@ -11,3 +11,34 @@ The `CampaignsDetailedTransformation` makes two additional API calls for every c
 Klaviyo uses the JSON:API specification where related resources are returned in a top-level `included` array rather than being nested in the record. The `KlaviyoIncludedFieldExtractor` resolves these relationships by matching `type` and `id` between the record's `relationships` and the `included` array, then merging the included resource's attributes back into the relationship data.
 
 **Why this matters:** Records extracted from Klaviyo do not contain their related data inline. Without the included field resolution, relationship fields would only contain `type` and `id` references instead of actual attribute data. This affects streams like events where metric and profile details need to be resolved from the included array.
+
+## 3. Endpoint-Specific Rate Limits and Concurrency
+
+Klaviyo's API rate limiting varies by endpoint size tier, each with a burst and steady-state limit:
+
+| Tier | Burst | Steady |
+|------|-------|--------|
+| XS   | 1/s   | 15/m   |
+| S    | 3/s   | 60/m   |
+| M    | 10/s  | 150/m  |
+| L    | 75/s  | 700/m  |
+| XL   | 350/s | 3500/m |
+
+As of 2024-11-11, the streams map to endpoint tiers and concurrency settings as follows:
+
+| Stream | Endpoint | Klaviyo Rate Limit Size | Source Concurrency Between Streams | Source Concurrency Within Stream | Source Max Number of Threads Sharing Rate Limits | Notes |
+|--------|----------|------------------------|------------------------------------|----------------------------------|--------------------------------------------------|-------|
+| profiles | [GET /profiles](https://developers.klaviyo.com/en/v2023-02-22/reference/get_profiles) | M | Yes, shared with global_exclusions | No (`step` not defined in `incremental_sync`) | 2 | With other streams (global_exclusions), not within stream |
+| global_exclusions | [GET /profiles](https://developers.klaviyo.com/en/v2023-02-22/reference/get_profiles) | M | Yes, shared with profiles | No (`step` not defined in `incremental_sync`) | 2 | With other streams (profiles), not within stream |
+| events | [GET /events](https://developers.klaviyo.com/en/reference/get_events) | XL | Yes, shared with events_detailed | Yes (sliced on `datetime`) | number of steps for events + number of steps for events_detailed | With other streams (events_detailed) and within stream |
+| events_detailed | [GET /events](https://developers.klaviyo.com/en/reference/get_events) | XL | Yes, shared with events | Yes (sliced on `datetime`) | number of steps for events + number of steps for events_detailed | With other streams (events) and within stream |
+| email_templates | [GET /templates](https://developers.klaviyo.com/en/reference/get_templates) | M | None | No (`step` not defined in `incremental_sync`) | 1 | None |
+| metrics | [GET /metrics](https://developers.klaviyo.com/en/reference/get_metrics) | M | None | No (`step` not defined in `incremental_sync`) | 1 | None |
+| lists | [GET /lists](https://developers.klaviyo.com/en/reference/get_lists) | L | Yes, shared with lists_detailed | No (`step` not defined in `incremental_sync`) | 2 | With other streams (lists_detailed), not within stream |
+| lists_detailed | [GET /lists](https://developers.klaviyo.com/en/reference/get_lists) | L | Yes, shared with lists | No (`step` not defined in `incremental_sync`) | 2 | With other streams (lists), not within stream |
+
+> **Note:** As of 2024-11-11, `metrics`, `lists`, and `lists_detailed` are not supported by the Concurrent CDK as they do client-side filtering.
+
+The only streams that allow for slicing (and hence may perform more concurrent HTTP requests) are `events` and `events_detailed`. All other streams have no slicing, so their concurrency is limited to the number of streams querying the same endpoint. Given that the events endpoint is XL tier, the default concurrency is set to **10**.
+
+**Why this matters:** Streams sharing the same endpoint share the same rate limit budget. Running `profiles` and `global_exclusions` simultaneously means both compete for the same M-tier limit. The `events` and `events_detailed` streams are the most impactful — both share the XL-tier endpoint AND support datetime slicing, so the total concurrent requests equals the sum of both streams' active slices.

--- a/airbyte-integrations/connectors/source-klaviyo/BEHAVIOR.md
+++ b/airbyte-integrations/connectors/source-klaviyo/BEHAVIOR.md
@@ -1,0 +1,13 @@
+# source-klaviyo: Unique Behaviors
+
+## 1. Hidden Per-Campaign API Calls for Detailed Campaign Data
+
+The `CampaignsDetailedTransformation` makes two additional API calls for every campaign record during transformation: one to fetch `estimated_recipient_count` from the `/campaign-recipient-estimations/{id}` endpoint, and one to fetch `campaign_messages` by following the `relationships.campaign-messages.links.related` URL from the record itself.
+
+**Why this matters:** Each campaign record triggers two hidden HTTP requests, so syncing 1,000 campaigns results in at least 2,000 additional API calls beyond the pagination requests. These calls have their own error handling and retry logic (including 404 ignore) that operates independently from the main stream's error handling.
+
+## 2. JSON:API Included Relationship Resolution
+
+Klaviyo uses the JSON:API specification where related resources are returned in a top-level `included` array rather than being nested in the record. The `KlaviyoIncludedFieldExtractor` resolves these relationships by matching `type` and `id` between the record's `relationships` and the `included` array, then merging the included resource's attributes back into the relationship data.
+
+**Why this matters:** Records extracted from Klaviyo do not contain their related data inline. Without the included field resolution, relationship fields would only contain `type` and `id` references instead of actual attribute data. This affects streams like events where metric and profile details need to be resolved from the included array.

--- a/airbyte-integrations/connectors/source-klaviyo/CLAUDE.md
+++ b/airbyte-integrations/connectors/source-klaviyo/CLAUDE.md
@@ -4,3 +4,4 @@
 - See `BEHAVIOR.md` for unique connector behaviors including:
   1. Hidden per-campaign API calls for recipient count and campaign messages
   2. JSON:API included relationship resolution for inline attribute data
+  3. Endpoint-specific rate limit tiers (XS–XL) and per-stream concurrency mapping

--- a/airbyte-integrations/connectors/source-klaviyo/CLAUDE.md
+++ b/airbyte-integrations/connectors/source-klaviyo/CLAUDE.md
@@ -1,0 +1,6 @@
+# source-klaviyo
+
+## Key Documentation
+- See `BEHAVIOR.md` for unique connector behaviors including:
+  1. Hidden per-campaign API calls for recipient count and campaign messages
+  2. JSON:API included relationship resolution for inline attribute data

--- a/airbyte-integrations/connectors/source-linkedin-ads/BEHAVIOR.md
+++ b/airbyte-integrations/connectors/source-linkedin-ads/BEHAVIOR.md
@@ -1,0 +1,131 @@
+# source-linkedin-ads: Unique Connector Behaviors
+
+This document describes the biggest non-obvious gotchas in `source-linkedin-ads` that deviate from standard
+declarative connector patterns. Read this before making changes to the connector.
+
+---
+
+## 1. Safe URL Encoding for LinkedIn's REST API Syntax
+
+LinkedIn's REST API uses a proprietary query parameter syntax with special characters like parentheses,
+colons, commas, and percent-encoded URNs (e.g., `pivot=(value:CAMPAIGN)`,
+`campaigns=List(urn%3Ali%3AsponsoredCampaign%3A123)`). Standard HTTP clients encode these characters
+during URL preparation, which breaks the API requests.
+
+The connector uses a custom `SafeHttpClient` and `SafeEncodeHttpRequester` that override the prepared
+request logic to call `urlencode(query_params, safe="():,%")`, preserving these characters verbatim in
+the URL.
+
+**Why this matters:** If you switch analytics streams to use the standard `HttpRequester`, every
+analytics API call will fail because the parentheses and colons in pivot values and URN lists will get
+double-encoded. This affects all analytics streams (ad_campaign_analytics, ad_creative_analytics, and
+all ad_member_*_analytics streams).
+
+---
+
+## 2. Analytics Property Chunking with 18-Field Limit
+
+LinkedIn's Ad Analytics API (`GET /adAnalytics`) requires you to specify which metric fields to return
+via the `fields` query parameter. The API enforces a maximum of 20 fields per request. The connector
+uses `QueryProperties` with `PropertyChunking` configured at a limit of 18 fields per chunk (reserving
+2 slots for the mandatory `dateRange` and `pivotValues` fields that are always included).
+
+Records from multiple chunks are stitched back together using `GroupByKeyMergeStrategy` keyed on
+`["end_date", "string_of_pivot_values"]`.
+
+**Why this matters:** With ~90 analytics fields defined, each analytics record requires approximately 5
+separate HTTP requests to assemble. Every analytics stream is also partitioned by parent entity (one
+campaign or creative per partition), so the total API call count is roughly
+`num_entities * num_date_slices * 5`. Adding new analytics fields increases the chunk count and
+silently multiplies API usage across every partition.
+
+---
+
+## 3. DNS Resolution Errors Treated as Transient
+
+The `LinkedInAdsErrorHandler` catches Python `InvalidURL` exceptions and classifies them as transient
+(retryable) errors rather than failing the sync. This is a workaround for intermittent DNS resolution
+failures that surface as `InvalidURL` exceptions in the requests library.
+
+**Why this matters:** Without this handler, a temporary DNS blip during a long-running sync would
+permanently fail the entire sync instead of retrying. If you replace or modify the error handler, make
+sure `InvalidURL` exceptions are still caught and retried, or syncs on unstable networks will fail
+intermittently.
+
+---
+
+## 4. Millisecond Timestamps and Multiple Datetime Formats
+
+LinkedIn's API returns timestamps in inconsistent formats across different endpoints. Entity streams
+(accounts, campaigns, creatives) return `lastModified` and `created` as millisecond Unix timestamps
+(e.g., `1629581275000`), while analytics streams use date objects with nested `year/month/day` fields.
+The `LinkedInAdsRecordExtractor` converts millisecond timestamps to RFC3339 format during extraction.
+
+The manifest declares multiple `cursor_datetime_formats` per stream: `"%ms"` for millisecond
+timestamps, `"%Y-%m-%dT%H:%M:%S%z"` for ISO 8601, and `"%Y-%m-%d"` for date-only analytics cursors.
+
+**Why this matters:** If you add a new incremental stream, you must check which timestamp format that
+specific LinkedIn endpoint returns and configure the correct `cursor_datetime_formats` list. Using the
+wrong format will cause cursor comparisons to silently fail, either re-syncing all data on every run
+or skipping records entirely.
+
+---
+
+## 5. Reserved Keyword Renaming for Destination Compatibility
+
+The `transform_data` function renames the `pivot` field to `_pivot` in every analytics record. This is
+because `PIVOT` is a reserved keyword in Amazon Redshift, and using it as a column name causes
+normalization failures at the destination.
+
+**Why this matters:** If you add new fields to analytics streams, check whether the field name
+conflicts with reserved keywords in common destinations (Redshift, BigQuery, Snowflake). The
+`DESTINATION_RESERVED_KEYWORDS` list in `components.py` is the mechanism for handling these conflicts
+-- add any new reserved words there rather than creating a separate transformation.
+
+---
+
+## 6. Custom Analytics Reports via Dynamic Streams
+
+Users can define custom analytics reports in their connection config under `ad_analytics_reports`. These
+are rendered as `DynamicDeclarativeStream` instances using `ConfigComponentsResolver`, which maps the
+user's `pivot_by` and `time_granularity` values into the request parameters of a shared stream
+template.
+
+The custom report streams use the same `SafeEncodeHttpRequester`, property chunking, and analytics
+field list as the built-in analytics streams.
+
+**Why this matters:** Custom analytics reports share all the same constraints as built-in analytics
+streams (property chunking, safe URL encoding, pivot value transformation). Any change to the analytics
+infrastructure affects both built-in and custom reports. The stream names are prefixed with `custom_` to
+avoid collisions with built-in stream names.
+
+---
+
+## 7. Unpublished Rate Limits with Per-Endpoint Daily Caps
+
+LinkedIn does not publish standard API rate limits. The connector's comments document that each endpoint
+has its own individually tracked rate limit that resets daily, with tiers that vary by account. The
+connector's OAuth app supports 15,000,000 requests/day for `/adAnalytics` endpoints specifically.
+
+The `api_budget` is configured conservatively at 6 requests per 10 seconds for analytics endpoints, and
+the default concurrency is set to 6 workers (configurable via `num_workers` up to 50). This was reduced
+from a higher default after customers experienced rate limiting issues.
+
+**Why this matters:** Because rate limits are per-endpoint and unpublished, there is no reliable way to
+predict when a customer will hit limits. If customers report rate limiting, the `num_workers` config
+value is the primary lever to reduce pressure. The analytics property chunking (5 requests per record
+page) means the effective request rate is much higher than the visible concurrency level suggests.
+
+---
+
+## 8. Analytics Streams Use NoPagination
+
+All analytics streams (ad_campaign_analytics, ad_creative_analytics, ad_impression_device_analytics,
+and all ad_member_*_analytics) use `NoPagination`. Each stream is partitioned by parent entity ID
+(campaign or creative) and sliced into 30-day date windows (`step: P30D`). The expectation is that each
+combination of entity + date window returns a single page of results.
+
+**Why this matters:** Do not add a paginator to analytics streams. LinkedIn's Ad Analytics API returns
+all matching rows for a given entity + date range in a single response. Adding pagination would break
+the property chunking merge strategy, which expects all chunks for a given entity + date slice to cover
+the same complete result set.

--- a/airbyte-integrations/connectors/source-linkedin-ads/BEHAVIOR.md
+++ b/airbyte-integrations/connectors/source-linkedin-ads/BEHAVIOR.md
@@ -84,24 +84,7 @@ conflicts with reserved keywords in common destinations (Redshift, BigQuery, Sno
 
 ---
 
-## 6. Custom Analytics Reports via Dynamic Streams
-
-Users can define custom analytics reports in their connection config under `ad_analytics_reports`. These
-are rendered as `DynamicDeclarativeStream` instances using `ConfigComponentsResolver`, which maps the
-user's `pivot_by` and `time_granularity` values into the request parameters of a shared stream
-template.
-
-The custom report streams use the same `SafeEncodeHttpRequester`, property chunking, and analytics
-field list as the built-in analytics streams.
-
-**Why this matters:** Custom analytics reports share all the same constraints as built-in analytics
-streams (property chunking, safe URL encoding, pivot value transformation). Any change to the analytics
-infrastructure affects both built-in and custom reports. The stream names are prefixed with `custom_` to
-avoid collisions with built-in stream names.
-
----
-
-## 7. Unpublished Rate Limits with Per-Endpoint Daily Caps
+## 6. Unpublished Rate Limits with Per-Endpoint Daily Caps
 
 LinkedIn does not publish standard API rate limits. The connector's comments document that each endpoint
 has its own individually tracked rate limit that resets daily, with tiers that vary by account. The
@@ -115,17 +98,3 @@ from a higher default after customers experienced rate limiting issues.
 predict when a customer will hit limits. If customers report rate limiting, the `num_workers` config
 value is the primary lever to reduce pressure. The analytics property chunking (5 requests per record
 page) means the effective request rate is much higher than the visible concurrency level suggests.
-
----
-
-## 8. Analytics Streams Use NoPagination
-
-All analytics streams (ad_campaign_analytics, ad_creative_analytics, ad_impression_device_analytics,
-and all ad_member_*_analytics) use `NoPagination`. Each stream is partitioned by parent entity ID
-(campaign or creative) and sliced into 30-day date windows (`step: P30D`). The expectation is that each
-combination of entity + date window returns a single page of results.
-
-**Why this matters:** Do not add a paginator to analytics streams. LinkedIn's Ad Analytics API returns
-all matching rows for a given entity + date range in a single response. Adding pagination would break
-the property chunking merge strategy, which expects all chunks for a given entity + date slice to cover
-the same complete result set.

--- a/airbyte-integrations/connectors/source-linkedin-ads/CLAUDE.md
+++ b/airbyte-integrations/connectors/source-linkedin-ads/CLAUDE.md
@@ -1,0 +1,15 @@
+# source-linkedin-ads
+
+LinkedIn Ads API source connector built on the declarative framework with custom Python components.
+
+## Key Behavior Documentation
+
+See [BEHAVIOR.md](BEHAVIOR.md) for the most important non-obvious gotchas in this connector, including:
+- Safe URL encoding that preserves LinkedIn's proprietary query parameter syntax
+- Analytics property chunking with an 18-field limit per request (~5 HTTP calls per record page)
+- DNS resolution errors treated as transient/retryable
+- Millisecond timestamp handling and multiple datetime formats across endpoints
+- Reserved keyword renaming (`pivot` -> `_pivot`) for destination compatibility
+- Custom analytics reports via dynamic streams
+- Unpublished per-endpoint rate limits with daily caps
+- Analytics streams intentionally use NoPagination

--- a/airbyte-integrations/connectors/source-linkedin-ads/CLAUDE.md
+++ b/airbyte-integrations/connectors/source-linkedin-ads/CLAUDE.md
@@ -10,6 +10,4 @@ See [BEHAVIOR.md](BEHAVIOR.md) for the most important non-obvious gotchas in thi
 - DNS resolution errors treated as transient/retryable
 - Millisecond timestamp handling and multiple datetime formats across endpoints
 - Reserved keyword renaming (`pivot` -> `_pivot`) for destination compatibility
-- Custom analytics reports via dynamic streams
 - Unpublished per-endpoint rate limits with daily caps
-- Analytics streams intentionally use NoPagination

--- a/airbyte-integrations/connectors/source-mailchimp/BEHAVIOR.md
+++ b/airbyte-integrations/connectors/source-mailchimp/BEHAVIOR.md
@@ -1,0 +1,12 @@
+# source-mailchimp: Unique Behaviors
+
+## 1. Dynamic API Base URL Determined by Data Center Extraction
+
+Mailchimp's API requires all requests to be sent to a data-center-specific subdomain (e.g., `us20.api.mailchimp.com`). The connector determines the correct data center at config time through one of two methods depending on the auth type:
+
+- **API key auth:** The data center is extracted from the API key suffix (e.g., `abc123-us20` yields `us20`).
+- **OAuth:** The connector makes an HTTP request to `https://login.mailchimp.com/oauth2/metadata` using the access token, and extracts the `dc` field from the response.
+
+This happens in `ExtractAndSetDataCenterConfigValue`, a config transformation that runs before any data syncing begins. If the metadata endpoint returns a 200 with `"error": "invalid_token"`, it raises a config error rather than proceeding with an invalid token.
+
+**Why this matters:** The API base URL is not static and cannot be hardcoded. If the data center extraction fails or returns an incorrect value, all subsequent API calls will go to the wrong host and fail silently or with confusing errors. The OAuth path also means a network call happens during config validation, before any sync starts.

--- a/airbyte-integrations/connectors/source-mailchimp/CLAUDE.md
+++ b/airbyte-integrations/connectors/source-mailchimp/CLAUDE.md
@@ -1,0 +1,5 @@
+# source-mailchimp
+
+## Key Documentation
+- See `BEHAVIOR.md` for unique connector behaviors including:
+  1. Dynamic API base URL determined by data center extraction from API key or OAuth metadata

--- a/airbyte-integrations/connectors/source-monday/BEHAVIOR.md
+++ b/airbyte-integrations/connectors/source-monday/BEHAVIOR.md
@@ -15,3 +15,19 @@ Unlike REST-based connectors, source-monday uses a single GraphQL endpoint for a
 The items stream uses a two-level pagination strategy where boards are paginated on the outer level and items within each board are paginated on the inner level. The `ItemPaginationStrategy` tracks both a `_page` (board page number) and a `_sub_page` (item cursor within a board). When items within a board are exhausted, the strategy advances to the next board page and resets the item cursor. A separate `ItemCursorPaginationStrategy` handles cursor-based pagination for the newer `items_page`/`next_items_page` API.
 
 **Why this matters:** A single items sync involves nested iteration that is not visible from the manifest. If pagination breaks, you need to determine whether the failure is at the board level or the item level within a board. The connector also maintains two different pagination strategies for items depending on whether it uses page-based or cursor-based pagination.
+
+## 3. Cursor Expiration After 60 Minutes (CursorExpiredError)
+
+Monday.com's `items_page`/`next_items_page` pagination cursors expire after 60 minutes. If the connector takes longer than an hour to process records within a single paginated sequence (e.g., due to rate limiting, large boards, or slow downstream processing), the API returns a `CursorExpiredError` with a 200 status code:
+
+```json
+{
+  "error_code": "CursorException",
+  "status_code": 200,
+  "error_message": "CursorExpiredError: The cursor provided for pagination has expired. Please refresh your query and obtain a new cursor to continue fetching items"
+}
+```
+
+The connector handles this by triggering `RESET_PAGINATION`, which restarts pagination from the beginning of the current stream. This means all records fetched before the expiration are re-read. See [Monday.com community discussion](https://developer-community.monday.com/api-apps-framework-4/cursor-used-for-pagination-expires-alternate-way-to-paginate-4083) for API context.
+
+**Why this matters:** For large boards, cursor expiration can cause repeated full re-reads if processing consistently takes longer than an hour. Each reset restarts from page 1, so syncs may never complete for very large boards if the processing time per page exceeds the cursor TTL.

--- a/airbyte-integrations/connectors/source-monday/BEHAVIOR.md
+++ b/airbyte-integrations/connectors/source-monday/BEHAVIOR.md
@@ -1,0 +1,17 @@
+# source-monday: Unique Behaviors
+
+## 1. GraphQL API with Schema-Driven Query Building
+
+Unlike REST-based connectors, source-monday uses a single GraphQL endpoint for all streams. The `MondayGraphqlRequester` dynamically builds GraphQL queries at runtime by traversing the stream's JSON schema to determine which fields to request. The query structure varies significantly by stream:
+
+- **items:** Must be queried through `boards` (Monday.com removed direct item queries in October 2022). The connector wraps item queries inside a `boards` query.
+- **activity_logs:** Also wrapped inside a `boards` query with timestamp filtering via a `from` parameter.
+- **column_values:** Requires GraphQL inline fragments (`... on MirrorValue`, `... on BoardRelationValue`, `... on DependencyValue`) because Monday.com uses union types for the `display_value` field.
+
+**Why this matters:** Modifying a stream's JSON schema directly affects the GraphQL query that gets sent to the API. Adding or removing fields from the schema will change the query structure. The stream-specific query builders (`_build_items_query`, `_build_activity_query`, `_build_teams_query`) each have different logic, so changes to one stream's query pattern do not apply to others.
+
+## 2. Two-Level Nested Pagination for Items
+
+The items stream uses a two-level pagination strategy where boards are paginated on the outer level and items within each board are paginated on the inner level. The `ItemPaginationStrategy` tracks both a `_page` (board page number) and a `_sub_page` (item cursor within a board). When items within a board are exhausted, the strategy advances to the next board page and resets the item cursor. A separate `ItemCursorPaginationStrategy` handles cursor-based pagination for the newer `items_page`/`next_items_page` API.
+
+**Why this matters:** A single items sync involves nested iteration that is not visible from the manifest. If pagination breaks, you need to determine whether the failure is at the board level or the item level within a board. The connector also maintains two different pagination strategies for items depending on whether it uses page-based or cursor-based pagination.

--- a/airbyte-integrations/connectors/source-monday/CLAUDE.md
+++ b/airbyte-integrations/connectors/source-monday/CLAUDE.md
@@ -4,3 +4,4 @@
 - See `BEHAVIOR.md` for unique connector behaviors including:
   1. GraphQL API with schema-driven query building and stream-specific query patterns
   2. Two-level nested pagination for items (boards outer, items inner)
+  3. Cursor expiration after 60 minutes triggers RESET_PAGINATION (full re-read)

--- a/airbyte-integrations/connectors/source-monday/CLAUDE.md
+++ b/airbyte-integrations/connectors/source-monday/CLAUDE.md
@@ -1,0 +1,6 @@
+# source-monday
+
+## Key Documentation
+- See `BEHAVIOR.md` for unique connector behaviors including:
+  1. GraphQL API with schema-driven query building and stream-specific query patterns
+  2. Two-level nested pagination for items (boards outer, items inner)

--- a/airbyte-integrations/connectors/source-notion/BEHAVIOR.md
+++ b/airbyte-integrations/connectors/source-notion/BEHAVIOR.md
@@ -1,0 +1,9 @@
+# source-notion: Unique Behaviors
+
+## 1. Recursive Block Retrieval Up to 30 Levels Deep
+
+The `BlocksRetriever` performs depth-first recursive fetching of Notion blocks. When a block has `has_children: true`, the retriever immediately makes a new API call to fetch that block's children before continuing to the next sibling. This recursion continues up to a maximum depth of 30 levels.
+
+A single page with deeply nested content (e.g., toggles inside toggles inside columns) can trigger dozens of additional API calls as the retriever walks the entire block tree. Each level of nesting adds another round of paginated API requests for that block's children.
+
+**Why this matters:** What looks like a single blocks stream read can fan out into a large number of API calls proportional to the depth and breadth of the block hierarchy. A page with 5 levels of nested blocks and 10 children per level could trigger hundreds of requests from a single parent page slice. The 30-level depth limit exists to prevent infinite recursion but is otherwise not enforced by Notion's API.

--- a/airbyte-integrations/connectors/source-notion/CLAUDE.md
+++ b/airbyte-integrations/connectors/source-notion/CLAUDE.md
@@ -1,0 +1,5 @@
+# source-notion
+
+## Key Documentation
+- See `BEHAVIOR.md` for unique connector behaviors including:
+  1. Recursive block retrieval that depth-first traverses nested blocks up to 30 levels

--- a/airbyte-integrations/connectors/source-pinterest/BEHAVIOR.md
+++ b/airbyte-integrations/connectors/source-pinterest/BEHAVIOR.md
@@ -1,0 +1,7 @@
+# source-pinterest: Unique Behaviors
+
+## 1. Analytics Retry Wait Time Parsed from Response Body Text
+
+The `PinterestAnalyticsBackoffStrategy` extracts the retry wait time from the response body's `message` field using a regex pattern (`Retry after N seconds`), not from standard HTTP headers like `Retry-After`. Pinterest's analytics endpoints return rate limit information as human-readable text embedded in the error message rather than in response headers.
+
+**Why this matters:** Standard retry logic that only reads HTTP headers will miss Pinterest's retry guidance entirely and fall back to exponential backoff. The connector's regex-based extraction is brittle and will break if Pinterest changes the wording of their error message. If the regex fails to match, it falls back to exponential backoff capped at 120 seconds.

--- a/airbyte-integrations/connectors/source-pinterest/CLAUDE.md
+++ b/airbyte-integrations/connectors/source-pinterest/CLAUDE.md
@@ -1,0 +1,5 @@
+# source-pinterest
+
+## Key Documentation
+- See `BEHAVIOR.md` for unique connector behaviors including:
+  1. Analytics retry wait time parsed from response body message text via regex

--- a/airbyte-integrations/connectors/source-sendgrid/BEHAVIOR.md
+++ b/airbyte-integrations/connectors/source-sendgrid/BEHAVIOR.md
@@ -1,0 +1,7 @@
+# source-sendgrid: Unique Behaviors
+
+## 1. Async Contacts Export with Gzipped CSV Download
+
+The `contacts` stream uses `AsyncRetriever` with a three-phase workflow: POST to `/v3/marketing/contacts/exports` to create an export job, poll the job status until `ready`, then download the result. Unlike all other streams in this connector which use standard synchronous JSON retrieval, the contacts export produces a gzipped CSV file that is decoded via `GzipDecoder` wrapping a `CsvDecoder`.
+
+**Why this matters:** The contacts stream behaves fundamentally differently from every other stream in the connector. It has no pagination, no incremental sync, and returns data in CSV format instead of JSON. Export jobs can take significant time to complete, and if the job fails or times out on SendGrid's side, no partial results are available.

--- a/airbyte-integrations/connectors/source-sendgrid/CLAUDE.md
+++ b/airbyte-integrations/connectors/source-sendgrid/CLAUDE.md
@@ -1,0 +1,5 @@
+# source-sendgrid
+
+## Unique Behaviors
+See [BEHAVIOR.md](./BEHAVIOR.md) for documented unique behaviors:
+1. Async contacts export with gzipped CSV download (three-phase create/poll/download)

--- a/airbyte-integrations/connectors/source-slack/BEHAVIOR.md
+++ b/airbyte-integrations/connectors/source-slack/BEHAVIOR.md
@@ -1,0 +1,13 @@
+# source-slack: Unique Behaviors
+
+## 1. Auto-Joining Channels During Sync
+
+When `join_channels` is enabled in the config, the `ChannelsRetriever` automatically joins Slack channels by making POST requests to `conversations.join` during the channels stream read. For each channel where the bot's `is_member` property is false, the connector fires a side-effect API call to join that channel before yielding the record. This means reading the channels stream can modify the Slack workspace state.
+
+**Why this matters:** The channels stream is not read-only when `join_channels` is enabled. It actively modifies the workspace by joining channels, which is a side effect that no other connector stream produces. The Slack API only returns messages from channels the bot has joined, so this behavior exists to ensure the messages and threads streams can actually retrieve data. If the bot lacks permission to join a channel, it logs a warning but does not fail the sync.
+
+## 2. Dynamic Rate Limit Policy Switching on First 429
+
+The `MessagesAndThreadsApiBudget` starts with an `UnlimitedCallRatePolicy` (no rate limiting) and dynamically switches to a `MovingWindowCallRatePolicy` of 1 request per 60 seconds after the first 429 response. This switch is permanent for the duration of the sync and only applies to OAuth connections (API token connections do not use this budget).
+
+**Why this matters:** The connector starts fast with no rate limiting and then abruptly drops to 1 request per minute after hitting its first 429. This dramatic slowdown is intentional but can make syncs appear to stall. The rate limit policy is not reset between stream reads within the same sync, so hitting a 429 on the messages stream will also throttle the threads stream.

--- a/airbyte-integrations/connectors/source-slack/CLAUDE.md
+++ b/airbyte-integrations/connectors/source-slack/CLAUDE.md
@@ -1,0 +1,6 @@
+# source-slack
+
+## Key Documentation
+- See `BEHAVIOR.md` for unique connector behaviors including:
+  1. Auto-joining channels during sync via POST side-effect calls
+  2. Dynamic rate limit policy that switches from unlimited to 1 req/min on first 429

--- a/airbyte-integrations/connectors/source-stripe/BEHAVIOR.md
+++ b/airbyte-integrations/connectors/source-stripe/BEHAVIOR.md
@@ -13,3 +13,21 @@ Stripe's Events API only retains events for 30 days. If the connector's state fa
 The base error handler is configured to IGNORE (not fail) responses with HTTP status 403 (permission denied), 400 (bad request), and 404 (not found). When the Stripe API returns any of these errors for a specific resource or subresource, the connector silently skips that record and continues syncing.
 
 **Why this matters:** If an API key loses access to a specific Stripe resource (e.g., Issuing endpoints require special permissions), those records will silently disappear from incremental syncs without any error or warning in the sync logs. A user may not notice they are missing data until they check record counts against the Stripe dashboard.
+
+## 3. Inaccessible Expandable Fields in Events API
+
+As of April 2024, the Stripe API does not support retrieving [expandable fields](https://docs.stripe.com/api/expanding_objects) from the Events API. This limits how the connector can process events during incremental syncs — it cannot reconstruct the full latest state of an object solely from event payloads when expandable fields are involved.
+
+**Why this matters:** During incremental syncs (which read from `/v1/events`), the connector only sees the non-expanded version of each object. Fields that require expansion (e.g., nested customer details on a charge) will be missing or returned as just an ID string. This is a fundamental Stripe API limitation, not a connector bug.
+
+## 4. Populating Data for Sandbox Accounts
+
+Using `Stripe Sandbox Account` test credentials, connect to https://dashboard.stripe.com/ and toggle "Test mode". New records can be added here, but modifying or deleting existing records may cause CAT failures. To create payments, use [Stripe's test credit cards](https://docs.stripe.com/testing#cards) in test mode.
+
+**Why this matters:** CAT tests depend on specific record states in the sandbox. Modifying or deleting records that tests rely on will break assertions. Only add new records when populating test data.
+
+## 5. API Version-Dependent Data Discrepancies in Events
+
+The data returned in event payloads depends on the Stripe API version the object was created with, not the version used to read the event. For example, `charge.refunds` may appear in events even though it is an [expandable field](https://docs.stripe.com/api/expanding_objects) that should not be present — this happens because the sandbox uses API version `2020-08-27`, and the `charge.refunds` field was only [removed in the 2022-11-15 upgrade](https://docs.stripe.com/upgrades#2022-11-15). See [Stripe API versioning](https://docs.stripe.com/api/versioning) for how versions are managed.
+
+**Why this matters:** When debugging unexpected fields appearing (or missing) in event payloads, the root cause may be the API version the data was originally created with, not the connector's behavior. This is especially confusing in sandbox environments where the API version may be much older than production.

--- a/airbyte-integrations/connectors/source-stripe/BEHAVIOR.md
+++ b/airbyte-integrations/connectors/source-stripe/BEHAVIOR.md
@@ -1,0 +1,15 @@
+# source-stripe: Unique Behaviors
+
+## 1. Events-Based Incremental Sync via StateDelegatingStream
+
+Most entity streams (customers, subscriptions, invoices, charges, refunds, transfers, etc.) use `StateDelegatingStream` with a 30-day `api_retention_period`. On the first sync (no state), the connector reads directly from the entity's own endpoint (e.g., `/v1/customers`). On subsequent incremental syncs, it switches to reading from `/v1/events` filtered by specific event types (e.g., `customer.created`, `customer.updated`, `customer.deleted`), then uses `DpathFlattenFields` to unwrap `data.object` and reconstruct the entity record from the event payload.
+
+Stripe's Events API only retains events for 30 days. If the connector's state falls behind by more than 30 days (e.g., after a long pause in syncing), it automatically reverts to a full refresh from the entity endpoint rather than trying to read events that no longer exist.
+
+**Why this matters:** What looks like a simple entity read is actually two completely different data paths depending on whether state exists and how old it is. Adding a new entity stream requires defining both the direct-read retriever AND the events-based retriever with the correct event type filter strings. If the event type strings are wrong, incremental syncs will silently miss updates.
+
+## 2. Silent 403/400/404 Error Ignoring
+
+The base error handler is configured to IGNORE (not fail) responses with HTTP status 403 (permission denied), 400 (bad request), and 404 (not found). When the Stripe API returns any of these errors for a specific resource or subresource, the connector silently skips that record and continues syncing.
+
+**Why this matters:** If an API key loses access to a specific Stripe resource (e.g., Issuing endpoints require special permissions), those records will silently disappear from incremental syncs without any error or warning in the sync logs. A user may not notice they are missing data until they check record counts against the Stripe dashboard.

--- a/airbyte-integrations/connectors/source-stripe/CLAUDE.md
+++ b/airbyte-integrations/connectors/source-stripe/CLAUDE.md
@@ -1,0 +1,6 @@
+# source-stripe
+
+## Key Documentation
+- See `BEHAVIOR.md` for unique connector behaviors including:
+  1. Events-based incremental sync via StateDelegatingStream with 30-day retention fallback
+  2. Silent 403/400/404 error ignoring that can hide missing data

--- a/airbyte-integrations/connectors/source-stripe/CLAUDE.md
+++ b/airbyte-integrations/connectors/source-stripe/CLAUDE.md
@@ -4,3 +4,6 @@
 - See `BEHAVIOR.md` for unique connector behaviors including:
   1. Events-based incremental sync via StateDelegatingStream with 30-day retention fallback
   2. Silent 403/400/404 error ignoring that can hide missing data
+  3. Inaccessible expandable fields in Events API — incremental syncs cannot reconstruct full object state
+  4. Populating sandbox data — only add records, do not modify/delete (breaks CATs)
+  5. API version-dependent data discrepancies — event payloads reflect the version the object was created with

--- a/airbyte-integrations/connectors/source-tiktok-marketing/BEHAVIOR.md
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/BEHAVIOR.md
@@ -84,3 +84,11 @@ this field would cause cursor comparison failures.
 **Why this matters:** This filter silently drops valid ad records from the sync output. If a user
 reports missing ads data, Smart+ ads without `modify_time` values are the likely cause. This is a known
 trade-off to maintain incremental sync reliability.
+
+---
+
+## 6. Sandbox Account Rate Limit and Credential Restriction
+
+The TikTok Sandbox account has a rate limit of 10 requests per second. If you run CATs in CI while simultaneously testing locally with the same credentials, you will exceed this limit and the credentials may be temporarily restricted — preventing **all** requests from succeeding. The restriction appears to last a couple of hours, and there is evidence that continued request attempts during the restriction period extend the lockout duration. There is no official TikTok documentation on this restriction behavior or its exact duration.
+
+**Why this matters:** Unlike most API rate limits that simply queue or retry, exceeding TikTok's sandbox rate limit can completely lock out the credentials for hours. Never run CI tests and local tests concurrently against the sandbox account. If you experience sudden 100% request failures with sandbox credentials, stop all requests and wait before retrying.

--- a/airbyte-integrations/connectors/source-tiktok-marketing/BEHAVIOR.md
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/BEHAVIOR.md
@@ -60,38 +60,7 @@ transformation or the stream will emit invalid metric types.
 
 ---
 
-## 4. Semi-Incremental Sync with Client-Side Filtering
-
-Entity streams (campaigns, ad_groups, ads, creative_assets_images, creative_assets_videos) use
-`is_client_side_incremental: true`, meaning the API does not support server-side filtering by
-`modify_time`. The connector fetches all records and filters them locally based on the cursor value.
-
-TikTok's entity listing endpoints (`campaign/get/`, `adgroup/get/`, `ad/get/`) do not support a
-`modified_since` or equivalent filter parameter. They only support status-based filtering.
-
-**Why this matters:** Every incremental sync of entity streams fetches the complete dataset from the
-API, regardless of cursor position. For accounts with many campaigns, ad groups, or ads, this means
-sync duration and API usage do not decrease over time -- they are always proportional to the total
-number of entities, not just recently modified ones.
-
----
-
-## 5. Report Attribution Window Lookback
-
-Report streams (daily and hourly) support a configurable `attribution_window` (default: 0 days) that
-is applied as a `lookback_window` on the `DatetimeBasedCursor`. TikTok's ad attribution can update
-conversion metrics retroactively as attribution data finalizes, meaning a report row for day X may
-change values for several days after day X.
-
-**Why this matters:** If users set `attribution_window` to a non-zero value (e.g., 7 days), the
-connector will re-fetch report data for the lookback period on every sync, even if that data was
-already synced. This is intentional to capture late-arriving attribution updates, but it means report
-syncs will always request at least `attribution_window` days of data regardless of the cursor position.
-Users must use an append-dedup sync mode in their destination to handle the re-emitted records.
-
----
-
-## 6. Rate Limit Detection via Response Body Code
+## 4. Rate Limit Detection via Response Body Code
 
 TikTok's API does not use standard HTTP 429 status codes for rate limiting. Instead, it returns HTTP
 200 with a `code` field in the JSON response body set to `40100`. The error handler uses a predicate
@@ -105,7 +74,7 @@ rate limits are per-access-token.
 
 ---
 
-## 7. Smart+ Ads Missing modify_time Filter
+## 5. Smart+ Ads Missing modify_time Filter
 
 The `ads` stream includes a `RecordFilter` that drops records where `modify_time` is `None`. This is
 specifically to handle TikTok's Smart+ Ad records, which can be returned by the API without a
@@ -115,19 +84,3 @@ this field would cause cursor comparison failures.
 **Why this matters:** This filter silently drops valid ad records from the sync output. If a user
 reports missing ads data, Smart+ ads without `modify_time` values are the likely cause. This is a known
 trade-off to maintain incremental sync reliability.
-
----
-
-## 8. Authentication via Header Injection (Not OAuth)
-
-Unlike most ad platform connectors, source-tiktok-marketing uses `ApiKeyAuthenticator` that injects the
-access token as an `Access-Token` header, not a Bearer token or OAuth flow. The token is extracted from
-either `config.credentials.access_token` or `config.access_token` (for backward compatibility).
-
-TikTok's Marketing API does not use standard OAuth 2.0 refresh token flows. Access tokens are
-long-lived and obtained through TikTok's developer portal or app authorization flow outside of Airbyte.
-
-**Why this matters:** There is no token refresh mechanism in this connector. If a user's access token
-expires or is revoked, the sync will fail with an authentication error and the user must manually
-obtain and configure a new token. Do not attempt to add an `OAuthAuthenticator` without understanding
-TikTok's specific auth requirements.

--- a/airbyte-integrations/connectors/source-tiktok-marketing/BEHAVIOR.md
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/BEHAVIOR.md
@@ -1,0 +1,133 @@
+# source-tiktok-marketing: Unique Connector Behaviors
+
+This document describes the biggest non-obvious gotchas in `source-tiktok-marketing` that deviate from
+standard declarative connector patterns. Read this before making changes to the connector.
+
+---
+
+## 1. Dynamic Sandbox vs Production Endpoint Selection
+
+The connector dynamically selects between two completely different API base URLs based on the
+authentication type in the config:
+- **Sandbox:** `https://sandbox-ads.tiktok.com/open_api/v1.3/`
+- **Production:** `https://business-api.tiktok.com/open_api/v1.3/`
+
+This is evaluated via a Jinja expression in the `url_base`:
+`"sandbox-ads" if config.get('credentials', {}).get('auth_type', "") == "sandbox_access_token" else "business-api"`.
+
+**Why this matters:** The sandbox and production APIs have different data availability and rate limits.
+When using a sandbox account, it is impossible to retrieve advertiser IDs via the API (the
+`oauth2/advertiser/get/` endpoint does not work), which is why the config allows specifying an
+`advertiser_id` directly. If you test changes against a sandbox account, be aware that some streams may
+behave differently or return no data compared to production.
+
+---
+
+## 2. Dual Advertiser ID Partition Routers
+
+The connector uses two custom partition routers that handle advertiser IDs differently depending on
+whether the ID is provided in the config or fetched from the API:
+
+- **`SingleAdvertiserIdPerPartition`:** Used by most streams. If `advertiser_id` is in the config,
+  yields a single partition with that ID and skips the parent stream entirely. Otherwise, yields one
+  partition per advertiser ID from the `advertiser_ids` parent stream.
+- **`MultipleAdvertiserIdsPerPartition`:** Used only by the `advertisers` stream. Batches up to 100
+  advertiser IDs into a single JSON array partition (e.g., `'["id1", "id2", ...]'`), because TikTok's
+  advertiser info endpoint accepts multiple IDs per request.
+
+Both routers check multiple config paths in priority order (`credentials.advertiser_id` then
+`environment.advertiser_id`).
+
+**Why this matters:** The `advertisers` stream sends advertiser IDs as a JSON array string in the
+request parameter, not as individual values. If you change how advertiser IDs are partitioned, the
+`advertisers` stream needs the batched format while all other streams need individual IDs. Mixing these
+up will cause either missing data (single ID sent where array expected) or API errors (array sent where
+single ID expected).
+
+---
+
+## 3. Empty Metric Values Returned as Dash Strings
+
+TikTok's Reporting API returns the string `"-"` (a literal dash) for metrics that have no data, rather
+than returning `null` or `0`. The `TransformEmptyMetrics` custom transformation iterates over the
+`metrics` object in each report record and converts any `"-"` values to `null`.
+
+**Why this matters:** Without this transformation, downstream schemas expecting numeric types for
+metrics like `spend`, `clicks`, and `impressions` would receive string values, causing type errors in
+destinations. Every report stream (daily, hourly, lifetime, audience, by-country) applies this
+transformation. If you add a new report stream, you must include the `TransformEmptyMetrics`
+transformation or the stream will emit invalid metric types.
+
+---
+
+## 4. Semi-Incremental Sync with Client-Side Filtering
+
+Entity streams (campaigns, ad_groups, ads, creative_assets_images, creative_assets_videos) use
+`is_client_side_incremental: true`, meaning the API does not support server-side filtering by
+`modify_time`. The connector fetches all records and filters them locally based on the cursor value.
+
+TikTok's entity listing endpoints (`campaign/get/`, `adgroup/get/`, `ad/get/`) do not support a
+`modified_since` or equivalent filter parameter. They only support status-based filtering.
+
+**Why this matters:** Every incremental sync of entity streams fetches the complete dataset from the
+API, regardless of cursor position. For accounts with many campaigns, ad groups, or ads, this means
+sync duration and API usage do not decrease over time -- they are always proportional to the total
+number of entities, not just recently modified ones.
+
+---
+
+## 5. Report Attribution Window Lookback
+
+Report streams (daily and hourly) support a configurable `attribution_window` (default: 0 days) that
+is applied as a `lookback_window` on the `DatetimeBasedCursor`. TikTok's ad attribution can update
+conversion metrics retroactively as attribution data finalizes, meaning a report row for day X may
+change values for several days after day X.
+
+**Why this matters:** If users set `attribution_window` to a non-zero value (e.g., 7 days), the
+connector will re-fetch report data for the lookback period on every sync, even if that data was
+already synced. This is intentional to capture late-arriving attribution updates, but it means report
+syncs will always request at least `attribution_window` days of data regardless of the cursor position.
+Users must use an append-dedup sync mode in their destination to handle the re-emitted records.
+
+---
+
+## 6. Rate Limit Detection via Response Body Code
+
+TikTok's API does not use standard HTTP 429 status codes for rate limiting. Instead, it returns HTTP
+200 with a `code` field in the JSON response body set to `40100`. The error handler uses a predicate
+(`response.get('code') == 40100`) to detect rate limiting, and a separate predicate
+(`response.get('code') != 0`) to detect general API errors.
+
+**Why this matters:** Standard HTTP status code-based rate limit detection will not work with TikTok's
+API. If you modify the error handler, make sure the response body code checks remain intact. The error
+message also specifically warns about concurrent connections with the same credentials, as TikTok's
+rate limits are per-access-token.
+
+---
+
+## 7. Smart+ Ads Missing modify_time Filter
+
+The `ads` stream includes a `RecordFilter` that drops records where `modify_time` is `None`. This is
+specifically to handle TikTok's Smart+ Ad records, which can be returned by the API without a
+`modify_time` value. Since the stream uses `modify_time` as its incremental cursor, records without
+this field would cause cursor comparison failures.
+
+**Why this matters:** This filter silently drops valid ad records from the sync output. If a user
+reports missing ads data, Smart+ ads without `modify_time` values are the likely cause. This is a known
+trade-off to maintain incremental sync reliability.
+
+---
+
+## 8. Authentication via Header Injection (Not OAuth)
+
+Unlike most ad platform connectors, source-tiktok-marketing uses `ApiKeyAuthenticator` that injects the
+access token as an `Access-Token` header, not a Bearer token or OAuth flow. The token is extracted from
+either `config.credentials.access_token` or `config.access_token` (for backward compatibility).
+
+TikTok's Marketing API does not use standard OAuth 2.0 refresh token flows. Access tokens are
+long-lived and obtained through TikTok's developer portal or app authorization flow outside of Airbyte.
+
+**Why this matters:** There is no token refresh mechanism in this connector. If a user's access token
+expires or is revoked, the sync will fail with an authentication error and the user must manually
+obtain and configure a new token. Do not attempt to add an `OAuthAuthenticator` without understanding
+TikTok's specific auth requirements.

--- a/airbyte-integrations/connectors/source-tiktok-marketing/CLAUDE.md
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/CLAUDE.md
@@ -9,8 +9,5 @@ See [BEHAVIOR.md](BEHAVIOR.md) for the most important non-obvious gotchas in thi
 - Dynamic sandbox vs production endpoint selection based on auth type
 - Dual advertiser ID partition routers (single vs batched) for different stream types
 - Empty metric values returned as "-" strings that must be transformed to null
-- Semi-incremental sync with client-side filtering (full dataset fetched every sync)
-- Report attribution window lookback for late-arriving conversion data
 - Rate limit detection via response body code (not HTTP 429)
 - Smart+ ads filtered out when missing modify_time values
-- Header-based authentication with no token refresh mechanism

--- a/airbyte-integrations/connectors/source-tiktok-marketing/CLAUDE.md
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/CLAUDE.md
@@ -11,3 +11,4 @@ See [BEHAVIOR.md](BEHAVIOR.md) for the most important non-obvious gotchas in thi
 - Empty metric values returned as "-" strings that must be transformed to null
 - Rate limit detection via response body code (not HTTP 429)
 - Smart+ ads filtered out when missing modify_time values
+- Sandbox account rate limit (10 RPS) with credential lockout on overuse

--- a/airbyte-integrations/connectors/source-tiktok-marketing/CLAUDE.md
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/CLAUDE.md
@@ -1,0 +1,16 @@
+# source-tiktok-marketing
+
+TikTok Marketing API source connector built on the declarative framework with custom Python components
+for advertiser ID partitioning and metric transformation.
+
+## Key Behavior Documentation
+
+See [BEHAVIOR.md](BEHAVIOR.md) for the most important non-obvious gotchas in this connector, including:
+- Dynamic sandbox vs production endpoint selection based on auth type
+- Dual advertiser ID partition routers (single vs batched) for different stream types
+- Empty metric values returned as "-" strings that must be transformed to null
+- Semi-incremental sync with client-side filtering (full dataset fetched every sync)
+- Report attribution window lookback for late-arriving conversion data
+- Rate limit detection via response body code (not HTTP 429)
+- Smart+ ads filtered out when missing modify_time values
+- Header-based authentication with no token refresh mechanism

--- a/airbyte-integrations/connectors/source-typeform/BEHAVIOR.md
+++ b/airbyte-integrations/connectors/source-typeform/BEHAVIOR.md
@@ -1,0 +1,7 @@
+# source-typeform: Unique Behaviors
+
+## 1. Single-Use Rotating Refresh Tokens
+
+Typeform's OAuth implementation issues single-use refresh tokens. Every time an access token is refreshed, the old refresh token is invalidated and a new one is returned. The connector uses `refresh_token_updater` to persist the new refresh token back to the connection configuration after each token exchange.
+
+**Why this matters:** If a token refresh succeeds but the new refresh token fails to persist (e.g., due to a crash or network issue between the exchange and the config update), the connection becomes permanently broken and requires re-authentication. Standard OAuth connectors can retry with the same refresh token, but Typeform cannot.

--- a/airbyte-integrations/connectors/source-typeform/CLAUDE.md
+++ b/airbyte-integrations/connectors/source-typeform/CLAUDE.md
@@ -1,0 +1,5 @@
+# source-typeform
+
+## Unique Behaviors
+See [BEHAVIOR.md](./BEHAVIOR.md) for documented unique behaviors:
+1. Single-use rotating refresh tokens

--- a/airbyte-integrations/connectors/source-zendesk-support/BEHAVIOR.md
+++ b/airbyte-integrations/connectors/source-zendesk-support/BEHAVIOR.md
@@ -1,0 +1,13 @@
+# source-zendesk-support: Unique Behaviors
+
+## 1. StateDelegatingStream for Ticket Metrics
+
+The `ticket_metrics` stream uses `StateDelegatingStream` to choose between two completely different retrieval strategies based on whether stream state exists. On initial sync (no state), it reads all ticket metrics from the bulk `/ticket_metrics` endpoint. On incremental syncs with existing state, it switches to fetching metrics per-ticket via `/tickets/{id}/metrics` using the tickets stream as a parent, which allows truly incremental reads but makes one API call per ticket.
+
+**Why this matters:** The first sync and subsequent syncs use entirely different API endpoints and data flow patterns. The incremental path's per-ticket requests mean sync time scales linearly with the number of updated tickets, and any issues with the parent tickets stream will directly block ticket metrics from syncing.
+
+## 2. Enterprise-Only Streams Disabled at Manifest Level
+
+Several streams (`ticket_forms`, `account_attributes`, `attribute_definitions`) are commented out in the manifest because they require Zendesk Enterprise plans and the CDK does not yet support `ConditionalStreams` based on API endpoint availability. The `ticket_forms` stream definition exists but will FAIL with a descriptive error on 403/404 rather than being silently skipped.
+
+**Why this matters:** These streams cannot be enabled without CDK changes to support conditional stream availability. If a user on an Enterprise plan expects these streams, they will not appear in the catalog at all despite the stream definitions existing in the manifest.

--- a/airbyte-integrations/connectors/source-zendesk-support/BEHAVIOR.md
+++ b/airbyte-integrations/connectors/source-zendesk-support/BEHAVIOR.md
@@ -1,12 +1,27 @@
 # source-zendesk-support: Unique Behaviors
 
-## 1. StateDelegatingStream for Ticket Metrics
+## 1. Tickets Incremental Export Uses `generated_timestamp`, Not `updated_at`
 
-The `ticket_metrics` stream uses `StateDelegatingStream` to choose between two completely different retrieval strategies based on whether stream state exists. On initial sync (no state), it reads all ticket metrics from the bulk `/ticket_metrics` endpoint. On incremental syncs with existing state, it switches to fetching metrics per-ticket via `/tickets/{id}/metrics` using the tickets stream as a parent, which allows truly incremental reads but makes one API call per ticket.
+The tickets stream uses Zendesk's [Time Based Incremental Ticket Export](https://developer.zendesk.com/api-reference/ticketing/ticket-management/incremental_exports/#incremental-ticket-export-time-based) (`GET /api/v2/incremental/tickets.json?start_time={unix_time}`). This endpoint compares `start_time` against each ticket's `generated_timestamp`, **not** its `updated_at` value. The `generated_timestamp` is updated on every ticket change (including silent system updates), while `updated_at` only changes when a [ticket event](https://developer.zendesk.com/api-reference/ticketing/ticket-management/incremental_exports/#incremental-ticket-event-export) is generated. This means the API can return tickets whose `updated_at` is earlier than the requested `start_time`, because a system update bumped the `generated_timestamp` after the last user-visible change.
 
-**Why this matters:** The first sync and subsequent syncs use entirely different API endpoints and data flow patterns. The incremental path's per-ticket requests mean sync time scales linearly with the number of updated tickets, and any issues with the parent tickets stream will directly block ticket metrics from syncing.
+**Why this matters:** `updated_at` is not a reliable cursor for this endpoint. If you filter or deduplicate based on `updated_at`, you will misclassify tickets — some will appear "stale" despite being legitimately returned by the API. The connector uses `generated_timestamp` as the true cursor.
 
-## 2. Enterprise-Only Streams Disabled at Manifest Level
+## 2. StateDelegatingStream for Ticket Metrics — Two Completely Different Sync Paths
+
+The `ticket_metrics` stream uses `StateDelegatingStream` to choose between two completely different retrieval strategies based on whether stream state exists:
+
+**Without state (initial sync / full refresh) — `StatelessTicketMetrics`:**
+Queries the bulk `GET /ticket_metrics` endpoint, which returns records sorted by `created_at` descending (newest first). However, the cursor field is `updated_at`, not `created_at`. Because the sort order doesn't match the cursor field, the stream **must read all records** and cannot checkpoint mid-stream (checkpointing would create state, which would switch to the stateful path on the next page). The stream tracks the most recent `updated_at` value across all records and converts it to a unix timestamp saved as `_ab_updated_at` in state:
+```json
+{ "_ab_updated_at": 1728670522 }
+```
+
+**With state (incremental syncs) — `StatefulTicketMetrics`:**
+Uses a two-step approach: first queries `GET /tickets/cursor.json` to get updated ticket IDs (filtered by `generated_timestamp`), then fetches `GET /tickets/{ticket_id}/metrics` for each ticket. This is more efficient for small deltas but makes one API call per updated ticket. The `generated_timestamp` from the tickets endpoint is converted to the `_ab_updated_at` state cursor to maintain consistency with the stateless path.
+
+**Why this matters:** The synthetic `_ab_updated_at` cursor bridges two fundamentally different data flows. The stateless path is efficient for initial bulk loads but cannot checkpoint. The stateful path scales linearly with the number of updated tickets — efficient for small incremental syncs but disastrous if state is reset and it tries to re-read all tickets one by one. Understanding which path is active (based on state presence) is critical for diagnosing performance issues.
+
+## 3. Enterprise-Only Streams Disabled at Manifest Level
 
 Several streams (`ticket_forms`, `account_attributes`, `attribute_definitions`) are commented out in the manifest because they require Zendesk Enterprise plans and the CDK does not yet support `ConditionalStreams` based on API endpoint availability. The `ticket_forms` stream definition exists but will FAIL with a descriptive error on 403/404 rather than being silently skipped.
 

--- a/airbyte-integrations/connectors/source-zendesk-support/CLAUDE.md
+++ b/airbyte-integrations/connectors/source-zendesk-support/CLAUDE.md
@@ -1,0 +1,6 @@
+# source-zendesk-support
+
+## Unique Behaviors
+See [BEHAVIOR.md](./BEHAVIOR.md) for documented unique behaviors:
+1. StateDelegatingStream for ticket_metrics (bulk endpoint vs per-ticket incremental)
+2. Enterprise-only streams disabled at manifest level (CDK lacks ConditionalStreams)

--- a/airbyte-integrations/connectors/source-zendesk-support/CLAUDE.md
+++ b/airbyte-integrations/connectors/source-zendesk-support/CLAUDE.md
@@ -2,5 +2,6 @@
 
 ## Unique Behaviors
 See [BEHAVIOR.md](./BEHAVIOR.md) for documented unique behaviors:
-1. StateDelegatingStream for ticket_metrics (bulk endpoint vs per-ticket incremental)
-2. Enterprise-only streams disabled at manifest level (CDK lacks ConditionalStreams)
+1. Tickets incremental export uses `generated_timestamp` not `updated_at` — API can return tickets with `updated_at` before the requested `start_time`
+2. StateDelegatingStream for ticket_metrics — stateless bulk path (no checkpointing, synthetic `_ab_updated_at` cursor) vs stateful per-ticket path (one API call per ticket)
+3. Enterprise-only streams disabled at manifest level (CDK lacks ConditionalStreams)

--- a/airbyte-integrations/connectors/source-zendesk-talk/BEHAVIOR.md
+++ b/airbyte-integrations/connectors/source-zendesk-talk/BEHAVIOR.md
@@ -1,0 +1,7 @@
+# source-zendesk-talk: Unique Behaviors
+
+## 1. Single-Use Rotating Refresh Tokens
+
+Zendesk Talk's OAuth implementation issues single-use refresh tokens. Every time an access token is refreshed, the old refresh token is invalidated and a new one is returned. The connector uses `refresh_token_updater` to persist the new refresh token back to the connection configuration after each token exchange.
+
+**Why this matters:** If a token refresh succeeds but the new refresh token fails to persist (e.g., due to a crash or network issue between the exchange and the config update), the connection becomes permanently broken and requires re-authentication. Standard OAuth connectors can retry with the same refresh token, but Zendesk Talk cannot.

--- a/airbyte-integrations/connectors/source-zendesk-talk/CLAUDE.md
+++ b/airbyte-integrations/connectors/source-zendesk-talk/CLAUDE.md
@@ -1,0 +1,5 @@
+# source-zendesk-talk
+
+## Unique Behaviors
+See [BEHAVIOR.md](./BEHAVIOR.md) for documented unique behaviors:
+1. Single-use rotating refresh tokens


### PR DESCRIPTION
## What

Adds `BEHAVIOR.md` and `CLAUDE.md` documentation files for 27 certified API source connectors, following the same pattern established in airbytehq/airbyte#74046 for source-hubspot. These files document the biggest non-obvious gotchas that deviate from standard declarative connector patterns, so that engineers (and AI agents via CLAUDE.md) have context before making changes.

Connectors covered (27 total):
- **source-linkedin-ads** (6 behaviors)
- **source-harvest** (2 behaviors)
- **source-google-search-console** (3 behaviors)
- **source-tiktok-marketing** (5 behaviors)
- **source-amazon-seller-partner** (3 behaviors)
- **source-bing-ads** (2 behaviors)
- **source-instagram** (2 behaviors)
- **source-intercom** (2 behaviors)
- **source-klaviyo** (2 behaviors)
- **source-mailchimp** (1 behavior)
- **source-monday** (3 behaviors)
- **source-notion** (1 behavior)
- **source-pinterest** (1 behavior)
- **source-slack** (2 behaviors)
- **source-stripe** (5 behaviors)
- **source-amazon-ads** (2 behaviors)
- **source-airtable** (1 behavior)
- **source-amplitude** (2 behaviors)
- **source-chargebee** (1 behavior)
- **source-gitlab** (1 behavior)
- **source-google-analytics-data-api** (5 behaviors)
- **source-google-sheets** (2 behaviors)
- **source-jira** (1 behavior)
- **source-sendgrid** (1 behavior)
- **source-typeform** (1 behavior)
- **source-zendesk-support** (3 behaviors)
- **source-zendesk-talk** (1 behavior)

**Connectors analyzed with no unique gotchas found** (no files created): source-freshdesk, source-paypal-transaction, source-sentry, source-snapchat-marketing, source-twilio, source-woocommerce, source-zendesk-chat. These connectors use only standard patterns (state migrations, record transformations, substream routers, auth selectors, standard error handling) that are well-documented in code or CDK docs.

## How

Added 54 new markdown files (one BEHAVIOR.md + one CLAUDE.md per connector). No code changes. Each BEHAVIOR.md follows the same structure: numbered sections with a description of the behavior, relevant API context, and a concise "Why this matters" paragraph explaining the practical impact.

## Updates since last revision

1. Significantly trimmed original four BEHAVIOR.md files per reviewer feedback. Removed common, well-documented patterns: state/config migrations, substreams, dynamic streams, client-side incremental sync, lookback windows, standard pagination/backoff, headers/parameters, auth injection.
2. Expanded coverage to 10 additional certified connectors with genuine unique behaviors. Analyzed all 30 remaining `manifest-only` + `certified` API source connectors (components.py + manifest.yaml). Only created files where truly non-obvious gotchas were identified.
3. Added BEHAVIOR.md and CLAUDE.md for **source-stripe** and **source-amazon-ads** (manifest-only connectors that were previously missed). Re-analyzed all 8 manifest-only connectors; only these 2 had genuine gotchas.
4. Added BEHAVIOR.md and CLAUDE.md for 11 additional connectors after more thorough analysis: source-airtable, source-amplitude, source-chargebee, source-gitlab, source-google-analytics-data-api, source-google-sheets, source-jira, source-sendgrid, source-typeform, source-zendesk-support, source-zendesk-talk.
5. Expanded **source-intercom** (1→2 behaviors) with Companies Scroll API singleton constraint, and expanded **source-google-analytics-data-api** (1→5 behaviors) with two-level Jinja interpolation, fully dynamic stream construction via ConfigComponentsResolver, DimensionFilter config transformation, and cohort report behavior.
6. Added **source-monday** CursorExpiredError section (2→3 behaviors). Monday.com pagination cursors expire after 60 minutes; the connector handles this via `RESET_PAGINATION` which restarts the full stream read. Linked to [Monday.com community discussion](https://developer-community.monday.com/api-apps-framework-4/cursor-used-for-pagination-expires-alternate-way-to-paginate-4083) for API context.
7. Expanded **source-zendesk-support** (2→3 behaviors) with detailed tickets and ticket_metrics behavior based on notes from previous code owner. Added new section 1 documenting that tickets incremental export uses `generated_timestamp` (not `updated_at`) as the true cursor, and significantly expanded section 2 with StatelessTicketMetrics vs StatefulTicketMetrics dual-path behavior, including the synthetic `_ab_updated_at` cursor that bridges the two flows.
8. **Latest:** Added **source-instagram** CAT test access token generation workflow (1→2 behaviors) and expanded **source-stripe** (2→5 behaviors) with three new sections: inaccessible expandable fields in Events API, sandbox data population guidelines, and API version-dependent data discrepancies in event payloads.

## Review guide

This is a docs-only PR. All content was derived from reading each connector's `manifest.yaml` and `components.py`, plus notes from previous code owners for source-zendesk-support, source-instagram, and source-stripe. The reviewer should validate technical accuracy of claims.

### Original 4 connectors (unchanged since last revision)
1. **source-linkedin-ads** — Property chunking math (18 fields/chunk), unpublished rate limits
2. **source-harvest** — Silent 401/403/404 degradation, report cursor format difference
3. **source-google-search-console** — 60 RPM default quota for new GCP projects, aggregationType override
4. **source-tiktok-marketing** — Smart+ ads silently filtered, rate limits via body code 40100

### 10 connectors with custom components (added in previous revision)
5. **source-amazon-seller-partner** — Claims token invalidation uses a *module-level global variable* to link backoff strategy to authenticator. Claims backoff uses *reciprocal* of Retry-After header.
6. **source-bing-ads** — Claims Azure Blob Storage inconsistently applies gzip compression, requiring fallback logic.
7. **source-instagram** — Claims carousel children trigger N additional API calls per record during transformation. **NEW:** Documents CAT test access token generation workflow via Airbyte Cloud OAuth + DevTools monitoring of `complete_oauth` POST request, with token stored in Google Secret Manager (`SECRET_SOURCE-INSTAGRAM__CREDS`).
8. **source-intercom** — Claims proactive rate limiting with specific thresholds (10ms at >50% capacity, 1.5s at medium, 8s at <10%). Claims Companies Scroll API enforces single active scroll per workspace, causing HTTP 400 on concurrent scrolls and HTTP 500 triggers RESET_PAGINATION.
9. **source-klaviyo** — Claims 2 additional API calls per campaign record (recipient count + messages).
10. **source-mailchimp** — Claims OAuth data center extraction makes HTTP call to metadata endpoint during config validation.
11. **source-monday** — Claims GraphQL queries are built at runtime by traversing JSON schema. Claims items use two-level nested pagination. Claims pagination cursors expire after 60 minutes, triggering `RESET_PAGINATION` (full re-read). Based on [Monday.com community discussion](https://developer-community.monday.com/api-apps-framework-4/cursor-used-for-pagination-expires-alternate-way-to-paginate-4083).
12. **source-notion** — Claims blocks retriever recursively fetches up to 30 levels deep.
13. **source-pinterest** — Claims retry wait time is parsed from response body text via regex, not headers.
14. **source-slack** — Claims rate limit policy switch (unlimited → 1 req/min) is permanent for sync duration and cross-stream. Claims channels stream makes POST side-effect calls to join channels.

### 2 manifest-only connectors (added in previous revision)
15. **source-stripe** — Claims StateDelegatingStream switches between entity endpoints and events API based on state age. Claims 30-day event retention causes automatic full-refresh fallback. Claims 403/400/404 errors are silently ignored. **NEW:** Documents that expandable fields are inaccessible in Events API (as of April 2024), sandbox data population guidelines (only add records, don't modify/delete to avoid breaking CATs), and API version-dependent data discrepancies (e.g., `charge.refunds` appearing in events because sandbox uses API version `2020-08-27` but field was removed in `2022-11-15`).
16. **source-amazon-ads** — Claims report streams use AsyncRetriever with three-phase create/poll/download workflow. Claims HTTP 425 (Too Early) is returned for duplicate concurrent report requests.

### 11 additional connectors (added in previous revision)
17. **source-airtable** — Claims single-use rotating refresh tokens via `refresh_token_updater`
18. **source-amplitude** — Claims matrix-style API responses require array zipping and transposition. Claims 4GB export size limit with timeout fallback.
19. **source-chargebee** — Claims Product Catalog version-gated streams silently return zero records via `configuration_incompatible` error code
20. **source-gitlab** — Claims single-use rotating refresh tokens via `refresh_token_updater`
21. **source-google-analytics-data-api** — Claims positional key-value array extraction (headers and values returned separately). Claims two-level Jinja interpolation (template-level vs runtime-level with `{% raw %}`), fully dynamic stream construction via 12+ ComponentMappingDefinition entries, DimensionFilter config transformation with 4 filter types, and cohort reports disable date ranges/incremental sync.
22. **source-google-sheets** — Claims schema derived from row 1 with positional value matching. Claims batch row fetching with 180-second per-request timeout.
23. **source-jira** — Claims global silent 400 error ignoring across all streams
24. **source-sendgrid** — Claims contacts stream uses async export with gzipped CSV download (three-phase create/poll/download)
25. **source-typeform** — Claims single-use rotating refresh tokens via `refresh_token_updater`
26. **source-zendesk-support** — Claims tickets incremental export uses `generated_timestamp` (not `updated_at`) as the true cursor, meaning API can return tickets with `updated_at` before the requested `start_time`. Claims StateDelegatingStream for ticket_metrics uses two completely different paths: StatelessTicketMetrics (bulk endpoint, no checkpointing, reads all records, synthetic `_ab_updated_at` cursor) vs StatefulTicketMetrics (per-ticket endpoint, one API call per ticket). Claims enterprise-only streams are commented out in manifest.
27. **source-zendesk-talk** — Claims single-use rotating refresh tokens via `refresh_token_updater`

### Human review checklist
- [ ] **source-instagram CAT test workflow:** Verify the OAuth flow via Airbyte Cloud + DevTools is accurate. Verify the secret name `SECRET_SOURCE-INSTAGRAM__CREDS` is correct for Google Secret Manager.
- [ ] **source-stripe expandable fields:** Verify the claim that expandable fields are inaccessible in Events API as of April 2024. Check if this limitation still exists or has been resolved.
- [ ] **source-stripe sandbox data:** Verify the guidance about only adding records (not modifying/deleting) to avoid breaking CATs is accurate for the test environment.
- [ ] **source-stripe API versioning:** Verify the example about `charge.refunds` appearing in events due to API version `2020-08-27` vs removal in `2022-11-15`. Verify the sandbox uses this older API version.
- [ ] **source-zendesk-support tickets behavior:** Verify that tickets stream uses `/api/v2/incremental/tickets.json?start_time=` endpoint and that it compares against `generated_timestamp` not `updated_at`. Verify the claim that API can return tickets with `updated_at` earlier than `start_time`. This claim is based on notes from a previous code owner and [Zendesk API documentation](https://developer.zendesk.com/api-reference/ticketing/ticket-management/incremental_exports/#incremental-ticket-export-time-based).
- [ ] **source-zendesk-support ticket_metrics dual-path:** Verify StatelessTicketMetrics uses `/ticket_metrics` endpoint sorted by `created_at` descending but tracks `updated_at` cursor. Verify StatefulTicketMetrics uses `/tickets/cursor.json` then `/tickets/{id}/metrics`. Verify the synthetic `_ab_updated_at` cursor is used in both paths. Verify the claim that stateless path cannot checkpoint mid-stream.
- [ ] **source-monday cursor expiration:** Verify that `CursorExpiredError` triggers `RESET_PAGINATION` in manifest.yaml error handler. Note that the 60-minute expiry claim is based on community forum posts, not official API documentation.
- [ ] **source-intercom scroll behavior:** Verify that companies stream uses `/companies/scroll` endpoint and that HTTP 400 "Scroll already exists" error is documented in error handler. Verify HTTP 500 triggers RESET_PAGINATION.
- [ ] **source-google-analytics-data-api interpolation:** Verify the two-level Jinja interpolation explanation is accurate by checking `components_mapping` section. Verify `{% raw %}` blocks exist and that string concatenation with `~` is used for schema filter.
- [ ] **source-google-analytics-data-api dynamic streams:** Verify 12+ ComponentMappingDefinition entries exist and that ConfigComponentsResolver is used. Verify conditional behaviors (runReport vs runPivotReport, pagination disabling, etc.).
- [ ] **source-google-analytics-data-api DimensionFilter:** Verify custom DimensionFilterConfigTransformation component exists and handles 4 filter types.
- [ ] **source-google-analytics-data-api cohort reports:** Verify cohortSpec disables date ranges and incremental sync.
- [ ] Verify that `refresh_token_updater` truly means single-use tokens for source-airtable, source-gitlab, source-typeform, and source-zendesk-talk (not just token rotation)
- [ ] Verify source-jira's global 400 IGNORE claim by checking the base error handler definition
- [ ] Verify source-zendesk-support's claim that enterprise streams are "commented out" in the manifest
- [ ] Verify source-google-sheets schema derivation is truly "non-obvious" (it may be well-documented in Google Sheets API docs)
- [ ] Verify source-chargebee's `configuration_incompatible` error code handling
- [ ] Verify source-sendgrid's contacts stream uses AsyncRetriever with gzipped CSV
- [ ] Verify source-amplitude's 4GB export limit and matrix response extraction claims
- [ ] Verify source-stripe's StateDelegatingStream claim: check that `api_retention_period: P30D` exists and that events are only retained 30 days
- [ ] Verify source-stripe's silent error ignoring claim: check base error handler for IGNORE action on 403/400/404
- [ ] Verify source-amazon-ads's HTTP 425 claim: check error handler for 425 status code and "duplicate report requests" message
- [ ] Verify source-amazon-seller-partner's global module variable claim (lines 38-76 in components.py)
- [ ] Verify source-bing-ads's Azure Blob Storage gzip inconsistency claim
- [ ] Verify source-slack's claim that rate limit policy switching is permanent and affects all streams in the sync
- [ ] Verify source-intercom's specific rate limiting threshold percentages (10%, 50%)
- [ ] Verify source-monday's claim that GraphQL queries are built from JSON schema at runtime
- [ ] Verify source-klaviyo's claim about 2 API calls per campaign (check CampaignsDetailedTransformation)
- [ ] Sanity-check that the 7 connectors without BEHAVIOR.md files truly have no unique gotchas worth documenting

## User Impact

No user-facing impact. Documentation only, consumed by engineers and AI coding agents working on these connectors.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Requested by: @brianjlai    
[Link to Devin run](https://app.devin.ai/sessions/5abb4107d5364d37bc5aceebee32beaf)