### PR TITLE
chore(source-sendgrid): Update external documentation URLs

### DIFF
--- a/airbyte-integrations/connectors/source-sendgrid/metadata.yaml
+++ b/airbyte-integrations/connectors/source-sendgrid/metadata.yaml
@@ -20,8 +20,11 @@ data:
   documentationUrl: https://docs.airbyte.com/integrations/sources/sendgrid
   externalDocumentationUrls:
     - title: API overview
-      url: https://docs.sendgrid.com/api-reference/how-to-use-the-sendgrid-v3-api/authentication
+      url: https://www.twilio.com/docs/sendgrid/api-reference/how-to-use-the-sendgrid-v3-api/authentication
       type: api_reference
+    - title: Twilio SendGrid Changelog
+      url: https://www.twilio.com/en-us/changelog?product=sendgrid-email-api%2Ctwilio-sendgrid-platform%2Cmarketing-campaigns
+      type: api_release_history
     - title: SendGrid API OpenAPI specification
       url: https://github.com/sendgrid/sendgrid-oai
       type: openapi_spec

--- a/airbyte-integrations/connectors/source-sendgrid/metadata.yaml
+++ b/airbyte-integrations/connectors/source-sendgrid/metadata.yaml
@@ -26,7 +26,7 @@ data:
       url: https://www.twilio.com/en-us/changelog?product=sendgrid-email-api%2Ctwilio-sendgrid-platform%2Cmarketing-campaigns
       type: api_release_history
     - title: SendGrid API OpenAPI specification
-      url: https://github.com/sendgrid/sendgrid-oai
+      url: https://github.com/twilio/sendgrid-oai
       type: openapi_spec
   githubIssueLabel: source-sendgrid
   icon: sendgrid.svg


### PR DESCRIPTION
## What

Updates `source-sendgrid` external documentation URLs used for API deprecation monitoring.

Resolves https://github.com/airbytehq/oncall/issues/10449

- https://github.com/airbytehq/oncall/issues/10449

Requested by: Danylo Jablonski (gl_danylo.jablonski@airbyte.io)

## How

1. Fixes the SendGrid API reference URL to the canonical Twilio docs URL after the `docs.sendgrid.com` URL began redirecting.
2. Adds the Twilio SendGrid changelog as an `api_release_history` entry so future deprecation monitoring can check release history directly.
3. Updates the OpenAPI specification URL from the stale `sendgrid/sendgrid-oai` GitHub repository, which now returns 404, to the current `twilio/sendgrid-oai` repository.

## Review guide

1. `airbyte-integrations/connectors/source-sendgrid/metadata.yaml`
   - Verify the API reference URL loads: https://www.twilio.com/docs/sendgrid/api-reference/how-to-use-the-sendgrid-v3-api/authentication
   - Verify the changelog URL loads: https://www.twilio.com/en-us/changelog?product=sendgrid-email-api%2Ctwilio-sendgrid-platform%2Cmarketing-campaigns
   - Verify the OpenAPI repo URL loads: https://github.com/twilio/sendgrid-oai

## User Impact

No user-facing impact. This is metadata-only and improves the accuracy of external documentation links used by deprecation monitoring tooling.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

---
[Devin session](https://app.devin.ai/sessions/beaec5efa28a4e51ad6061e2368c717a)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/74245" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
