### PR TITLE
docs(destinations): add supported sync modes tables to all Marketplace destinations

### DIFF
--- a/docs/integrations/destinations/amazon-sqs.md
+++ b/docs/integrations/destinations/amazon-sqs.md
@@ -23,6 +23,16 @@ in all three formats. See the **Writing Text or XML messages** section for more 
 | Incremental - Append + Deduped | No                   |       |
 | Namespaces                     | No                   |       |
 
+## Supported sync modes
+
+| Sync mode | Supported? |
+| :--- | :--- |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite) | No |
+| [Full Refresh - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
+| [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
+
 ## Getting started
 
 ### Requirements

--- a/docs/integrations/destinations/amazon-sqs.md
+++ b/docs/integrations/destinations/amazon-sqs.md
@@ -32,6 +32,7 @@ in all three formats. See the **Writing Text or XML messages** section for more 
 | [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
 | [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
+| Support [Namespaces](https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces) | No |
 
 ## Getting started
 

--- a/docs/integrations/destinations/amazon-sqs.md
+++ b/docs/integrations/destinations/amazon-sqs.md
@@ -14,15 +14,6 @@ All streams will be output into a single SQS Queue.
 Amazon SQS messages can only contain JSON, XML or text, and this connector supports writing messages
 in all three formats. See the **Writing Text or XML messages** section for more info.
 
-#### Features
-
-| Feature                        | Supported?\(Yes/No\) | Notes |
-| :----------------------------- | :------------------- | :---- |
-| Full Refresh Sync              | No                   |       |
-| Incremental - Append Sync      | Yes                  |       |
-| Incremental - Append + Deduped | No                   |       |
-| Namespaces                     | No                   |       |
-
 ## Supported sync modes
 
 | Sync mode | Supported? |

--- a/docs/integrations/destinations/astra.md
+++ b/docs/integrations/destinations/astra.md
@@ -27,14 +27,15 @@ This page contains the setup guide and reference information for the destination
 - Copy the Endpoint under Database Details and load into Airbyte under the name astra_db_endpoint
 - Click generate token, copy the application token and load under astra_db_app_token
 
-## Supported Sync Modes
+## Supported sync modes
 
-| Feature                        | Supported?\(Yes/No\) | Notes |
-| :----------------------------- | :------------------- | :---- |
-| Full Refresh Sync              | Yes                  |       |
-| Incremental - Append Sync      | Yes                  |       |
-| Incremental - Append + Deduped | Yes                  |       |
-
+| Sync mode | Supported? |
+| :--- | :--- |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite) | Yes |
+| [Full Refresh - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | Yes |
+| [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | Yes |
 
 ## Changelog
 

--- a/docs/integrations/destinations/astra.md
+++ b/docs/integrations/destinations/astra.md
@@ -36,6 +36,7 @@ This page contains the setup guide and reference information for the destination
 | [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | Yes |
 | [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | Yes |
+| Support [Namespaces](https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces) | Yes |
 
 ## Changelog
 

--- a/docs/integrations/destinations/aws-datalake.md
+++ b/docs/integrations/destinations/aws-datalake.md
@@ -76,6 +76,7 @@ in AWS Lakeformation. You will find more information about Lake Formation permis
 | [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
 | [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
+| Support [Namespaces](https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces) | Yes |
 
 ## Data type map
 

--- a/docs/integrations/destinations/aws-datalake.md
+++ b/docs/integrations/destinations/aws-datalake.md
@@ -69,11 +69,13 @@ in AWS Lakeformation. You will find more information about Lake Formation permis
 
 ## Supported sync modes
 
-| Feature                   | Supported?\(Yes/No\) | Notes |
-| :------------------------ | :------------------- | :---- |
-| Full Refresh Sync         | Yes                  |       |
-| Incremental - Append Sync | Yes                  |       |
-| Namespaces                | No                   |       |
+| Sync mode | Supported? |
+| :--- | :--- |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite) | Yes |
+| [Full Refresh - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
+| [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
 
 ## Data type map
 

--- a/docs/integrations/destinations/chroma.md
+++ b/docs/integrations/destinations/chroma.md
@@ -25,6 +25,7 @@ For each record, a UUID string is generated and used as the document id. The emb
 | [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | Yes |
 | [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | Yes |
+| Support [Namespaces](https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces) | Yes |
 
 ## Getting Started \(Airbyte Open Source\)
 

--- a/docs/integrations/destinations/chroma.md
+++ b/docs/integrations/destinations/chroma.md
@@ -2,14 +2,6 @@
 
 This page guides you through the process of setting up the [Chroma](https://docs.trychroma.com/?lang=py) destination connector.
 
-## Features
-
-| Feature                        | Supported?\(Yes/No\) | Notes |
-| :----------------------------- | :------------------- | :---- |
-| Full Refresh Sync              | Yes                  |       |
-| Incremental - Append Sync      | Yes                  |       |
-| Incremental - Append + Deduped | Yes                  |       |
-
 #### Output Schema
 
 Only one stream will exist to collect data from all source streams. This will be in a [collection](https://docs.trychroma.com/usage-guide#using-collections) in [Chroma](https://docs.trychroma.com/?lang=py) whose name will be defined by the user, and validated and corrected by Airbyte.

--- a/docs/integrations/destinations/chroma.md
+++ b/docs/integrations/destinations/chroma.md
@@ -16,6 +16,16 @@ Only one stream will exist to collect data from all source streams. This will be
 
 For each record, a UUID string is generated and used as the document id. The embeddings generated as defined will be stored as embeddings. Data in the text fields will be stored as documents and those in the metadata fields will be stored as metadata.
 
+## Supported sync modes
+
+| Sync mode | Supported? |
+| :--- | :--- |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite) | Yes |
+| [Full Refresh - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | Yes |
+| [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | Yes |
+
 ## Getting Started \(Airbyte Open Source\)
 
 You can connect to a Chroma instance either in client/server mode or in a local persistent mode. For the local persistent mode, the database file will be saved in the path defined in the `path` config parameter. Note that `path` must be an absolute path, prefixed with `/local`.

--- a/docs/integrations/destinations/convex.md
+++ b/docs/integrations/destinations/convex.md
@@ -15,17 +15,6 @@ Each stream will be output into a table in Convex. Convex's table naming rules a
 
 Each record is a [document](https://docs.convex.dev/using/types) in Convex and is assigned `_id` and `_creationTime` fields during sync.
 
-### Features
-
-| Feature                       | Supported? |
-| :---------------------------- | :--------- |
-| Full Refresh Sync             | Yes        |
-| Incremental - Append Sync     | Yes        |
-| Incremental - Dedupe Sync     | Yes        |
-| Replicate Incremental Deletes | Yes        |
-| Change Data Capture           | Yes        |
-| Namespaces                    | Yes        |
-
 ### Performance considerations
 
 Take care to use the appropriate sync method and frequency for the quantity of data streaming from the source. Performance may suffer with large, frequent syncs with Full Refresh. Prefer Incremental modes when they are supported and especially for large tables.

--- a/docs/integrations/destinations/convex.md
+++ b/docs/integrations/destinations/convex.md
@@ -40,6 +40,7 @@ If you see performance issues, please reach via email to [Convex support](mailto
 | [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | Yes |
 | [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | Yes |
+| Support [Namespaces](https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces) | Yes |
 
 ## Getting started
 

--- a/docs/integrations/destinations/convex.md
+++ b/docs/integrations/destinations/convex.md
@@ -31,6 +31,16 @@ Each record is a [document](https://docs.convex.dev/using/types) in Convex and i
 Take care to use the appropriate sync method and frequency for the quantity of data streaming from the source. Performance may suffer with large, frequent syncs with Full Refresh. Prefer Incremental modes when they are supported and especially for large tables.
 If you see performance issues, please reach via email to [Convex support](mailto:support@convex.dev) or on [Discord](https://convex.dev/community).
 
+## Supported sync modes
+
+| Sync mode | Supported? |
+| :--- | :--- |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite) | Yes |
+| [Full Refresh - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | Yes |
+| [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | Yes |
+
 ## Getting started
 
 ### Requirements

--- a/docs/integrations/destinations/convex.md
+++ b/docs/integrations/destinations/convex.md
@@ -7,7 +7,7 @@ See your data on the [Convex dashboard](https://dashboard.convex.dev/).
 
 ## Overview
 
-The Convex destination connector supports Full Refresh Overwrite, Full Refresh Append, Incremental Append, and Incremental Dedup. Note that for Incremental Dedup, Convex does not store a history table like some other destinations that use DBT, but Convex does store a deduped snapshot.
+The Convex destination connector supports Full Refresh Overwrite, Full Refresh Append, Incremental Append, and Incremental Dedup. Note that for Incremental Dedup, Convex does not store a history table like some other destinations that use DBT, but Convex does store a deduped snapshot. Convex also supports Change Data Capture (CDC) and replicating incremental deletes.
 
 ### Output schema
 

--- a/docs/integrations/destinations/couchbase.md
+++ b/docs/integrations/destinations/couchbase.md
@@ -34,6 +34,16 @@ Each stream will be output into a collection in Couchbase. The connector follows
 * For large datasets, consider using incremental sync modes
 * Adjust the batch size if needed (default: 1000 documents)
 
+## Supported sync modes
+
+| Sync mode | Supported? |
+| :--- | :--- |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite) | Yes |
+| [Full Refresh - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | Yes |
+| [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | Yes |
+
 ## Getting started
 
 ### Requirements

--- a/docs/integrations/destinations/couchbase.md
+++ b/docs/integrations/destinations/couchbase.md
@@ -18,15 +18,6 @@ Each stream will be output into a collection in Couchbase. The connector follows
   * `stream`: The source stream name
   * `data`: The actual record data
 
-### Features
-
-| Feature                       | Supported? |
-| :---------------------------- | :--------- |
-| Full Refresh Sync            | Yes        |
-| Incremental - Append Sync    | Yes        |
-| Incremental - Dedupe Sync    | Yes        |
-| Namespaces                   | Yes        |
-
 ### Performance considerations
 
 * The connector uses batch operations for better performance

--- a/docs/integrations/destinations/couchbase.md
+++ b/docs/integrations/destinations/couchbase.md
@@ -43,6 +43,7 @@ Each stream will be output into a collection in Couchbase. The connector follows
 | [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | Yes |
 | [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | Yes |
+| Support [Namespaces](https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces) | Yes |
 
 ## Getting started
 

--- a/docs/integrations/destinations/csv.md
+++ b/docs/integrations/destinations/csv.md
@@ -26,15 +26,6 @@ Each stream will be output into its own file. Each file will contain 3 columns:
 - `_airbyte_emitted_at`: a timestamp representing when the event was pulled from the data source.
 - `_airbyte_data`: a json blob representing with the event data.
 
-#### Features
-
-| Feature                        | Supported |     |
-| :----------------------------- | :-------- | :-- |
-| Full Refresh Sync              | Yes       |     |
-| Incremental - Append Sync      | Yes       |     |
-| Incremental - Append + Deduped | No        |     |
-| Namespaces                     | No        |     |
-
 #### Performance considerations
 
 This integration will be constrained by the speed at which your filesystem accepts writes.

--- a/docs/integrations/destinations/csv.md
+++ b/docs/integrations/destinations/csv.md
@@ -39,6 +39,16 @@ Each stream will be output into its own file. Each file will contain 3 columns:
 
 This integration will be constrained by the speed at which your filesystem accepts writes.
 
+## Supported sync modes
+
+| Sync mode | Supported? |
+| :--- | :--- |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite) | Yes |
+| [Full Refresh - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
+| [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
+
 ## Getting Started
 
 The `destination_path` will always start with `/local` whether it is specified by the user or not. Any directory nesting within local will be mapped onto the local mount.

--- a/docs/integrations/destinations/csv.md
+++ b/docs/integrations/destinations/csv.md
@@ -48,6 +48,7 @@ This integration will be constrained by the speed at which your filesystem accep
 | [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
 | [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
+| Support [Namespaces](https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces) | No |
 
 ## Getting Started
 

--- a/docs/integrations/destinations/cumulio.md
+++ b/docs/integrations/destinations/cumulio.md
@@ -11,6 +11,16 @@ seamlessly embedded in their product. Cumul.io's intuitive, low-code interface e
 users with insight-driven actions in record time **without straining engineering resources from the
 core product**.
 
+## Supported sync modes
+
+| Sync mode | Supported? |
+| :--- | :--- |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite) | Yes |
+| [Full Refresh - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
+| [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
+
 ## Getting started
 
 In order to use the Cumul.io destination, you'll first need to **create a
@@ -43,10 +53,10 @@ _If you have any questions or want to get started with Cumul.io, don't hesitate 
 
 | [Sync modes](https://docs.airbyte.com/understanding-airbyte/connections/#sync-modes)                                     | Supported?\(Yes/No\) | Notes                                                 |
 | :----------------------------------------------------------------------------------------------------------------------- | :------------------- | :---------------------------------------------------- |
-| [Full Refresh - Append](https://docs.airbyte.com/understanding-airbyte/connections/full-refresh-append/)                 | Yes                  | /                                                     |
-| [Full Refresh - Replace](https://docs.airbyte.com/understanding-airbyte/connections/full-refresh-overwrite/)             | Yes                  | /                                                     |
-| [Incremental Sync - Append](https://docs.airbyte.com/understanding-airbyte/connections/incremental-append/)              | Yes                  | /                                                     |
-| [Incremental - Append + Deduped ](https://docs.airbyte.com/understanding-airbyte/connections/incremental-append-deduped) | No                   | Cumul.io's data warehouse does not support dbt (yet). |
+| [Full Refresh - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-append/)                 | Yes                  | /                                                     |
+| [Full Refresh - Replace](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite)             | Yes                  | /                                                     |
+| [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append/)              | Yes                  | /                                                     |
+| [Incremental - Append + Deduped ](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No                   | Cumul.io's data warehouse does not support dbt (yet). |
 
 ### Airbyte Features support
 

--- a/docs/integrations/destinations/cumulio.md
+++ b/docs/integrations/destinations/cumulio.md
@@ -56,7 +56,7 @@ _If you have any questions or want to get started with Cumul.io, don't hesitate 
 | [Full Refresh - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-append/)                 | Yes                  | /                                                     |
 | [Full Refresh - Replace](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite)             | Yes                  | /                                                     |
 | [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append/)              | Yes                  | /                                                     |
-| [Incremental - Append + Deduped ](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No                   | Cumul.io's data warehouse does not support dbt (yet). |
+| [Incremental - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No                   | Cumul.io's data warehouse does not support dbt (yet). |
 
 ### Airbyte Features support
 

--- a/docs/integrations/destinations/cumulio.md
+++ b/docs/integrations/destinations/cumulio.md
@@ -20,6 +20,7 @@ core product**.
 | [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
 | [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
+| Support [Namespaces](https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces) | No |
 
 ## Getting started
 

--- a/docs/integrations/destinations/databend.md
+++ b/docs/integrations/destinations/databend.md
@@ -3,13 +3,6 @@
 This page guides you through the process of setting up the [Databend](https://databend.rs/)
 destination connector.
 
-## Features
-
-| Feature                   | Supported?\(Yes/No\) | Notes |
-| :------------------------ | :------------------- | :---- |
-| Full Refresh Sync         | Yes                  |       |
-| Incremental - Append Sync | Yes                  |       |
-
 #### Output Schema
 
 Each stream will be output into its own table in Databend. Each table will contain 3 columns:

--- a/docs/integrations/destinations/databend.md
+++ b/docs/integrations/destinations/databend.md
@@ -30,6 +30,7 @@ Each stream will be output into its own table in Databend. Each table will conta
 | [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
 | [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
+| Support [Namespaces](https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces) | No |
 
 ## Getting Started (Airbyte Cloud)
 

--- a/docs/integrations/destinations/databend.md
+++ b/docs/integrations/destinations/databend.md
@@ -21,6 +21,16 @@ Each stream will be output into its own table in Databend. Each table will conta
 - `_airbyte_data`: a json blob representing with the event data. The column type in Databend is
   `VARVHAR`.
 
+## Supported sync modes
+
+| Sync mode | Supported? |
+| :--- | :--- |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite) | Yes |
+| [Full Refresh - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
+| [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
+
 ## Getting Started (Airbyte Cloud)
 
 Coming soon...

--- a/docs/integrations/destinations/deepset.md
+++ b/docs/integrations/destinations/deepset.md
@@ -2,6 +2,16 @@
 
 deepset AI Platform is a SaaS platform for building LLM applications and managing them across the whole lifecycle - from early prototyping to large-scale production. For details, see [deepset documentation](https://docs.cloud.deepset.ai/docs/getting-started).
 
+## Supported sync modes
+
+| Sync mode | Supported? |
+| :--- | :--- |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite) | Yes |
+| [Full Refresh - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | Yes |
+| [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | Yes |
+
 ## Data Integration with Airbyte
 
 To make it possible to synchronize data to deepset AI Platform using Airbyte, we've added an Airbyte deepset destination connector. You can use it to stream data into deepset from any Airbyte source that emits records matching the document file type. The synchronized data are available in deepset on the Files page as Markdown files.
@@ -12,10 +22,10 @@ _Note_: The deepset destination connector writes data to your deepset workspace,
 
 The deepset destination connector supports the following sync modes:
 
-* [Full refresh - append](https://docs.airbyte.com/understanding-airbyte/connections/full-refresh-append/)
-* [Full refresh - overwrite](https://docs.airbyte.com/understanding-airbyte/connections/full-refresh-overwrite/)
-* [Incremental sync - append](https://docs.airbyte.com/understanding-airbyte/connections/incremental-append/)
-* [Incremental sync - append + deduped ](https://docs.airbyte.com/understanding-airbyte/connections/incremental-append-deduped)
+* [Full refresh - append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-append/)
+* [Full refresh - overwrite](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite)
+* [Incremental sync - append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append/)
+* [Incremental sync - append + deduped ](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped)
 
 ## Syncing Data to deepset AI Platform
 

--- a/docs/integrations/destinations/deepset.md
+++ b/docs/integrations/destinations/deepset.md
@@ -11,6 +11,7 @@ deepset AI Platform is a SaaS platform for building LLM applications and managin
 | [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | Yes |
 | [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | Yes |
+| Support [Namespaces](https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces) | Yes |
 
 ## Data Integration with Airbyte
 

--- a/docs/integrations/destinations/deepset.md
+++ b/docs/integrations/destinations/deepset.md
@@ -18,15 +18,6 @@ To make it possible to synchronize data to deepset AI Platform using Airbyte, we
 
 _Note_: The deepset destination connector writes data to your deepset workspace, but does not delete any data from the workspace. If a file with the same name already exists in the destination workspace, it is overwritten.
 
-### Supported Sync Modes
-
-The deepset destination connector supports the following sync modes:
-
-* [Full refresh - append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-append/)
-* [Full refresh - overwrite](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite)
-* [Incremental sync - append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append/)
-* [Incremental sync - append + deduped ](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped)
-
 ## Syncing Data to deepset AI Platform
 
 To use the deepset destination in Airbyte:

--- a/docs/integrations/destinations/dev-null.md
+++ b/docs/integrations/destinations/dev-null.md
@@ -2,6 +2,16 @@
 
 This destination is for testing of Airbyte connections. It can be set up as a source message logger, a `/dev/null`, or to mimic specific behaviors (e.g. exception during the sync). Please use it with discretion. This destination may log your data, and expose sensitive information.
 
+## Supported sync modes
+
+| Sync mode | Supported? |
+| :--- | :--- |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite) | Yes |
+| [Full Refresh - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | Yes |
+| [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | Yes |
+
 ## Features
 
 | Feature                       | Supported | Notes |

--- a/docs/integrations/destinations/dev-null.md
+++ b/docs/integrations/destinations/dev-null.md
@@ -13,16 +13,6 @@ This destination is for testing of Airbyte connections. It can be set up as a so
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | Yes |
 | Support [Namespaces](https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces) | No |
 
-## Features
-
-| Feature                       | Supported | Notes |
-| :---------------------------- | :-------- | :---- |
-| Full Refresh Sync             | Yes       |       |
-| Incremental Sync              | Yes       |       |
-| Replicate Incremental Deletes | No        |       |
-| SSL connection                | No        |       |
-| SSH Tunnel Support            | No        |       |
-
 ## Mode
 
 ### Silent (`/dev/null`)

--- a/docs/integrations/destinations/dev-null.md
+++ b/docs/integrations/destinations/dev-null.md
@@ -11,6 +11,7 @@ This destination is for testing of Airbyte connections. It can be set up as a so
 | [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | Yes |
 | [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | Yes |
+| Support [Namespaces](https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces) | No |
 
 ## Features
 

--- a/docs/integrations/destinations/duckdb.md
+++ b/docs/integrations/destinations/duckdb.md
@@ -72,6 +72,7 @@ This integration will be constrained by the speed at which your filesystem accep
 | [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
 | [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
+| Support [Namespaces](https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces) | Yes |
 
 ## Getting Started with Local Database Files
 

--- a/docs/integrations/destinations/duckdb.md
+++ b/docs/integrations/destinations/duckdb.md
@@ -63,6 +63,16 @@ This integration will be constrained by the speed at which your filesystem accep
 
 <!-- env:oss -->
 
+## Supported sync modes
+
+| Sync mode | Supported? |
+| :--- | :--- |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite) | Yes |
+| [Full Refresh - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
+| [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
+
 ## Getting Started with Local Database Files
 
 The `destination_path` will always start with `/local` whether it is specified by the user or not. Any directory nesting within local will be mapped onto the local mount.
@@ -109,7 +119,6 @@ Note: If you are running Airbyte on Windows with Docker backed by WSL2, you have
 This error may indicate that you are connecting with a DuckDB client version that is incompatible with your database version. For example, if you are using DuckDB Destination connector version 0.6.0 or later (which uses DuckDB 1.4.x), your database must be compatible with DuckDB 1.4.x. To resolve this, you'll need to manually upgrade your database or revert to a previous version of the DuckDB Destination connector.
 
 For information about migrating between different versions of DuckDB, please see the [DuckDB Migration Guide](./duckdb-migrations).
-
 
 
 ## Changelog

--- a/docs/integrations/destinations/duckdb.md
+++ b/docs/integrations/destinations/duckdb.md
@@ -48,15 +48,6 @@ Each table will contain 3 columns:
 
 If you set [Normalization](https://docs.airbyte.com/understanding-airbyte/basic-normalization/), source data will be normalized to a tabular form. Let's say you have a source such as GitHub with nested JSONs; the Normalization ensures you end up with tables and columns. Suppose you have a many-to-many relationship between the users and commits. Normalization will create separate tables for it. The end state is the [third normal form](https://en.wikipedia.org/wiki/Third_normal_form) (3NF).
 
-#### Features
-
-| Feature                        | Supported |     |
-| :----------------------------- | :-------- | :-- |
-| Full Refresh Sync              | Yes       |     |
-| Incremental - Append Sync      | Yes       |     |
-| Incremental - Append + Deduped | No        |     |
-| Namespaces                     | No        |     |
-
 #### Performance consideration
 
 This integration will be constrained by the speed at which your filesystem accepts writes.

--- a/docs/integrations/destinations/duckdb.md
+++ b/docs/integrations/destinations/duckdb.md
@@ -121,7 +121,6 @@ This error may indicate that you are connecting with a DuckDB client version tha
 
 For information about migrating between different versions of DuckDB, please see the [DuckDB Migration Guide](./duckdb-migrations).
 
-
 ## Changelog
 
 <details>

--- a/docs/integrations/destinations/dynamodb.md
+++ b/docs/integrations/destinations/dynamodb.md
@@ -47,6 +47,7 @@ provision more capacity units in the DynamoDB console when there are performance
 | [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
 | [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
+| Support [Namespaces](https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces) | Yes |
 
 ## Getting started
 

--- a/docs/integrations/destinations/dynamodb.md
+++ b/docs/integrations/destinations/dynamodb.md
@@ -24,15 +24,6 @@ objects containing 4 fields:
 - `_airbyte_data`: a json blob representing with the extracted data.
 - `sync_time`: a timestamp representing when the sync up task be triggered.
 
-### Features
-
-| Feature                        | Support | Notes                                                                                   |
-| :----------------------------- | :-----: | :-------------------------------------------------------------------------------------- |
-| Full Refresh Sync              |   ✅    | Warning: this mode deletes all previously synced data in the configured DynamoDB table. |
-| Incremental - Append Sync      |   ✅    |                                                                                         |
-| Incremental - Append + Deduped |   ❌    |                                                                                         |
-| Namespaces                     |   ✅    | Namespace will be used as part of the table name.                                       |
-
 ### Performance considerations
 
 This connector by default uses 10 capacity units for both Read and Write in DynamoDB tables. Please

--- a/docs/integrations/destinations/dynamodb.md
+++ b/docs/integrations/destinations/dynamodb.md
@@ -38,6 +38,16 @@ objects containing 4 fields:
 This connector by default uses 10 capacity units for both Read and Write in DynamoDB tables. Please
 provision more capacity units in the DynamoDB console when there are performance constraints.
 
+## Supported sync modes
+
+| Sync mode | Supported? |
+| :--- | :--- |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite) | Yes |
+| [Full Refresh - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
+| [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
+
 ## Getting started
 
 ### Requirements

--- a/docs/integrations/destinations/elasticsearch.md
+++ b/docs/integrations/destinations/elasticsearch.md
@@ -46,6 +46,16 @@ This section should contain a table with the following format:
 Batch/bulk writes are performed. Large records may impact performance.  
 The connector should be enhanced to support variable batch sizes.
 
+## Supported sync modes
+
+| Sync mode | Supported? |
+| :--- | :--- |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite) | Yes |
+| [Full Refresh - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
+| [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
+
 ## Getting started
 
 ### Requirements

--- a/docs/integrations/destinations/elasticsearch.md
+++ b/docs/integrations/destinations/elasticsearch.md
@@ -29,18 +29,6 @@ This section should contain a table mapping each of the connector's data types t
 | numeric          | integer      | [more info](https://www.elastic.co/guide/en/elasticsearch/reference/current/number.html)  |
 | numeric          | number       | [more info](https://www.elastic.co/guide/en/elasticsearch/reference/current/number.html)  |
 
-### Features
-
-This section should contain a table with the following format:
-
-| Feature                       | Supported?(Yes/No) | Notes |
-| :---------------------------- | :----------------- | :---- |
-| Full Refresh Sync             | yes                |       |
-| Incremental Sync              | yes                |       |
-| Replicate Incremental Deletes | no                 |       |
-| SSL connection                | yes                |       |
-| SSH Tunnel Support            | yes                |       |
-
 ### Performance considerations
 
 Batch/bulk writes are performed. Large records may impact performance.  

--- a/docs/integrations/destinations/elasticsearch.md
+++ b/docs/integrations/destinations/elasticsearch.md
@@ -55,6 +55,7 @@ The connector should be enhanced to support variable batch sizes.
 | [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
 | [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
+| Support [Namespaces](https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces) | Yes |
 
 ## Getting started
 

--- a/docs/integrations/destinations/firebolt.md
+++ b/docs/integrations/destinations/firebolt.md
@@ -72,11 +72,13 @@ Additionally, for S3 strategy:
 
 ## Supported sync modes
 
-The Firebolt destination connector supports the following
-[sync modes](https://docs.airbyte.com/cloud/core-concepts/#connection-sync-mode):
-
-- Full Refresh
-- Incremental - Append Sync
+| Sync mode | Supported? |
+| :--- | :--- |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite) | Yes |
+| [Full Refresh - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
+| [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
 
 ## Connector-specific features & highlights
 

--- a/docs/integrations/destinations/firebolt.md
+++ b/docs/integrations/destinations/firebolt.md
@@ -79,6 +79,7 @@ Additionally, for S3 strategy:
 | [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
 | [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
+| Support [Namespaces](https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces) | No |
 
 ## Connector-specific features & highlights
 

--- a/docs/integrations/destinations/firestore.md
+++ b/docs/integrations/destinations/firestore.md
@@ -13,6 +13,7 @@ Google Firestore, officially known as Cloud Firestore, is a flexible, scalable d
 | [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
 | [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
+| Support [Namespaces](https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces) | No |
 
 ## Getting started
 

--- a/docs/integrations/destinations/firestore.md
+++ b/docs/integrations/destinations/firestore.md
@@ -4,6 +4,16 @@ This destination writes data to Google Firestore.
 
 Google Firestore, officially known as Cloud Firestore, is a flexible, scalable database for mobile, web, and server development from Firebase and Google Cloud. It is commonly used for developing applications as a NoSQL database that provides real-time data syncing across user devices.
 
+## Supported sync modes
+
+| Sync mode | Supported? |
+| :--- | :--- |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite) | Yes |
+| [Full Refresh - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
+| [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
+
 ## Getting started
 
 ### Requirements

--- a/docs/integrations/destinations/firestore.md
+++ b/docs/integrations/destinations/firestore.md
@@ -34,15 +34,6 @@ Google Firestore, officially known as Cloud Firestore, is a flexible, scalable d
 
 Each stream will be output into a BigQuery table.
 
-#### Features
-
-| Feature                        | Supported?\(Yes/No\) | Notes |
-| :----------------------------- | :------------------- | :---- |
-| Full Refresh Sync              | ✅                   |       |
-| Incremental - Append Sync      | ✅                   |       |
-| Incremental - Append + Deduped | ✅                   |       |
-| Namespaces                     | ✅                   |       |
-
 ## Changelog
 
 <details>

--- a/docs/integrations/destinations/gcs.md
+++ b/docs/integrations/destinations/gcs.md
@@ -46,8 +46,6 @@ The Airbyte GCS destination allows you to sync data to cloud storage buckets. Ea
     - Corresponding key to the above access ID.
 - Make sure your GCS bucket is accessible from the machine running Airbyte. This depends on your networking setup. The easiest way to verify if Airbyte is able to connect to your GCS bucket is via the check connection tool in the UI.
 
-### Sync mode support
-
 ## Configuration
 
 | Parameter          |  Type   | Notes                                                                                                                                                                                                                                                                       |

--- a/docs/integrations/destinations/gcs.md
+++ b/docs/integrations/destinations/gcs.md
@@ -48,15 +48,6 @@ The Airbyte GCS destination allows you to sync data to cloud storage buckets. Ea
 
 ### Sync mode support
 
-#### Features
-
-| Feature                        | Support | Notes                                                                                                                                                                                                    |
-| :----------------------------- | :-----: | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Full Refresh Sync              |   ✅    | Warning: this mode deletes all previously synced data in the configured bucket path.                                                                                                                     |
-| Incremental - Append Sync      |   ✅    | Warning: Airbyte provides at-least-once delivery. Depending on your source, you may see duplicated data. Learn more [here](/platform/using-airbyte/core-concepts/sync-modes/incremental-append#inclusive-cursors) |
-| Incremental - Append + Deduped |   ❌    |                                                                                                                                                                                                          |
-| Namespaces                     |   ❌    | Setting a specific bucket path is equivalent to having separate namespaces.                                                                                                                              |
-
 ## Configuration
 
 | Parameter          |  Type   | Notes                                                                                                                                                                                                                                                                       |

--- a/docs/integrations/destinations/gcs.md
+++ b/docs/integrations/destinations/gcs.md
@@ -6,6 +6,16 @@ This destination writes data to GCS bucket.
 
 The Airbyte GCS destination allows you to sync data to cloud storage buckets. Each stream is written to its own directory under the bucket.
 
+## Supported sync modes
+
+| Sync mode | Supported? |
+| :--- | :--- |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite) | Yes |
+| [Full Refresh - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
+| [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
+
 ## Getting started
 
 ### Requirements
@@ -97,7 +107,6 @@ Each stream will be outputted to its dedicated directory according to the config
 
 - Under Full Refresh Sync mode, old output files will be purged before new files are created.
 - Under Incremental - Append Sync mode, new output files will be added that only contain the new data.
-
 
 
 ### Avro

--- a/docs/integrations/destinations/gcs.md
+++ b/docs/integrations/destinations/gcs.md
@@ -109,7 +109,6 @@ Each stream will be outputted to its dedicated directory according to the config
 - Under Full Refresh Sync mode, old output files will be purged before new files are created.
 - Under Incremental - Append Sync mode, new output files will be added that only contain the new data.
 
-
 ### Avro
 
 [Apache Avro](https://avro.apache.org/) serializes data in a compact binary format. Currently, the Airbyte S3 Avro connector always uses the [binary encoding](https://avro.apache.org/docs/1.12.0/specification/#binary-encoding), and assumes that all data records follow the same schema.

--- a/docs/integrations/destinations/gcs.md
+++ b/docs/integrations/destinations/gcs.md
@@ -15,6 +15,7 @@ The Airbyte GCS destination allows you to sync data to cloud storage buckets. Ea
 | [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
 | [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
+| Support [Namespaces](https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces) | No |
 
 ## Getting started
 

--- a/docs/integrations/destinations/glassflow.md
+++ b/docs/integrations/destinations/glassflow.md
@@ -37,6 +37,7 @@ The message will be serialized as JSON.
 | [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
 | [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
+| Support [Namespaces](https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces) | Yes |
 
 ## Getting started
 

--- a/docs/integrations/destinations/glassflow.md
+++ b/docs/integrations/destinations/glassflow.md
@@ -28,6 +28,16 @@ The message will be serialized as JSON.
 | Incremental - Append + Deduped | No                   |       |
 | Namespaces                     | Yes                  |       |
 
+## Supported sync modes
+
+| Sync mode | Supported? |
+| :--- | :--- |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite) | No |
+| [Full Refresh - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
+| [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
+
 ## Getting started
 
 ### Requirements

--- a/docs/integrations/destinations/glassflow.md
+++ b/docs/integrations/destinations/glassflow.md
@@ -19,15 +19,6 @@ Each stream will be output a GlassFlow message. The message properties will be
 
 The message will be serialized as JSON.
 
-#### Features
-
-| Feature                        | Supported?\(Yes/No\) | Notes |
-| :----------------------------- | :------------------- | :---- |
-| Full Refresh Sync              | Yes                  |       |
-| Incremental - Append Sync      | Yes                  |       |
-| Incremental - Append + Deduped | No                   |       |
-| Namespaces                     | Yes                  |       |
-
 ## Supported sync modes
 
 | Sync mode | Supported? |

--- a/docs/integrations/destinations/google-sheets.md
+++ b/docs/integrations/destinations/google-sheets.md
@@ -10,6 +10,16 @@ Read more about the [limitations](#limitations) of using Google Sheets below.
 
 :::
 
+## Supported sync modes
+
+| Sync mode | Supported? |
+| :--- | :--- |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite) | Yes |
+| [Full Refresh - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | Yes |
+| [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | Yes |
+
 ## Prerequisites
 
 - Google Account or GCP Service Account for authentication

--- a/docs/integrations/destinations/google-sheets.md
+++ b/docs/integrations/destinations/google-sheets.md
@@ -178,15 +178,6 @@ EXAMPLE:
 | :--------------- | :----------- |
 | Any Type         | `string`     |
 
-### Features & Supported sync modes
-
-| Feature                        | Supported?\(Yes/No\) |
-| :----------------------------- | :------------------- |
-| Ful-Refresh Overwrite          | Yes                  |
-| Ful-Refresh Append             | Yes                  |
-| Incremental Append             | Yes                  |
-| Incremental Append-Deduplicate | Yes                  |
-
 ## Changelog
 
 <details>

--- a/docs/integrations/destinations/google-sheets.md
+++ b/docs/integrations/destinations/google-sheets.md
@@ -19,6 +19,7 @@ Read more about the [limitations](#limitations) of using Google Sheets below.
 | [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | Yes |
 | [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | Yes |
+| Support [Namespaces](https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces) | No |
 
 ## Prerequisites
 

--- a/docs/integrations/destinations/kafka.md
+++ b/docs/integrations/destinations/kafka.md
@@ -32,6 +32,16 @@ Each record will contain in its key the uuid assigned by Airbyte, and in the val
 | Incremental - Append + Deduped | No                   |       |
 | Namespaces                     | Yes                  |       |
 
+## Supported sync modes
+
+| Sync mode | Supported? |
+| :--- | :--- |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite) | No |
+| [Full Refresh - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
+| [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
+
 ## Getting started
 
 ### Requirements

--- a/docs/integrations/destinations/kafka.md
+++ b/docs/integrations/destinations/kafka.md
@@ -41,6 +41,7 @@ Each record will contain in its key the uuid assigned by Airbyte, and in the val
 | [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
 | [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
+| Support [Namespaces](https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces) | Yes |
 
 ## Getting started
 

--- a/docs/integrations/destinations/kafka.md
+++ b/docs/integrations/destinations/kafka.md
@@ -23,15 +23,6 @@ Each record will contain in its key the uuid assigned by Airbyte, and in the val
 - `_airbyte_data`: a json blob representing with the event data.
 - `_airbyte_stream`: the name of each record's stream.
 
-#### Features
-
-| Feature                        | Supported?\(Yes/No\) | Notes |
-| :----------------------------- | :------------------- | :---- |
-| Full Refresh Sync              | No                   |       |
-| Incremental - Append Sync      | Yes                  |       |
-| Incremental - Append + Deduped | No                   |       |
-| Namespaces                     | Yes                  |       |
-
 ## Supported sync modes
 
 | Sync mode | Supported? |

--- a/docs/integrations/destinations/kvdb.md
+++ b/docs/integrations/destinations/kvdb.md
@@ -12,7 +12,13 @@ TODO
 
 ## Supported sync modes
 
-TODO
+| Sync mode | Supported? |
+| :--- | :--- |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite) | Yes |
+| [Full Refresh - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
+| [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
 
 ## Supported streams
 

--- a/docs/integrations/destinations/kvdb.md
+++ b/docs/integrations/destinations/kvdb.md
@@ -19,6 +19,7 @@ TODO
 | [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
 | [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
+| Support [Namespaces](https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces) | No |
 
 ## Supported streams
 

--- a/docs/integrations/destinations/local-json.md
+++ b/docs/integrations/destinations/local-json.md
@@ -20,15 +20,6 @@ Each stream will be output into its own file. Each file will a collections of `j
 - `_airbyte_emitted_at`: a timestamp representing when the event was pulled from the data source.
 - `_airbyte_data`: a json blob representing with the extracted data.
 
-#### Features
-
-| Feature                        | Supported |     |
-| :----------------------------- | :-------- | :-- |
-| Full Refresh Sync              | Yes       |     |
-| Incremental - Append Sync      | Yes       |     |
-| Incremental - Append + Deduped | No        |     |
-| Namespaces                     | No        |     |
-
 #### Performance considerations
 
 This integration will be constrained by the speed at which your filesystem accepts writes.

--- a/docs/integrations/destinations/local-json.md
+++ b/docs/integrations/destinations/local-json.md
@@ -42,6 +42,7 @@ This integration will be constrained by the speed at which your filesystem accep
 | [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
 | [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
+| Support [Namespaces](https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces) | No |
 
 ## Getting Started
 

--- a/docs/integrations/destinations/local-json.md
+++ b/docs/integrations/destinations/local-json.md
@@ -33,6 +33,16 @@ Each stream will be output into its own file. Each file will a collections of `j
 
 This integration will be constrained by the speed at which your filesystem accepts writes.
 
+## Supported sync modes
+
+| Sync mode | Supported? |
+| :--- | :--- |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite) | Yes |
+| [Full Refresh - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
+| [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
+
 ## Getting Started
 
 The `destination_path` will always start with `/local` whether it is specified by the user or not. Any directory nesting within local will be mapped onto the local mount.

--- a/docs/integrations/destinations/mongodb.md
+++ b/docs/integrations/destinations/mongodb.md
@@ -30,6 +30,7 @@ Each stream will be output into its own collection in MongoDB. Each collection w
 | [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
 | [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
+| Support [Namespaces](https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces) | Yes |
 
 ## Getting Started \(Airbyte Cloud\)
 

--- a/docs/integrations/destinations/mongodb.md
+++ b/docs/integrations/destinations/mongodb.md
@@ -21,6 +21,16 @@ Each stream will be output into its own collection in MongoDB. Each collection w
 - `_airbyte_emitted_at`: a timestamp representing when the event was pulled from the data source. The field type in MongoDB is `Timestamp`.
 - `_airbyte_data`: a json blob representing with the event data. The field type in MongoDB is `Object`.
 
+## Supported sync modes
+
+| Sync mode | Supported? |
+| :--- | :--- |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite) | Yes |
+| [Full Refresh - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
+| [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
+
 ## Getting Started \(Airbyte Cloud\)
 
 Airbyte Cloud only supports connecting to your MongoDB instance with TLS encryption. Other than that, you can proceed with the open-source instructions below.

--- a/docs/integrations/destinations/mongodb.md
+++ b/docs/integrations/destinations/mongodb.md
@@ -1,14 +1,5 @@
 # MongoDB
 
-## Features
-
-| Feature                        | Supported?\(Yes/No\) | Notes |
-| :----------------------------- | :------------------- | :---- |
-| Full Refresh Sync              | Yes                  |       |
-| Incremental - Append Sync      | Yes                  |       |
-| Incremental - Append + Deduped | No                   |       |
-| Namespaces                     | Yes                  |       |
-
 ## Prerequisites
 
 - For Airbyte Open Source users using the [Postgres](https://docs.airbyte.com/integrations/sources/postgres) source connector, [upgrade](https://docs.airbyte.com/operator-guides/upgrading-airbyte/) your Airbyte platform to version `v0.40.0-alpha` or newer and upgrade your MongoDB connector to version `0.1.6` or newer

--- a/docs/integrations/destinations/motherduck.md
+++ b/docs/integrations/destinations/motherduck.md
@@ -10,7 +10,7 @@ For file-based DBs, data is written to `/tmp/airbyte_local` by default. To chang
 
 This destination implements [Destinations V2](/release_notes/upgrading_to_destinations_v2/#what-is-destinations-v2), which provides improved final table structures. It's a new version of the existing DuckDB destination and works both with DuckDB and MotherDuck.
 
-Learn more about what's new in Destinations V2 [here](/platform/using-airbyte/core-concepts/typing-deduping).
+Learn more about what's new in Destinations V2 [here](/platform/using-airbyte/core-concepts/typing-deduping). Note that [data generations](/platform/operator-guides/refreshes#data-generations) are not currently supported.
 
 ## Supported sync modes
 

--- a/docs/integrations/destinations/motherduck.md
+++ b/docs/integrations/destinations/motherduck.md
@@ -57,17 +57,6 @@ Each table will contain at least the following columns:
 
 In addition, columns specified in the [JSON schema](https://docs.airbyte.com/connector-development/schema-reference) will also be created.
 
-#### Features
-
-| Feature                                                                  | Supported |     |
-| :----------------------------------------------------------------------- | :-------- | :-- |
-| Full Refresh Sync                                                        | Yes       |     |
-| Incremental - Append Sync                                                | Yes       |     |
-| Incremental - Append + Deduped                                           | Yes       |     |
-| [Typing and Deduplication](/platform/using-airbyte/core-concepts/typing-deduping) | Yes       |     |
-| [Namespaces](/platform/using-airbyte/core-concepts/namespaces)                    | No        |     |
-| [Data Generations](/platform/operator-guides/refreshes#data-generations)          | No        |     |
-
 #### Performance consideration
 
 This integration will be constrained by the speed at which your filesystem accepts writes.

--- a/docs/integrations/destinations/motherduck.md
+++ b/docs/integrations/destinations/motherduck.md
@@ -12,6 +12,16 @@ This destination implements [Destinations V2](/release_notes/upgrading_to_destin
 
 Learn more about what's new in Destinations V2 [here](/platform/using-airbyte/core-concepts/typing-deduping).
 
+## Supported sync modes
+
+| Sync mode | Supported? |
+| :--- | :--- |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite) | Yes |
+| [Full Refresh - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | Yes |
+| [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | Yes |
+
 ## Use with MotherDuck
 
 This DuckDB destination is compatible with [MotherDuck](https://motherduck.com).

--- a/docs/integrations/destinations/motherduck.md
+++ b/docs/integrations/destinations/motherduck.md
@@ -21,6 +21,7 @@ Learn more about what's new in Destinations V2 [here](/platform/using-airbyte/co
 | [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | Yes |
 | [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | Yes |
+| Support [Namespaces](https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces) | Yes |
 
 ## Use with MotherDuck
 

--- a/docs/integrations/destinations/mysql.md
+++ b/docs/integrations/destinations/mysql.md
@@ -5,16 +5,6 @@ There are two flavors of connectors for this destination:
 1. destination-mysql connector. Supports both SSL and non SSL connections.
 2. destination-mysql-strict-encrypt connector. Pretty same as connector above, but supports SSL connections only.
 
-## Features
-
-| Feature                        | Supported?\(Yes/No\) | Notes |
-| :----------------------------- | :------------------- | :---- |
-| Full Refresh Sync              | Yes                  |       |
-| Incremental - Append Sync      | Yes                  |       |
-| Incremental - Append + Deduped | No                   |       |
-| Namespaces                     | Yes                  |       |
-| SSH Tunnel Connection          | Yes                  |       |
-
 ## Supported sync modes
 
 | Sync mode | Supported? |

--- a/docs/integrations/destinations/mysql.md
+++ b/docs/integrations/destinations/mysql.md
@@ -15,6 +15,16 @@ There are two flavors of connectors for this destination:
 | Namespaces                     | Yes                  |       |
 | SSH Tunnel Connection          | Yes                  |       |
 
+## Supported sync modes
+
+| Sync mode | Supported? |
+| :--- | :--- |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite) | Yes |
+| [Full Refresh - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | Yes |
+| [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | Yes |
+
 ## Getting Started \(Airbyte Cloud\)
 
 Airbyte Cloud only supports connecting to your MySQL instance with TLS encryption. Other than that, you can proceed with the open-source instructions below.

--- a/docs/integrations/destinations/mysql.md
+++ b/docs/integrations/destinations/mysql.md
@@ -24,6 +24,7 @@ There are two flavors of connectors for this destination:
 | [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | Yes |
 | [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | Yes |
+| Support [Namespaces](https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces) | Yes |
 
 ## Getting Started \(Airbyte Cloud\)
 

--- a/docs/integrations/destinations/oracle.md
+++ b/docs/integrations/destinations/oracle.md
@@ -1,17 +1,5 @@
 # Oracle DB
 
-## Features
-
-| Feature                        | Supported?\(Yes/No\) | Notes                                                                 |
-| :----------------------------- | :------------------- | :-------------------------------------------------------------------- |
-| Full Refresh Sync              | Yes                  |                                                                       |
-| Incremental - Append Sync      | Yes                  |                                                                       |
-| Incremental - Append + Deduped | Yes                  |                                                                       |
-| Namespaces                     | Yes                  |                                                                       |
-| Basic Normalization            | Yes                  | Doesn't support for nested json yet                                   |
-| SSH Tunnel Connection          | Yes                  |                                                                       |
-| Encryption                     | Yes                  | Support Native Network Encryption (NNE) as well as TLS using SSL cert |
-
 ## Output Schema
 
 By default, each stream will be output into its own table in Oracle. Each table will contain 3 columns:

--- a/docs/integrations/destinations/oracle.md
+++ b/docs/integrations/destinations/oracle.md
@@ -31,6 +31,7 @@ Enabling normalization will also create normalized, strongly typed tables.
 | [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
 | [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
+| Support [Namespaces](https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces) | Yes |
 
 ## Getting Started \(Airbyte Cloud\)
 

--- a/docs/integrations/destinations/oracle.md
+++ b/docs/integrations/destinations/oracle.md
@@ -22,6 +22,16 @@ By default, each stream will be output into its own table in Oracle. Each table 
 
 Enabling normalization will also create normalized, strongly typed tables.
 
+## Supported sync modes
+
+| Sync mode | Supported? |
+| :--- | :--- |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite) | Yes |
+| [Full Refresh - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
+| [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
+
 ## Getting Started \(Airbyte Cloud\)
 
 The Oracle connector is currently in Alpha on Airbyte Cloud. Only TLS encrypted connections to your DB can be made from Airbyte Cloud. Other than that, follow the open-source instructions below.

--- a/docs/integrations/destinations/pubsub.md
+++ b/docs/integrations/destinations/pubsub.md
@@ -38,6 +38,16 @@ The data will be a serialized JSON, containing the following fields
 | Incremental - Append + Deduped | No                   |       |
 | Namespaces                     | Yes                  |       |
 
+## Supported sync modes
+
+| Sync mode | Supported? |
+| :--- | :--- |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite) | No |
+| [Full Refresh - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
+| [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
+
 ## Getting started
 
 ### Requirements

--- a/docs/integrations/destinations/pubsub.md
+++ b/docs/integrations/destinations/pubsub.md
@@ -29,15 +29,6 @@ The data will be a serialized JSON, containing the following fields
 - `_airbyte_emitted_at`: a long timestamp\(ms\) representing when the event was pulled from the data source.
 - `_airbyte_data`: a json string representing source data.
 
-#### Features
-
-| Feature                        | Supported?\(Yes/No\) | Notes |
-| :----------------------------- | :------------------- | :---- |
-| Full Refresh Sync              | Yes                  |       |
-| Incremental - Append Sync      | Yes                  |       |
-| Incremental - Append + Deduped | No                   |       |
-| Namespaces                     | Yes                  |       |
-
 ## Supported sync modes
 
 | Sync mode | Supported? |

--- a/docs/integrations/destinations/pubsub.md
+++ b/docs/integrations/destinations/pubsub.md
@@ -47,6 +47,7 @@ The data will be a serialized JSON, containing the following fields
 | [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
 | [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
+| Support [Namespaces](https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces) | No |
 
 ## Getting started
 

--- a/docs/integrations/destinations/qdrant.md
+++ b/docs/integrations/destinations/qdrant.md
@@ -25,6 +25,7 @@ For each [point](https://qdrant.tech/documentation/concepts/points/) in the coll
 | [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | Yes |
 | [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | Yes |
+| Support [Namespaces](https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces) | Yes |
 
 ## Getting Started
 

--- a/docs/integrations/destinations/qdrant.md
+++ b/docs/integrations/destinations/qdrant.md
@@ -16,6 +16,16 @@ Only one stream will exist to collect payload and vectors (optional) from all so
 
 For each [point](https://qdrant.tech/documentation/concepts/points/) in the collection, a UUID string is generated and used as the [point id](https://qdrant.tech/documentation/concepts/points/#point-ids). The embeddings generated as defined or extracted from the source stream will be stored as the point vectors. The point payload will contain primarily the record metadata. The text field will then be stored in a field (as defined in the config) in the point payload.
 
+## Supported sync modes
+
+| Sync mode | Supported? |
+| :--- | :--- |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite) | Yes |
+| [Full Refresh - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | Yes |
+| [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | Yes |
+
 ## Getting Started
 
 You can connect to a Qdrant instance either in local mode or cloud mode.

--- a/docs/integrations/destinations/qdrant.md
+++ b/docs/integrations/destinations/qdrant.md
@@ -2,14 +2,6 @@
 
 This page guides you through the process of setting up the [Qdrant](https://qdrant.tech/documentation/) destination connector.
 
-## Features
-
-| Feature                        | Supported?\(Yes/No\) | Notes |
-| :----------------------------- | :------------------- | :---- |
-| Full Refresh Sync              | Yes                  |       |
-| Incremental - Append Sync      | Yes                  |       |
-| Incremental - Append + Deduped | Yes                  |       |
-
 #### Output Schema
 
 Only one stream will exist to collect payload and vectors (optional) from all source streams. This will be in a [collection](https://qdrant.tech/documentation/concepts/collections/) in [Qdrant](https://qdrant.tech/documentation/) whose name will be defined by the user. If the collection does not already exist in the Qdrant instance, a new collection with the same name will be created.

--- a/docs/integrations/destinations/rabbitmq.md
+++ b/docs/integrations/destinations/rabbitmq.md
@@ -19,15 +19,6 @@ Each stream will be output a RabbitMQ message with properties. The message prope
 
 The `AirbyteRecord` data will be serialized as JSON and set as the RabbitMQ message body.
 
-#### Features
-
-| Feature                        | Supported?\(Yes/No\) | Notes |
-| :----------------------------- | :------------------- | :---- |
-| Full Refresh Sync              | Yes                  |       |
-| Incremental - Append Sync      | Yes                  |       |
-| Incremental - Append + Deduped | No                   |       |
-| Namespaces                     | Yes                  |       |
-
 ## Supported sync modes
 
 | Sync mode | Supported? |

--- a/docs/integrations/destinations/rabbitmq.md
+++ b/docs/integrations/destinations/rabbitmq.md
@@ -28,6 +28,16 @@ The `AirbyteRecord` data will be serialized as JSON and set as the RabbitMQ mess
 | Incremental - Append + Deduped | No                   |       |
 | Namespaces                     | Yes                  |       |
 
+## Supported sync modes
+
+| Sync mode | Supported? |
+| :--- | :--- |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite) | No |
+| [Full Refresh - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
+| [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
+
 ## Getting started
 
 ### Requirements

--- a/docs/integrations/destinations/rabbitmq.md
+++ b/docs/integrations/destinations/rabbitmq.md
@@ -37,6 +37,7 @@ The `AirbyteRecord` data will be serialized as JSON and set as the RabbitMQ mess
 | [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
 | [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
+| Support [Namespaces](https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces) | No |
 
 ## Getting started
 

--- a/docs/integrations/destinations/ragie.md
+++ b/docs/integrations/destinations/ragie.md
@@ -9,16 +9,6 @@ This connector transforms your records into documents and ingests them into Ragi
 
 ---
 
-## Features
-
-- 🔁 Supports **append**, **overwrite**, and **append + dedup** sync modes.
-- 🧠 Extracts vector content from specified fields.
-- 📎 Attaches custom or static metadata to each document.
-- 🏷️ Assigns document names and external IDs.
-- 📦 Supports partitioning into multiple datasets (indexes).
-
----
-
 ## Supported sync modes
 
 | Sync mode | Supported? |

--- a/docs/integrations/destinations/ragie.md
+++ b/docs/integrations/destinations/ragie.md
@@ -9,6 +9,15 @@ This connector transforms your records into documents and ingests them into Ragi
 
 ---
 
+## Features
+
+- Extracts vector content from specified fields.
+- Attaches custom or static metadata to each document.
+- Assigns document names and external IDs.
+- Supports partitioning into multiple datasets (indexes).
+
+---
+
 ## Supported sync modes
 
 | Sync mode | Supported? |

--- a/docs/integrations/destinations/ragie.md
+++ b/docs/integrations/destinations/ragie.md
@@ -19,6 +19,16 @@ This connector transforms your records into documents and ingests them into Ragi
 
 ---
 
+## Supported sync modes
+
+| Sync mode | Supported? |
+| :--- | :--- |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite) | Yes |
+| [Full Refresh - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | Yes |
+| [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | Yes |
+
 ## Prerequisites
 
 - A [Ragie.ai](https://www.ragie.ai) account.

--- a/docs/integrations/destinations/ragie.md
+++ b/docs/integrations/destinations/ragie.md
@@ -28,6 +28,7 @@ This connector transforms your records into documents and ingests them into Ragi
 | [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | Yes |
 | [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | Yes |
+| Support [Namespaces](https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces) | Yes |
 
 ## Prerequisites
 

--- a/docs/integrations/destinations/redis.md
+++ b/docs/integrations/destinations/redis.md
@@ -19,17 +19,6 @@ For the **_hash_** implementation as a Redis data type the keys and the hashes a
 - `_airbyte_emitted_at`: a timestamp representing when the event was received from the data source.
 - `_airbyte_data`: a json text/object representing the data that was received from the data source.
 
-### Features
-
-| Feature                        | Support | Notes                                                                          |
-| :----------------------------- | :-----: | :----------------------------------------------------------------------------- |
-| Full Refresh Sync              |   ✅    | Existing keys in the Redis cache are deleted and replaced with the new keys.   |
-| Incremental - Append Sync      |   ✅    | New keys are inserted in the same keyspace without touching the existing keys. |
-| Incremental - Append + Deduped |   ❌    |                                                                                |
-| Namespaces                     |   ✅    | Namespaces will be used to determine the correct Redis key.                    |
-| SSH Tunnel Connection          |   ✅    |                                                                                |
-| SSL connection                 |   ✅    |                                                                                |
-
 ### Performance considerations
 
 As long as you have the necessary memory capacity for your cache, Redis should be able to handle even millions of records without any issues since the data is stored in-memory with the option to

--- a/docs/integrations/destinations/redis.md
+++ b/docs/integrations/destinations/redis.md
@@ -35,6 +35,16 @@ For the **_hash_** implementation as a Redis data type the keys and the hashes a
 As long as you have the necessary memory capacity for your cache, Redis should be able to handle even millions of records without any issues since the data is stored in-memory with the option to
 save snapshots periodically on disk.
 
+## Supported sync modes
+
+| Sync mode | Supported? |
+| :--- | :--- |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite) | Yes |
+| [Full Refresh - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
+| [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
+
 ## Getting started
 
 ### Requirements

--- a/docs/integrations/destinations/redis.md
+++ b/docs/integrations/destinations/redis.md
@@ -44,6 +44,7 @@ save snapshots periodically on disk.
 | [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
 | [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
+| Support [Namespaces](https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces) | Yes |
 
 ## Getting started
 

--- a/docs/integrations/destinations/sftp-json.md
+++ b/docs/integrations/destinations/sftp-json.md
@@ -23,6 +23,16 @@ Each file will contain a collection of `json` objects which correspond directly 
 
 This integration will be constrained by the connection speed to the SFTP server and speed at which that server accepts writes.
 
+## Supported sync modes
+
+| Sync mode | Supported? |
+| :--- | :--- |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite) | Yes |
+| [Full Refresh - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
+| [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
+
 ## Getting Started
 
 The `destination_path` can refer to any path that the associated account has write permissions to.

--- a/docs/integrations/destinations/sftp-json.md
+++ b/docs/integrations/destinations/sftp-json.md
@@ -32,6 +32,7 @@ This integration will be constrained by the connection speed to the SFTP server 
 | [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
 | [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
+| Support [Namespaces](https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces) | No |
 
 ## Getting Started
 

--- a/docs/integrations/destinations/sftp-json.md
+++ b/docs/integrations/destinations/sftp-json.md
@@ -11,14 +11,6 @@ This destination writes data to a directory on an SFTP server.
 Each stream will be output into its own file.
 Each file will contain a collection of `json` objects which correspond directly with the data supplied by the source.
 
-#### Features
-
-| Feature                   | Supported |
-| :------------------------ | :-------- |
-| Full Refresh Sync         | Yes       |
-| Incremental - Append Sync | Yes       |
-| Namespaces                | No        |
-
 #### Performance considerations
 
 This integration will be constrained by the connection speed to the SFTP server and speed at which that server accepts writes.

--- a/docs/integrations/destinations/singlestore.md
+++ b/docs/integrations/destinations/singlestore.md
@@ -12,15 +12,6 @@ with [Typing and Deduping](https://docs.airbyte.com/using-airbyte/core-concepts/
 not supported.
 :::
 
-## Features
-
-| Feature                        | Supported?\(Yes/No\) | Notes |
-|:-------------------------------|:---------------------|:------|
-| Full Refresh Sync              | Yes                  |       |
-| Incremental - Append Sync      | Yes                  |       |
-| Incremental - Append + Deduped | Yes                  |       |
-| Namespaces                     | Yes                  |       |
-
 ## Supported sync modes
 
 | Sync mode | Supported? |

--- a/docs/integrations/destinations/singlestore.md
+++ b/docs/integrations/destinations/singlestore.md
@@ -30,6 +30,7 @@ not supported.
 | [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | Yes |
 | [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | Yes |
+| Support [Namespaces](https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces) | Yes |
 
 ## Getting Started
 

--- a/docs/integrations/destinations/singlestore.md
+++ b/docs/integrations/destinations/singlestore.md
@@ -21,6 +21,16 @@ not supported.
 | Incremental - Append + Deduped | Yes                  |       |
 | Namespaces                     | Yes                  |       |
 
+## Supported sync modes
+
+| Sync mode | Supported? |
+| :--- | :--- |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite) | Yes |
+| [Full Refresh - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | Yes |
+| [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | Yes |
+
 ## Getting Started
 
 #### Requirements

--- a/docs/integrations/destinations/sqlite.md
+++ b/docs/integrations/destinations/sqlite.md
@@ -26,15 +26,6 @@ Each stream will be output into its own table `_airbyte_raw_{stream_name}`. Each
 - `_airbyte_emitted_at`: a timestamp representing when the event was pulled from the data source.
 - `_airbyte_data`: a json blob representing with the event data.
 
-#### Features
-
-| Feature                        | Supported |     |
-| :----------------------------- | :-------- | :-- |
-| Full Refresh Sync              | Yes       |     |
-| Incremental - Append Sync      | Yes       |     |
-| Incremental - Append + Deduped | No        |     |
-| Namespaces                     | No        |     |
-
 #### Performance considerations
 
 This integration will be constrained by the speed at which your filesystem accepts writes.

--- a/docs/integrations/destinations/sqlite.md
+++ b/docs/integrations/destinations/sqlite.md
@@ -48,6 +48,7 @@ This integration will be constrained by the speed at which your filesystem accep
 | [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
 | [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
+| Support [Namespaces](https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces) | No |
 
 ## Getting Started
 

--- a/docs/integrations/destinations/sqlite.md
+++ b/docs/integrations/destinations/sqlite.md
@@ -39,6 +39,16 @@ Each stream will be output into its own table `_airbyte_raw_{stream_name}`. Each
 
 This integration will be constrained by the speed at which your filesystem accepts writes.
 
+## Supported sync modes
+
+| Sync mode | Supported? |
+| :--- | :--- |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite) | Yes |
+| [Full Refresh - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
+| [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
+
 ## Getting Started
 
 The `destination_path` will always start with `/local` whether it is specified by the user or not. Any directory nesting within local will be mapped onto the local mount.

--- a/docs/integrations/destinations/starburst-galaxy.md
+++ b/docs/integrations/destinations/starburst-galaxy.md
@@ -85,6 +85,16 @@ Learn more about [how source data is converted to Avro](https://docs.airbyte.io/
 
 Learn more about [Starburst Galaxy Iceberg type mapping](https://docs.starburst.io/latest/connector/iceberg.html#iceberg-to-trino-type-mapping).
 
+## Supported sync modes
+
+| Sync mode | Supported? |
+| :--- | :--- |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite) | Yes |
+| [Full Refresh - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
+| [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
+
 ## Getting started
 
 ### Requirements

--- a/docs/integrations/destinations/starburst-galaxy.md
+++ b/docs/integrations/destinations/starburst-galaxy.md
@@ -94,6 +94,7 @@ Learn more about [Starburst Galaxy Iceberg type mapping](https://docs.starburst.
 | [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
 | [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
+| Support [Namespaces](https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces) | Yes |
 
 ## Getting started
 

--- a/docs/integrations/destinations/starburst-galaxy.md
+++ b/docs/integrations/destinations/starburst-galaxy.md
@@ -5,16 +5,6 @@
 The Starburst Galaxy destination syncs data to Starburst Galaxy [great lake catalogs](https://docs.starburst.io/starburst-galaxy/sql/great-lakes.html)
 in [Apache Iceberg](https://iceberg.apache.org/) table format. Each stream is written to its own Iceberg table.
 
-## Features
-
-| Feature          | Supported | Notes                                                                               |
-| :--------------- | :-------: | :---------------------------------------------------------------------------------- |
-| Overwrite Sync   |    ✅     | **Warning**: this mode deletes all previously synced data in the destination table. |
-| Append Sync      |    ✅     |                                                                                     |
-| Append + Deduped |    ❌     |                                                                                     |
-| Namespaces       |    ✅     |                                                                                     |
-| SSL              |    ✅     | SSL is enabled.                                                                     |
-
 ## Data storage
 
 Starburst Galaxy supports various [object storages](https://docs.starburst.io/starburst-galaxy/catalogs/index.html#object-storage);

--- a/docs/integrations/destinations/surrealdb.md
+++ b/docs/integrations/destinations/surrealdb.md
@@ -22,6 +22,16 @@ The connector use this as the ID of each record in the destination SurrealDB tab
 - `_airbyte_extracted_at`: a timestamp representing when the event was pulled from the data source. The column type in SurrealDB is `datetime`.
 - `_airbyte_data`: a json blob representing with the event data. The column type in SurrealDB is `object`.
 
+## Supported sync modes
+
+| Sync mode | Supported? |
+| :--- | :--- |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite) | Yes |
+| [Full Refresh - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | Yes |
+| [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | Yes |
+
 ## Getting Started
 
 ### Requirements

--- a/docs/integrations/destinations/surrealdb.md
+++ b/docs/integrations/destinations/surrealdb.md
@@ -4,15 +4,6 @@
 
 This page guides you through the process of setting up the SurrealDB destination connector.
 
-## Features
-
-| Feature                        | Supported?\(Yes/No\) | Notes |
-| :----------------------------- | :------------------- | :---- |
-| Full Refresh Sync              | Yes                  |       |
-| Incremental - Append Sync      | No                  |       |
-| Incremental - Append + Deduped | No                  |       |
-| Namespaces                     | No                  |       |
-
 #### Output Schema
 
 Each stream will be output into its own table in SurrealDB. Each table will contain 3 columns:

--- a/docs/integrations/destinations/surrealdb.md
+++ b/docs/integrations/destinations/surrealdb.md
@@ -31,6 +31,7 @@ The connector use this as the ID of each record in the destination SurrealDB tab
 | [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | Yes |
 | [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | Yes |
+| Support [Namespaces](https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces) | Yes |
 
 ## Getting Started
 

--- a/docs/integrations/destinations/teradata.md
+++ b/docs/integrations/destinations/teradata.md
@@ -58,19 +58,6 @@ will contain below columns:
 | time_without_timezone      | TIME                     |
 | date                       | DATE                     |
 
-### Features
-
-The Teradata destination connector supports the
-following[ sync modes](https://docs.airbyte.com/cloud/core-concepts#connection-sync-modes):
-
-| Feature                        | Supported?\(Yes/No\) | Notes |
-| :----------------------------- |:---------------------| :---- |
-| Full Refresh Sync              | Yes                  |       |
-| Incremental - Append Sync      | Yes                  |       |
-| Incremental - Append + Deduped | Yes                  |       |
-| Namespaces                     | Yes                  |       |
-
-
 ## Schema map
 
 

--- a/docs/integrations/destinations/teradata.md
+++ b/docs/integrations/destinations/teradata.md
@@ -85,6 +85,7 @@ following[ sync modes](https://docs.airbyte.com/cloud/core-concepts#connection-s
 | [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | Yes |
 | [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | Yes |
+| Support [Namespaces](https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces) | Yes |
 
 ## Getting started
 

--- a/docs/integrations/destinations/teradata.md
+++ b/docs/integrations/destinations/teradata.md
@@ -74,8 +74,17 @@ following[ sync modes](https://docs.airbyte.com/cloud/core-concepts#connection-s
 ## Schema map
 
 
-
 ### Performance considerations
+
+## Supported sync modes
+
+| Sync mode | Supported? |
+| :--- | :--- |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite) | Yes |
+| [Full Refresh - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | Yes |
+| [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | Yes |
 
 ## Getting started
 

--- a/docs/integrations/destinations/timeplus.md
+++ b/docs/integrations/destinations/timeplus.md
@@ -14,6 +14,16 @@ destination connector.
 
 Each stream will be output into its own stream in Timeplus, with corresponding schema/columns.
 
+## Supported sync modes
+
+| Sync mode | Supported? |
+| :--- | :--- |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite) | Yes |
+| [Full Refresh - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
+| [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
+
 ## Getting Started (Airbyte Cloud)
 
 Timeplus destination connector is available on Airbyte Cloud as a marketplace connector.

--- a/docs/integrations/destinations/timeplus.md
+++ b/docs/integrations/destinations/timeplus.md
@@ -23,6 +23,7 @@ Each stream will be output into its own stream in Timeplus, with corresponding s
 | [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
 | [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
+| Support [Namespaces](https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces) | No |
 
 ## Getting Started (Airbyte Cloud)
 

--- a/docs/integrations/destinations/timeplus.md
+++ b/docs/integrations/destinations/timeplus.md
@@ -3,13 +3,6 @@
 This page guides you through the process of setting up the [Timeplus](https://timeplus.com)
 destination connector.
 
-## Features
-
-| Feature                   | Supported?\(Yes/No\) | Notes |
-| :------------------------ | :------------------- | :---- |
-| Overwrite                 | Yes                  |       |
-| Incremental - Append Sync | Yes                  |       |
-
 #### Output Schema
 
 Each stream will be output into its own stream in Timeplus, with corresponding schema/columns.

--- a/docs/integrations/destinations/typesense.md
+++ b/docs/integrations/destinations/typesense.md
@@ -14,15 +14,6 @@ With append mode, you have to create the collection first and can use [pre-defin
 
 Each stream will be output into its own collection in Typesense. If an id column is not provided, it will be generated.
 
-#### Features
-
-| Feature                        | Supported?\(Yes/No\) | Notes |
-| :----------------------------- | :------------------- | :---- |
-| Full Refresh Sync              | Yes                  |       |
-| Incremental - Append Sync      | Yes                  |       |
-| Incremental - Append + Deduped | No                   |       |
-| Namespaces                     | No                   |       |
-
 ## Supported sync modes
 
 | Sync mode | Supported? |

--- a/docs/integrations/destinations/typesense.md
+++ b/docs/integrations/destinations/typesense.md
@@ -23,6 +23,16 @@ Each stream will be output into its own collection in Typesense. If an id column
 | Incremental - Append + Deduped | No                   |       |
 | Namespaces                     | No                   |       |
 
+## Supported sync modes
+
+| Sync mode | Supported? |
+| :--- | :--- |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite) | Yes |
+| [Full Refresh - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
+| [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
+
 ## Getting started
 
 ### Requirements

--- a/docs/integrations/destinations/typesense.md
+++ b/docs/integrations/destinations/typesense.md
@@ -32,6 +32,7 @@ Each stream will be output into its own collection in Typesense. If an id column
 | [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
 | [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
+| Support [Namespaces](https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces) | No |
 
 ## Getting started
 

--- a/docs/integrations/destinations/vectara.md
+++ b/docs/integrations/destinations/vectara.md
@@ -24,14 +24,6 @@ All streams will be output into a corpus in Vectara whose name must be specified
 
 Note that there are no restrictions in naming the Vectara corpus and if a corpus with the specified name is not found, a new corpus with that name will be created. Also, if multiple corpora exists with the same name, an error will be returned as Airbyte will be unable to determine the preferred corpus.
 
-### Features
-
-| Feature                   | Supported? |
-| :------------------------ | :--------- |
-| Full Refresh Sync         | Yes        |
-| Incremental - Append Sync | Yes        |
-| Incremental - Dedupe Sync | Yes        |
-
 ## Supported sync modes
 
 | Sync mode | Supported? |

--- a/docs/integrations/destinations/vectara.md
+++ b/docs/integrations/destinations/vectara.md
@@ -32,6 +32,16 @@ Note that there are no restrictions in naming the Vectara corpus and if a corpus
 | Incremental - Append Sync | Yes        |
 | Incremental - Dedupe Sync | Yes        |
 
+## Supported sync modes
+
+| Sync mode | Supported? |
+| :--- | :--- |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite) | Yes |
+| [Full Refresh - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
+| [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
+
 ## Getting started
 
 You will need a Vectara account to use Vectara with Airbyte. To get started, use the following steps:

--- a/docs/integrations/destinations/vectara.md
+++ b/docs/integrations/destinations/vectara.md
@@ -41,6 +41,7 @@ Note that there are no restrictions in naming the Vectara corpus and if a corpus
 | [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
 | [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
+| Support [Namespaces](https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces) | Yes |
 
 ## Getting started
 

--- a/docs/integrations/destinations/xata.md
+++ b/docs/integrations/destinations/xata.md
@@ -25,6 +25,16 @@ name. If the message has the following shape:
 the table must have the same columns, mapping the names and
 [data types](https://xata.io/docs/concepts/data-model), one-by-one.
 
+## Supported sync modes
+
+| Sync mode | Supported? |
+| :--- | :--- |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite) | No |
+| [Full Refresh - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
+| [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
+
 ## Getting Started
 
 In order to connect, you need:

--- a/docs/integrations/destinations/xata.md
+++ b/docs/integrations/destinations/xata.md
@@ -34,6 +34,7 @@ the table must have the same columns, mapping the names and
 | [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | No |
 | [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | No |
+| Support [Namespaces](https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces) | No |
 
 ## Getting Started
 

--- a/docs/integrations/destinations/yellowbrick.md
+++ b/docs/integrations/destinations/yellowbrick.md
@@ -144,15 +144,13 @@ columns are created using Quoted identifiers preserving the case sensitivity.
 
 ## Supported sync modes
 
-The Yellowbrick destination connector supports the
-following[ sync modes](https://docs.airbyte.com/cloud/core-concepts#connection-sync-modes):
-
-| Feature                        | Supported?\(Yes/No\) | Notes |
-| :----------------------------- | :------------------- | :---- |
-| Full Refresh Sync              | Yes                  |       |
-| Incremental - Append Sync      | Yes                  |       |
-| Incremental - Append + Deduped | Yes                  |       |
-| Namespaces                     | Yes                  |       |
+| Sync mode | Supported? |
+| :--- | :--- |
+| [Full Refresh - Overwrite](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite) | Yes |
+| [Full Refresh - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-append) | Yes |
+| [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | Yes |
+| [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
+| [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | Yes |
 
 ## Schema map
 

--- a/docs/integrations/destinations/yellowbrick.md
+++ b/docs/integrations/destinations/yellowbrick.md
@@ -151,6 +151,7 @@ columns are created using Quoted identifiers preserving the case sensitivity.
 | [Full Refresh - Overwrite + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite-deduped) | Yes |
 | [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | Yes |
+| Support [Namespaces](https://docs.airbyte.com/platform/using-airbyte/core-concepts/namespaces) | Yes |
 
 ## Schema map
 


### PR DESCRIPTION
## What

Adds a standardized "Supported sync modes" table to 42 community (Marketplace) Airbyte destination documentation pages and removes legacy duplicate "Features" tables. Each connector now has a single canonical table listing all five sync modes with Yes/No support, namespace support, and links to documentation — derived from each connector's source code.

Requested by @ian-at-airbyte.

## How

1. Identified all destinations with `supportLevel: community` in their `metadata.yaml` (42 connectors; `destination-cassandra` was excluded because it has no source code and is disabled for both OSS and Cloud).
2. Extracted `supported_destination_sync_modes` from each connector's `spec.json` or Python `destination.py` file.
3. Mapped spec values to user-facing sync modes:
   - `overwrite` → Full Refresh - Overwrite
   - `append` → Full Refresh - Append, Incremental Sync - Append
   - `append_dedup` → Full Refresh - Overwrite + Deduped, Incremental Sync - Append + Deduped
4. Determined namespace support by reviewing each connector's source code for: `supportsNamespaces` in spec, `schema` fields used as namespace, namespace handling in write logic (`AirbyteStreamNameNamespacePair`, `createNamespace`, key/topic/collection naming), and `AbstractJdbcDestination` inheritance. Result: 24 support namespaces, 18 do not.
5. Inserted a `## Supported sync modes` section into each doc. Where a section already existed (astra, aws-datalake, firebolt, kvdb, yellowbrick), it was replaced with the new standardized table.
6. Removed legacy "Features" tables from 34 docs that had duplicate sync mode / namespace information. Other content in those docs (Output Schema, Performance considerations, etc.) was preserved.
7. All links use the canonical URL prefix: `https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/`.

### Updates since last revision

Addressed reviewer feedback on legacy table removal:

- **ragie.md**: Restored the `## Features` section (non-sync-mode capabilities: vector content extraction, metadata attachment, document naming, partitioning). Removed only the sync-mode bullet since that's now in the standardized table.
- **convex.md**: Added note about CDC and incremental delete support to the Overview section, preserving information from the removed legacy table.
- **motherduck.md**: Added note that [data generations](/platform/operator-guides/refreshes#data-generations) are not currently supported (typing/deduping was already covered in the existing "Destinations V2" section).
- **gcs.md**: Removed the now-empty `### Sync mode support` heading left over after legacy table removal.
- **elasticsearch.md, oracle.md, mysql.md, redis.md**: Confirmed that SSH tunneling, SSL/TLS, encryption, and normalization features removed from legacy tables are already documented in dedicated sections of each article.

## Review guide

**⚠️ Key area for review — sync mode mapping logic:**

The mapping of `append_dedup` → "Full Refresh - Overwrite + Deduped" is based on reading `CatalogParser.kt` (lines 46–48, 178–182), which converts `OVERWRITE` to `APPEND` internally and handles overwrite behavior via generation IDs (`minimumGenerationId == generationId`). Deduplication is independently controlled by `APPEND_DEDUP` → `ImportType.DEDUPE`. This means a destination needs `append_dedup` to support deduped modes, and the "overwrite" aspect is handled by the platform, not by the destination declaring `overwrite`. **Please verify this mapping is correct.**

**⚠️ Namespace support determination:**

Namespace support was determined by code review, not a declarative field (only `destination-elasticsearch` declares `supportsNamespaces: true` in its spec). For other connectors, the determination was based on whether the connector's write logic uses namespace for data organization (schema selection, collection naming, key prefixing, etc.). **Please spot-check a few connectors to verify accuracy.** The full namespace evidence is in the table below.

**Reviewer checklist:**
- [x] Verify `append_dedup` → "Full Refresh - Overwrite + Deduped" mapping is correct per `CatalogParser.kt`
- [x] Spot-check a few namespace Yes/No values against the evidence table below
- [x] Confirm convex CDC/incremental deletes note is sufficient (or if it needs more detail)
- [x] Check that ragie.md Features section restoration preserved the right content

<details>
<summary><b>Evidence — spec values and namespace support per connector</b></summary>

| Destination | `supported_destination_sync_modes` | Source | Namespaces | Namespace evidence |
|---|---|---|---|---|
| amazon-sqs | `["append"]` | `spec.json` | No | No namespace references in code |
| astra | `["overwrite", "append", "append_dedup"]` | `destination.py` | Yes | `indexer.py` uses namespace for collection naming |
| aws-datalake | `["overwrite", "append"]` | `spec.json` | Yes | `stream_writer.py` uses namespace for path organization |
| chroma | `["overwrite", "append", "append_dedup"]` | `destination.py` | Yes | `indexer.py` uses namespace for collection naming |
| convex | `["overwrite", "append", "append_dedup"]` | `spec.json` | Yes | `destination.py` uses namespace (5 references) |
| couchbase | `["overwrite", "append", "append_dedup"]` | `spec.json` | Yes | `destination.py` uses namespace for scope/collection naming |
| csv | `["overwrite", "append"]` | `spec.json` | No | File-based destination, no namespace concept |
| cumulio | `["overwrite", "append"]` | `spec.json` | No | No namespace references, API push destination |
| databend | `["overwrite", "append"]` | `spec.json` | No | No namespace handling, writes to single database |
| deepset | `["append", "append_dedup", "overwrite"]` | `spec.json` | Yes | `util.py`/`models.py` uses namespace for file organization |
| dev-null | `["overwrite", "append", "append_dedup"]` | `spec.json` (test resources) | No | Test destination, discards data |
| duckdb | `["overwrite", "append"]` | `spec.json` | Yes | `schema` field in spec used as namespace |
| dynamodb | `["overwrite", "append"]` | `spec.json` | Yes | `DynamodbOutputTableHelper` uses namespace in table naming |
| elasticsearch | `["overwrite", "append"]` | `spec.json` | Yes | Declares `supportsNamespaces: true` in spec |
| firebolt | `["overwrite", "append"]` | `spec.json` | No | No namespace handling, writes to database with no schema |
| firestore | `["append", "overwrite"]` | `spec.json` | No | No namespace references in code |
| gcs | `["overwrite", "append"]` | `spec.json` | No | Extends BaseGcsDestination, no namespace in main code |
| glassflow | `["append"]` | `spec.json` | Yes | `destination.py` uses namespace |
| google-sheets | `["overwrite", "append", "append_dedup"]` | `spec.json` | No | No namespace references, writes to spreadsheet |
| kafka | `["append"]` | `spec.json` | Yes | Uses namespace in topic naming template |
| kvdb | `["overwrite", "append"]` | `spec.json` | No | No namespace references, simple KV store |
| local-json | `["overwrite", "append"]` | `spec.json` | No | File-based destination, no namespace concept |
| mongodb | `["overwrite", "append"]` | `spec.json` | Yes | Uses `AirbyteStreamNameNamespacePair` for collection naming |
| motherduck | `["overwrite", "append", "append_dedup"]` | `spec.json` | Yes | `schema` field in spec + namespace in destination.py |
| mysql | `["overwrite", "append", "append_dedup"]` | `spec.json` | Yes | AbstractJdbcDestination + full namespace handling |
| oracle | `["overwrite", "append"]` | `spec.json` | Yes | `schema` field + AbstractJdbcDestination |
| pubsub | `["append"]` | `spec.json` | No | No namespace in main code (only metadata) |
| qdrant | `["overwrite", "append", "append_dedup"]` | `destination.py` | Yes | `indexer.py` uses namespace for collection naming |
| rabbitmq | `["append"]` | `spec.json` | No | Only passes namespace in headers, not for routing |
| ragie | `["overwrite", "append", "append_dedup"]` | `destination.py` | Yes | `writer.py` uses namespace for document organization |
| redis | `["overwrite", "append"]` | `spec.json` | Yes | `RedisNameTransformer` uses namespace in key naming |
| sftp-json | `["overwrite", "append"]` | `spec.json` | No | File-based destination, no namespace concept |
| singlestore | `["overwrite", "append", "append_dedup"]` | `spec.json` | Yes | AbstractJdbcDestination + createNamespace in code |
| sqlite | `["overwrite", "append"]` | `spec.json` | No | Single SQLite file, no namespace/schema concept |
| starburst-galaxy | `["overwrite", "append"]` | `spec.json` | Yes | Uses namespace in StreamCopier + IcebergWriter |
| surrealdb | `["overwrite", "append", "append_dedup"]` | `spec.json` | Yes | `destination.py` uses namespace extensively |
| teradata | `["overwrite", "append", "append_dedup"]` | `spec.json` | Yes | `schema` field + full namespace handling |
| timeplus | `["overwrite", "append"]` | `spec.json` | No | No namespace references, writes to Timeplus streams |
| typesense | `["overwrite", "append"]` | `spec.json` | No | No namespace references, writes to collections by stream name |
| vectara | `["overwrite", "append"]` | `destination.py` | Yes | `writer.py` uses namespace |
| xata | `["append"]` | `spec.json` | No | No namespace references at all |
| yellowbrick | `["overwrite", "append", "append_dedup"]` | `spec.json` | Yes | `schema` field + AbstractJdbcDestination + SqlGenerator |

</details>

## User Impact

Users viewing Marketplace destination documentation will now see a clear, standardized table showing which sync modes and namespace support are available for each connector, with links to detailed documentation. Legacy duplicate tables have been removed for clarity, with connector-specific non-sync-mode features preserved in dedicated sections.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

[Devin session](https://app.devin.ai/sessions/3ec57faa1d5c4bdbac598aebf09fa00f)