### PR TITLE
fix(source-intercom): add step size and end_datetime to prevent stale cursor OOM (rc.4)

### DIFF
--- a/airbyte-integrations/connectors/source-intercom/manifest.yaml
+++ b/airbyte-integrations/connectors/source-intercom/manifest.yaml
@@ -54,17 +54,27 @@ definitions:
       incremental_sync:
         type: DatetimeBasedCursor
         cursor_field: created_at
-        lookback_window: P{{ config.get('lookback_window', 0) }}D
         cursor_datetime_formats:
           - "%s"
         datetime_format: "%s"
         start_datetime:
           type: MinMaxDatetime
-          datetime: "{{ config[\"start_date\"] }}"
+          datetime: "{{ config['start_date'] }}"
           datetime_format: "%Y-%m-%dT%H:%M:%SZ"
+        end_datetime:
+          type: MinMaxDatetime
+          datetime: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"
+          datetime_format: "%Y-%m-%dT%H:%M:%SZ"
+        step: P30D
+        cursor_granularity: PT1S
+        lookback_window: P{{ config.get('lookback_window', 0) }}D
         start_time_option:
           type: RequestOption
           field_name: created_at_after
+          inject_into: request_parameter
+        end_time_option:
+          type: RequestOption
+          field_name: created_at_before
           inject_into: request_parameter
       schema_loader:
         type: InlineSchemaLoader
@@ -415,8 +425,13 @@ definitions:
             Intercom-Version: "2.11"
           request_body_json:
             query: >-
-              { 'operator': 'OR', 'value': [ { 'field': 'updated_at', 'operator': '>', 'value': {{ stream_interval.get('start_time', {}) or format_datetime(config['start_date'], '%s') }} }, { 'field': 'updated_at', 'operator': '=', 'value': {{ stream_interval.get('start_time', {}) or format_datetime(config['start_date'], '%s') }} } ] }
-            sort: "{'field': 'updated_at', 'order': 'ascending'}"
+              {"operator" : "AND", "value" : [ {"operator" : "OR", "value" : [
+              {"field" : "updated_at", "operator" : ">", "value" : {{
+              stream_interval['start_time'] }} }, {"field" : "updated_at",
+              "operator" : "=", "value" : {{ stream_interval['start_time'] }}
+              }]},  {"field" : "updated_at", "operator" : "<", "value" :  {{
+              stream_interval['end_time'] }} } ]}
+            sort: "{\"field\": \"updated_at\", \"order\": \"ascending\"}"
           error_handler:
             type: CustomErrorHandler
             class_name: source_declarative_manifest.components.ErrorHandlerWithRateLimiter
@@ -453,14 +468,20 @@ definitions:
       incremental_sync:
         type: DatetimeBasedCursor
         cursor_field: updated_at
-        start_datetime:
-          type: MinMaxDatetime
-          datetime: "{{ format_datetime(config['start_date'], '%s') }}"
-          datetime_format: "%s"
-        datetime_format: "%s"
-        lookback_window: P{{ config.get('lookback_window', 0) }}D
         cursor_datetime_formats:
           - "%s"
+        datetime_format: "%s"
+        start_datetime:
+          type: MinMaxDatetime
+          datetime: "{{ config['start_date'] }}"
+          datetime_format: "%Y-%m-%dT%H:%M:%SZ"
+        end_datetime:
+          type: MinMaxDatetime
+          datetime: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"
+          datetime_format: "%Y-%m-%dT%H:%M:%SZ"
+        step: P30D
+        cursor_granularity: PT1S
+        lookback_window: P{{ config.get('lookback_window', 0) }}D
         is_client_side_incremental: true
       schema_loader:
         type: InlineSchemaLoader
@@ -481,14 +502,14 @@ definitions:
             Accept: application/json
             Intercom-Version: "2.11"
           request_body_json:
-            sort: "{'field': 'updated_at', 'order': 'ascending'}"
+            sort: "{\"field\": \"updated_at\", \"order\": \"ascending\"}"
             query: >-
-              { 'operator': 'OR', 'value': [ { 'field': 'updated_at',
-              'operator': '>', 'value': {{ stream_interval.get('start_time', {}) or
-              format_datetime(config['start_date'], '%s') }} }, { 'field':
-              'updated_at', 'operator': '=', 'value': {{
-              stream_interval.get('start_time', {}) or format_datetime(config['start_date'],
-              '%s') }} }, ], }
+              {"operator" : "AND", "value" : [ {"operator" : "OR", "value" : [
+              {"field" : "updated_at", "operator" : ">", "value" : {{
+              stream_interval['start_time'] }} }, {"field" : "updated_at",
+              "operator" : "=", "value" : {{ stream_interval['start_time'] }}
+              }]},  {"field" : "updated_at", "operator" : "<", "value" :  {{
+              stream_interval['end_time'] }} } ]}
           error_handler:
             type: CustomErrorHandler
             class_name: source_declarative_manifest.components.ErrorHandlerWithRateLimiter
@@ -525,14 +546,20 @@ definitions:
       incremental_sync:
         type: DatetimeBasedCursor
         cursor_field: updated_at
-        start_datetime:
-          type: MinMaxDatetime
-          datetime: "{{ format_datetime(config['start_date'], '%s') }}"
-          datetime_format: "%s"
-        datetime_format: "%s"
-        lookback_window: P{{ config.get('lookback_window', 0) }}D
         cursor_datetime_formats:
           - "%s"
+        datetime_format: "%s"
+        start_datetime:
+          type: MinMaxDatetime
+          datetime: "{{ config['start_date'] }}"
+          datetime_format: "%Y-%m-%dT%H:%M:%SZ"
+        end_datetime:
+          type: MinMaxDatetime
+          datetime: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"
+          datetime_format: "%Y-%m-%dT%H:%M:%SZ"
+        step: P30D
+        cursor_granularity: PT1S
+        lookback_window: P{{ config.get('lookback_window', 0) }}D
         is_client_side_incremental: true
       schema_loader:
         type: InlineSchemaLoader

--- a/airbyte-integrations/connectors/source-intercom/metadata.yaml
+++ b/airbyte-integrations/connectors/source-intercom/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: d8313939-3782-41b0-be29-b3ca20d8dd3a
-  dockerImageTag: 0.13.16-rc.2
+  dockerImageTag: 0.13.16-rc.4
   dockerRepository: airbyte/source-intercom
   documentationUrl: https://docs.airbyte.com/integrations/sources/intercom
   externalDocumentationUrls:

--- a/docs/integrations/sources/intercom.md
+++ b/docs/integrations/sources/intercom.md
@@ -97,6 +97,7 @@ The Intercom connector should not run into Intercom API limitations under normal
 
 | Version     | Date       | Pull Request                                             | Subject                                                                                                                              |
 |:------------|:-----------|:---------------------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------|
+| 0.13.16-rc.4 | 2026-03-02 | [74142](https://github.com/airbytehq/airbyte/pull/74142) | fix(source-intercom): add step size and end_datetime to prevent stale cursor OOM |
 | 0.13.16-rc.2 | 2026-02-18 | [73635](https://github.com/airbytehq/airbyte/pull/73635) | fix(source-intercom): bump heartbeat timeout from 6h to 9h |
 | 0.13.16-rc.1 | 2025-12-11 | [70335](https://github.com/airbytehq/airbyte/pull/70335) | Fix pagination on companies stream |
 | 0.13.15 | 2025-11-25 | [69563](https://github.com/airbytehq/airbyte/pull/69563) | Update dependencies |


### PR DESCRIPTION
## What
Addresses OOM/slow-sync failures in `source-intercom` when a stream’s cursor is far behind (stale), causing the connector to attempt syncing a very large time range in a single slice.

Related context: https://github.com/airbytehq/oncall/issues/11198  
This PR is intended as an RC.4 follow-up to the previously pinned fix in https://github.com/airbytehq/airbyte/pull/72955.

## How
Adds **bounded, windowed time slicing** (`step: P30D`) and an **upper bound** (`end_datetime`) to streams that support server-side time filtering:
- `contacts`: updates the search query from unbounded `updated_at >= start` to `start <= updated_at < end`
- `conversations`: same change as `contacts`
- `activity_logs`: adds `created_at_before` via `end_time_option` and enables windowing

Also sets `cursor_granularity: PT1S` (required by the CDK when `step` is set).

Bumps progressive rollout version to `0.13.16-rc.4` and updates the connector docs changelog entry accordingly.

## Review guide
1. `airbyte-integrations/connectors/source-intercom/manifest.yaml`
   - `activity_logs` incremental config: verify `created_at_before` mapping + windowing
   - `contacts` search query: verify AND/OR nesting and `< end_time` constraint
   - `contacts` + `conversations` incremental config: verify `step`, `end_datetime`, and cursor formatting assumptions
2. `airbyte-integrations/connectors/source-intercom/metadata.yaml`
   - version bump to `0.13.16-rc.4`
3. `docs/integrations/sources/intercom.md`
   - changelog row added for `0.13.16-rc.4`

### Reviewer checklist (highest risk)
- [ ] Confirm Intercom search API accepts the updated query JSON structure and the `< end` constraint.
- [ ] Confirm `admins/activity_logs` supports `created_at_before` (paired with `created_at_after`).
- [ ] Sanity-check that step/windowing + cursor formats won’t break existing state advancement for `contacts`/`conversations`.

## User Impact
Connections with stale cursors should progress in predictable 30-day windows rather than attempting an unbounded historical backfill in one slice, significantly reducing memory pressure and improving recoverability on retry.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌

---
[Devin session](https://app.devin.ai/sessions/111aeecb196a4bf6a471f7c06e7f4e25)  
Requested by: @agarctfi