### PR TITLE
docs(source-amazon-seller-partner): Add known limitation for ListFinancialEvents dedup on BigQuery

### DIFF
--- a/docs/integrations/sources/amazon-seller-partner.md
+++ b/docs/integrations/sources/amazon-seller-partner.md
@@ -260,6 +260,20 @@ We recommend next steps to overcome the rate limits issue:
 
 This configuration will sync partial data, until the source gets rate limited. Once state value reaches date that equal the date of sync, next sync will have only one partition(date period for report). The source will make only one request for affected report which should be enough to avoid rate limits issue.
 
+### ListFinancialEvents stream incompatible with deduplication on BigQuery
+
+The `ListFinancialEvents` stream does not define a primary key because the Amazon SP-API returns aggregated event lists per time range rather than individual events with unique identifiers. All top-level fields in this stream are arrays, such as `ShipmentEventList` and `RefundEventList`.
+
+BigQuery requires non-JSON, non-array types for its `CLUSTER BY` clause, which Airbyte uses during deduplication. Syncing `ListFinancialEvents` to BigQuery in deduplication mode fails with:
+
+```text
+CLUSTER BY expression must be groupable, but type is JSON.
+```
+
+**Solution:**
+
+Use **Append** sync mode instead of **Dedup** for the `ListFinancialEvents` stream when syncing to BigQuery. If you need deduplicated data, perform deduplication in BigQuery using SQL after the data lands in append mode.
+
 ### InvalidInput error for ListFinancialEvents stream
 
 ```text


### PR DESCRIPTION
## What

Documents a known limitation where the `ListFinancialEvents` stream fails when synced to BigQuery in deduplication mode, due to all top-level fields being JSON/array types that BigQuery cannot use for `CLUSTER BY`.

Closes: [airbytehq/oncall#7860](https://github.com/airbytehq/oncall/issues/7860)

## How

Adds a new subsection under **Limitations & Troubleshooting** in the Amazon Seller Partner connector docs explaining:
- Why the stream has no primary key (`primary_key: []` in `manifest.yaml`)
- Why BigQuery dedup fails (JSON types incompatible with `CLUSTER BY`)
- The workaround: use Append sync mode instead of Dedup

## Review guide

1. `docs/integrations/sources/amazon-seller-partner.md` — new section added between the existing "Rate Limit issue" and "InvalidInput error" subsections

Key items for review:
- Verify the technical explanation is accurate (the stream's `primary_key: []` was confirmed in `manifest.yaml:972`)
- Confirm the Append mode workaround is the correct recommendation

## User Impact

Users syncing `ListFinancialEvents` to BigQuery with dedup mode will now find documented guidance explaining the error and the workaround, rather than encountering an unexplained failure.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Link to Devin session: https://app.devin.ai/sessions/c0957357d29f44db8abe1e62b494ea15
Requested by: @sophiecuiy
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/74278" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
