### PR TITLE
docs(ai-agents): rename CLI from `adp` to `agent-engine` and remove `--prerelease allow`

### DIFF
--- a/docs/ai-agents/mcp-server/cli-reference.md
+++ b/docs/ai-agents/mcp-server/cli-reference.md
@@ -5,35 +5,35 @@ sidebar_position: 4
 
 # Command line reference
 
-All commands use `uv run adp <command>`. Use `--help` on any command for full options.
+All commands use `uv run agent-engine <command>`. Use `--help` on any command for full options.
 
 ## Global flags
 
 | Flag | Description |
 | --- | --- |
 | `--config-dir`, `-d` | Config directory (default: `~/.airbyte_agent_mcp`). Can also be set with the `AIRBYTE_CONFIG_DIR` environment variable. |
-| `--org` | Organization ID to use, overriding the default set by `adp login`. |
+| `--org` | Organization ID to use, overriding the default set by `agent-engine login`. |
 
-## `adp connectors list-oss`
+## `agent-engine connectors list-oss`
 
 List available open source connectors from the Airbyte registry.
 
 ```bash
-uv run adp connectors list-oss
-uv run adp connectors list-oss --pattern salesforce
+uv run agent-engine connectors list-oss
+uv run agent-engine connectors list-oss --pattern salesforce
 ```
 
 | Flag              | Description               |
 | ----------------- | ------------------------- |
 | `--pattern`, `-p` | Filter connectors by name |
 
-## `adp connectors list-cloud`
+## `agent-engine connectors list-cloud`
 
-List connectors configured in your Agent Engine organization. Requires [`adp login`](#adp-login) first.
+List connectors configured in your Agent Engine organization. Requires [`agent-engine login`](#agent-engine-login) first.
 
 ```bash
-uv run adp connectors list-cloud
-uv run adp connectors list-cloud --customer acme
+uv run agent-engine connectors list-cloud
+uv run agent-engine connectors list-cloud --customer acme
 ```
 
 | Flag             | Description             |
@@ -41,13 +41,13 @@ uv run adp connectors list-cloud --customer acme
 | `--customer`, `-c` | Filter by customer name |
 | `--customer-id`  | Filter by customer ID   |
 
-## `adp connectors configure`
+## `agent-engine connectors configure`
 
 Generate a connector configuration file by inspecting the connector's authentication requirements.
 
 ```bash
-uv run adp connectors configure --package airbyte-agent-gong
-uv run adp connectors configure --connector-id <your-connector-id>
+uv run agent-engine connectors configure --package airbyte-agent-gong
+uv run agent-engine connectors configure --connector-id <your-connector-id>
 ```
 
 | Flag                   | Description                                          |
@@ -58,26 +58,26 @@ uv run adp connectors configure --connector-id <your-connector-id>
 | `--filename`, `-f`      | Output file path (auto-generated if not specified)     |
 | `--overwrite`, `-o`    | Overwrite the output file if it already exists        |
 
-## `adp login`
+## `agent-engine login`
 
 Save Agent Engine credentials to the global config directory. Prompts for your Client ID and Secret, then stores them for subsequent commands.
 
 ```bash
-uv run adp login <organization-id>
+uv run agent-engine login <organization-id>
 ```
 
 | Flag                | Description                                  |
 | ------------------- | -------------------------------------------- |
 | `<organization-id>` | Your Agent Engine organization ID (required) |
 
-## `adp orgs`
+## `agent-engine orgs`
 
 Manage logged-in organizations.
 
 ```bash
-uv run adp orgs list
-uv run adp orgs default
-uv run adp orgs default <org-id>
+uv run agent-engine orgs list
+uv run agent-engine orgs default
+uv run agent-engine orgs default <org-id>
 ```
 
 | Subcommand         | Description                      |
@@ -86,13 +86,13 @@ uv run adp orgs default <org-id>
 | `default`          | Show the default organization    |
 | `default <org-id>` | Set the default organization     |
 
-## `adp mcp serve`
+## `agent-engine mcp serve`
 
 Start the MCP server with a connector configuration.
 
 ```bash
-uv run adp mcp serve connector-gong-package.yaml
-uv run adp mcp serve connector-gong-package.yaml --transport http --port 8080
+uv run agent-engine mcp serve connector-gong-package.yaml
+uv run agent-engine mcp serve connector-gong-package.yaml --transport http --port 8080
 ```
 
 | Flag                | Default     | Description                            |
@@ -101,13 +101,13 @@ uv run adp mcp serve connector-gong-package.yaml --transport http --port 8080
 | `--host`, `-h`      | `127.0.0.1` | Host to bind to (HTTP only)            |
 | `--port`, `-p`      | `8000`      | Port to bind to (HTTP only)            |
 
-## `adp mcp add-to`
+## `agent-engine mcp add-to`
 
 Register the MCP server with an agent. Supported targets: `claude-code`, `claude-desktop`, `cursor`, `codex`.
 
 ```bash
-uv run adp mcp add-to claude-code connector-gong-package.yaml
-uv run adp mcp add-to cursor connector-gong-package.yaml --scope project
+uv run agent-engine mcp add-to claude-code connector-gong-package.yaml
+uv run agent-engine mcp add-to cursor connector-gong-package.yaml --scope project
 ```
 
 | Flag            | Default | Description                                                    |
@@ -115,13 +115,13 @@ uv run adp mcp add-to cursor connector-gong-package.yaml --scope project
 | `--name`, `-n`  | Auto    | Name for the MCP server (default: `airbyte-<connector>`)       |
 | `--scope`, `-s` | `user`  | Configuration scope: `user` or `project` (Claude Code, Cursor)  |
 
-## `adp chat`
+## `agent-engine chat`
 
 Chat with connector data using natural language in the terminal. Uses Claude and requires an `ANTHROPIC_API_KEY` environment variable. Pass a prompt argument for one-shot mode, or omit it to start an interactive REPL.
 
 ```bash
-uv run adp chat connector-gong-package.yaml "show me 5 recent calls"
-uv run adp chat connector-gong-package.yaml
+uv run agent-engine chat connector-gong-package.yaml "show me 5 recent calls"
+uv run agent-engine chat connector-gong-package.yaml
 ```
 
 | Flag            | Default           | Description                                  |

--- a/docs/ai-agents/mcp-server/configuration.md
+++ b/docs/ai-agents/mcp-server/configuration.md
@@ -30,7 +30,7 @@ credentials:
   access_key_secret: ${env.GONG_ACCESS_KEY_SECRET}
 ```
 
-Some connectors also accept a `config` section for additional parameters like subdomains or workspace IDs. The `adp connectors configure` command generates the correct structure for each connector.
+Some connectors also accept a `config` section for additional parameters like subdomains or workspace IDs. The `agent-engine connectors configure` command generates the correct structure for each connector.
 
 You can [configure multiple connectors](#use-multiple-connectors-with-one-mcp-server) in the same MCP server.
 
@@ -40,7 +40,7 @@ In open source mode, the MCP server installs a connector package and calls the t
 
 ### PyPI packages
 
-The most common configuration. Run `uv run adp connectors list-oss` to see available packages and their versions, then specify a package name from the Airbyte connector registry.
+The most common configuration. Run `uv run agent-engine connectors list-oss` to see available packages and their versions, then specify a package name from the Airbyte connector registry.
 
 ```yaml title="connector-gong-package.yaml"
 connector:
@@ -104,7 +104,7 @@ credentials:
   access_key_secret: ${env.GONG_ACCESS_KEY_SECRET}
 ```
 
-The `adp` command line tool automatically loads `.env` files from the current working directory. Create a `.env` file alongside your connector configuration:
+The `agent-engine` command line tool automatically loads `.env` files from the current working directory. Create a `.env` file alongside your connector configuration:
 
 ```text title=".env"
 GONG_ACCESS_KEY=your-access-key
@@ -127,26 +127,26 @@ Before you can use a connector in hosted mode, you need to [authenticate with th
 
 ### Step 1: Log in to Agent Engine
 
-Run `adp login` with your organization ID. This opens a link to your Airbyte authentication page where you can find your Client ID and Secret.
+Run `agent-engine login` with your organization ID. This opens a link to your Airbyte authentication page where you can find your Client ID and Secret.
 
 ```bash
-uv run adp login <organization-id>
+uv run agent-engine login <organization-id>
 ```
 
-The command prompts for your client ID and secret, saves them to `~/.airbyte_agent_mcp/orgs/<organization-id>/.env`, and sets the organization as the default. All subsequent `adp` commands automatically load these credentials.
+The command prompts for your client ID and secret, saves them to `~/.airbyte_agent_mcp/orgs/<organization-id>/.env`, and sets the organization as the default. All subsequent `agent-engine` commands automatically load these credentials.
 
 ### Step 2: Find your connector ID
 
 List the connectors configured in your organization:
 
 ```bash
-uv run adp connectors list-cloud
+uv run agent-engine connectors list-cloud
 ```
 
 Use `--customer` to filter by customer name:
 
 ```bash
-uv run adp connectors list-cloud --customer acme
+uv run agent-engine connectors list-cloud --customer acme
 ```
 
 ### Step 3: Generate a configuration
@@ -154,7 +154,7 @@ uv run adp connectors list-cloud --customer acme
 Pass the connector ID from the previous step:
 
 ```bash
-uv run adp connectors configure --connector-id <your-connector-id>
+uv run agent-engine connectors configure --connector-id <your-connector-id>
 ```
 
 This generates a configuration file like this:
@@ -172,9 +172,9 @@ credentials:
 If you work with multiple Agent Engine organizations, you can log into each one and switch between them.
 
 ```bash
-uv run adp orgs list                  # List logged-in organizations
-uv run adp orgs default <org-id>      # Set the default organization
-uv run adp --org <org-id> <command>   # Override for a single command
+uv run agent-engine orgs list                  # List logged-in organizations
+uv run agent-engine orgs default <org-id>      # Set the default organization
+uv run agent-engine --org <org-id> <command>   # Override for a single command
 ```
 
 ## Use multiple connectors with one MCP server {#use-multiple-connectors-with-one-mcp-server}
@@ -203,7 +203,7 @@ Then, register the aggregate config with your agent the same way you would a sin
 This command runs `claude mcp add` under the hood and registers the server at the user scope.
 
 ```bash
-uv run adp mcp add-to claude-code connectors.yaml
+uv run agent-engine mcp add-to claude-code connectors.yaml
 ```
 
 To register at the project scope instead, add `--scope project` to that command.
@@ -214,7 +214,7 @@ To register at the project scope instead, add `--scope project` to that command.
 This command modifies your Claude Desktop configuration file directly.
 
 ```bash
-uv run adp mcp add-to claude-desktop connectors.yaml
+uv run agent-engine mcp add-to claude-desktop connectors.yaml
 ```
 
 </TabItem>
@@ -223,7 +223,7 @@ uv run adp mcp add-to claude-desktop connectors.yaml
 This modifies the Cursor MCP configuration file.
 
 ```bash
-uv run adp mcp add-to cursor connectors.yaml
+uv run agent-engine mcp add-to cursor connectors.yaml
 ```
 
 To register at the project scope instead of user scope, add a `--scope project` flag.
@@ -234,7 +234,7 @@ To register at the project scope instead of user scope, add a `--scope project` 
 This command runs `codex mcp add` to register the server.
 
 ```bash
-uv run adp mcp add-to codex connectors.yaml
+uv run agent-engine mcp add-to codex connectors.yaml
 ```
 
 </TabItem>
@@ -243,7 +243,7 @@ uv run adp mcp add-to codex connectors.yaml
 You can optionally specify a custom name for the server with `--name`:
 
 ```bash
-uv run adp mcp add-to claude-code connector-github-package.yaml --name my-server-name
+uv run agent-engine mcp add-to claude-code connector-github-package.yaml --name my-server-name
 ```
 
-For a full list of all `adp` commands and their options, see the [CLI reference](cli-reference).
+For a full list of all `agent-engine` commands and their options, see the [CLI reference](cli-reference).

--- a/docs/ai-agents/mcp-server/readme.md
+++ b/docs/ai-agents/mcp-server/readme.md
@@ -36,13 +36,13 @@ The server supports two execution modes:
 
 - **Hosted mode**: The server calls the Airbyte Cloud API, which manages credentials and provides additional capabilities like indexed search through the [context store](../platform/context-store).
 
-A command line tool called `adp` manages the full lifecycle:
+A command line tool called `agent-engine` manages the full lifecycle:
 
-1. **Discover** connectors with `adp connectors list-oss` or `adp connectors list-cloud`.
+1. **Discover** connectors with `agent-engine connectors list-oss` or `agent-engine connectors list-cloud`.
 
-2. **Configure** a connector with `adp connectors configure`, which generates a YAML config file.
+2. **Configure** a connector with `agent-engine connectors configure`, which generates a YAML config file.
 
-3. **Register** the server with your AI tool using `adp mcp add-to`.
+3. **Register** the server with your AI tool using `agent-engine mcp add-to`.
 
 4. **Use** the server by prompting your AI tool with natural language questions.
 

--- a/docs/ai-agents/mcp-server/troubleshooting.md
+++ b/docs/ai-agents/mcp-server/troubleshooting.md
@@ -18,7 +18,7 @@ Your agent can't discover the MCP server's tools.
 
 The MCP server fails to start or returns credential errors.
 
-- Verify your `.env` file is in the same directory where you run `adp` commands.
+- Verify your `.env` file is in the same directory where you run `agent-engine` commands.
 - Confirm the variable names in your `.env` file match the `${env.VAR_NAME}` placeholders in your YAML configuration.
 - Check that there are no extra spaces or characters in your `.env` values.
 
@@ -27,7 +27,7 @@ The MCP server fails to start or returns credential errors.
 Authentication failed.
 
 - **Open source mode**: Your API credential is invalid or expired. Generate a new credential from the third-party service and update your `.env` file.
-- **Hosted mode**: Your Agent Engine credentials are invalid. Run `uv run adp login <organization-id>` to re-enter your Client ID and Secret.
+- **Hosted mode**: Your Agent Engine credentials are invalid. Run `uv run agent-engine login <organization-id>` to re-enter your Client ID and Secret.
 
 ## HTTP 403 errors
 

--- a/docs/ai-agents/mcp-server/usage.md
+++ b/docs/ai-agents/mcp-server/usage.md
@@ -96,14 +96,14 @@ Files are saved to `~/.airbyte_agent_mcp/downloads/` (or `~/.airbyte_agent_mcp/o
 
 ### stdio (default)
 
-The default transport mode. The MCP server communicates over standard input/output, which is how most AI coding tools expect to interact with MCP servers. This is what `adp mcp add-to` configures.
+The default transport mode. The MCP server communicates over standard input/output, which is how most AI coding tools expect to interact with MCP servers. This is what `agent-engine mcp add-to` configures.
 
 ### HTTP
 
 For integrations that need an HTTP endpoint:
 
 ```bash
-uv run adp mcp serve connector-gong-package.yaml --transport http --port 8080
+uv run agent-engine mcp serve connector-gong-package.yaml --transport http --port 8080
 ```
 
 | Flag | Default | Description |
@@ -114,28 +114,28 @@ uv run adp mcp serve connector-gong-package.yaml --transport http --port 8080
 
 ## Terminal chat
 
-The `adp chat` command is a lightweight terminal agent for querying your connector data with natural language. It uses Claude to interpret your questions, call the MCP server tools, and return formatted answers without needing an IDE integration. This is useful for testing your connector setup or running ad-hoc data queries.
+The `agent-engine chat` command is a lightweight terminal agent for querying your connector data with natural language. It uses Claude to interpret your questions, call the MCP server tools, and return formatted answers without needing an IDE integration. This is useful for testing your connector setup or running ad-hoc data queries.
 
-`adp chat` requires an `ANTHROPIC_API_KEY` environment variable and only supports Anthropic models. The default model is `claude-opus-4-6`. Use `--model` to select a different Anthropic model.
+`agent-engine chat` requires an `ANTHROPIC_API_KEY` environment variable and only supports Anthropic models. The default model is `claude-opus-4-6`. Use `--model` to select a different Anthropic model.
 
 ### One-shot mode
 
 Pass a prompt as an argument to get a single response. Tool call progress is written to stderr, so you can pipe the final answer to a file:
 
 ```bash
-uv run adp chat connector-gong-package.yaml "show me 5 recent calls"
+uv run agent-engine chat connector-gong-package.yaml "show me 5 recent calls"
 ```
 
 Use `--quiet` to hide tool call details and show only the final answer.
 
 ```bash
-uv run adp chat connector-gong-package.yaml "show me 5 recent calls" --quiet
+uv run agent-engine chat connector-gong-package.yaml "show me 5 recent calls" --quiet
 ```
 
 You can also use an aggregate configuration.
 
 ```bash
-uv run adp chat connectors.yaml "show me 5 users from each system"
+uv run agent-engine chat connectors.yaml "show me 5 users from each system"
 ```
 
 ### Interactive REPL
@@ -143,7 +143,7 @@ uv run adp chat connectors.yaml "show me 5 users from each system"
 Omit the prompt to start an interactive session. The REPL maintains conversation history across turns, so you can ask follow-up questions.
 
 ```bash
-uv run adp chat connector-gong-package.yaml
+uv run agent-engine chat connector-gong-package.yaml
 ```
 
 Type `exit`, `quit`, or press Ctrl-C to end the session.

--- a/docs/ai-agents/tutorials/quickstarts/tutorial-mcp-server.md
+++ b/docs/ai-agents/tutorials/quickstarts/tutorial-mcp-server.md
@@ -43,28 +43,24 @@ mkdir my-mcp-server && cd my-mcp-server
 uv init --python 3.13
 ```
 
-Add `airbyte-agent-mcp` as a dependency. This installs the package and makes the `adp` command-line tool, available through `uv run`. You use `adp` to discover connectors, generate configurations, and register the MCP server with your agent.
+Add `airbyte-agent-mcp` as a dependency. This installs the package and makes the `agent-engine` command-line tool available through `uv run`. You use `agent-engine` to discover connectors, generate configurations, and register the MCP server with your agent.
 
 ```bash
-uv add --prerelease allow airbyte-agent-mcp
+uv add airbyte-agent-mcp
 ```
-
-:::note
-The `--prerelease allow` flag is required because `airbyte-agent-mcp` depends on a pre-release version of one of its upstream libraries. This flag is only needed during installation.
-:::
 
 ## Part 2: List available connectors
 
 Run the following command to see the available open source connectors. This queries the Airbyte connector registry and displays a table of available connectors, their package names, versions, and definition IDs.
 
 ```bash
-uv run adp connectors list-oss
+uv run agent-engine connectors list-oss
 ```
 
 To filter connectors by name, use the `--pattern` flag
 
 ```bash
-uv run adp connectors list-oss --pattern github
+uv run agent-engine connectors list-oss --pattern github
 ```
 
 ## Part 3: Generate a connector configuration
@@ -72,7 +68,7 @@ uv run adp connectors list-oss --pattern github
 Generate a configuration file for the GitHub connector:
 
 ```bash
-uv run adp connectors configure --package airbyte-agent-github
+uv run agent-engine connectors configure --package airbyte-agent-github
 ```
 
 This installs the connector package, inspects its authentication requirements, and generates a YAML configuration file called `connector-github-package.yaml`. The file looks like this:
@@ -98,7 +94,7 @@ Create a `.env` file in the same directory as your connector configuration. Repl
 GITHUB_ACCESS_TOKEN=your-github-personal-access-token
 ```
 
-The `adp` command line tool automatically loads `.env` files from the current directory. The `${env.VAR}` syntax in your YAML configuration resolves to the values in this file.
+The `agent-engine` command line tool automatically loads `.env` files from the current directory. The `${env.VAR}` syntax in your YAML configuration resolves to the values in this file.
 
 :::warning
 Never commit your `.env` file to version control. If you do this by mistake, rotate your secrets immediately.
@@ -114,7 +110,7 @@ Register the MCP server with your preferred agent.
 This command runs `claude mcp add` under the hood and registers the server at the user scope.
 
 ```bash
-uv run adp mcp add-to claude-code connector-github-package.yaml
+uv run agent-engine mcp add-to claude-code connector-github-package.yaml
 ```
 
 To register at the project scope instead, add `--scope project` to that command.
@@ -125,7 +121,7 @@ To register at the project scope instead, add `--scope project` to that command.
 This command modifies your Claude Desktop configuration file directly.
 
 ```bash
-uv run adp mcp add-to claude-desktop connector-github-package.yaml
+uv run agent-engine mcp add-to claude-desktop connector-github-package.yaml
 ```
 
 </TabItem>
@@ -134,7 +130,7 @@ uv run adp mcp add-to claude-desktop connector-github-package.yaml
 This modifies the Cursor MCP configuration file.
 
 ```bash
-uv run adp mcp add-to cursor connector-github-package.yaml
+uv run agent-engine mcp add-to cursor connector-github-package.yaml
 ```
 
 To register at the project scope instead of user scope, add a `--scope project` flag.
@@ -145,7 +141,7 @@ To register at the project scope instead of user scope, add a `--scope project` 
 This command runs `codex mcp add` to register the server.
 
 ```bash
-uv run adp mcp add-to codex connector-github-package.yaml
+uv run agent-engine mcp add-to codex connector-github-package.yaml
 ```
 
 </TabItem>
@@ -154,7 +150,7 @@ uv run adp mcp add-to codex connector-github-package.yaml
 You can optionally specify a custom name for the server with `--name`. If you don't specify a name, the server name is based on the connector. For example, `airbyte-github`.
 
 ```bash
-uv run adp mcp add-to claude-code connector-github-package.yaml --name my-server-name
+uv run agent-engine mcp add-to claude-code connector-github-package.yaml --name my-server-name
 ```
 
 ## Part 6: Use the MCP server
@@ -177,7 +173,7 @@ In this tutorial, you learned how to:
 
 - Set up a project with the Agent Engine MCP server
 
-- Discover available connectors with the `adp` command line tool
+- Discover available connectors with the `agent-engine` command line tool
 
 - Generate a connector configuration file
 
@@ -189,7 +185,7 @@ In this tutorial, you learned how to:
 
 ## Next steps
 
-- Try other connectors. Run `uv run adp connectors list-oss` to see all available connectors and repeat these steps with a different data source.
+- Try other connectors. Run `uv run agent-engine connectors list-oss` to see all available connectors and repeat these steps with a different data source.
 
 - Learn how to [configure the MCP server](../../mcp-server/configuration) for advanced scenarios like Agent Engine hosted execution, git-based packages, and aggregate configurations with multiple connectors.
 


### PR DESCRIPTION
## What

Updates all Agent Engine MCP server documentation to reflect the CLI rename from `adp` to `agent-engine` introduced in [airbytehq/sonar#2881](https://github.com/airbytehq/sonar/pull/2881).

Also removes the `--prerelease allow` flag from the installation command and its explanatory note, since `fastmcp` 3.0.0 stable is now published on PyPI (the pre-release dependency that originally required the flag).

## How

Pure find-and-replace of `adp` → `agent-engine` across all 6 affected doc files, plus removal of the `--prerelease allow` flag and `:::note` block in the tutorial.

## Review guide

1. `docs/ai-agents/mcp-server/cli-reference.md` — bulk rename; also updates the `#adp-login` anchor to `#agent-engine-login`
2. `docs/ai-agents/mcp-server/configuration.md` — bulk rename in prose and code blocks
3. `docs/ai-agents/mcp-server/readme.md` — rename in overview section
4. `docs/ai-agents/mcp-server/troubleshooting.md` — rename in two troubleshooting bullets
5. `docs/ai-agents/mcp-server/usage.md` — rename in transport and chat sections
6. `docs/ai-agents/tutorials/quickstarts/tutorial-mcp-server.md` — rename + removal of `--prerelease allow` and its note

**Things worth verifying:**
- The internal anchor link `#agent-engine-login` (in cli-reference.md line 32) resolves correctly given the heading uses backticks: `` ## `agent-engine login` ``. Docusaurus should slugify this correctly but worth a quick check on the preview deploy.
- Confirm `uv add airbyte-agent-mcp` works without `--prerelease allow` (fastmcp 3.0.0 stable is on PyPI as of this writing).

## User Impact

Documentation now matches the actual CLI entry point (`agent-engine` instead of the old `adp`). Users following the tutorial or reference docs will use the correct command. The simpler install command (`uv add airbyte-agent-mcp` without flags) reduces friction for new users.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

[Link to Devin Session](https://app.devin.ai/sessions/4c5cf4c9c9484531b58db7d20c47c391)
Requested by: @ian-at-airbyte