### PR TITLE
return to debezium 3.1.2 with postgres 42.6.1

### DIFF
--- a/airbyte-integrations/connectors/source-postgres/build.gradle
+++ b/airbyte-integrations/connectors/source-postgres/build.gradle
@@ -15,9 +15,7 @@ airbyteBulkConnector {
 
 dependencies {
     implementation 'com.azure:azure-identity:1.17.0'
-
-    api platform('io.debezium:debezium-bom:3.4.1.Final')
-
+    // version specified by the debezium bom dependency in the cdc toolkit
     implementation 'io.debezium:debezium-connector-postgres'
     // Use Postgres JDBC driver version specified by Debezium
     implementation 'org.postgresql:postgresql'


### PR DESCRIPTION
Use non-breaking dependencies. We will release the rewritten connector as 3.8.0 before introducing breaking changes.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌
