### PR TITLE
chore(source-snapchat-marketing): Update external documentation URLs

### DIFF
--- a/airbyte-integrations/connectors/source-snapchat-marketing/metadata.yaml
+++ b/airbyte-integrations/connectors/source-snapchat-marketing/metadata.yaml
@@ -62,6 +62,12 @@ data:
     - title: Ads API announcements
       url: https://developers.snap.com/api/marketing-api/Ads-API/announcements
       type: api_reference
+    - title: Ads API breaking changes log
+      url: https://developers.snap.com/api/marketing-api/Ads-API/breaking-changes-log
+      type: api_deprecations
+    - title: Ads API change log
+      url: https://developers.snap.com/api/marketing-api/Ads-API/changelog
+      type: api_release_history
   suggestedStreams:
     streams:
       - campaigns


### PR DESCRIPTION
## What

Adds missing external documentation URLs to the `source-snapchat-marketing` connector metadata, discovered during API deprecation monitoring research.

Related: https://github.com/airbytehq/oncall/issues/10442

Resolves https://github.com/airbytehq/oncall/issues/10442

- https://github.com/airbytehq/oncall/issues/10442

## How

Adds two new entries to the `externalDocumentationUrls` section in `metadata.yaml`:

1. **Breaking Changes Log** (`api_deprecations`): https://developers.snap.com/api/marketing-api/Ads-API/breaking-changes-log
2. **Change Log** (`api_release_history`): https://developers.snap.com/api/marketing-api/Ads-API/changelog

The existing Announcements URL was the only external doc URL listed. These additional URLs improve future deprecation monitoring coverage by including the vendor's dedicated breaking changes and changelog pages.

## Review guide

1. `airbyte-integrations/connectors/source-snapchat-marketing/metadata.yaml` — Only file changed. Verify the new URL entries have correct `type` values and valid URLs.

## User Impact

No user-facing impact. This is a metadata-only change that improves internal deprecation monitoring tooling.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Link to Devin session: https://app.devin.ai/sessions/f83a208d4dfa48f69e414f585a2518ae
Requested by: Danylo Jablonski (@DanyloGL)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/74244" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
