### PR TITLE
chore(source-salesforce): Update external documentation URLs

### DIFF
--- a/airbyte-integrations/connectors/source-salesforce/metadata.yaml
+++ b/airbyte-integrations/connectors/source-salesforce/metadata.yaml
@@ -20,9 +20,12 @@ data:
     - title: REST API Release Notes
       url: https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/rest_rns.htm
       type: api_release_history
-    - title: Winter 2026 release notes - API
-      url: https://help.salesforce.com/s/articleView?id=release-notes.salesforce_release_notes.htm&release=258&type=5
+    - title: Spring 2026 release notes - API
+      url: https://help.salesforce.com/s/articleView?id=release-notes.salesforce_release_notes.htm&release=260&type=5
       type: api_release_history
+    - title: API End-of-Life Policy
+      url: https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/api_rest_eol.htm
+      type: api_deprecations
   githubIssueLabel: source-salesforce
   icon: salesforce.svg
   license: ELv2


### PR DESCRIPTION
## What

Updates the `externalDocumentationUrls` in the source-salesforce connector's `metadata.yaml` to keep documentation references current and improve future deprecation monitoring.

This was identified during a routine API deprecation audit for the Salesforce connector family. No material upstream deprecations were found affecting this connector (tracked in [oncall#10433](https://github.com/airbytehq/oncall/issues/10433)).

## How

Two changes to `metadata.yaml`:
1. **Updated release notes URL**: Winter '26 (`release=258`) → Spring '26 (`release=260`) to point to the current Salesforce release notes.
2. **Added API End-of-Life Policy URL**: New entry with type `api_deprecations` pointing to the canonical Salesforce page that lists which API versions are supported, deprecated, or retired. This is the most useful page for future deprecation monitoring.

## Review guide
1. `airbyte-integrations/connectors/source-salesforce/metadata.yaml` — only file changed. Verify the two new URLs resolve correctly and that `api_deprecations` is a valid value for the `type` field.

## User Impact

No user-facing impact. Metadata-only change that improves the accuracy of external documentation references used for deprecation monitoring tooling.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚

---
Requested by: @DanyloGL
[Devin session](https://app.devin.ai/sessions/925ed0fa476e4cafb01d1b29d7c8d973)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/74246" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
