### PR TITLE
ci: enable progressive rollout for source-tiktok-marketing 5.0.3-rc.1

### DIFF
--- a/airbyte-integrations/connectors/source-tiktok-marketing/metadata.yaml
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/metadata.yaml
@@ -32,10 +32,8 @@ data:
   registryOverrides:
     cloud:
       enabled: true
-      dockerImageTag: 5.0.2
     oss:
       enabled: true
-      dockerImageTag: 5.0.2
   releases:
     rolloutConfiguration:
       enableProgressiveRollout: true

--- a/airbyte-integrations/connectors/source-tiktok-marketing/metadata.yaml
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/metadata.yaml
@@ -4,8 +4,8 @@ data:
     sl: 300
   allowedHosts:
     hosts:
-      - sandbox-ads.tiktok.com
-      - business-api.tiktok.com
+    - sandbox-ads.tiktok.com
+    - business-api.tiktok.com
   connectorBuildOptions:
     baseImage: docker.io/airbyte/source-declarative-manifest:7.10.1@sha256:bd69f6b52bdd92ce06c30786d67546427b828ffb553363c8950b2816c552d6e0
   connectorSubtype: api
@@ -15,15 +15,15 @@ data:
   dockerRepository: airbyte/source-tiktok-marketing
   documentationUrl: https://docs.airbyte.com/integrations/sources/tiktok-marketing
   externalDocumentationUrls:
-    - title: Versioning docs
-      url: https://business-api.tiktok.com/portal/docs?id=1740029169927169
-      type: api_reference
-    - title: Changelog
-      url: https://business-api.tiktok.com/portal/docs?id=1740029165513730
-      type: api_release_history
-    - title: TikTok Business API Documentation
-      url: https://business-api.tiktok.com/portal/docs?id=1740302848670722
-      type: api_release_history
+  - title: Versioning docs
+    url: https://business-api.tiktok.com/portal/docs?id=1740029169927169
+    type: api_reference
+  - title: Changelog
+    url: https://business-api.tiktok.com/portal/docs?id=1740029165513730
+    type: api_release_history
+  - title: TikTok Business API Documentation
+    url: https://business-api.tiktok.com/portal/docs?id=1740302848670722
+    type: api_release_history
   githubIssueLabel: source-tiktok-marketing
   icon: tiktok.svg
   license: ELv2
@@ -32,67 +32,69 @@ data:
   registryOverrides:
     cloud:
       enabled: true
+      dockerImageTag: 5.0.2
     oss:
       enabled: true
+      dockerImageTag: 5.0.2
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
     breakingChanges:
       5.0.0:
-        message:
-          The `currency` field in the `pixels` stream's `events` array has been corrected
-          from `boolean` to `string` type. Users syncing the `pixels` stream will need to
-          refresh the source schema and reset the stream after upgrading.
-          For more information, see our migration documentation for source TikTok Marketing.
-        upgradeDeadline: "2026-03-03"
+        message: The `currency` field in the `pixels` stream's `events` array has
+          been corrected from `boolean` to `string` type. Users syncing the `pixels`
+          stream will need to refresh the source schema and reset the stream after
+          upgrading. For more information, see our migration documentation for source
+          TikTok Marketing.
+        upgradeDeadline: '2026-03-03'
         scopedImpact:
-          - scopeType: stream
-            impactedScopes:
-              - "pixels"
+        - scopeType: stream
+          impactedScopes:
+          - pixels
       4.0.0:
-        message:
-          The source TikTok Marketing connector is being migrated from the Python CDK
-          to our declarative low-code CDK. Due to changes in the handling of state
-          format for incremental substreams, this migration constitutes a breaking
-          change for the following streams - ad_groups, ads, campaigns, creative_assets_images, creative_assets_videos,
-          *_reports_daily, *_reports_hourly, *_reports_by_country_daily, *_reports_by_platform_daily.
-          Also the schema for advertiser_ids stream was changed to use string type of advertiser_id
-          field as API docs declares it.
-          Users will need to reset source configuration, refresh the source schema and reset the impacted streams after upgrading.
-          For more information, see our migration documentation for source TikTok Marketing.
-        upgradeDeadline: "2024-07-15"
+        message: The source TikTok Marketing connector is being migrated from the
+          Python CDK to our declarative low-code CDK. Due to changes in the handling
+          of state format for incremental substreams, this migration constitutes a
+          breaking change for the following streams - ad_groups, ads, campaigns, creative_assets_images,
+          creative_assets_videos, *_reports_daily, *_reports_hourly, *_reports_by_country_daily,
+          *_reports_by_platform_daily. Also the schema for advertiser_ids stream was
+          changed to use string type of advertiser_id field as API docs declares it.
+          Users will need to reset source configuration, refresh the source schema
+          and reset the impacted streams after upgrading. For more information, see
+          our migration documentation for source TikTok Marketing.
+        upgradeDeadline: '2024-07-15'
         scopedImpact:
-          - scopeType: stream
-            impactedScopes:
-              - "advertiser_ids"
-              - "ad_group_audience_reports_by_country_daily"
-              - "ad_group_audience_reports_by_platform_daily"
-              - "ad_group_audience_reports_daily"
-              - "ad_groups"
-              - "ad_groups_reports_daily"
-              - "ad_groups_reports_hourly"
-              - "ads"
-              - "ads_audience_reports_by_country_daily"
-              - "ads_audience_reports_by_platform_daily"
-              - "ads_audience_reports_by_province_daily"
-              - "ads_audience_reports_daily"
-              - "ads_reports_daily"
-              - "ads_reports_hourly"
-              - "ads_reports_by_country_daily"
-              - "ads_reports_by_country_hourly"
-              - "advertisers_audience_reports_by_country_daily"
-              - "advertisers_audience_reports_by_platform_daily"
-              - "advertisers_audience_reports_daily"
-              - "advertisers_reports_daily"
-              - "advertisers_reports_hourly"
-              - "campaigns"
-              - "campaigns_audience_reports_by_country_daily"
-              - "campaigns_audience_reports_by_platform_daily"
-              - "campaigns_audience_reports_daily"
-              - "campaigns_reports_daily"
-              - "campaigns_reports_hourly"
-              - "creative_assets_images"
-              - "creative_assets_videos"
+        - scopeType: stream
+          impactedScopes:
+          - advertiser_ids
+          - ad_group_audience_reports_by_country_daily
+          - ad_group_audience_reports_by_platform_daily
+          - ad_group_audience_reports_daily
+          - ad_groups
+          - ad_groups_reports_daily
+          - ad_groups_reports_hourly
+          - ads
+          - ads_audience_reports_by_country_daily
+          - ads_audience_reports_by_platform_daily
+          - ads_audience_reports_by_province_daily
+          - ads_audience_reports_daily
+          - ads_reports_daily
+          - ads_reports_hourly
+          - ads_reports_by_country_daily
+          - ads_reports_by_country_hourly
+          - advertisers_audience_reports_by_country_daily
+          - advertisers_audience_reports_by_platform_daily
+          - advertisers_audience_reports_daily
+          - advertisers_reports_daily
+          - advertisers_reports_hourly
+          - campaigns
+          - campaigns_audience_reports_by_country_daily
+          - campaigns_audience_reports_by_platform_daily
+          - campaigns_audience_reports_daily
+          - campaigns_reports_daily
+          - campaigns_reports_hourly
+          - creative_assets_images
+          - creative_assets_videos
   releaseStage: generally_available
   remoteRegistries:
     pypi:
@@ -100,100 +102,100 @@ data:
       packageName: airbyte-source-tiktok-marketing
   suggestedStreams:
     streams:
-      - ads_reports_daily
-      - ads
-      - campaigns
-      - campaigns_reports_daily
-      - ad_groups
-      - ad_groups_reports_daily
-      - advertisers_reports_daily
+    - ads_reports_daily
+    - ads
+    - campaigns
+    - campaigns_reports_daily
+    - ad_groups
+    - ad_groups_reports_daily
+    - advertisers_reports_daily
   supportLevel: certified
   tags:
-    - cdk:low-code
-    - language:manifest-only
+  - cdk:low-code
+  - language:manifest-only
   connectorTestSuitesOptions:
-    - suite: liveTests
-      testConnections:
-        - name: tiktok-marketing_prod_config_with_lifetime_granularity_dev_null
-          id: 2a53fa01-351c-45af-84d8-a9f200a0c988
-        - name: tiktok-marketing_prod_config_with_day_granularity_dev_null
-          id: 35e62f0f-903a-4fcd-afc6-98259a4f2fea
-        - name: tiktok-marketing_sandbox_config_dev_null
-          id: 36e6778b-a04d-4356-a670-e41123fe9596
-        - name: tiktok-marketing_config_dev_null
-          id: 4da9b9c1-10bd-46c1-915b-bb3d1651153b
-        - name: tiktok-marketing_new_config_prod_dev_null
-          id: 59935970-bbee-4122-88c9-219e97dae272
-        - name: tiktok-marketing_prod_config_dev_null
-          id: 5b364ce8-b98d-4ccf-9a43-56ebd53d481a
-        - name: tiktok-marketing_config_oauth_dev_null
-          id: 60c12fbb-bc41-4df1-9b33-9a5455312b0e
-        - name: tiktok-marketing_new_config_sandbox_dev_null
-          id: 9aab8bf6-b4cd-4bad-b319-ed39bcddfe2a
-        - name: tiktok-marketing_prod_config_day_dev_null
-          id: bb8311bf-6def-4119-bf32-38c001a1e549
-    - suite: unitTests
-      testSecrets:
-        - name: SECRET_SOURCE-TIKTOK-MARKETING_SANDBOX_CREDS
-          fileName: sandbox_config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-        - name: SECRET_SOURCE-TIKTOK-MARKETING_PROD_CREDS
-          fileName: prod_config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-        - name: SECRET_SOURCE-TIKTOK-MARKETING_CREDS
-          fileName: config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-    - suite: acceptanceTests
-      testSecrets:
-        - name: SECRET_SOURCE-TIKTOK-MARKETING_CREDS
-          fileName: config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-        - name: SECRET_SOURCE-TIKTOK-MARKETING_NEW_CREDS
-          fileName: new_config_sandbox.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-        - name: SECRET_SOURCE-TIKTOK-MARKETING_NEW_PROD_CREDS
-          fileName: new_config_prod.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-        - name: SECRET_SOURCE-TIKTOK-MARKETING_OAUTH_CREDS
-          fileName: config_oauth.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-        - name: SECRET_SOURCE-TIKTOK-MARKETING_PROD_CREDS
-          fileName: prod_config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-        - name: SECRET_SOURCE-TIKTOK-MARKETING_PROD_CREDS_WITH_DAY_GRANULARITY
-          fileName: prod_config_with_day_granularity.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-        - name: SECRET_SOURCE-TIKTOK-MARKETING_PROD_CREDS_WITH_LIFETIME_GRANULARITY
-          fileName: prod_config_with_lifetime_granularity.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-        - name: SECRET_SOURCE-TIKTOK-MARKETING_PROD_DAY_CREDS
-          fileName: prod_config_day.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-        - name: SECRET_SOURCE-TIKTOK-MARKETING_SANDBOX_CREDS
-          fileName: sandbox_config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-metadataSpecVersion: "1.0"
+  - suite: liveTests
+    testConnections:
+    - name: tiktok-marketing_prod_config_with_lifetime_granularity_dev_null
+      id: 2a53fa01-351c-45af-84d8-a9f200a0c988
+    - name: tiktok-marketing_prod_config_with_day_granularity_dev_null
+      id: 35e62f0f-903a-4fcd-afc6-98259a4f2fea
+    - name: tiktok-marketing_sandbox_config_dev_null
+      id: 36e6778b-a04d-4356-a670-e41123fe9596
+    - name: tiktok-marketing_config_dev_null
+      id: 4da9b9c1-10bd-46c1-915b-bb3d1651153b
+    - name: tiktok-marketing_new_config_prod_dev_null
+      id: 59935970-bbee-4122-88c9-219e97dae272
+    - name: tiktok-marketing_prod_config_dev_null
+      id: 5b364ce8-b98d-4ccf-9a43-56ebd53d481a
+    - name: tiktok-marketing_config_oauth_dev_null
+      id: 60c12fbb-bc41-4df1-9b33-9a5455312b0e
+    - name: tiktok-marketing_new_config_sandbox_dev_null
+      id: 9aab8bf6-b4cd-4bad-b319-ed39bcddfe2a
+    - name: tiktok-marketing_prod_config_day_dev_null
+      id: bb8311bf-6def-4119-bf32-38c001a1e549
+  - suite: unitTests
+    testSecrets:
+    - name: SECRET_SOURCE-TIKTOK-MARKETING_SANDBOX_CREDS
+      fileName: sandbox_config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+    - name: SECRET_SOURCE-TIKTOK-MARKETING_PROD_CREDS
+      fileName: prod_config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+    - name: SECRET_SOURCE-TIKTOK-MARKETING_CREDS
+      fileName: config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+  - suite: acceptanceTests
+    testSecrets:
+    - name: SECRET_SOURCE-TIKTOK-MARKETING_CREDS
+      fileName: config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+    - name: SECRET_SOURCE-TIKTOK-MARKETING_NEW_CREDS
+      fileName: new_config_sandbox.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+    - name: SECRET_SOURCE-TIKTOK-MARKETING_NEW_PROD_CREDS
+      fileName: new_config_prod.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+    - name: SECRET_SOURCE-TIKTOK-MARKETING_OAUTH_CREDS
+      fileName: config_oauth.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+    - name: SECRET_SOURCE-TIKTOK-MARKETING_PROD_CREDS
+      fileName: prod_config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+    - name: SECRET_SOURCE-TIKTOK-MARKETING_PROD_CREDS_WITH_DAY_GRANULARITY
+      fileName: prod_config_with_day_granularity.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+    - name: SECRET_SOURCE-TIKTOK-MARKETING_PROD_CREDS_WITH_LIFETIME_GRANULARITY
+      fileName: prod_config_with_lifetime_granularity.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+    - name: SECRET_SOURCE-TIKTOK-MARKETING_PROD_DAY_CREDS
+      fileName: prod_config_day.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+    - name: SECRET_SOURCE-TIKTOK-MARKETING_SANDBOX_CREDS
+      fileName: sandbox_config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/source-tiktok-marketing/metadata.yaml
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/metadata.yaml
@@ -4,8 +4,8 @@ data:
     sl: 300
   allowedHosts:
     hosts:
-    - sandbox-ads.tiktok.com
-    - business-api.tiktok.com
+      - sandbox-ads.tiktok.com
+      - business-api.tiktok.com
   connectorBuildOptions:
     baseImage: docker.io/airbyte/source-declarative-manifest:7.10.1@sha256:bd69f6b52bdd92ce06c30786d67546427b828ffb553363c8950b2816c552d6e0
   connectorSubtype: api
@@ -15,15 +15,15 @@ data:
   dockerRepository: airbyte/source-tiktok-marketing
   documentationUrl: https://docs.airbyte.com/integrations/sources/tiktok-marketing
   externalDocumentationUrls:
-  - title: Versioning docs
-    url: https://business-api.tiktok.com/portal/docs?id=1740029169927169
-    type: api_reference
-  - title: Changelog
-    url: https://business-api.tiktok.com/portal/docs?id=1740029165513730
-    type: api_release_history
-  - title: TikTok Business API Documentation
-    url: https://business-api.tiktok.com/portal/docs?id=1740302848670722
-    type: api_release_history
+    - title: Versioning docs
+      url: https://business-api.tiktok.com/portal/docs?id=1740029169927169
+      type: api_reference
+    - title: Changelog
+      url: https://business-api.tiktok.com/portal/docs?id=1740029165513730
+      type: api_release_history
+    - title: TikTok Business API Documentation
+      url: https://business-api.tiktok.com/portal/docs?id=1740302848670722
+      type: api_release_history
   githubIssueLabel: source-tiktok-marketing
   icon: tiktok.svg
   license: ELv2
@@ -41,60 +41,60 @@ data:
       enableProgressiveRollout: true
     breakingChanges:
       5.0.0:
-        message: The `currency` field in the `pixels` stream's `events` array has
-          been corrected from `boolean` to `string` type. Users syncing the `pixels`
-          stream will need to refresh the source schema and reset the stream after
-          upgrading. For more information, see our migration documentation for source
-          TikTok Marketing.
-        upgradeDeadline: '2026-03-03'
+        message:
+          The `currency` field in the `pixels` stream's `events` array has been corrected
+          from `boolean` to `string` type. Users syncing the `pixels` stream will need to
+          refresh the source schema and reset the stream after upgrading.
+          For more information, see our migration documentation for source TikTok Marketing.
+        upgradeDeadline: "2026-03-03"
         scopedImpact:
-        - scopeType: stream
-          impactedScopes:
-          - pixels
+          - scopeType: stream
+            impactedScopes:
+              - "pixels"
       4.0.0:
-        message: The source TikTok Marketing connector is being migrated from the
-          Python CDK to our declarative low-code CDK. Due to changes in the handling
-          of state format for incremental substreams, this migration constitutes a
-          breaking change for the following streams - ad_groups, ads, campaigns, creative_assets_images,
-          creative_assets_videos, *_reports_daily, *_reports_hourly, *_reports_by_country_daily,
-          *_reports_by_platform_daily. Also the schema for advertiser_ids stream was
-          changed to use string type of advertiser_id field as API docs declares it.
-          Users will need to reset source configuration, refresh the source schema
-          and reset the impacted streams after upgrading. For more information, see
-          our migration documentation for source TikTok Marketing.
-        upgradeDeadline: '2024-07-15'
+        message:
+          The source TikTok Marketing connector is being migrated from the Python CDK
+          to our declarative low-code CDK. Due to changes in the handling of state
+          format for incremental substreams, this migration constitutes a breaking
+          change for the following streams - ad_groups, ads, campaigns, creative_assets_images, creative_assets_videos,
+          *_reports_daily, *_reports_hourly, *_reports_by_country_daily, *_reports_by_platform_daily.
+          Also the schema for advertiser_ids stream was changed to use string type of advertiser_id
+          field as API docs declares it.
+          Users will need to reset source configuration, refresh the source schema and reset the impacted streams after upgrading.
+          For more information, see our migration documentation for source TikTok Marketing.
+        upgradeDeadline: "2024-07-15"
         scopedImpact:
-        - scopeType: stream
-          impactedScopes:
-          - advertiser_ids
-          - ad_group_audience_reports_by_country_daily
-          - ad_group_audience_reports_by_platform_daily
-          - ad_group_audience_reports_daily
-          - ad_groups
-          - ad_groups_reports_daily
-          - ad_groups_reports_hourly
-          - ads
-          - ads_audience_reports_by_country_daily
-          - ads_audience_reports_by_platform_daily
-          - ads_audience_reports_by_province_daily
-          - ads_audience_reports_daily
-          - ads_reports_daily
-          - ads_reports_hourly
-          - ads_reports_by_country_daily
-          - ads_reports_by_country_hourly
-          - advertisers_audience_reports_by_country_daily
-          - advertisers_audience_reports_by_platform_daily
-          - advertisers_audience_reports_daily
-          - advertisers_reports_daily
-          - advertisers_reports_hourly
-          - campaigns
-          - campaigns_audience_reports_by_country_daily
-          - campaigns_audience_reports_by_platform_daily
-          - campaigns_audience_reports_daily
-          - campaigns_reports_daily
-          - campaigns_reports_hourly
-          - creative_assets_images
-          - creative_assets_videos
+          - scopeType: stream
+            impactedScopes:
+              - "advertiser_ids"
+              - "ad_group_audience_reports_by_country_daily"
+              - "ad_group_audience_reports_by_platform_daily"
+              - "ad_group_audience_reports_daily"
+              - "ad_groups"
+              - "ad_groups_reports_daily"
+              - "ad_groups_reports_hourly"
+              - "ads"
+              - "ads_audience_reports_by_country_daily"
+              - "ads_audience_reports_by_platform_daily"
+              - "ads_audience_reports_by_province_daily"
+              - "ads_audience_reports_daily"
+              - "ads_reports_daily"
+              - "ads_reports_hourly"
+              - "ads_reports_by_country_daily"
+              - "ads_reports_by_country_hourly"
+              - "advertisers_audience_reports_by_country_daily"
+              - "advertisers_audience_reports_by_platform_daily"
+              - "advertisers_audience_reports_daily"
+              - "advertisers_reports_daily"
+              - "advertisers_reports_hourly"
+              - "campaigns"
+              - "campaigns_audience_reports_by_country_daily"
+              - "campaigns_audience_reports_by_platform_daily"
+              - "campaigns_audience_reports_daily"
+              - "campaigns_reports_daily"
+              - "campaigns_reports_hourly"
+              - "creative_assets_images"
+              - "creative_assets_videos"
   releaseStage: generally_available
   remoteRegistries:
     pypi:
@@ -102,100 +102,100 @@ data:
       packageName: airbyte-source-tiktok-marketing
   suggestedStreams:
     streams:
-    - ads_reports_daily
-    - ads
-    - campaigns
-    - campaigns_reports_daily
-    - ad_groups
-    - ad_groups_reports_daily
-    - advertisers_reports_daily
+      - ads_reports_daily
+      - ads
+      - campaigns
+      - campaigns_reports_daily
+      - ad_groups
+      - ad_groups_reports_daily
+      - advertisers_reports_daily
   supportLevel: certified
   tags:
-  - cdk:low-code
-  - language:manifest-only
+    - cdk:low-code
+    - language:manifest-only
   connectorTestSuitesOptions:
-  - suite: liveTests
-    testConnections:
-    - name: tiktok-marketing_prod_config_with_lifetime_granularity_dev_null
-      id: 2a53fa01-351c-45af-84d8-a9f200a0c988
-    - name: tiktok-marketing_prod_config_with_day_granularity_dev_null
-      id: 35e62f0f-903a-4fcd-afc6-98259a4f2fea
-    - name: tiktok-marketing_sandbox_config_dev_null
-      id: 36e6778b-a04d-4356-a670-e41123fe9596
-    - name: tiktok-marketing_config_dev_null
-      id: 4da9b9c1-10bd-46c1-915b-bb3d1651153b
-    - name: tiktok-marketing_new_config_prod_dev_null
-      id: 59935970-bbee-4122-88c9-219e97dae272
-    - name: tiktok-marketing_prod_config_dev_null
-      id: 5b364ce8-b98d-4ccf-9a43-56ebd53d481a
-    - name: tiktok-marketing_config_oauth_dev_null
-      id: 60c12fbb-bc41-4df1-9b33-9a5455312b0e
-    - name: tiktok-marketing_new_config_sandbox_dev_null
-      id: 9aab8bf6-b4cd-4bad-b319-ed39bcddfe2a
-    - name: tiktok-marketing_prod_config_day_dev_null
-      id: bb8311bf-6def-4119-bf32-38c001a1e549
-  - suite: unitTests
-    testSecrets:
-    - name: SECRET_SOURCE-TIKTOK-MARKETING_SANDBOX_CREDS
-      fileName: sandbox_config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
-    - name: SECRET_SOURCE-TIKTOK-MARKETING_PROD_CREDS
-      fileName: prod_config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
-    - name: SECRET_SOURCE-TIKTOK-MARKETING_CREDS
-      fileName: config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
-  - suite: acceptanceTests
-    testSecrets:
-    - name: SECRET_SOURCE-TIKTOK-MARKETING_CREDS
-      fileName: config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
-    - name: SECRET_SOURCE-TIKTOK-MARKETING_NEW_CREDS
-      fileName: new_config_sandbox.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
-    - name: SECRET_SOURCE-TIKTOK-MARKETING_NEW_PROD_CREDS
-      fileName: new_config_prod.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
-    - name: SECRET_SOURCE-TIKTOK-MARKETING_OAUTH_CREDS
-      fileName: config_oauth.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
-    - name: SECRET_SOURCE-TIKTOK-MARKETING_PROD_CREDS
-      fileName: prod_config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
-    - name: SECRET_SOURCE-TIKTOK-MARKETING_PROD_CREDS_WITH_DAY_GRANULARITY
-      fileName: prod_config_with_day_granularity.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
-    - name: SECRET_SOURCE-TIKTOK-MARKETING_PROD_CREDS_WITH_LIFETIME_GRANULARITY
-      fileName: prod_config_with_lifetime_granularity.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
-    - name: SECRET_SOURCE-TIKTOK-MARKETING_PROD_DAY_CREDS
-      fileName: prod_config_day.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
-    - name: SECRET_SOURCE-TIKTOK-MARKETING_SANDBOX_CREDS
-      fileName: sandbox_config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
-metadataSpecVersion: '1.0'
+    - suite: liveTests
+      testConnections:
+        - name: tiktok-marketing_prod_config_with_lifetime_granularity_dev_null
+          id: 2a53fa01-351c-45af-84d8-a9f200a0c988
+        - name: tiktok-marketing_prod_config_with_day_granularity_dev_null
+          id: 35e62f0f-903a-4fcd-afc6-98259a4f2fea
+        - name: tiktok-marketing_sandbox_config_dev_null
+          id: 36e6778b-a04d-4356-a670-e41123fe9596
+        - name: tiktok-marketing_config_dev_null
+          id: 4da9b9c1-10bd-46c1-915b-bb3d1651153b
+        - name: tiktok-marketing_new_config_prod_dev_null
+          id: 59935970-bbee-4122-88c9-219e97dae272
+        - name: tiktok-marketing_prod_config_dev_null
+          id: 5b364ce8-b98d-4ccf-9a43-56ebd53d481a
+        - name: tiktok-marketing_config_oauth_dev_null
+          id: 60c12fbb-bc41-4df1-9b33-9a5455312b0e
+        - name: tiktok-marketing_new_config_sandbox_dev_null
+          id: 9aab8bf6-b4cd-4bad-b319-ed39bcddfe2a
+        - name: tiktok-marketing_prod_config_day_dev_null
+          id: bb8311bf-6def-4119-bf32-38c001a1e549
+    - suite: unitTests
+      testSecrets:
+        - name: SECRET_SOURCE-TIKTOK-MARKETING_SANDBOX_CREDS
+          fileName: sandbox_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-TIKTOK-MARKETING_PROD_CREDS
+          fileName: prod_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-TIKTOK-MARKETING_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-TIKTOK-MARKETING_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-TIKTOK-MARKETING_NEW_CREDS
+          fileName: new_config_sandbox.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-TIKTOK-MARKETING_NEW_PROD_CREDS
+          fileName: new_config_prod.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-TIKTOK-MARKETING_OAUTH_CREDS
+          fileName: config_oauth.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-TIKTOK-MARKETING_PROD_CREDS
+          fileName: prod_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-TIKTOK-MARKETING_PROD_CREDS_WITH_DAY_GRANULARITY
+          fileName: prod_config_with_day_granularity.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-TIKTOK-MARKETING_PROD_CREDS_WITH_LIFETIME_GRANULARITY
+          fileName: prod_config_with_lifetime_granularity.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-TIKTOK-MARKETING_PROD_DAY_CREDS
+          fileName: prod_config_day.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-TIKTOK-MARKETING_SANDBOX_CREDS
+          fileName: sandbox_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+metadataSpecVersion: "1.0"


### PR DESCRIPTION
## What

Enable progressive rollout for `source-tiktok-marketing` version `5.0.3-rc.1`.

The `dockerImageTag` was already set to `5.0.3-rc.1` on master (via [#74085](https://github.com/airbytehq/airbyte/pull/74085)). This PR enables the progressive rollout flag so the rollout system can initialize and manage controlled migration of actors to the RC version.

## How

Single change to `metadata.yaml`:

- Set `releases.rolloutConfiguration.enableProgressiveRollout: true`

No registry overrides are needed — the rollout system handles version pinning at the actor/database level (consistent with how `source-hubspot` rollouts operate).

## Review guide

1. `airbyte-integrations/connectors/source-tiktok-marketing/metadata.yaml` — 1-line diff.

### Recommended human review checklist
- [ ] Confirm `5.0.3-rc.1` (already set as `dockerImageTag`) is the intended RC version for rollout
- [ ] Confirm no registry overrides are needed (precedent: `source-hubspot` progressive rollout works without them)

## User Impact

No immediate user impact. Once merged and published, the progressive rollout workflow will initialize, allowing controlled migration of a subset of actors to `5.0.3-rc.1`.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Link to Devin Session: https://app.devin.ai/sessions/abd01dfc51924328aba05cd0df4d6d9e
Requested by: @sophiecuiy

> [!NOTE]
> **Auto-merge may have been disabled. Please check the PR status to confirm.**