### PR TITLE
chore(source-stripe): Bump CDK to 7.8.1.post53.dev22629670261

### DIFF
--- a/airbyte-integrations/connectors/source-stripe/metadata.yaml
+++ b/airbyte-integrations/connectors/source-stripe/metadata.yaml
@@ -6,11 +6,11 @@ data:
     hosts:
       - api.stripe.com
   connectorBuildOptions:
-    baseImage: docker.io/airbyte/source-declarative-manifest:7.8.1.post50.dev22418146992@sha256:87d5005c063294752aa3f5d2392dec131f1c60966da6da6a80dfba60d055bdaa
+    baseImage: docker.io/airbyte/source-declarative-manifest:7.8.1.post53.dev22629670261@sha256:458395cec7641f8c17242af87b4691c042eadab70bfab2fab17337903d0fb9f1
   connectorSubtype: api
   connectorType: source
   definitionId: e094cb9a-26de-4645-8761-65c0c425d1de
-  dockerImageTag: 5.15.21-rc.2
+  dockerImageTag: 5.15.21-rc.3
   dockerRepository: airbyte/source-stripe
   documentationUrl: https://docs.airbyte.com/integrations/sources/stripe
   erdUrl: https://dbdocs.io/airbyteio/source-stripe?view=relationships

--- a/docs/integrations/sources/stripe.md
+++ b/docs/integrations/sources/stripe.md
@@ -291,7 +291,7 @@ Each record is marked with `is_deleted` flag when the appropriate event happens 
 
 | Version     | Date       | Pull Request                                                 | Subject                                                                                                                                                                                                                       |
 |:------------|:-----------|:-------------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 5.15.21-rc.3 | 2026-03-03 | [74132](https://github.com/airbytehq/airbyte/pull/74132) | Fix cursor age validation to clear state before constructing full refresh stream, ensuring true full refresh from start_date |
+| 5.15.21-rc.3 | 2026-03-03 | [74259](https://github.com/airbytehq/airbyte/pull/74259) | Fix cursor age validation to clear state before constructing full refresh stream, ensuring true full refresh from start_date |
 | 5.15.21-rc.2 | 2026-02-25 | [74051](https://github.com/airbytehq/airbyte/pull/74051) | Fix sync failure when unselected parent streams have stale cursor state during cursor age validation |
 | 5.15.21-rc.1 | 2026-02-25 | [73646](https://github.com/airbytehq/airbyte/pull/73646) | Add cursor age validation for StateDelegatingStream streams to prevent data loss when initial sync fails mid-way |
 | 5.15.20 | 2026-02-24 | [73944](https://github.com/airbytehq/airbyte/pull/73944) | Update dependencies |

--- a/docs/integrations/sources/stripe.md
+++ b/docs/integrations/sources/stripe.md
@@ -291,6 +291,7 @@ Each record is marked with `is_deleted` flag when the appropriate event happens 
 
 | Version     | Date       | Pull Request                                                 | Subject                                                                                                                                                                                                                       |
 |:------------|:-----------|:-------------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 5.15.21-rc.3 | 2026-03-03 | [74132](https://github.com/airbytehq/airbyte/pull/74132) | Fix cursor age validation to clear state before constructing full refresh stream, ensuring true full refresh from start_date |
 | 5.15.21-rc.2 | 2026-02-25 | [74051](https://github.com/airbytehq/airbyte/pull/74051) | Fix sync failure when unselected parent streams have stale cursor state during cursor age validation |
 | 5.15.21-rc.1 | 2026-02-25 | [73646](https://github.com/airbytehq/airbyte/pull/73646) | Add cursor age validation for StateDelegatingStream streams to prevent data loss when initial sync fails mid-way |
 | 5.15.20 | 2026-02-24 | [73944](https://github.com/airbytehq/airbyte/pull/73944) | Update dependencies |


### PR DESCRIPTION
## What

Bumps the `source-declarative-manifest` base image for source-stripe to pick up the `StateDelegatingStream` cursor age validation fix from [airbytehq/airbyte-python-cdk#890](https://github.com/airbytehq/airbyte-python-cdk/pull/890).

That CDK PR fixes a temporal ordering bug: when cursor age validation detected a stale cursor, the `full_refresh_stream` was constructed **before** clearing state, so its cursor inherited the old stale position instead of starting from `start_date`. The fix clears state first, then constructs the stream.

## How

- Updated `connectorBuildOptions.baseImage` in `metadata.yaml` from `7.8.1.post50` to `7.8.1.post53` with the corresponding sha256 digest.
- Bumped `dockerImageTag` from `5.15.21-rc.2` to `5.15.21-rc.3`.
- Added changelog entry in `docs/integrations/sources/stripe.md`.

## Review guide

1. `airbyte-integrations/connectors/source-stripe/metadata.yaml` — verify the base image tag and sha256 digest are correct.
2. `docs/integrations/sources/stripe.md` — verify changelog entry for `5.15.21-rc.3`.

**Important:** This is a **pre-release** CDK version (`.dev` suffix). The upstream CDK PR ([airbytehq/airbyte-python-cdk#890](https://github.com/airbytehq/airbyte-python-cdk/pull/890)) should be reviewed in parallel.

### Human review checklist

- [ ] Verify the sha256 digest `458395cec7641f8c17242af87b4691c042eadab70bfab2fab17337903d0fb9f1` matches the published `7.8.1.post53.dev22629670261` image
- [ ] Confirm upstream CDK PR [#890](https://github.com/airbytehq/airbyte-python-cdk/pull/890) is approved / on track to merge

## User Impact

No immediate user-facing changes. This enables testing of the CDK fix which ensures that when source-stripe detects a cursor older than the 30-day event retention period, it correctly performs a true full refresh from `start_date` rather than starting from the stale cursor position.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Link to Devin session: https://app.devin.ai/sessions/782b85a317204e3c833c3ecc3bc02f1e
Requested by: @agarctfi