### PR TITLE
fix(iceberg): map NumberType to DecimalType to support deduplication

### DIFF
--- a/airbyte-cdk/bulk/core/load/changelog.md
+++ b/airbyte-cdk/bulk/core/load/changelog.md
@@ -7,10 +7,11 @@ The Load CDK provides functionality for destination connectors including stream-
 <details>
   <summary>Expand to review</summary>
 
-| Version | Date       | Pull Request | Subject                                                                                                                                                           |
-|---------|------------|--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 1.0.2   | 2026-02-24 | | Bump bulk-cdk-core-base to 1.0.1 to pick up CVE fixes (CVE-2021-47621, CVE-2022-36944). |
-| 1.0.1   | 2026-02-09 | [#72959](https://github.com/airbytehq/airbyte/pull/72959) | Fix: CVE-2026-25526 (Jinjava dependency bump). |
+| Version | Date       | Pull Request | Subject                                                                                         |
+|---------|------------|--------------|-------------------------------------------------------------------------------------------------|
+| 1.0.3   | 2026-03-05 | [#74272](https://github.com/airbytehq/airbyte/pull/74272) | Fix iceberg dedup.                                                                              |
+| 1.0.2   | 2026-02-24 | | Bump bulk-cdk-core-base to 1.0.1 to pick up CVE fixes (CVE-2021-47621, CVE-2022-36944).         |
+| 1.0.1   | 2026-02-09 | [#72959](https://github.com/airbytehq/airbyte/pull/72959) | Fix: CVE-2026-25526 (Jinjava dependency bump).                                                  |
 | 1.0.0   | 2026-02-02 | [#72376](https://github.com/airbytehq/airbyte/pull/72376) | Initial independent release of bulk-cdk-core-load. Separate versioning for load package begins. |
 
 </details>

--- a/airbyte-cdk/bulk/core/load/version.properties
+++ b/airbyte-cdk/bulk/core/load/version.properties
@@ -1,1 +1,1 @@
-version=1.0.2
+version=1.0.3

--- a/airbyte-cdk/bulk/core/load/version.properties
+++ b/airbyte-cdk/bulk/core/load/version.properties
@@ -1,1 +1,1 @@
-version=1.0.3
+version=1.0.2

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/data/iceberg/parquet/AirbyteTypeToIcebergSchema.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/data/iceberg/parquet/AirbyteTypeToIcebergSchema.kt
@@ -67,7 +67,7 @@ class AirbyteTypeToIcebergSchema {
             is BooleanType -> Types.BooleanType.get()
             is DateType -> Types.DateType.get()
             is IntegerType -> Types.LongType.get()
-            is NumberType -> Types.DoubleType.get()
+            is NumberType -> Types.StringType.get()
             // Schemaless types are converted to string
             is ArrayTypeWithoutSchema,
             is ObjectTypeWithEmptySchema,
@@ -117,13 +117,8 @@ fun ObjectType.toIcebergSchema(primaryKeys: List<List<String>>): Schema {
                 icebergType,
             ),
         )
-        // Identifier fields must be primitive types, and cannot be float/double.
-        if (
-            isPrimaryKey &&
-                icebergType.isPrimitiveType &&
-                icebergType != Types.DoubleType.get() &&
-                icebergType != Types.FloatType.get()
-        ) {
+        // Identifier fields must be primitive types.
+        if (isPrimaryKey && icebergType.isPrimitiveType) {
             identifierFields.add(id)
         }
     }

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/data/iceberg/parquet/AirbyteTypeToIcebergSchema.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/data/iceberg/parquet/AirbyteTypeToIcebergSchema.kt
@@ -67,7 +67,7 @@ class AirbyteTypeToIcebergSchema {
             is BooleanType -> Types.BooleanType.get()
             is DateType -> Types.DateType.get()
             is IntegerType -> Types.LongType.get()
-            is NumberType -> Types.DoubleType.get()
+            is NumberType -> Types.DecimalType.of(38, 18)
             // Schemaless types are converted to string
             is ArrayTypeWithoutSchema,
             is ObjectTypeWithEmptySchema,
@@ -107,16 +107,8 @@ fun ObjectType.toIcebergSchema(primaryKeys: List<List<String>>): Schema {
         // There's no _airbyte_data field, because we flatten the fields.
         // But we should leave the _airbyte_meta field as an actual object.
         val stringifyObjects = name != Meta.COLUMN_NAME_AB_META
-        // Primary key NumberType fields are stored as StringType because Iceberg
-        // disallows Double/Float as identifier fields (floating-point equality is
-        // unreliable). Non-PK NumberType fields remain as DoubleType to preserve
-        // analytical query compatibility.
         val icebergType =
-            if (isPrimaryKey && field.type is NumberType) {
-                Types.StringType.get()
-            } else {
-                icebergTypeConverter.convert(field.type, stringifyObjects = stringifyObjects)
-            }
+            icebergTypeConverter.convert(field.type, stringifyObjects = stringifyObjects)
         fields.add(
             NestedField.of(
                 id,

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/data/iceberg/parquet/AirbyteTypeToIcebergSchema.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/data/iceberg/parquet/AirbyteTypeToIcebergSchema.kt
@@ -67,7 +67,7 @@ class AirbyteTypeToIcebergSchema {
             is BooleanType -> Types.BooleanType.get()
             is DateType -> Types.DateType.get()
             is IntegerType -> Types.LongType.get()
-            is NumberType -> Types.StringType.get()
+            is NumberType -> Types.DoubleType.get()
             // Schemaless types are converted to string
             is ArrayTypeWithoutSchema,
             is ObjectTypeWithEmptySchema,
@@ -107,8 +107,16 @@ fun ObjectType.toIcebergSchema(primaryKeys: List<List<String>>): Schema {
         // There's no _airbyte_data field, because we flatten the fields.
         // But we should leave the _airbyte_meta field as an actual object.
         val stringifyObjects = name != Meta.COLUMN_NAME_AB_META
+        // Primary key NumberType fields are stored as StringType because Iceberg
+        // disallows Double/Float as identifier fields (floating-point equality is
+        // unreliable). Non-PK NumberType fields remain as DoubleType to preserve
+        // analytical query compatibility.
         val icebergType =
-            icebergTypeConverter.convert(field.type, stringifyObjects = stringifyObjects)
+            if (isPrimaryKey && field.type is NumberType) {
+                Types.StringType.get()
+            } else {
+                icebergTypeConverter.convert(field.type, stringifyObjects = stringifyObjects)
+            }
         fields.add(
             NestedField.of(
                 id,
@@ -117,8 +125,13 @@ fun ObjectType.toIcebergSchema(primaryKeys: List<List<String>>): Schema {
                 icebergType,
             ),
         )
-        // Identifier fields must be primitive types.
-        if (isPrimaryKey && icebergType.isPrimitiveType) {
+        // Identifier fields must be primitive types, and cannot be float/double.
+        if (
+            isPrimaryKey &&
+                icebergType.isPrimitiveType &&
+                icebergType != Types.DoubleType.get() &&
+                icebergType != Types.FloatType.get()
+        ) {
             identifierFields.add(id)
         }
     }

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/data/iceberg/parquet/AirbyteTypeToIcebergSchema.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/data/iceberg/parquet/AirbyteTypeToIcebergSchema.kt
@@ -67,7 +67,7 @@ class AirbyteTypeToIcebergSchema {
             is BooleanType -> Types.BooleanType.get()
             is DateType -> Types.DateType.get()
             is IntegerType -> Types.LongType.get()
-            is NumberType -> Types.DecimalType.of(38, 18)
+            is NumberType -> Types.DoubleType.get()
             // Schemaless types are converted to string
             is ArrayTypeWithoutSchema,
             is ObjectTypeWithEmptySchema,
@@ -107,8 +107,16 @@ fun ObjectType.toIcebergSchema(primaryKeys: List<List<String>>): Schema {
         // There's no _airbyte_data field, because we flatten the fields.
         // But we should leave the _airbyte_meta field as an actual object.
         val stringifyObjects = name != Meta.COLUMN_NAME_AB_META
+        // Primary key NumberType fields are stored as DecimalType because Iceberg
+        // disallows Double/Float as identifier fields (floating-point equality is
+        // unreliable). Non-PK NumberType fields remain as DoubleType to preserve
+        // analytical query compatibility.
         val icebergType =
-            icebergTypeConverter.convert(field.type, stringifyObjects = stringifyObjects)
+            if (isPrimaryKey && field.type is NumberType) {
+                Types.DecimalType.of(38, 18)
+            } else {
+                icebergTypeConverter.convert(field.type, stringifyObjects = stringifyObjects)
+            }
         fields.add(
             NestedField.of(
                 id,

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/data/iceberg/parquet/AirbyteTypeToIcebergSchema.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/data/iceberg/parquet/AirbyteTypeToIcebergSchema.kt
@@ -67,7 +67,7 @@ class AirbyteTypeToIcebergSchema {
             is BooleanType -> Types.BooleanType.get()
             is DateType -> Types.DateType.get()
             is IntegerType -> Types.LongType.get()
-            is NumberType -> Types.DoubleType.get()
+            is NumberType -> Types.DecimalType.of(38, 18)
             // Schemaless types are converted to string
             is ArrayTypeWithoutSchema,
             is ObjectTypeWithEmptySchema,
@@ -107,16 +107,8 @@ fun ObjectType.toIcebergSchema(primaryKeys: List<List<String>>): Schema {
         // There's no _airbyte_data field, because we flatten the fields.
         // But we should leave the _airbyte_meta field as an actual object.
         val stringifyObjects = name != Meta.COLUMN_NAME_AB_META
-        // Primary key NumberType fields are stored as DecimalType because Iceberg
-        // disallows Double/Float as identifier fields (floating-point equality is
-        // unreliable). Non-PK NumberType fields remain as DoubleType to preserve
-        // analytical query compatibility.
         val icebergType =
-            if (isPrimaryKey && field.type is NumberType) {
-                Types.DecimalType.of(38, 18)
-            } else {
-                icebergTypeConverter.convert(field.type, stringifyObjects = stringifyObjects)
-            }
+            icebergTypeConverter.convert(field.type, stringifyObjects = stringifyObjects)
         fields.add(
             NestedField.of(
                 id,

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/data/iceberg/parquet/AirbyteValueToIcebergRecord.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/data/iceberg/parquet/AirbyteValueToIcebergRecord.kt
@@ -65,8 +65,8 @@ class AirbyteValueToIcebergRecord {
             is NullValue -> return null
             is NumberValue ->
                 return when (type.typeId()) {
-                    // PK NumberType fields are stored as StringType in Iceberg.
-                    Type.TypeID.STRING -> airbyteValue.value.toPlainString()
+                    // NumberType is mapped to DecimalType in Iceberg.
+                    Type.TypeID.DECIMAL -> airbyteValue.value
                     else -> airbyteValue.value.toDouble()
                 }
             is StringValue -> return airbyteValue.value

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/data/iceberg/parquet/AirbyteValueToIcebergRecord.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/data/iceberg/parquet/AirbyteValueToIcebergRecord.kt
@@ -63,7 +63,12 @@ class AirbyteValueToIcebergRecord {
             is DateValue -> return airbyteValue.value
             is IntegerValue -> return airbyteValue.value.toLong()
             is NullValue -> return null
-            is NumberValue -> return airbyteValue.value.toDouble()
+            is NumberValue ->
+                return when (type.typeId()) {
+                    // PK NumberType fields are stored as StringType in Iceberg.
+                    Type.TypeID.STRING -> airbyteValue.value.toPlainString()
+                    else -> airbyteValue.value.toDouble()
+                }
             is StringValue -> return airbyteValue.value
             is TimeWithTimezoneValue ->
                 return when (type.typeId()) {

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/IcebergSuperTypeFinder.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/IcebergSuperTypeFinder.kt
@@ -23,7 +23,7 @@ import org.apache.iceberg.types.Types.*
  */
 @Singleton
 class IcebergSuperTypeFinder(private val icebergTypesComparator: IcebergTypesComparator) {
-    private val unsupportedTypeIds = setOf(BINARY, DECIMAL, FIXED, UUID, MAP, TIMESTAMP_NANO)
+    private val unsupportedTypeIds = setOf(BINARY, FIXED, UUID, MAP, TIMESTAMP_NANO)
 
     /**
      * Returns a supertype for [existingType] and [incomingType] if one exists.
@@ -64,7 +64,7 @@ class IcebergSuperTypeFinder(private val icebergTypesComparator: IcebergTypesCom
     }
 
     /**
-     * Checks whether either type is unsupported or unmapped (e.g. BINARY, DECIMAL, FIXED, etc.).
+     * Checks whether either type is unsupported or unmapped (e.g. BINARY, FIXED, UUID, etc.).
      *
      * @throws ConfigErrorException if either type is unsupported.
      */
@@ -106,6 +106,16 @@ class IcebergSuperTypeFinder(private val icebergTypesComparator: IcebergTypesCom
         // If both are the same type ID, we just use the existing type
         if (existingTypeId == incomingTypeId) {
             // For timestamps, you'd want to reconcile UTC. This is simplified here.
+            // For decimals, return the wider precision (Iceberg allows widening precision).
+            if (existingTypeId == DECIMAL) {
+                val existingDecimal = existingType as DecimalType
+                val incomingDecimal = incomingType as DecimalType
+                return if (incomingDecimal.precision() > existingDecimal.precision()) {
+                    incomingType
+                } else {
+                    existingType
+                }
+            }
             return existingType
         }
 

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/IcebergTypesComparator.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/IcebergTypesComparator.kt
@@ -222,8 +222,14 @@ class IcebergTypesComparator {
                 // but for this function's purpose, we only check the existing fields.
                 true
             }
+            Type.TypeID.DECIMAL -> {
+                require(
+                    existingType is Types.DecimalType && incomingType is Types.DecimalType
+                ) { "Expected DECIMAL types, got $existingType and $incomingType." }
+                existingType.precision() == incomingType.precision() &&
+                    existingType.scale() == incomingType.scale()
+            }
             Type.TypeID.BINARY,
-            Type.TypeID.DECIMAL,
             Type.TypeID.FIXED,
             Type.TypeID.UUID,
             Type.TypeID.MAP,

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/IcebergTypesComparator.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/IcebergTypesComparator.kt
@@ -223,9 +223,9 @@ class IcebergTypesComparator {
                 true
             }
             Type.TypeID.DECIMAL -> {
-                require(
-                    existingType is Types.DecimalType && incomingType is Types.DecimalType
-                ) { "Expected DECIMAL types, got $existingType and $incomingType." }
+                require(existingType is Types.DecimalType && incomingType is Types.DecimalType) {
+                    "Expected DECIMAL types, got $existingType and $incomingType."
+                }
                 existingType.precision() == incomingType.precision() &&
                     existingType.scale() == incomingType.scale()
             }

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/IcebergUtil.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/IcebergUtil.kt
@@ -15,7 +15,6 @@ import io.airbyte.cdk.load.data.ArrayTypeWithoutSchema
 import io.airbyte.cdk.load.data.ArrayValue
 import io.airbyte.cdk.load.data.EnrichedAirbyteValue
 import io.airbyte.cdk.load.data.NullValue
-import io.airbyte.cdk.load.data.NumberType
 import io.airbyte.cdk.load.data.ObjectType
 import io.airbyte.cdk.load.data.ObjectTypeWithEmptySchema
 import io.airbyte.cdk.load.data.ObjectTypeWithoutSchema
@@ -150,14 +149,6 @@ class IcebergUtil(private val tableIdGenerator: TableIdGenerator) {
                         StringValue(element.serializeToString()),
                         changeDescription = null,
                     )
-                // NumberType is stored as StringType in Iceberg to allow use as
-                // identifier fields (Iceberg disallows Double/Float identifiers).
-                NumberType ->
-                    ChangedValue(
-                        StringValue(element.serializeToString()),
-                        changeDescription = null,
-                    )
-
                 // otherwise, don't change anything
                 else -> null
             }

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/IcebergUtil.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/IcebergUtil.kt
@@ -15,6 +15,7 @@ import io.airbyte.cdk.load.data.ArrayTypeWithoutSchema
 import io.airbyte.cdk.load.data.ArrayValue
 import io.airbyte.cdk.load.data.EnrichedAirbyteValue
 import io.airbyte.cdk.load.data.NullValue
+import io.airbyte.cdk.load.data.NumberType
 import io.airbyte.cdk.load.data.ObjectType
 import io.airbyte.cdk.load.data.ObjectTypeWithEmptySchema
 import io.airbyte.cdk.load.data.ObjectTypeWithoutSchema
@@ -145,6 +146,13 @@ class IcebergUtil(private val tableIdGenerator: TableIdGenerator) {
                 is UnknownType ->
                     // serializing to string is a non-lossy operation, so don't generate a
                     // Meta.Change object.
+                    ChangedValue(
+                        StringValue(element.serializeToString()),
+                        changeDescription = null,
+                    )
+                // NumberType is stored as StringType in Iceberg to allow use as
+                // identifier fields (Iceberg disallows Double/Float identifiers).
+                NumberType ->
                     ChangedValue(
                         StringValue(element.serializeToString()),
                         changeDescription = null,

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/test/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/IcebergSuperTypeFinderTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/test/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/IcebergSuperTypeFinderTest.kt
@@ -126,11 +126,30 @@ class IcebergSuperTypeFinderTest {
     }
 
     @Test
-    fun testDecimalIsUnsupported() {
+    fun testIdenticalDecimalTypes() {
+        val decimalType = Types.DecimalType.of(38, 18)
+        val result = superTypeFinder.findSuperType(decimalType, decimalType, "column_name")
+
+        // Identical decimals => return existing
+        assertThat(result).isSameAs(decimalType)
+    }
+
+    @Test
+    fun testDecimalPrecisionWidening() {
+        val narrowDecimal = Types.DecimalType.of(10, 2)
+        val wideDecimal = Types.DecimalType.of(20, 2)
+
+        val result = superTypeFinder.findSuperType(narrowDecimal, wideDecimal, "column_name")
+        // Wider precision should be returned
+        assertThat(result).isSameAs(wideDecimal)
+    }
+
+    @Test
+    fun testDecimalToIntIsNotAllowed() {
         val decimalType = Types.DecimalType.of(10, 2)
         val intType = Types.IntegerType.get()
 
-        // Fails in validateTypeIds => DECIMAL is not supported
+        // Decimal to Int promotion is not allowed by Iceberg
         assertThatThrownBy { superTypeFinder.findSuperType(decimalType, intType, "column_name") }
             .isInstanceOf(ConfigErrorException::class.java)
             .hasMessageContaining(

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/test/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/IcebergTypesComparatorTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/test/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/IcebergTypesComparatorTest.kt
@@ -391,7 +391,7 @@ class IcebergTypesComparatorTest {
     }
 
     @Test
-    fun testUnsupportedTypeDecimal() {
+    fun testDecimalTypesEqual() {
         val existingSchema =
             buildSchema(
                 field("decimal_col", Types.DecimalType.of(10, 2), false),
@@ -401,10 +401,52 @@ class IcebergTypesComparatorTest {
                 field("decimal_col", Types.DecimalType.of(10, 2), false),
             )
 
-        // The code in typesAreEqual() throws for TypeID.DECIMAL
-        assertThatThrownBy { comparator.compareSchemas(incomingSchema, existingSchema) }
-            .isInstanceOf(IllegalArgumentException::class.java)
-            .hasMessageContaining("Unsupported or unmapped Iceberg type: DECIMAL")
+        val diff = comparator.compareSchemas(incomingSchema, existingSchema)
+
+        assertThat(diff.newColumns).isEmpty()
+        assertThat(diff.updatedDataTypes).isEmpty()
+        assertThat(diff.removedColumns).isEmpty()
+        assertThat(diff.newlyOptionalColumns).isEmpty()
+    }
+
+    @Test
+    fun testDecimalTypesDifferentPrecision() {
+        val existingSchema =
+            buildSchema(
+                field("decimal_col", Types.DecimalType.of(10, 2), false),
+            )
+        val incomingSchema =
+            buildSchema(
+                field("decimal_col", Types.DecimalType.of(20, 2), false),
+            )
+
+        val diff = comparator.compareSchemas(incomingSchema, existingSchema)
+
+        // Different precision means the type has been updated
+        assertThat(diff.updatedDataTypes).containsExactly("decimal_col")
+        assertThat(diff.newColumns).isEmpty()
+        assertThat(diff.removedColumns).isEmpty()
+        assertThat(diff.newlyOptionalColumns).isEmpty()
+    }
+
+    @Test
+    fun testDecimalTypesDifferentScale() {
+        val existingSchema =
+            buildSchema(
+                field("decimal_col", Types.DecimalType.of(10, 2), false),
+            )
+        val incomingSchema =
+            buildSchema(
+                field("decimal_col", Types.DecimalType.of(10, 5), false),
+            )
+
+        val diff = comparator.compareSchemas(incomingSchema, existingSchema)
+
+        // Different scale means the type has been updated
+        assertThat(diff.updatedDataTypes).containsExactly("decimal_col")
+        assertThat(diff.newColumns).isEmpty()
+        assertThat(diff.removedColumns).isEmpty()
+        assertThat(diff.newlyOptionalColumns).isEmpty()
     }
 
     @Test

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/testFixtures/kotlin/io/airbyte/cdk/load/data/icerberg/parquet/AirbyteTypeToIcebergSchemaTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/testFixtures/kotlin/io/airbyte/cdk/load/data/icerberg/parquet/AirbyteTypeToIcebergSchemaTest.kt
@@ -101,7 +101,7 @@ class AirbyteTypeToIcebergSchemaTest {
     @Test
     fun `convert handles NumberType`() {
         assertEquals(
-            Types.DoubleType.get(),
+            Types.DecimalType.of(38, 18),
             converter.convert(NumberType, stringifyObjects = false)
         )
     }
@@ -234,10 +234,10 @@ class AirbyteTypeToIcebergSchemaTest {
         assertFalse(idColumn!!.isOptional)
         assertEquals(Types.DecimalType.of(38, 18), idColumn.type())
 
-        // Non-PK NumberType field should remain DoubleType (for analytical queries)
+        // Non-PK NumberType field should also be DecimalType
         assertNotNull(amountColumn)
         assertTrue(amountColumn!!.isOptional)
-        assertEquals(Types.DoubleType.get(), amountColumn.type())
+        assertEquals(Types.DecimalType.of(38, 18), amountColumn.type())
 
         // PK field should be in identifier fields (DecimalType is allowed)
         val identifierFieldIds = schema.identifierFieldIds()

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/testFixtures/kotlin/io/airbyte/cdk/load/data/icerberg/parquet/AirbyteTypeToIcebergSchemaTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/testFixtures/kotlin/io/airbyte/cdk/load/data/icerberg/parquet/AirbyteTypeToIcebergSchemaTest.kt
@@ -101,7 +101,7 @@ class AirbyteTypeToIcebergSchemaTest {
     @Test
     fun `convert handles NumberType`() {
         assertEquals(
-            Types.DoubleType.get(),
+            Types.DecimalType.of(38, 18),
             converter.convert(NumberType, stringifyObjects = false)
         )
     }
@@ -215,7 +215,7 @@ class AirbyteTypeToIcebergSchemaTest {
     }
 
     @Test
-    fun `toIcebergSchema maps PK NumberType to StringType for identifier compatibility`() {
+    fun `toIcebergSchema maps PK NumberType to DecimalType for identifier compatibility`() {
         val objectType =
             ObjectType(
                 linkedMapOf(
@@ -229,17 +229,17 @@ class AirbyteTypeToIcebergSchemaTest {
         val idColumn = schema.findField("id")
         val amountColumn = schema.findField("amount")
 
-        // PK NumberType field should be StringType (for Iceberg identifier compatibility)
+        // PK NumberType field should be DecimalType (for Iceberg identifier compatibility)
         assertNotNull(idColumn)
         assertFalse(idColumn!!.isOptional)
-        assertEquals(Types.StringType.get(), idColumn.type())
+        assertEquals(Types.DecimalType.of(38, 18), idColumn.type())
 
-        // Non-PK NumberType field should remain DoubleType (for analytical queries)
+        // Non-PK NumberType field should also be DecimalType
         assertNotNull(amountColumn)
         assertTrue(amountColumn!!.isOptional)
-        assertEquals(Types.DoubleType.get(), amountColumn.type())
+        assertEquals(Types.DecimalType.of(38, 18), amountColumn.type())
 
-        // PK field should be in identifier fields
+        // PK field should be in identifier fields (DecimalType is allowed)
         val identifierFieldIds = schema.identifierFieldIds()
         assertEquals(1, identifierFieldIds.size)
         assertTrue(identifierFieldIds.contains(idColumn.fieldId()))

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/testFixtures/kotlin/io/airbyte/cdk/load/data/icerberg/parquet/AirbyteTypeToIcebergSchemaTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/testFixtures/kotlin/io/airbyte/cdk/load/data/icerberg/parquet/AirbyteTypeToIcebergSchemaTest.kt
@@ -101,7 +101,7 @@ class AirbyteTypeToIcebergSchemaTest {
     @Test
     fun `convert handles NumberType`() {
         assertEquals(
-            Types.StringType.get(),
+            Types.DoubleType.get(),
             converter.convert(NumberType, stringifyObjects = false)
         )
     }
@@ -212,5 +212,36 @@ class AirbyteTypeToIcebergSchemaTest {
         val identifierFieldIds = schema.identifierFieldIds()
         assertEquals(1, identifierFieldIds.size)
         assertEquals(true, identifierFieldIds.contains(ageColumn.fieldId()))
+    }
+
+    @Test
+    fun `toIcebergSchema maps PK NumberType to StringType for identifier compatibility`() {
+        val objectType =
+            ObjectType(
+                linkedMapOf(
+                    "id" to FieldType(NumberType, false),
+                    "amount" to FieldType(NumberType, true),
+                ),
+            )
+        val schema = objectType.toIcebergSchema(mutableListOf(mutableListOf("id")))
+
+        assertEquals(2, schema.columns().size)
+        val idColumn = schema.findField("id")
+        val amountColumn = schema.findField("amount")
+
+        // PK NumberType field should be StringType (for Iceberg identifier compatibility)
+        assertNotNull(idColumn)
+        assertFalse(idColumn!!.isOptional)
+        assertEquals(Types.StringType.get(), idColumn.type())
+
+        // Non-PK NumberType field should remain DoubleType (for analytical queries)
+        assertNotNull(amountColumn)
+        assertTrue(amountColumn!!.isOptional)
+        assertEquals(Types.DoubleType.get(), amountColumn.type())
+
+        // PK field should be in identifier fields
+        val identifierFieldIds = schema.identifierFieldIds()
+        assertEquals(1, identifierFieldIds.size)
+        assertTrue(identifierFieldIds.contains(idColumn.fieldId()))
     }
 }

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/testFixtures/kotlin/io/airbyte/cdk/load/data/icerberg/parquet/AirbyteTypeToIcebergSchemaTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/testFixtures/kotlin/io/airbyte/cdk/load/data/icerberg/parquet/AirbyteTypeToIcebergSchemaTest.kt
@@ -101,7 +101,7 @@ class AirbyteTypeToIcebergSchemaTest {
     @Test
     fun `convert handles NumberType`() {
         assertEquals(
-            Types.DecimalType.of(38, 18),
+            Types.DoubleType.get(),
             converter.convert(NumberType, stringifyObjects = false)
         )
     }
@@ -234,10 +234,10 @@ class AirbyteTypeToIcebergSchemaTest {
         assertFalse(idColumn!!.isOptional)
         assertEquals(Types.DecimalType.of(38, 18), idColumn.type())
 
-        // Non-PK NumberType field should also be DecimalType
+        // Non-PK NumberType field should remain DoubleType (for analytical queries)
         assertNotNull(amountColumn)
         assertTrue(amountColumn!!.isOptional)
-        assertEquals(Types.DecimalType.of(38, 18), amountColumn.type())
+        assertEquals(Types.DoubleType.get(), amountColumn.type())
 
         // PK field should be in identifier fields (DecimalType is allowed)
         val identifierFieldIds = schema.identifierFieldIds()

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/testFixtures/kotlin/io/airbyte/cdk/load/data/icerberg/parquet/AirbyteTypeToIcebergSchemaTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/testFixtures/kotlin/io/airbyte/cdk/load/data/icerberg/parquet/AirbyteTypeToIcebergSchemaTest.kt
@@ -101,7 +101,7 @@ class AirbyteTypeToIcebergSchemaTest {
     @Test
     fun `convert handles NumberType`() {
         assertEquals(
-            Types.DoubleType.get(),
+            Types.StringType.get(),
             converter.convert(NumberType, stringifyObjects = false)
         )
     }

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/testFixtures/kotlin/io/airbyte/cdk/load/data/icerberg/parquet/IcebergWriteTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/testFixtures/kotlin/io/airbyte/cdk/load/data/icerberg/parquet/IcebergWriteTest.kt
@@ -146,7 +146,7 @@ abstract class IcebergWriteTest(
                 InputRecord(
                     finalStream,
                     """{"id": 42, "same": 43, "to_add": "val3"}""",
-                    emittedAtMs = 1234,
+                    emittedAtMs = 1235,
                 ),
             ),
         )
@@ -160,7 +160,7 @@ abstract class IcebergWriteTest(
                     airbyteMeta = OutputRecord.Meta(syncId = 42),
                 ),
                 OutputRecord(
-                    extractedAt = 1234,
+                    extractedAt = 1235,
                     generationId = 0,
                     data = mapOf("id" to 42, "same" to 43, "to_add" to "val3"),
                     airbyteMeta = OutputRecord.Meta(syncId = 43),

--- a/airbyte-integrations/connectors/destination-gcs-data-lake/src/main/kotlin/io/airbyte/integrations/destination/gcs_data_lake/dataflow/GcsDataLakeAggregate.kt
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/src/main/kotlin/io/airbyte/integrations/destination/gcs_data_lake/dataflow/GcsDataLakeAggregate.kt
@@ -8,7 +8,6 @@ import io.airbyte.cdk.load.command.Dedupe
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.data.AirbyteValue
 import io.airbyte.cdk.load.data.ArrayValue
-import io.airbyte.cdk.load.data.NumberValue
 import io.airbyte.cdk.load.data.ObjectValue
 import io.airbyte.cdk.load.data.StringValue
 import io.airbyte.cdk.load.data.iceberg.parquet.AirbyteValueToIcebergRecord
@@ -98,8 +97,6 @@ class GcsDataLakeAggregate(
             fieldName in stringFields && value is ObjectValue ->
                 StringValue(value.serializeToString())
             fieldName in stringFields && value is ArrayValue ->
-                StringValue(value.serializeToString())
-            fieldName in stringFields && value is NumberValue ->
                 StringValue(value.serializeToString())
             else -> value
         }

--- a/airbyte-integrations/connectors/destination-gcs-data-lake/src/main/kotlin/io/airbyte/integrations/destination/gcs_data_lake/dataflow/GcsDataLakeAggregate.kt
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/src/main/kotlin/io/airbyte/integrations/destination/gcs_data_lake/dataflow/GcsDataLakeAggregate.kt
@@ -8,6 +8,7 @@ import io.airbyte.cdk.load.command.Dedupe
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.data.AirbyteValue
 import io.airbyte.cdk.load.data.ArrayValue
+import io.airbyte.cdk.load.data.NumberValue
 import io.airbyte.cdk.load.data.ObjectValue
 import io.airbyte.cdk.load.data.StringValue
 import io.airbyte.cdk.load.data.iceberg.parquet.AirbyteValueToIcebergRecord
@@ -97,6 +98,8 @@ class GcsDataLakeAggregate(
             fieldName in stringFields && value is ObjectValue ->
                 StringValue(value.serializeToString())
             fieldName in stringFields && value is ArrayValue ->
+                StringValue(value.serializeToString())
+            fieldName in stringFields && value is NumberValue ->
                 StringValue(value.serializeToString())
             else -> value
         }


### PR DESCRIPTION
## What

Maps Airbyte `NumberType` to Iceberg `DecimalType(38, 18)` instead of `DoubleType` for **all fields**. This fixes [#63359](https://github.com/airbytehq/airbyte/issues/63359), where S3/GCS Data Lake destinations fail with `Equality field ids shouldn't be null or empty` when all primary keys are `NumberType`.

**Root cause:** Iceberg disallows `DoubleType`/`FloatType` as identifier fields (floating-point equality is unreliable). The CDK silently excluded these from identifier fields, causing an empty identifier set when all PKs were `NumberType` → `DoubleType`.

**This is a breaking change** — all `NumberType` columns change from `DoubleType` to `DecimalType(38, 18)` on next sync. `DecimalType` preserves numeric semantics (SUM, AVG, ORDER BY, comparisons work natively) and is allowed as an Iceberg identifier field per [the spec](https://iceberg.apache.org/spec/).

Requested by: @lleadbet
[Devin session](https://app.devin.ai/sessions/5a4d676a65fe4fc39167721d2a487be4)

Closes: https://github.com/airbytehq/airbyte/issues/63359

## How

1. **`AirbyteTypeToIcebergSchema.kt`** — `convert()` now maps `NumberType` → `Types.DecimalType.of(38, 18)` universally (was `DoubleType`).
2. **`AirbyteValueToIcebergRecord.kt`** — `NumberValue` conversion checks the target Iceberg type: if `DECIMAL`, returns the raw `BigDecimal` value directly; otherwise falls back to `toDouble()`.
3. **`IcebergSuperTypeFinder.kt`** — Removed `DECIMAL` from `unsupportedTypeIds`. Added decimal precision widening logic (Iceberg allows widening precision with same scale).
4. **`IcebergTypesComparator.kt`** — Added `DECIMAL` case to `typesAreEqual()` that compares precision and scale.
5. **`IcebergWriteTest.kt`** — Fixed pre-existing flaky `testAppendSchemaEvolution` by using distinct `extractedAt` values for deterministic sort order.
6. **Tests** — Added tests verifying NumberType → DecimalType mapping, decimal equality, precision widening, and different scale/precision comparisons.

> **Note:** This PR contains only CDK changes. The GCS Data Lake connector (`GcsDataLakeAggregate.kt`) also needs a corresponding update, but must be done in a separate connector PR per CI policy.

### Updates since last revision
- **Applied DecimalType universally** per @benmoriceau and @subodh1810 consensus. Initially scoped to PK fields only per @tryangul feedback, then expanded to universal per reviewer alignment.
- Previous revision: **Switched from StringType to DecimalType** per @subodh1810's review feedback.
- Previous revision: **Added Decimal support to schema evolution utilities**: `IcebergSuperTypeFinder` and `IcebergTypesComparator` now handle `DecimalType` properly.

## Review guide

1. `AirbyteTypeToIcebergSchema.kt` — Universal NumberType → DecimalType(38, 18) mapping in `convert()` (~1 line change)
2. `AirbyteValueToIcebergRecord.kt` — Type-aware NumberValue → BigDecimal conversion (~5 lines)
3. `IcebergSuperTypeFinder.kt` — Remove DECIMAL from unsupported, add precision widening (~15 lines)
4. `IcebergTypesComparator.kt` — Add DECIMAL equality check (~8 lines)
5. `IcebergWriteTest.kt` — Flaky test fix using distinct extractedAt values (~2 lines)
6. Test files — All NumberType expectations updated to DecimalType(38, 18)

**⚠️ Items for reviewer attention:**

- **Schema evolution from DoubleType → DecimalType for ALL NumberType columns:** Iceberg's `TypeUtil.isPromotionAllowed` likely does NOT allow `Double` → `Decimal` promotion. Existing tables with ANY `NumberType` columns (currently `DoubleType`) will need full refresh or manual column migration. This affects ALL connections using NumberType fields, not just those with NumberType PKs.
- **Decimal precision/scale limits:** `Decimal(38, 18)` provides 20 integer digits and 18 fractional digits. Max value: ~10^20. Is this sufficient for all use cases? Airbyte `NumberType` is backed by `BigDecimal` which has arbitrary precision. Values exceeding this range will be truncated or rejected.
- **BigDecimal → Iceberg Decimal conversion:** The code passes raw `BigDecimal` to Iceberg's `GenericRecord`. Verify this works correctly — does Iceberg accept raw `BigDecimal` for `DecimalType` fields, or does it need conversion to `org.apache.iceberg.types.Decimal`?
- **GCS Data Lake follow-up required:** This PR does NOT include the corresponding `GcsDataLakeAggregate.kt` change (CI requires CDK and connector changes in separate PRs). A follow-up connector PR is needed.
- **Decimal precision widening logic:** `IcebergSuperTypeFinder` handles same-scale precision widening, but different-scale decimals fall through to `isPromotionAllowed` which may reject them. Is this correct behavior?
- **Missing breaking change metadata:** This PR doesn't include:
  - `metadata.yaml` updates with `breakingChanges` entry
  - Migration guide at `docs/integrations/destinations/s3-data-lake-migrations.md`
  - Connector version bumps
  
  Should these be added now or in a follow-up?

## User Impact

**Positive:**
- Dedup sync mode now works for streams where all/some primary keys are `NumberType` (previously failed with "equality field ids shouldn't be null or empty" error).
- Numeric semantics preserved: SUM(), AVG(), ORDER BY, numeric comparisons, and sorting work natively without explicit casting (vs. StringType approach which would have required casting).

**Breaking:**
- **ALL `NumberType` columns** change from `DoubleType` to `DecimalType(38, 18)` on next sync.
- Existing tables with ANY `NumberType` columns require schema migration (likely full refresh) — Iceberg does not support `Double` → `Decimal` promotion.
- Downstream queries/dashboards referencing `NumberType` columns as `DOUBLE` type will see type mismatches.
- Numbers in ANY `NumberType` column exceeding `Decimal(38, 18)` range (>10^20 or >18 fractional digits) will be truncated or rejected.

## Can this PR be safely reverted and rolled back?

- [ ] YES 💚
- [x] NO ❌

**Rationale:** Once merged, tables with ANY `NumberType` columns will be migrated to the new schema (DoubleType → DecimalType). Reverting would require manual table schema migration back to DoubleType, and any data synced with the new version would need re-ingestion. The blast radius affects ALL connections using `NumberType` fields (not just those with NumberType PKs).