### PR TITLE
chore: update source-facebook-marketing v5.0.0 upgradeDeadline to 2026-03-20

### DIFF
--- a/airbyte-integrations/connectors/source-facebook-marketing/metadata.yaml
+++ b/airbyte-integrations/connectors/source-facebook-marketing/metadata.yaml
@@ -74,7 +74,7 @@ data:
               - "ad_creatives"
       5.0.0:
         message: "This update includes multiple breaking schema changes: (1) Custom Insights streams now use level-based primary keys — when `level` is set to `adset`, `campaign`, or `account`, the primary key will use `adset_id`, `campaign_id`, or just `account_id` respectively, instead of always using `ad_id`. (2) The deprecated `7d_view` and `28d_view` attribution window columns have been removed from all Ads Insights streams, as Meta stopped returning data for these windows on January 12, 2026. (3) The `wish_bid` field has been removed from Ads Insights streams. All users should refresh their source schema and reset affected streams after upgrading. For more information, see the [migration guide](https://docs.airbyte.com/integrations/sources/facebook-marketing-migrations)."
-        upgradeDeadline: "2026-03-06"
+        upgradeDeadline: "2026-03-20"
   suggestedStreams:
     streams:
       - ads_insights


### PR DESCRIPTION
## What
Extends the `upgradeDeadline` for `source-facebook-marketing` v5.0.0 breaking change from `2026-03-06` to `2026-03-20`.

## How
Single-line change in `metadata.yaml` updating the `upgradeDeadline` field under `releases.breakingChanges.5.0.0`.

## Review guide
1. `airbyte-integrations/connectors/source-facebook-marketing/metadata.yaml` — verify the date change on line 77.

## User Impact
Users of `source-facebook-marketing` will have until 2026-03-20 (instead of 2026-03-06) to upgrade to v5.0.0 before the deadline enforces the upgrade.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚

---
Requested by: @darynaishchenko
[Link to Devin session](https://app.devin.ai/sessions/2a17dc7bff8a44f5be065c62530660ca)