### PR TITLE
fix(iceberg): add clear error message when dedup identifier fields are empty

### DIFF
--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/IcebergTableWriterFactory.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/IcebergTableWriterFactory.kt
@@ -4,6 +4,7 @@
 
 package io.airbyte.cdk.load.toolkits.iceberg.parquet.io
 
+import io.airbyte.cdk.ConfigErrorException
 import io.airbyte.cdk.load.command.Append
 import io.airbyte.cdk.load.command.Dedupe
 import io.airbyte.cdk.load.command.ImportType
@@ -91,7 +92,14 @@ class IcebergTableWriterFactory {
                     outputFileFactory = outputFileFactory,
                     format = format
                 )
-            is Dedupe ->
+            is Dedupe -> {
+                if (identifierFieldIds.isEmpty()) {
+                    throw ConfigErrorException(
+                        "Deduplication requires primary key columns that map to Iceberg identifier-compatible types. " +
+                            "Primary key columns with float or double types cannot be used as Iceberg identifier fields. " +
+                            "Use append or overwrite sync mode, or change the primary key to a non-floating-point column."
+                    )
+                }
                 newDeltaWriter(
                     table = table,
                     schema = schema,
@@ -101,6 +109,7 @@ class IcebergTableWriterFactory {
                     outputFileFactory = outputFileFactory,
                     format = format
                 )
+            }
             else -> throw IllegalArgumentException("Unsupported import type $importType")
         }
     }

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/test/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/IcebergTableWriterFactoryTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/test/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/IcebergTableWriterFactoryTest.kt
@@ -4,6 +4,7 @@
 
 package io.airbyte.cdk.load.toolkits.iceberg.parquet.io
 
+import io.airbyte.cdk.ConfigErrorException
 import io.airbyte.cdk.load.command.Append
 import io.airbyte.cdk.load.command.Dedupe
 import io.mockk.every
@@ -23,6 +24,7 @@ import org.apache.iceberg.io.OutputFile
 import org.apache.iceberg.types.Types
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 internal class IcebergTableWriterFactoryTest {
 
@@ -240,5 +242,63 @@ internal class IcebergTableWriterFactoryTest {
             )
         assertNotNull(writer)
         assertEquals(UnpartitionedAppendWriter::class.java, writer.javaClass)
+    }
+
+    @Test
+    fun testCreateWriterDedupeWithEmptyIdentifierFieldsThrowsConfigError() {
+        // Schema with DoubleType primary key — Iceberg disallows Double as identifier field,
+        // so identifierFieldIds will be empty even though a PK is configured.
+        val columns =
+            mutableListOf(
+                Types.NestedField.required(1, "id", Types.DoubleType.get()),
+                Types.NestedField.required(2, "name", Types.StringType.get()),
+            )
+        // No identifier field IDs — simulates the case where all PKs are Double/Float
+        val tableSchema = Schema(columns, emptySet<Int>())
+        val tableProperties = mapOf<String, String>()
+        val outputFile: OutputFile = mockk { every { location() } returns "location" }
+        val encryptionKeyMetadata: EncryptionKeyMetadata = mockk {
+            every { buffer() } returns ByteBuffer.allocate(8)
+        }
+        val encryptedOutputFile: EncryptedOutputFile = mockk {
+            every { encryptingOutputFile() } returns outputFile
+            every { keyMetadata() } returns encryptionKeyMetadata
+        }
+        val encryptionManager: EncryptionManager = mockk {
+            every { encrypt(any<OutputFile>()) } returns encryptedOutputFile
+        }
+        val fileIo: FileIO = mockk { every { newOutputFile(any()) } returns outputFile }
+        val locationProvider: LocationProvider = mockk {
+            every { newDataLocation(any()) } returns "location"
+            every { newDataLocation(any(), any(), any()) } returns "location"
+        }
+        val tableSpec: PartitionSpec = mockk {
+            every { fields() } returns emptyList()
+            every { isUnpartitioned } returns true
+        }
+        val table: Table = mockk {
+            every { encryption() } returns encryptionManager
+            every { io() } returns fileIo
+            every { locationProvider() } returns locationProvider
+            every { properties() } returns tableProperties
+            every { schema() } returns tableSchema
+            every { spec() } returns tableSpec
+        }
+
+        val factory = IcebergTableWriterFactory()
+        val exception =
+            assertThrows<ConfigErrorException> {
+                factory.create(
+                    table = table,
+                    generationId = generationIdSuffix,
+                    importType =
+                        Dedupe(
+                            primaryKey = listOf(listOf("id")),
+                            cursor = listOf("id")
+                        ),
+                    tableSchema,
+                )
+            }
+        assert(exception.message!!.contains("Deduplication requires primary key columns"))
     }
 }

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/test/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/IcebergTableWriterFactoryTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/test/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/IcebergTableWriterFactoryTest.kt
@@ -291,11 +291,7 @@ internal class IcebergTableWriterFactoryTest {
                 factory.create(
                     table = table,
                     generationId = generationIdSuffix,
-                    importType =
-                        Dedupe(
-                            primaryKey = listOf(listOf("id")),
-                            cursor = listOf("id")
-                        ),
+                    importType = Dedupe(primaryKey = listOf(listOf("id")), cursor = listOf("id")),
                     tableSchema,
                 )
             }


### PR DESCRIPTION
## What

Adds early validation in `IcebergTableWriterFactory` to throw a clear `ConfigErrorException` when deduplication mode is used but no Iceberg-compatible identifier fields exist in the schema. This replaces a cryptic `IllegalStateException` from deep in the Iceberg SDK.

Related issue: https://github.com/airbytehq/airbyte/issues/63359

## How

In `IcebergTableWriterFactory.create()`, before constructing a delta writer for `Dedupe` import type, check if `identifierFieldIds` is empty. If so, throw a `ConfigErrorException` with a message explaining that float/double primary key columns are incompatible with Iceberg's equality-delete mechanism.

**Root cause context:** When primary key columns have Airbyte `NumberType`, they map to Iceberg `DoubleType`, which Iceberg disallows as identifier fields (floating-point equality is unreliable). The PK columns are silently excluded in `AirbyteTypeToIcebergSchema.toIcebergSchema()`, and the empty identifier set then causes the Iceberg SDK to throw an unhelpful `IllegalStateException` at write time. This PR is the error-message-only fix; a separate PR ([#74272](https://github.com/airbytehq/airbyte/pull/74272)) will address the underlying type mapping.

## Review guide

1. `IcebergTableWriterFactory.kt` — the guard clause added before `newDeltaWriter` call (~7 lines)
2. `IcebergTableWriterFactoryTest.kt` — new test `testCreateWriterDedupeWithEmptyIdentifierFieldsThrowsConfigError`

**Things to check:**
- Is `ConfigErrorException` the correct exception type here? (It surfaces as `config_error` / `failureType` to the user, which seems appropriate since the user's PK column choice is incompatible.)
- The error message specifically calls out float/double. There could be other edge cases where identifier fields are empty (e.g., non-primitive PK types). Is the message too narrow?
- The test uses `assert()` for the message check rather than a JUnit assertion — minor style point.

## User Impact

Users hitting this bug (e.g., S3 Data Lake destination with dedup mode and `number`-typed PKs) will now see a clear error message explaining the incompatibility and suggesting alternatives, instead of a raw Iceberg SDK stack trace.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Requested by: @lleadbet
[Devin session](https://app.devin.ai/sessions/5a4d676a65fe4fc39167721d2a487be4)