### PR TITLE
feat(source-facebook-marketing): add video metrics in ads insights reports

### DIFF
--- a/airbyte-integrations/connectors/source-facebook-marketing/erd/discovered_catalog.json
+++ b/airbyte-integrations/connectors/source-facebook-marketing/erd/discovered_catalog.json
@@ -5931,6 +5931,25 @@
               }
             }
           },
+          "video_thruplay_watched_actions": {
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "1d_click": { "type": ["null", "number"] },
+                "7d_click": { "type": ["null", "number"] },
+                "28d_click": { "type": ["null", "number"] },
+                "1d_view": { "type": ["null", "number"] },
+                "7d_view": { "type": ["null", "number"] },
+                "28d_view": { "type": ["null", "number"] },
+                "action_destination": { "type": ["null", "string"] },
+                "action_target_id": { "type": ["null", "string"] },
+                "action_type": { "type": ["null", "string"] },
+                "value": { "type": ["null", "number"] },
+                "lead": { "type": ["null", "number"] }
+              }
+            }
+          },
           "video_play_actions": {
             "type": ["null", "array"],
             "items": {
@@ -7019,6 +7038,25 @@
             }
           },
           "video_p95_watched_actions": {
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "1d_click": { "type": ["null", "number"] },
+                "7d_click": { "type": ["null", "number"] },
+                "28d_click": { "type": ["null", "number"] },
+                "1d_view": { "type": ["null", "number"] },
+                "7d_view": { "type": ["null", "number"] },
+                "28d_view": { "type": ["null", "number"] },
+                "action_destination": { "type": ["null", "string"] },
+                "action_target_id": { "type": ["null", "string"] },
+                "action_type": { "type": ["null", "string"] },
+                "value": { "type": ["null", "number"] },
+                "lead": { "type": ["null", "number"] }
+              }
+            }
+          },
+          "video_thruplay_watched_actions": {
             "type": ["null", "array"],
             "items": {
               "type": ["null", "object"],
@@ -8157,6 +8195,25 @@
               }
             }
           },
+          "video_thruplay_watched_actions": {
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "1d_click": { "type": ["null", "number"] },
+                "7d_click": { "type": ["null", "number"] },
+                "28d_click": { "type": ["null", "number"] },
+                "1d_view": { "type": ["null", "number"] },
+                "7d_view": { "type": ["null", "number"] },
+                "28d_view": { "type": ["null", "number"] },
+                "action_destination": { "type": ["null", "string"] },
+                "action_target_id": { "type": ["null", "string"] },
+                "action_type": { "type": ["null", "string"] },
+                "value": { "type": ["null", "number"] },
+                "lead": { "type": ["null", "number"] }
+              }
+            }
+          },
           "video_play_actions": {
             "type": ["null", "array"],
             "items": {
@@ -9254,6 +9311,25 @@
             }
           },
           "video_p95_watched_actions": {
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "1d_click": { "type": ["null", "number"] },
+                "7d_click": { "type": ["null", "number"] },
+                "28d_click": { "type": ["null", "number"] },
+                "1d_view": { "type": ["null", "number"] },
+                "7d_view": { "type": ["null", "number"] },
+                "28d_view": { "type": ["null", "number"] },
+                "action_destination": { "type": ["null", "string"] },
+                "action_target_id": { "type": ["null", "string"] },
+                "action_type": { "type": ["null", "string"] },
+                "value": { "type": ["null", "number"] },
+                "lead": { "type": ["null", "number"] }
+              }
+            }
+          },
+          "video_thruplay_watched_actions": {
             "type": ["null", "array"],
             "items": {
               "type": ["null", "object"],
@@ -10387,6 +10463,25 @@
               }
             }
           },
+          "video_thruplay_watched_actions": {
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "1d_click": { "type": ["null", "number"] },
+                "7d_click": { "type": ["null", "number"] },
+                "28d_click": { "type": ["null", "number"] },
+                "1d_view": { "type": ["null", "number"] },
+                "7d_view": { "type": ["null", "number"] },
+                "28d_view": { "type": ["null", "number"] },
+                "action_destination": { "type": ["null", "string"] },
+                "action_target_id": { "type": ["null", "string"] },
+                "action_type": { "type": ["null", "string"] },
+                "value": { "type": ["null", "number"] },
+                "lead": { "type": ["null", "number"] }
+              }
+            }
+          },
           "video_play_actions": {
             "type": ["null", "array"],
             "items": {
@@ -11484,6 +11579,25 @@
             }
           },
           "video_p95_watched_actions": {
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "1d_click": { "type": ["null", "number"] },
+                "7d_click": { "type": ["null", "number"] },
+                "28d_click": { "type": ["null", "number"] },
+                "1d_view": { "type": ["null", "number"] },
+                "7d_view": { "type": ["null", "number"] },
+                "28d_view": { "type": ["null", "number"] },
+                "action_destination": { "type": ["null", "string"] },
+                "action_target_id": { "type": ["null", "string"] },
+                "action_type": { "type": ["null", "string"] },
+                "value": { "type": ["null", "number"] },
+                "lead": { "type": ["null", "number"] }
+              }
+            }
+          },
+          "video_thruplay_watched_actions": {
             "type": ["null", "array"],
             "items": {
               "type": ["null", "object"],
@@ -12627,6 +12741,25 @@
               }
             }
           },
+          "video_thruplay_watched_actions": {
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "1d_click": { "type": ["null", "number"] },
+                "7d_click": { "type": ["null", "number"] },
+                "28d_click": { "type": ["null", "number"] },
+                "1d_view": { "type": ["null", "number"] },
+                "7d_view": { "type": ["null", "number"] },
+                "28d_view": { "type": ["null", "number"] },
+                "action_destination": { "type": ["null", "string"] },
+                "action_target_id": { "type": ["null", "string"] },
+                "action_type": { "type": ["null", "string"] },
+                "value": { "type": ["null", "number"] },
+                "lead": { "type": ["null", "number"] }
+              }
+            }
+          },
           "video_play_actions": {
             "type": ["null", "array"],
             "items": {
@@ -13733,6 +13866,25 @@
               }
             }
           },
+          "video_thruplay_watched_actions": {
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "1d_click": { "type": ["null", "number"] },
+                "7d_click": { "type": ["null", "number"] },
+                "28d_click": { "type": ["null", "number"] },
+                "1d_view": { "type": ["null", "number"] },
+                "7d_view": { "type": ["null", "number"] },
+                "28d_view": { "type": ["null", "number"] },
+                "action_destination": { "type": ["null", "string"] },
+                "action_target_id": { "type": ["null", "string"] },
+                "action_type": { "type": ["null", "string"] },
+                "value": { "type": ["null", "number"] },
+                "lead": { "type": ["null", "number"] }
+              }
+            }
+          },
           "video_play_actions": {
             "type": ["null", "array"],
             "items": {
@@ -14821,6 +14973,25 @@
             }
           },
           "video_p95_watched_actions": {
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "1d_click": { "type": ["null", "number"] },
+                "7d_click": { "type": ["null", "number"] },
+                "28d_click": { "type": ["null", "number"] },
+                "1d_view": { "type": ["null", "number"] },
+                "7d_view": { "type": ["null", "number"] },
+                "28d_view": { "type": ["null", "number"] },
+                "action_destination": { "type": ["null", "string"] },
+                "action_target_id": { "type": ["null", "string"] },
+                "action_type": { "type": ["null", "string"] },
+                "value": { "type": ["null", "number"] },
+                "lead": { "type": ["null", "number"] }
+              }
+            }
+          },
+          "video_thruplay_watched_actions": {
             "type": ["null", "array"],
             "items": {
               "type": ["null", "object"],
@@ -15954,6 +16125,25 @@
               }
             }
           },
+          "video_thruplay_watched_actions": {
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "1d_click": { "type": ["null", "number"] },
+                "7d_click": { "type": ["null", "number"] },
+                "28d_click": { "type": ["null", "number"] },
+                "1d_view": { "type": ["null", "number"] },
+                "7d_view": { "type": ["null", "number"] },
+                "28d_view": { "type": ["null", "number"] },
+                "action_destination": { "type": ["null", "string"] },
+                "action_target_id": { "type": ["null", "string"] },
+                "action_type": { "type": ["null", "string"] },
+                "value": { "type": ["null", "number"] },
+                "lead": { "type": ["null", "number"] }
+              }
+            }
+          },
           "video_play_actions": {
             "type": ["null", "array"],
             "items": {
@@ -17051,6 +17241,25 @@
             }
           },
           "video_p95_watched_actions": {
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "1d_click": { "type": ["null", "number"] },
+                "7d_click": { "type": ["null", "number"] },
+                "28d_click": { "type": ["null", "number"] },
+                "1d_view": { "type": ["null", "number"] },
+                "7d_view": { "type": ["null", "number"] },
+                "28d_view": { "type": ["null", "number"] },
+                "action_destination": { "type": ["null", "string"] },
+                "action_target_id": { "type": ["null", "string"] },
+                "action_type": { "type": ["null", "string"] },
+                "value": { "type": ["null", "number"] },
+                "lead": { "type": ["null", "number"] }
+              }
+            }
+          },
+          "video_thruplay_watched_actions": {
             "type": ["null", "array"],
             "items": {
               "type": ["null", "object"],
@@ -18175,6 +18384,25 @@
               }
             }
           },
+          "video_thruplay_watched_actions": {
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "1d_click": { "type": ["null", "number"] },
+                "7d_click": { "type": ["null", "number"] },
+                "28d_click": { "type": ["null", "number"] },
+                "1d_view": { "type": ["null", "number"] },
+                "7d_view": { "type": ["null", "number"] },
+                "28d_view": { "type": ["null", "number"] },
+                "action_destination": { "type": ["null", "string"] },
+                "action_target_id": { "type": ["null", "string"] },
+                "action_type": { "type": ["null", "string"] },
+                "value": { "type": ["null", "number"] },
+                "lead": { "type": ["null", "number"] }
+              }
+            }
+          },
           "video_play_actions": {
             "type": ["null", "array"],
             "items": {
@@ -19281,6 +19509,25 @@
               }
             }
           },
+          "video_thruplay_watched_actions": {
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "1d_click": { "type": ["null", "number"] },
+                "7d_click": { "type": ["null", "number"] },
+                "28d_click": { "type": ["null", "number"] },
+                "1d_view": { "type": ["null", "number"] },
+                "7d_view": { "type": ["null", "number"] },
+                "28d_view": { "type": ["null", "number"] },
+                "action_destination": { "type": ["null", "string"] },
+                "action_target_id": { "type": ["null", "string"] },
+                "action_type": { "type": ["null", "string"] },
+                "value": { "type": ["null", "number"] },
+                "lead": { "type": ["null", "number"] }
+              }
+            }
+          },
           "video_play_actions": {
             "type": ["null", "array"],
             "items": {
@@ -20369,6 +20616,25 @@
             }
           },
           "video_p95_watched_actions": {
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "1d_click": { "type": ["null", "number"] },
+                "7d_click": { "type": ["null", "number"] },
+                "28d_click": { "type": ["null", "number"] },
+                "1d_view": { "type": ["null", "number"] },
+                "7d_view": { "type": ["null", "number"] },
+                "28d_view": { "type": ["null", "number"] },
+                "action_destination": { "type": ["null", "string"] },
+                "action_target_id": { "type": ["null", "string"] },
+                "action_type": { "type": ["null", "string"] },
+                "value": { "type": ["null", "number"] },
+                "lead": { "type": ["null", "number"] }
+              }
+            }
+          },
+          "video_thruplay_watched_actions": {
             "type": ["null", "array"],
             "items": {
               "type": ["null", "object"],
@@ -21502,6 +21768,25 @@
               }
             }
           },
+          "video_thruplay_watched_actions": {
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "1d_click": { "type": ["null", "number"] },
+                "7d_click": { "type": ["null", "number"] },
+                "28d_click": { "type": ["null", "number"] },
+                "1d_view": { "type": ["null", "number"] },
+                "7d_view": { "type": ["null", "number"] },
+                "28d_view": { "type": ["null", "number"] },
+                "action_destination": { "type": ["null", "string"] },
+                "action_target_id": { "type": ["null", "string"] },
+                "action_type": { "type": ["null", "string"] },
+                "value": { "type": ["null", "number"] },
+                "lead": { "type": ["null", "number"] }
+              }
+            }
+          },
           "video_play_actions": {
             "type": ["null", "array"],
             "items": {
@@ -22599,6 +22884,25 @@
             }
           },
           "video_p95_watched_actions": {
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "1d_click": { "type": ["null", "number"] },
+                "7d_click": { "type": ["null", "number"] },
+                "28d_click": { "type": ["null", "number"] },
+                "1d_view": { "type": ["null", "number"] },
+                "7d_view": { "type": ["null", "number"] },
+                "28d_view": { "type": ["null", "number"] },
+                "action_destination": { "type": ["null", "string"] },
+                "action_target_id": { "type": ["null", "string"] },
+                "action_type": { "type": ["null", "string"] },
+                "value": { "type": ["null", "number"] },
+                "lead": { "type": ["null", "number"] }
+              }
+            }
+          },
+          "video_thruplay_watched_actions": {
             "type": ["null", "array"],
             "items": {
               "type": ["null", "object"],
@@ -23737,6 +24041,25 @@
               }
             }
           },
+          "video_thruplay_watched_actions": {
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "1d_click": { "type": ["null", "number"] },
+                "7d_click": { "type": ["null", "number"] },
+                "28d_click": { "type": ["null", "number"] },
+                "1d_view": { "type": ["null", "number"] },
+                "7d_view": { "type": ["null", "number"] },
+                "28d_view": { "type": ["null", "number"] },
+                "action_destination": { "type": ["null", "string"] },
+                "action_target_id": { "type": ["null", "string"] },
+                "action_type": { "type": ["null", "string"] },
+                "value": { "type": ["null", "number"] },
+                "lead": { "type": ["null", "number"] }
+              }
+            }
+          },
           "video_play_actions": {
             "type": ["null", "array"],
             "items": {
@@ -24834,6 +25157,25 @@
             }
           },
           "video_p95_watched_actions": {
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "1d_click": { "type": ["null", "number"] },
+                "7d_click": { "type": ["null", "number"] },
+                "28d_click": { "type": ["null", "number"] },
+                "1d_view": { "type": ["null", "number"] },
+                "7d_view": { "type": ["null", "number"] },
+                "28d_view": { "type": ["null", "number"] },
+                "action_destination": { "type": ["null", "string"] },
+                "action_target_id": { "type": ["null", "string"] },
+                "action_type": { "type": ["null", "string"] },
+                "value": { "type": ["null", "number"] },
+                "lead": { "type": ["null", "number"] }
+              }
+            }
+          },
+          "video_thruplay_watched_actions": {
             "type": ["null", "array"],
             "items": {
               "type": ["null", "object"],
@@ -25967,6 +26309,25 @@
               }
             }
           },
+          "video_thruplay_watched_actions": {
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "1d_click": { "type": ["null", "number"] },
+                "7d_click": { "type": ["null", "number"] },
+                "28d_click": { "type": ["null", "number"] },
+                "1d_view": { "type": ["null", "number"] },
+                "7d_view": { "type": ["null", "number"] },
+                "28d_view": { "type": ["null", "number"] },
+                "action_destination": { "type": ["null", "string"] },
+                "action_target_id": { "type": ["null", "string"] },
+                "action_type": { "type": ["null", "string"] },
+                "value": { "type": ["null", "number"] },
+                "lead": { "type": ["null", "number"] }
+              }
+            }
+          },
           "video_play_actions": {
             "type": ["null", "array"],
             "items": {
@@ -27064,6 +27425,25 @@
             }
           },
           "video_p95_watched_actions": {
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "1d_click": { "type": ["null", "number"] },
+                "7d_click": { "type": ["null", "number"] },
+                "28d_click": { "type": ["null", "number"] },
+                "1d_view": { "type": ["null", "number"] },
+                "7d_view": { "type": ["null", "number"] },
+                "28d_view": { "type": ["null", "number"] },
+                "action_destination": { "type": ["null", "string"] },
+                "action_target_id": { "type": ["null", "string"] },
+                "action_type": { "type": ["null", "string"] },
+                "value": { "type": ["null", "number"] },
+                "lead": { "type": ["null", "number"] }
+              }
+            }
+          },
+          "video_thruplay_watched_actions": {
             "type": ["null", "array"],
             "items": {
               "type": ["null", "object"],

--- a/airbyte-integrations/connectors/source-facebook-marketing/metadata.yaml
+++ b/airbyte-integrations/connectors/source-facebook-marketing/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: e7778cfc-e97c-4458-9ecb-b4f2bba8946c
-  dockerImageTag: 5.1.1
+  dockerImageTag: 5.1.2-rc.1
   dockerRepository: airbyte/source-facebook-marketing
   documentationUrl: https://docs.airbyte.com/integrations/sources/facebook-marketing
   externalDocumentationUrls:

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/schemas/ads_insights.json
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/schemas/ads_insights.json
@@ -376,6 +376,10 @@
       "description": "Actions where 95% of the video was watched",
       "$ref": "ads_action_stats.json"
     },
+    "video_thruplay_watched_actions": {
+      "description": "Video thruplay watched actions",
+      "$ref": "ads_action_stats.json"
+    },
     "video_play_actions": {
       "description": "Actions where the video was played",
       "$ref": "ads_action_stats.json"

--- a/airbyte-integrations/connectors/source-facebook-marketing/unit_tests/integration/test_ads_insights_action_product_id.py
+++ b/airbyte-integrations/connectors/source-facebook-marketing/unit_tests/integration/test_ads_insights_action_product_id.py
@@ -131,6 +131,7 @@ _JOB_START_FIELDS = [
     "video_p50_watched_actions",
     "video_p75_watched_actions",
     "video_p95_watched_actions",
+    "video_thruplay_watched_actions",
     "video_play_actions",
     "video_play_curve_actions",
     "video_play_retention_0_to_15s_actions",

--- a/airbyte-integrations/connectors/source-facebook-marketing/unit_tests/test_base_insight_streams.py
+++ b/airbyte-integrations/connectors/source-facebook-marketing/unit_tests/test_base_insight_streams.py
@@ -625,7 +625,7 @@ class TestBaseInsightsStream:
         schema = stream.get_json_schema()
 
         # These fields should NOT be in the built-in schema (they are only in ads_insights_custom_fields.json)
-        extra_fields = ["conversion_leads", "cost_per_objective_result", "video_thruplay_watched_actions"]
+        extra_fields = ["conversion_leads", "cost_per_objective_result"]
         for field in extra_fields:
             assert field not in schema["properties"], f"Extra field '{field}' should NOT be in built-in schema"
 


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->
Add `video_thruplay_watched_actions` field to the base `ads_insights.json` schema to make it available by default for all Ads Insights streams, including `ads_insights_action_type`.

Currently, this field only exists in `ads_insights_custom_fields.json` and is only available for Custom Insights streams. Users must manually create a custom insight to access this metric. Since `video_thruplay_watched_actions` is a standard Facebook Marketing API field that measures video views to completion or for at least 15 seconds, it should be available by default in all Ads Insights streams.

## How
<!--
* Describe how code changes achieve the solution.
-->
1. **Schema update**: Added `video_thruplay_watched_actions` field to the base schema in `ads_insights.json` after `video_p95_watched_actions` with description "Video thruplay watched actions" and reference to `ads_action_stats.json`
2. **Test update**: Updated `test_base_insight_streams.py` to remove `video_thruplay_watched_actions` from the `extra_fields` list since it's now part of the built-in schema (no longer exclusive to custom insights)
3. **Catalog update**: Updated `discovered_catalog.json` to add the field definition with full attribution properties (1d_click, 7d_click, 28d_click, 1d_view, 7d_view, 28d_view, action_destination, action_target_id, action_type, value, lead) in all 20 Ads Insights streams - all streams inherit from the base `ads_insights.json` schema via the `AdsInsights` class
4. **Version bump**: Bumped connector version from `5.1.1` to `5.1.2-rc.1` in `metadata.yaml`
5. **Documentation**: Added changelog entry in `facebook-marketing.md`

The field remains in `ads_insights_custom_fields.json` for backward compatibility with existing custom insights configurations.

## Review guide
<!--
1. `x.py`
2. `y.py`
-->
1. **Schema definition**: [ads_insights.json](airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/schemas/ads_insights.json#L378-L381) - New field added after `video_p95_watched_actions`
2. **Test update**: [test_base_insight_streams.py](airbyte-integrations/connectors/source-facebook-marketing/unit_tests/test_base_insight_streams.py#L628) - Removed from `extra_fields` list
3. **Generated catalog**: [discovered_catalog.json](airbyte-integrations/connectors/source-facebook-marketing/erd/discovered_catalog.json) - Field added to all 20 Ads Insights streams (search for `"video_thruplay_watched_actions"` to see all 20 occurrences)
4. **Version**: [metadata.yaml](airbyte-integrations/connectors/source-facebook-marketing/metadata.yaml#L12) - Version bump to 5.1.2-rc.1
5. **Changelog**: [facebook-marketing.md](docs/integrations/sources/facebook-marketing.md#L428) - Changelog entry added

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->
**Positive impacts:**
- The `video_thruplay_watched_actions` field will automatically appear in all Ads Insights streams (ads_insights, ads_insights_action_type, ads_insights_age_and_gender, ads_insights_country, ads_insights_region, ads_insights_dma, ads_insights_platform_and_device, and 13 other streams) without requiring custom configuration
- Users can now access this key video engagement metric (views to completion or 15+ seconds) by default
- No configuration changes needed for existing users - the field will simply become available in the next sync
- Existing custom insights that already use this field will continue to work without changes

**No negative impacts:**
- Fully backward compatible - field is nullable/optional with type `["null", "array"]`
- Existing syncs will not break
- Users can choose whether to sync this field or not via their catalog configuration
- No data migration required

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌

**Justification**: The change is fully backward compatible with no breaking changes. The field is optional and nullable, so reverting would simply remove the field from the default schema without causing data migration issues or breaking existing syncs. The field remains in `ads_insights_custom_fields.json`, so custom insights using this field would continue to work even after a revert.