### PR TITLE
docs(destinations): add sync mode support tables and namespace support for 17 destinations

### DIFF
--- a/docs/integrations/destinations/azure-blob-storage.md
+++ b/docs/integrations/destinations/azure-blob-storage.md
@@ -11,11 +11,11 @@ as `<stream_namespace>/<stream_name>/yyyy_mm_dd_<unix_epoch>_<part_number>.<file
 
 | Sync mode | Supported? |
 | :--- | :--- |
-| [Full Refresh - Overwrite](https://docs.airbyte.com/understanding-airbyte/connections/full-refresh-overwrite/) | Yes |
-| [Full Refresh - Append](https://docs.airbyte.com/understanding-airbyte/connections/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite) | Yes |
+| [Full Refresh - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-append) | Yes |
 | [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
-| [Incremental Sync - Append](https://docs.airbyte.com/understanding-airbyte/connections/incremental-append) | Yes |
-| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/understanding-airbyte/connections/incremental-append-deduped) | No |
+| [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
 
 ## Configuration
 

--- a/docs/integrations/destinations/azure-blob-storage.md
+++ b/docs/integrations/destinations/azure-blob-storage.md
@@ -16,6 +16,7 @@ as `<stream_namespace>/<stream_name>/yyyy_mm_dd_<unix_epoch>_<part_number>.<file
 | [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
 | [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
+| Support [Namespaces](https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces) | Yes |
 
 ## Configuration
 

--- a/docs/integrations/destinations/azure-blob-storage.md
+++ b/docs/integrations/destinations/azure-blob-storage.md
@@ -7,13 +7,15 @@ This destination writes data to Azure Blob Storage.
 The Airbyte Azure Blob Storage destination allows you to sync data to Azure Blob Storage. Each stream is written to its own blob under the container,
 as `<stream_namespace>/<stream_name>/yyyy_mm_dd_<unix_epoch>_<part_number>.<file_extension>`.
 
-## Sync Mode
+## Supported sync modes
 
-| Feature                        | Support |
-| :----------------------------- | :-----: |
-| Full Refresh Sync              |   ✅    |
-| Incremental - Append Sync      |   ✅    |
-| Incremental - Append + Deduped |   ❌    |
+| Sync mode | Supported? |
+| :--- | :--- |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/understanding-airbyte/connections/full-refresh-overwrite/) | Yes |
+| [Full Refresh - Append](https://docs.airbyte.com/understanding-airbyte/connections/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
+| [Incremental Sync - Append](https://docs.airbyte.com/understanding-airbyte/connections/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/understanding-airbyte/connections/incremental-append-deduped) | No |
 
 ## Configuration
 

--- a/docs/integrations/destinations/bigquery.md
+++ b/docs/integrations/destinations/bigquery.md
@@ -116,6 +116,7 @@ The BigQuery destination connector supports the following
 | [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | Yes |
 | [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | Yes |
+| Support [Namespaces](https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces) | Yes |
 
 ## Output schema
 

--- a/docs/integrations/destinations/bigquery.md
+++ b/docs/integrations/destinations/bigquery.md
@@ -111,11 +111,11 @@ The BigQuery destination connector supports the following
 
 | Sync mode | Supported? |
 | :--- | :--- |
-| [Full Refresh - Overwrite](https://docs.airbyte.com/understanding-airbyte/connections/full-refresh-overwrite/) | Yes |
-| [Full Refresh - Append](https://docs.airbyte.com/understanding-airbyte/connections/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite) | Yes |
+| [Full Refresh - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-append) | Yes |
 | [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | Yes |
-| [Incremental Sync - Append](https://docs.airbyte.com/understanding-airbyte/connections/incremental-append) | Yes |
-| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/understanding-airbyte/connections/incremental-append-deduped) | Yes |
+| [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | Yes |
 
 ## Output schema
 

--- a/docs/integrations/destinations/bigquery.md
+++ b/docs/integrations/destinations/bigquery.md
@@ -109,9 +109,13 @@ concurrent rate limit, making it easier to start many queries at once.
 The BigQuery destination connector supports the following
 [sync modes](https://docs.airbyte.com/cloud/core-concepts#connection-sync-modes):
 
-- Full Refresh Sync
-- Incremental - Append Sync
-- Incremental - Append + Deduped
+| Sync mode | Supported? |
+| :--- | :--- |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/understanding-airbyte/connections/full-refresh-overwrite/) | Yes |
+| [Full Refresh - Append](https://docs.airbyte.com/understanding-airbyte/connections/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | Yes |
+| [Incremental Sync - Append](https://docs.airbyte.com/understanding-airbyte/connections/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/understanding-airbyte/connections/incremental-append-deduped) | Yes |
 
 ## Output schema
 

--- a/docs/integrations/destinations/clickhouse.md
+++ b/docs/integrations/destinations/clickhouse.md
@@ -22,6 +22,7 @@ Version 2.0.0 represents a complete architectural redesign of the ClickHouse des
 | [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | Yes |
 | [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | Yes |
+| Support [Namespaces](https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces) | Yes |
 
 Deduplication leverages ClickHouse's [ReplacingMergeTree](https://clickhouse.com/docs/engines/table-engines/mergetree-family/replacingmergetree) table engine. See [Deduplication](#deduplication) below for details.
 

--- a/docs/integrations/destinations/clickhouse.md
+++ b/docs/integrations/destinations/clickhouse.md
@@ -23,6 +23,8 @@ Version 2.0.0 represents a complete architectural redesign of the ClickHouse des
 | [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | Yes |
 
+Deduplication leverages ClickHouse's [ReplacingMergeTree](https://clickhouse.com/docs/engines/table-engines/mergetree-family/replacingmergetree) table engine. See [Deduplication](#deduplication) below for details.
+
 ## Deduplication
 
 For optimal deduplication in Incremental - Append + Deduped sync mode, use a cursor column with one of these types:

--- a/docs/integrations/destinations/clickhouse.md
+++ b/docs/integrations/destinations/clickhouse.md
@@ -17,11 +17,11 @@ Version 2.0.0 represents a complete architectural redesign of the ClickHouse des
 
 | Sync mode | Supported? |
 | :--- | :--- |
-| [Full Refresh - Overwrite](https://docs.airbyte.com/understanding-airbyte/connections/full-refresh-overwrite/) | Yes |
-| [Full Refresh - Append](https://docs.airbyte.com/understanding-airbyte/connections/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite) | Yes |
+| [Full Refresh - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-append) | Yes |
 | [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | Yes |
-| [Incremental Sync - Append](https://docs.airbyte.com/understanding-airbyte/connections/incremental-append) | Yes |
-| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/understanding-airbyte/connections/incremental-append-deduped) | Yes |
+| [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | Yes |
 
 ## Deduplication
 

--- a/docs/integrations/destinations/clickhouse.md
+++ b/docs/integrations/destinations/clickhouse.md
@@ -15,14 +15,13 @@ Version 2.0.0 represents a complete architectural redesign of the ClickHouse des
 
 ## Supported sync modes
 
-The connectors supports all sync modes.
-
-| Feature                        | Supported?\(Yes/No\) | Notes                          |
-| :----------------------------- |:---------------------|:-------------------------------|
-| Full Refresh Sync              | Yes                  |                                |
-| Incremental - Append Sync      | Yes                  |                                |
-| Incremental - Append + Deduped | Yes                  | Leverages `ReplacingMergeTree` |
-| Namespaces                     | Yes                  |                                |
+| Sync mode | Supported? |
+| :--- | :--- |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/understanding-airbyte/connections/full-refresh-overwrite/) | Yes |
+| [Full Refresh - Append](https://docs.airbyte.com/understanding-airbyte/connections/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | Yes |
+| [Incremental Sync - Append](https://docs.airbyte.com/understanding-airbyte/connections/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/understanding-airbyte/connections/incremental-append-deduped) | Yes |
 
 ## Deduplication
 

--- a/docs/integrations/destinations/customer-io.md
+++ b/docs/integrations/destinations/customer-io.md
@@ -54,6 +54,8 @@ Here are the destination objects and their respective operations that are curren
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
 | Support [Namespaces](https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces) | No |
 
+This is a [data activation](/platform/move-data/elt-data-activation) destination. In addition to the Airbyte sync modes above, Customer.io supports identify (person) and track (event) operations configured per stream.
+
 ### Restrictions
 
 - Each entry sent to the API needs to be 32kb or smaller

--- a/docs/integrations/destinations/customer-io.md
+++ b/docs/integrations/destinations/customer-io.md
@@ -43,14 +43,15 @@ Here are the destination objects and their respective operations that are curren
 - [Person](https://docs.customer.io/journeys/create-update-person/): Identifies a person and assigns traits to them.
 - [Person Events](https://docs.customer.io/journeys/events/): Track an event for a user that is known or not by Customer.io. Required fields: `person_email`, `event_name`. Optional fields: `event_id` (for event deduplication), `timestamp`.
 
-### Features
+### Supported sync modes
 
-| Feature                       | Supported? |
-| :---------------------------- | :--------- |
-| Full Refresh Sync            | Yes        |
-| Incremental - Append Sync    | Yes        |
-| Incremental - Dedupe Sync    | Yes        |
-| Namespaces                   | Yes        |
+| Sync mode | Supported? |
+| :--- | :--- |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite) | No |
+| [Full Refresh - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
+| [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
 
 ### Restrictions
 

--- a/docs/integrations/destinations/customer-io.md
+++ b/docs/integrations/destinations/customer-io.md
@@ -52,6 +52,7 @@ Here are the destination objects and their respective operations that are curren
 | [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
 | [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
+| Support [Namespaces](https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces) | No |
 
 ### Restrictions
 

--- a/docs/integrations/destinations/databricks.md
+++ b/docs/integrations/destinations/databricks.md
@@ -70,6 +70,7 @@ to generate a client ID and secret.
 | [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | Yes |
 | [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | Yes |
+| Support [Namespaces](https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces) | Yes |
 
 ## Output Schema
 

--- a/docs/integrations/destinations/databricks.md
+++ b/docs/integrations/destinations/databricks.md
@@ -61,14 +61,15 @@ to generate a client ID and secret.
 - `Default Schema` - The schema that will contain your data. You can later override this on a per-connection basis.
 - `Purge Staging Files and Tables` - Whether Airbyte should delete files after loading them into tables. Note: if deselected, Databricks will still delete your files after your retention period has passed (default - 7 days).
 
-## Sync Mode
+## Supported sync modes
 
-| Feature                        | Support | Notes                                                                                |
-| :----------------------------- | :-----: | :----------------------------------------------------------------------------------- |
-| Full Refresh Sync              |   ✅    | Warning: this mode deletes all previously synced data in the configured bucket path. |
-| Incremental - Append Sync      |   ✅    |                                                                                      |
-| Incremental - Append + Deduped |   ✅    |                                                                                      |
-| Namespaces                     |   ✅    |                                                                                      |
+| Sync mode | Supported? |
+| :--- | :--- |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite) | Yes |
+| [Full Refresh - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | Yes |
+| [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | Yes |
 
 ## Output Schema
 

--- a/docs/integrations/destinations/gcs-data-lake.md
+++ b/docs/integrations/destinations/gcs-data-lake.md
@@ -117,11 +117,11 @@ When **Catalog Type** is set to `Polaris`, configure these additional fields:
 
 | Sync mode | Supported? |
 | :--- | :--- |
-| [Full Refresh - Overwrite](https://docs.airbyte.com/understanding-airbyte/connections/full-refresh-overwrite/) | Yes |
-| [Full Refresh - Append](https://docs.airbyte.com/understanding-airbyte/connections/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite) | Yes |
+| [Full Refresh - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-append) | Yes |
 | [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | Yes |
-| [Incremental Sync - Append](https://docs.airbyte.com/understanding-airbyte/connections/incremental-append) | Yes |
-| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/understanding-airbyte/connections/incremental-append-deduped) | Yes |
+| [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | Yes |
 
 ## Output schema
 

--- a/docs/integrations/destinations/gcs-data-lake.md
+++ b/docs/integrations/destinations/gcs-data-lake.md
@@ -113,6 +113,16 @@ When **Catalog Type** is set to `Polaris`, configure these additional fields:
 | **Client ID**          | Yes        | The OAuth Client ID for authenticating with the Polaris server                         |
 | **Client Secret**      | Yes        | The OAuth Client Secret for authenticating with the Polaris server                     |
 
+## Supported sync modes
+
+| Sync mode | Supported? |
+| :--- | :--- |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/understanding-airbyte/connections/full-refresh-overwrite/) | Yes |
+| [Full Refresh - Append](https://docs.airbyte.com/understanding-airbyte/connections/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | Yes |
+| [Incremental Sync - Append](https://docs.airbyte.com/understanding-airbyte/connections/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/understanding-airbyte/connections/incremental-append-deduped) | Yes |
+
 ## Output schema
 
 ### How Airbyte generates the Iceberg schema

--- a/docs/integrations/destinations/gcs-data-lake.md
+++ b/docs/integrations/destinations/gcs-data-lake.md
@@ -122,6 +122,7 @@ When **Catalog Type** is set to `Polaris`, configure these additional fields:
 | [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | Yes |
 | [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | Yes |
+| Support [Namespaces](https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces) | Yes |
 
 ## Output schema
 

--- a/docs/integrations/destinations/hubspot.md
+++ b/docs/integrations/destinations/hubspot.md
@@ -61,6 +61,7 @@ If you're using an S3 bucket to store rejected records, you also need the follow
 | [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
 | [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
+| Support [Namespaces](https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces) | No |
 
 ## Supported Objects
 

--- a/docs/integrations/destinations/hubspot.md
+++ b/docs/integrations/destinations/hubspot.md
@@ -63,6 +63,8 @@ If you're using an S3 bucket to store rejected records, you also need the follow
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
 | Support [Namespaces](https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces) | No |
 
+This is a [data activation](/platform/move-data/elt-data-activation) destination. In addition to the Airbyte sync modes above, HubSpot supports per-object write operations (insert, upsert, update, and soft delete) configured in the connection settings.
+
 ## Supported Objects
 
 The HubSpot destination connector supports the following streams:

--- a/docs/integrations/destinations/hubspot.md
+++ b/docs/integrations/destinations/hubspot.md
@@ -52,6 +52,16 @@ If you're using an S3 bucket to store rejected records, you also need the follow
 
 6. Click **Set up destination** and wait for the tests to complete.
 
+## Supported sync modes
+
+| Sync mode | Supported? |
+| :--- | :--- |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite) | No |
+| [Full Refresh - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
+| [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
+
 ## Supported Objects
 
 The HubSpot destination connector supports the following streams:

--- a/docs/integrations/destinations/milvus.md
+++ b/docs/integrations/destinations/milvus.md
@@ -33,6 +33,7 @@ You'll need the following information to configure the destination:
 | [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
 | [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | Yes |
+| Support [Namespaces](https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces) | No |
 
 ## Configuration
 

--- a/docs/integrations/destinations/milvus.md
+++ b/docs/integrations/destinations/milvus.md
@@ -24,15 +24,15 @@ You'll need the following information to configure the destination:
 - Either **Milvus API token** or **Milvus Instance Username and Password**
 - **Milvus Collection name** - The name of the collection to load data into
 
-## Features
+## Supported sync modes
 
-| Feature                        | Supported? | Notes                       |
-| :----------------------------- | :--------- | :-------------------------- |
-| Full Refresh Sync              | Yes        |                             |
-| Incremental - Append Sync      | Yes        |                             |
-| Incremental - Append + Deduped | Yes        |                             |
-| Partitions                     | No         |                             |
-| Record-defined ID              | No         | Auto-id needs to be enabled |
+| Sync mode | Supported? |
+| :--- | :--- |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite) | Yes |
+| [Full Refresh - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
+| [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | Yes |
 
 ## Configuration
 

--- a/docs/integrations/destinations/mssql.md
+++ b/docs/integrations/destinations/mssql.md
@@ -1,13 +1,14 @@
 # MSSQL
 
-## Features
+## Supported sync modes
 
-| Feature                        | Supported?\(Yes/No\) | Notes |
-| :----------------------------- | :------------------- | :---- |
-| Full Refresh Sync              | Yes                  |       |
-| Incremental - Append Sync      | Yes                  |       |
-| Incremental - Append + Deduped | Yes                  |       |
-| Namespaces                     | Yes                  |       |
+| Sync mode | Supported? |
+| :--- | :--- |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/understanding-airbyte/connections/full-refresh-overwrite/) | Yes |
+| [Full Refresh - Append](https://docs.airbyte.com/understanding-airbyte/connections/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | Yes |
+| [Incremental Sync - Append](https://docs.airbyte.com/understanding-airbyte/connections/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/understanding-airbyte/connections/incremental-append-deduped) | Yes |
 
 ## Output Schema
 

--- a/docs/integrations/destinations/mssql.md
+++ b/docs/integrations/destinations/mssql.md
@@ -9,6 +9,7 @@
 | [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | Yes |
 | [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | Yes |
+| Support [Namespaces](https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces) | Yes |
 
 ## Output Schema
 

--- a/docs/integrations/destinations/mssql.md
+++ b/docs/integrations/destinations/mssql.md
@@ -4,11 +4,11 @@
 
 | Sync mode | Supported? |
 | :--- | :--- |
-| [Full Refresh - Overwrite](https://docs.airbyte.com/understanding-airbyte/connections/full-refresh-overwrite/) | Yes |
-| [Full Refresh - Append](https://docs.airbyte.com/understanding-airbyte/connections/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite) | Yes |
+| [Full Refresh - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-append) | Yes |
 | [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | Yes |
-| [Incremental Sync - Append](https://docs.airbyte.com/understanding-airbyte/connections/incremental-append) | Yes |
-| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/understanding-airbyte/connections/incremental-append-deduped) | Yes |
+| [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | Yes |
 
 ## Output Schema
 

--- a/docs/integrations/destinations/pgvector.md
+++ b/docs/integrations/destinations/pgvector.md
@@ -137,6 +137,7 @@ The schema names are case sensitive. The 'public' schema is set by default.
 | [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
 | [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | Yes |
+| Support [Namespaces](https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces) | No |
 
 ## Data type mapping
 

--- a/docs/integrations/destinations/pgvector.md
+++ b/docs/integrations/destinations/pgvector.md
@@ -128,13 +128,15 @@ The schema names are case sensitive. The 'public' schema is set by default.
    [Step 1](#step-1-optional-create-a-dedicated-read-only-user).
 
 
-## Features
+## Supported sync modes
 
-| Feature                        | Supported?           | Notes |
-| :----------------------------- | :------------------- | :---- |
-| Full Refresh Sync              | Yes                  |       |
-| Incremental - Append Sync      | Yes                  |       |
-| Incremental - Append + Deduped | Yes                  |       |
+| Sync mode | Supported? |
+| :--- | :--- |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite) | Yes |
+| [Full Refresh - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
+| [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | Yes |
 
 ## Data type mapping
 

--- a/docs/integrations/destinations/pinecone.md
+++ b/docs/integrations/destinations/pinecone.md
@@ -33,6 +33,7 @@ You'll need the following information to configure the destination:
 | [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
 | [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | Yes |
+| Support [Namespaces](https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces) | Yes |
 
 ## Data type mapping
 

--- a/docs/integrations/destinations/pinecone.md
+++ b/docs/integrations/destinations/pinecone.md
@@ -24,14 +24,15 @@ You'll need the following information to configure the destination:
 - **Pinecone Environment** - The name of the Pinecone environment to use
 - **Pinecone Index name** - The name of the Pinecone index to load data into
 
-## Features
+## Supported sync modes
 
-| Feature                        | Supported? | Notes                                                                                                             |
-| :----------------------------- | :--------- | :---------------------------------------------------------------------------------------------------------------- |
-| Full Refresh Sync              | Yes        |                                                                                                                   |
-| Incremental - Append Sync      | Yes        |                                                                                                                   |
-| Incremental - Append + Deduped | Yes        | Deleting records via CDC is not supported (see issue [#29827](https://github.com/airbytehq/airbyte/issues/29827)) |
-| Namespaces                     | Yes        |                                                                                                                   |
+| Sync mode | Supported? |
+| :--- | :--- |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite) | Yes |
+| [Full Refresh - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
+| [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | Yes |
 
 ## Data type mapping
 

--- a/docs/integrations/destinations/postgres.md
+++ b/docs/integrations/destinations/postgres.md
@@ -190,6 +190,7 @@ following [sync modes](https://docs.airbyte.com/cloud/core-concepts#connection-s
 | [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | Yes |
 | [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | Yes |
+| Support [Namespaces](https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces) | Yes |
 
 ## Schema map
 

--- a/docs/integrations/destinations/postgres.md
+++ b/docs/integrations/destinations/postgres.md
@@ -185,11 +185,11 @@ following [sync modes](https://docs.airbyte.com/cloud/core-concepts#connection-s
 
 | Sync mode | Supported? |
 | :--- | :--- |
-| [Full Refresh - Overwrite](https://docs.airbyte.com/understanding-airbyte/connections/full-refresh-overwrite/) | Yes |
-| [Full Refresh - Append](https://docs.airbyte.com/understanding-airbyte/connections/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite) | Yes |
+| [Full Refresh - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-append) | Yes |
 | [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | Yes |
-| [Incremental Sync - Append](https://docs.airbyte.com/understanding-airbyte/connections/incremental-append) | Yes |
-| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/understanding-airbyte/connections/incremental-append-deduped) | Yes |
+| [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | Yes |
 
 ## Schema map
 

--- a/docs/integrations/destinations/postgres.md
+++ b/docs/integrations/destinations/postgres.md
@@ -181,14 +181,15 @@ Mode**; otherwise, the connection will fail.
 ## Supported sync modes
 
 The Postgres destination connector supports the
-following[ sync modes](https://docs.airbyte.com/cloud/core-concepts#connection-sync-modes):
+following [sync modes](https://docs.airbyte.com/cloud/core-concepts#connection-sync-modes):
 
-| Feature                        | Supported?\(Yes/No\) | Notes |
-| :----------------------------- | :------------------- | :---- |
-| Full Refresh Sync              | Yes                  |       |
-| Incremental - Append Sync      | Yes                  |       |
-| Incremental - Append + Deduped | Yes                  |       |
-| Namespaces                     | Yes                  |       |
+| Sync mode | Supported? |
+| :--- | :--- |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/understanding-airbyte/connections/full-refresh-overwrite/) | Yes |
+| [Full Refresh - Append](https://docs.airbyte.com/understanding-airbyte/connections/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | Yes |
+| [Incremental Sync - Append](https://docs.airbyte.com/understanding-airbyte/connections/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/understanding-airbyte/connections/incremental-append-deduped) | Yes |
 
 ## Schema map
 

--- a/docs/integrations/destinations/s3-data-lake.md
+++ b/docs/integrations/destinations/s3-data-lake.md
@@ -243,6 +243,16 @@ To authenticate with Apache Polaris, follow these steps.
 
 6. Ensure that your Polaris catalog has been configured with the appropriate storage credentials to access your S3 bucket.
 
+## Supported sync modes
+
+| Sync mode | Supported? |
+| :--- | :--- |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite) | Yes |
+| [Full Refresh - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | Yes |
+| [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | Yes |
+
 ## Output schema
 
 ### How Airbyte generates the Iceberg schema

--- a/docs/integrations/destinations/s3-data-lake.md
+++ b/docs/integrations/destinations/s3-data-lake.md
@@ -252,6 +252,7 @@ To authenticate with Apache Polaris, follow these steps.
 | [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | Yes |
 | [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | Yes |
+| Support [Namespaces](https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces) | Yes |
 
 ## Output schema
 

--- a/docs/integrations/destinations/s3.md
+++ b/docs/integrations/destinations/s3.md
@@ -313,6 +313,7 @@ sync may create multiple files as the output files can be partitioned by size (t
 | [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
 | [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
+| Support [Namespaces](https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces) | Yes |
 
 The Airbyte S3 destination allows you to sync data to AWS S3 or Minio S3. Each stream is written to
 its own directory under the bucket.

--- a/docs/integrations/destinations/s3.md
+++ b/docs/integrations/destinations/s3.md
@@ -306,12 +306,13 @@ sync may create multiple files as the output files can be partitioned by size (t
 
 ## Supported sync modes
 
-| Feature                        | Support | Notes                                                                                                                                                                                                    |
-| :----------------------------- | :-----: | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| FullRefresh - Overwrite Sync   |   ✅    | Warning: this mode deletes all previously synced data in the configured bucket path.                                                                                                                     |
-| Incremental - Append Sync      |   ✅    | Warning: Airbyte provides at-least-once delivery. Depending on your source, you may see duplicated data. Learn more [here](/platform/using-airbyte/core-concepts/sync-modes/incremental-append#inclusive-cursors) |
-| Incremental - Append + Deduped |   ❌    |                                                                                                                                                                                                          |
-| Namespaces                     |   ❌    | Setting a specific bucket path is equivalent to having separate namespaces.                                                                                                                              |
+| Sync mode | Supported? |
+| :--- | :--- |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/understanding-airbyte/connections/full-refresh-overwrite/) | Yes |
+| [Full Refresh - Append](https://docs.airbyte.com/understanding-airbyte/connections/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
+| [Incremental Sync - Append](https://docs.airbyte.com/understanding-airbyte/connections/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/understanding-airbyte/connections/incremental-append-deduped) | No |
 
 The Airbyte S3 destination allows you to sync data to AWS S3 or Minio S3. Each stream is written to
 its own directory under the bucket.

--- a/docs/integrations/destinations/s3.md
+++ b/docs/integrations/destinations/s3.md
@@ -308,11 +308,11 @@ sync may create multiple files as the output files can be partitioned by size (t
 
 | Sync mode | Supported? |
 | :--- | :--- |
-| [Full Refresh - Overwrite](https://docs.airbyte.com/understanding-airbyte/connections/full-refresh-overwrite/) | Yes |
-| [Full Refresh - Append](https://docs.airbyte.com/understanding-airbyte/connections/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite) | Yes |
+| [Full Refresh - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-append) | Yes |
 | [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
-| [Incremental Sync - Append](https://docs.airbyte.com/understanding-airbyte/connections/incremental-append) | Yes |
-| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/understanding-airbyte/connections/incremental-append-deduped) | No |
+| [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
 
 The Airbyte S3 destination allows you to sync data to AWS S3 or Minio S3. Each stream is written to
 its own directory under the bucket.

--- a/docs/integrations/destinations/snowflake-cortex.md
+++ b/docs/integrations/destinations/snowflake-cortex.md
@@ -35,6 +35,7 @@ You'll need the following information to configure the destination:
 | [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
 | [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | Yes |
+| Support [Namespaces](https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces) | No |
 
 ## Data type mapping
 

--- a/docs/integrations/destinations/snowflake-cortex.md
+++ b/docs/integrations/destinations/snowflake-cortex.md
@@ -24,8 +24,7 @@ You'll need the following information to configure the destination:
 - **Snowflake Password** - The password for your Snowflake account
 - **Snowflake Database** - The database name in Snowflake to load data into
 - **Snowflake Warehouse** - The warehouse name in Snowflake to use
-- **Snowflake Role** - The role name in Snowflake to use. 
-
+- **Snowflake Role** - The role name in Snowflake to use.
 
 ## Supported sync modes
 

--- a/docs/integrations/destinations/snowflake-cortex.md
+++ b/docs/integrations/destinations/snowflake-cortex.md
@@ -27,13 +27,15 @@ You'll need the following information to configure the destination:
 - **Snowflake Role** - The role name in Snowflake to use. 
 
 
-## Features
+## Supported sync modes
 
-| Feature                        | Supported?           | Notes |
-| :----------------------------- | :------------------- | :---- |
-| Full Refresh Sync              | Yes                  |       |
-| Incremental - Append Sync      | Yes                  |       |
-| Incremental - Append + Deduped | Yes                  |       |
+| Sync mode | Supported? |
+| :--- | :--- |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite) | Yes |
+| [Full Refresh - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
+| [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | Yes |
 
 ## Data type mapping
 

--- a/docs/integrations/destinations/weaviate.md
+++ b/docs/integrations/destinations/weaviate.md
@@ -25,15 +25,15 @@ You'll need the following information to configure the destination:
 - **Weaviate cluster URL** - The URL of the Weaviate cluster to load data into. Airbyte Cloud only supports connecting to your Weaviate Instance instance with TLS encryption.
 - **Weaviate credentials** - The credentials for your Weaviate instance (either API token or username/password)
 
-## Features
+## Supported sync modes
 
-| Feature                        | Supported?\(Yes/No\) | Notes                                                    |
-| :----------------------------- | :------------------- | :------------------------------------------------------- |
-| Full Refresh Sync              | Yes                  |                                                          |
-| Incremental - Append Sync      | Yes                  |                                                          |
-| Incremental - Append + Deduped | Yes                  |                                                          |
-| Namespaces                     | No                   |                                                          |
-| Provide vector                 | Yes                  | Either from field are calculated during the load process |
+| Sync mode | Supported? |
+| :--- | :--- |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite) | Yes |
+| [Full Refresh - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
+| [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | Yes |
 
 ## Data type mapping
 

--- a/docs/integrations/destinations/weaviate.md
+++ b/docs/integrations/destinations/weaviate.md
@@ -34,6 +34,7 @@ You'll need the following information to configure the destination:
 | [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
 | [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | Yes |
+| Support [Namespaces](https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces) | No |
 
 ## Data type mapping
 

--- a/docs/integrations/enterprise-connectors/destination-salesforce.md
+++ b/docs/integrations/enterprise-connectors/destination-salesforce.md
@@ -165,7 +165,6 @@ The connector uses OAuth 2.0 authentication with your Salesforce Connected App c
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
 | Support [Namespaces](https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces) | No |
 
-This is a [data activation](/platform/move-data/elt-data-activation) destination. While the underlying implementation supports additional write operations (update, upsert, delete), only append (insert) mode is currently exposed through the connector specification. Contact support if you need additional operations for your use case.
 
 ## Limitations and considerations
 

--- a/docs/integrations/enterprise-connectors/destination-salesforce.md
+++ b/docs/integrations/enterprise-connectors/destination-salesforce.md
@@ -165,11 +165,7 @@ The connector uses OAuth 2.0 authentication with your Salesforce Connected App c
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
 | Support [Namespaces](https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces) | No |
 
-:::info
-
-While the underlying implementation supports additional operations (update, upsert, delete), only append mode is currently exposed through the connector specification. Contact support if you need additional sync modes for your use case.
-
-:::
+This is a [data activation](/platform/move-data/elt-data-activation) destination. While the underlying implementation supports additional write operations (update, upsert, delete), only append (insert) mode is currently exposed through the connector specification. Contact support if you need additional operations for your use case.
 
 ## Limitations and considerations
 

--- a/docs/integrations/enterprise-connectors/destination-salesforce.md
+++ b/docs/integrations/enterprise-connectors/destination-salesforce.md
@@ -156,9 +156,14 @@ The connector uses OAuth 2.0 authentication with your Salesforce Connected App c
 
 ## Supported sync modes
 
-The Salesforce destination currently supports:
-
-- **Append**: Insert new records into Salesforce objects
+| Sync mode | Supported? |
+| :--- | :--- |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite) | No |
+| [Full Refresh - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
+| [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
+| Support [Namespaces](https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces) | No |
 
 :::info
 

--- a/docs/integrations/enterprise-connectors/destination-salesforce.md
+++ b/docs/integrations/enterprise-connectors/destination-salesforce.md
@@ -165,8 +165,6 @@ The connector uses OAuth 2.0 authentication with your Salesforce Connected App c
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
 | Support [Namespaces](https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces) | No |
 
-This is a [data activation](/platform/move-data/elt-data-activation) destination. While the underlying implementation supports additional write operations (update, upsert, delete), only append (insert) mode is currently exposed through the connector specification. Contact support if you need additional operations for your use case.
-
 ## Limitations and considerations
 
 - **API Limits**: respect Salesforce API limits based on your edition and purchased API calls


### PR DESCRIPTION
## What

Adds standardized sync mode support tables to documentation for 17 destination connectors (every certified destination except Redshift and Snowflake, plus the enterprise Salesforce destination):

**Database / warehouse destinations:**
- destination-bigquery
- destination-clickhouse
- destination-databricks
- destination-mssql
- destination-postgres

**Object storage / data lake destinations:**
- destination-azure-blob-storage
- destination-gcs-data-lake
- destination-s3
- destination-s3-data-lake

**Vector DB destinations:**
- destination-milvus
- destination-pgvector
- destination-pinecone
- destination-snowflake-cortex
- destination-weaviate

**Data activation destinations:**
- destination-customer-io
- destination-hubspot
- destination-salesforce *(enterprise connector)*

Each table lists all 5 user-facing sync modes with Yes/No support, links to the canonical sync mode documentation page, and a row indicating namespace support.

## How

Replaced existing sync mode sections (which varied in format: bullet lists, emoji tables, mixed feature tables) with a uniform markdown table format across all 17 destinations.

All sync mode links use the canonical URL base: `https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/`

**Sync mode support was determined from each connector's spec declarations (code as source of truth):**

| Destination | `overwrite` | `append` | `append_dedup` | `supportsRefreshes` | Supports all 5 modes? |
|---|---|---|---|---|---|
| BigQuery | Yes | Yes | Yes | Yes | ✅ Yes |
| ClickHouse | Yes | Yes | Yes | Yes | ✅ Yes |
| Databricks | Yes | Yes | Yes | Yes | ✅ Yes |
| GCS Data Lake | Yes | Yes | Yes | Yes | ✅ Yes |
| MSSQL | Yes | Yes | Yes | Yes | ✅ Yes |
| Postgres | Yes | Yes | Yes | Yes | ✅ Yes |
| S3 Data Lake | Yes | Yes | Yes | Yes | ✅ Yes |
| Azure Blob Storage | Yes | Yes | No | No | No (no dedup modes) |
| S3 | Yes | Yes | No | No | No (no dedup modes) |
| Milvus | Yes | Yes | Yes | No | No (no overwrite+dedup) |
| PGVector | Yes | Yes | Yes | No | No (no overwrite+dedup) |
| Pinecone | Yes | Yes | Yes | No | No (no overwrite+dedup) |
| Snowflake Cortex | Yes | Yes | Yes | No | No (no overwrite+dedup) |
| Weaviate | Yes | Yes | Yes | No | No (no overwrite+dedup) |
| Customer.io | No | Yes | No | Yes* | No (append only) |
| HubSpot | No | Yes | No | Yes* | No (append only) |
| Salesforce | No | Yes | No | — | No (append only) |

\* `supportsRefreshes` is set on Customer.io and HubSpot but is noted as "needed for the CDK to work" — since they don't declare `overwrite` or `append_dedup`, it doesn't affect user-facing sync modes.

**Note on Salesforce**: This is an enterprise connector whose code is not in this repo. Sync mode values are based on the existing documentation, which states only append mode is currently exposed through the connector specification.

**Key logic**: "Full Refresh - Overwrite + Deduped" is synthetically created by the platform only when a destination declares `append_dedup` + `overwrite` + `supportsRefreshes=true` (via `getFinalDestinationSyncModes()` in the platform code). This is why vector DB destinations support Incremental Append+Deduped but not Full Refresh Overwrite+Deduped — they have `append_dedup` and `overwrite` but haven't opted into `supportsRefreshes`.

**Namespace support was determined from connector code analysis:**

| Destination | Namespaces | Reasoning |
|---|---|---|
| BigQuery | Yes | Maps namespace to dataset name |
| ClickHouse | Yes | Maps namespace to database name |
| Databricks | Yes | Maps namespace to schema name |
| MSSQL | Yes | Maps namespace to schema name |
| Postgres | Yes | Maps namespace to schema name |
| GCS Data Lake | Yes | Maps namespace to Iceberg namespace |
| S3 Data Lake | Yes | Maps namespace to Iceberg namespace |
| S3 | Yes | Incorporates namespace into file path templates (`${NAMESPACE}`) |
| Azure Blob Storage | Yes | Incorporates namespace into file path templates (`<stream_namespace>/`) |
| Pinecone | Yes | Passes `namespace=stream.stream.namespace` to Pinecone API |
| Milvus | No | Accepts namespace param through CDK but doesn't use it in Milvus API calls |
| PGVector | No | Uses fixed schema from config rather than mapping stream namespace |
| Snowflake Cortex | No | Uses fixed schema from config rather than mapping stream namespace |
| Weaviate | No | Accepts namespace param through CDK but doesn't use it in Weaviate API calls |
| Customer.io | No | No namespace references in connector code |
| HubSpot | No | No namespace references in connector code |
| Salesforce | No | Syncs to Salesforce objects with no namespace concept |

### Updates since last revision

- **clickhouse.md**: Added back a note below the sync modes table that deduplication leverages ClickHouse's [ReplacingMergeTree](https://clickhouse.com/docs/engines/table-engines/mergetree-family/replacingmergetree) table engine, with a link to both the ClickHouse docs and the existing Deduplication section on the same page. (Per reviewer feedback.)

- **All 16 certified destinations**: Added a "Support Namespaces" row to the bottom of each sync modes table. Values determined from code analysis as documented above. (Per reviewer feedback.)

- **destination-salesforce.md**: Added standardized sync mode table + namespace row for the enterprise Salesforce destination. Based on existing docs, Salesforce only exposes append mode (same pattern as Customer.io and HubSpot). (Per reviewer request.)

- **Data activation destinations (HubSpot, Customer.io, Salesforce)**: Added notes below the sync mode tables explaining that these destinations support additional write operations beyond Airbyte sync modes. HubSpot supports per-object write operations (insert, upsert, update, soft delete). Customer.io supports identify (person) and track (event) operations. Salesforce's underlying implementation supports update, upsert, and delete but only append (insert) is currently exposed. (Per reviewer feedback to clarify data activation nuances.)

## Review guide

1. All 17 files follow the same pattern — spot-check a few for correctness:
   - `docs/integrations/destinations/customer-io.md` — data activation connector with append-only support (previously claimed Full Refresh and Dedupe support), now includes note about identify/track operations
   - `docs/integrations/destinations/hubspot.md` — data activation connector with append-only support, now includes note about write operations
   - `docs/integrations/destinations/s3.md` — object storage destination with no dedup modes
   - `docs/integrations/destinations/milvus.md` — vector DB with append_dedup but no overwrite+dedup
   - `docs/integrations/destinations/bigquery.md` — representative "all Yes" destination
   - `docs/integrations/destinations/clickhouse.md` — includes ReplacingMergeTree note
   - `docs/integrations/enterprise-connectors/destination-salesforce.md` — enterprise connector with append-only support, now includes note about underlying write operations

2. **IMPORTANT — Customer.io and HubSpot spec discrepancy**: The old Customer.io docs claimed "Full Refresh Sync: Yes" and "Incremental - Dedupe Sync: Yes", but the connector spec only declares `["append"]`. The new table corrects this to show only append modes supported. Reviewer should verify this is accurate.

3. **IMPORTANT — Data activation write operations**: The notes about HubSpot supporting "insert, upsert, update, and soft delete" and Customer.io supporting "identify and track" are based on code inspection. Verify these match the actual product behavior and UI.

4. **IMPORTANT — Salesforce sync modes**: The enterprise Salesforce connector code is not in this repo. Sync mode values are based on the existing documentation, which states only append mode is currently exposed. The docs note that the underlying implementation supports additional operations (update, upsert, delete) but these aren't exposed through the connector specification.

5. **IMPORTANT — Namespace support changes from old docs**:
   - **S3**: Was previously documented as "Namespaces: No" but now marked "Yes" because namespace is incorporated into file paths
   - **Customer.io**: Was previously documented as "Namespaces: Yes" but now marked "No" because the connector code has no namespace handling
   - **PGVector and Snowflake Cortex**: Conservative "No" because they use fixed schema from config rather than mapping stream namespace. These inherit from SQL base classes that *could* handle namespace mapping, but the connector code uses a fixed schema.

6. Verify the 5 canonical doc links in the table rows resolve to valid pages.

7. Verify namespace URL (`https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces`) resolves correctly.

### Suggested human review checklist

- [x] **Critical**: Verify Customer.io and HubSpot Yes/No values match actual behavior (old docs claimed features not in spec)
- [x] **Critical**: Verify data activation write operations descriptions are accurate for HubSpot, Customer.io, and Salesforce (check against product UI/behavior)
- [ ] **Critical**: Verify Salesforce sync mode values match actual connector behavior (values based on docs, not code inspection)
- [ ] **Critical**: Verify namespace support values, especially S3/Azure (now "Yes" when previously "No"), Customer.io (now "No" when previously "Yes"), and PGVector/Snowflake Cortex (conservative "No" — verify these don't actually map namespaces)
- [ ] Confirm Yes/No values for all 17 destinations match actual spec declarations or documented behavior
- [x] Verify `https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/{slug}` URLs all resolve
- [x] Verify `https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces` URL resolves
- [ ] Spot-check vector DB destinations (milvus, pgvector, pinecone, snowflake-cortex, weaviate) — all should have "No" for Full Refresh - Overwrite + Deduped (because they lack `supportsRefreshes: true`)
- [x] Verify ClickHouse ReplacingMergeTree note is accurate and links work

## User Impact

Users viewing destination connector documentation will now see a consistent, complete table of all 5 sync modes with links to detailed documentation for each mode, plus a row indicating namespace support across all certified and enterprise destinations. Data activation destinations (HubSpot, Customer.io, Salesforce) now include notes explaining the additional write operations they support beyond standard Airbyte sync modes. Previously:
- Some destinations listed only a subset of modes or used inconsistent formats
- Customer.io docs may have incorrectly claimed Full Refresh and Dedupe support that wasn't implemented in the connector
- Namespace support information was missing or inconsistent across destinations
- The enterprise Salesforce destination lacked a standardized sync mode table
- Data activation destinations didn't clearly explain the distinction between Airbyte sync modes and their additional write operation capabilities

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Requested by: @ian-at-airbyte  
[Link to Devin Session](https://app.devin.ai/sessions/21bc310237b24e80a9bdeb712237b2c9)