### PR TITLE
feat(source-slack): improve channel filtering with wildcard support, exclude list, and external channel toggle

### DIFF
--- a/airbyte-integrations/connectors/source-slack/components.py
+++ b/airbyte-integrations/connectors/source-slack/components.py
@@ -108,12 +108,18 @@ class ChannelsRetriever(SimpleRetriever):
         super().__post_init__(parameters)
         self.record_selector.transformations = []
 
-    def is_channel_included(self, config: Mapping[str, Any], channel_name: str) -> bool:
+    def is_channel_included(self, config: Mapping[str, Any], record: Record) -> bool:
         """
-        Returns True if the channel should be included based on channel_filter (whitelist) and
-        channel_exclude_filter (blacklist). Both support fnmatch wildcards (e.g. 'acme-*').
-        Exclude takes precedence over include.
+        Returns True if the channel should be included in the sync.
+        - include_external_channels controls whether external shared channels are included (default: True)
+        - channel_exclude_filter (blacklist) takes precedence over channel_filter (whitelist)
+        - Both support wildcard patterns (e.g. 'acme-*')
         """
+        channel_name = record.get("name", "")
+
+        if record.get("is_ext_shared") and not config.get("include_external_channels", True):
+            return False
+
         exclude_filter = config.get("channel_exclude_filter") or []
         if exclude_filter and matches_any_pattern(channel_name, exclude_filter):
             return False
@@ -128,21 +134,8 @@ class ChannelsRetriever(SimpleRetriever):
         """
         The `is_member` property indicates whether the API Bot is already assigned / joined to the channel.
         https://api.slack.com/types/conversation#booleans
-        The bot joins a channel if:
-        - join_channels is True and the bot is not yet a member, OR
-        - join_external_channels is True, the channel is an external shared channel, and the bot is not yet a member
         """
-        is_member = record.get("is_member", False)
-        if is_member:
-            return False
-
-        if config.get("join_channels"):
-            return True
-
-        if config.get("join_external_channels") and record.get("is_ext_shared"):
-            return True
-
-        return False
+        return config["join_channels"] and not record.get("is_member")
 
     def make_join_channel_slice(self, channel: Mapping[str, Any]) -> Mapping[str, Any]:
         channel_id: str = channel.get("id")
@@ -178,8 +171,7 @@ class ChannelsRetriever(SimpleRetriever):
         )
 
         for stream_data in self._read_pages(record_generator, _slice):
-            channel_name = stream_data.get("name", "") if isinstance(stream_data, dict) else ""
-            if not self.is_channel_included(self.config, channel_name):
+            if not self.is_channel_included(self.config, stream_data):
                 continue
 
             if self.should_join_to_channel(self.config, stream_data):

--- a/airbyte-integrations/connectors/source-slack/components.py
+++ b/airbyte-integrations/connectors/source-slack/components.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Airbyte, Inc., all rights reserved.
 
+import fnmatch
 import logging
 from copy import deepcopy
 from dataclasses import dataclass
@@ -42,6 +43,11 @@ from airbyte_cdk.utils.datetime_helpers import ab_datetime_parse
 
 
 LOGGER = logging.getLogger("airbyte_logger")
+
+
+def matches_any_pattern(name: str, patterns: List[str]) -> bool:
+    """Return True if `name` matches any pattern in `patterns`. Supports fnmatch wildcards (e.g. 'acme-*')."""
+    return any(fnmatch.fnmatch(name, pattern) for pattern in patterns)
 
 
 class JoinChannelsStream(HttpStream):
@@ -102,12 +108,41 @@ class ChannelsRetriever(SimpleRetriever):
         super().__post_init__(parameters)
         self.record_selector.transformations = []
 
+    def is_channel_included(self, config: Mapping[str, Any], channel_name: str) -> bool:
+        """
+        Returns True if the channel should be included based on channel_filter (whitelist) and
+        channel_exclude_filter (blacklist). Both support fnmatch wildcards (e.g. 'acme-*').
+        Exclude takes precedence over include.
+        """
+        exclude_filter = config.get("channel_exclude_filter") or []
+        if exclude_filter and matches_any_pattern(channel_name, exclude_filter):
+            return False
+
+        include_filter = config.get("channel_filter") or []
+        if include_filter:
+            return matches_any_pattern(channel_name, include_filter)
+
+        return True
+
     def should_join_to_channel(self, config: Mapping[str, Any], record: Record) -> bool:
         """
         The `is_member` property indicates whether the API Bot is already assigned / joined to the channel.
         https://api.slack.com/types/conversation#booleans
+        The bot joins a channel if:
+        - join_channels is True and the bot is not yet a member, OR
+        - join_external_channels is True, the channel is an external shared channel, and the bot is not yet a member
         """
-        return config["join_channels"] and not record.get("is_member")
+        is_member = record.get("is_member", False)
+        if is_member:
+            return False
+
+        if config.get("join_channels"):
+            return True
+
+        if config.get("join_external_channels") and record.get("is_ext_shared"):
+            return True
+
+        return False
 
     def make_join_channel_slice(self, channel: Mapping[str, Any]) -> Mapping[str, Any]:
         channel_id: str = channel.get("id")
@@ -143,6 +178,10 @@ class ChannelsRetriever(SimpleRetriever):
         )
 
         for stream_data in self._read_pages(record_generator, _slice):
+            channel_name = stream_data.get("name", "") if isinstance(stream_data, dict) else ""
+            if not self.is_channel_included(self.config, channel_name):
+                continue
+
             if self.should_join_to_channel(self.config, stream_data):
                 self.join_channel(self.config, stream_data)
 

--- a/airbyte-integrations/connectors/source-slack/components.py
+++ b/airbyte-integrations/connectors/source-slack/components.py
@@ -110,15 +110,25 @@ class ChannelsRetriever(SimpleRetriever):
 
     def is_channel_included(self, config: Mapping[str, Any], record: Record) -> bool:
         """
-        Returns True if the channel should be included in the sync.
-        - include_external_channels controls whether external shared channels are included (default: True)
-        - channel_exclude_filter (blacklist) takes precedence over channel_filter (whitelist)
-        - Both support wildcard patterns (e.g. 'acme-*')
-        """
-        channel_name = record.get("name", "")
+        Returns True if the channel should be included in the sync based on channel type toggles and name filters.
 
-        if record.get("is_ext_shared") and not config.get("include_external_channels", True):
+        Channel type toggles (all default to True except include_private_channels):
+        - include_shared_channels: externally shared channels (is_ext_shared=True)
+        - include_public_channels: standard public channels (not externally shared)
+        - include_private_channels: private channels
+
+        Name filters (both support wildcard patterns, e.g. 'acme-*'):
+        - channel_exclude_filter (blacklist) takes precedence over channel_filter (whitelist)
+        """
+        is_ext_shared = record.get("is_ext_shared", False)
+        is_private = record.get("is_private", False)
+
+        if is_ext_shared and not config.get("include_shared_channels", True):
             return False
+        if not is_ext_shared and not is_private and not config.get("include_public_channels", True):
+            return False
+
+        channel_name = record.get("name", "")
 
         exclude_filter = config.get("channel_exclude_filter") or []
         if exclude_filter and matches_any_pattern(channel_name, exclude_filter):

--- a/airbyte-integrations/connectors/source-slack/manifest.yaml
+++ b/airbyte-integrations/connectors/source-slack/manifest.yaml
@@ -145,9 +145,6 @@ definitions:
           types: "{{ 'public_channel,private_channel' if config['include_private_channels'] == true else 'public_channel' }}"
       record_selector:
         $ref: "#/definitions/selector"
-        record_filter:
-          type: RecordFilter
-          condition: "{{ record.name in config.channel_filter or not config.channel_filter }}"
       paginator:
         $ref: "#/definitions/default_paginator"
         $parameters:
@@ -428,10 +425,26 @@ spec:
           type: string
           minLength: 0
         title: Channel name filter
-        description: A channel name list (without leading '#' char) which limit the channels from which you'd like to sync. Empty list means no filter.
+        description: A list of channel names (without leading '#') to sync. Supports fnmatch wildcards (e.g. 'acme-*'). Empty list means no filter.
         examples:
           - channel_one
-          - channel_two
+          - acme-*
+      channel_exclude_filter:
+        type: array
+        default: []
+        items:
+          type: string
+          minLength: 0
+        title: Channel name exclude filter
+        description: A list of channel names (without leading '#') to exclude from syncing. Supports fnmatch wildcards (e.g. 'ext-*'). Exclusions take precedence over channel_filter.
+        examples:
+          - ext-*
+          - archived-channel
+      join_external_channels:
+        type: boolean
+        default: false
+        title: Join external shared channels
+        description: Whether to automatically join external shared channels (is_ext_shared=true). Requires join_channels to be false; use this to target only external channels specifically.
       credentials:
         title: Authentication mechanism
         description: Choose how to authenticate into Slack

--- a/airbyte-integrations/connectors/source-slack/manifest.yaml
+++ b/airbyte-integrations/connectors/source-slack/manifest.yaml
@@ -418,7 +418,7 @@ spec:
         type: boolean
         default: true
         title: Join channels
-        description: Whether to automatically join channels of the enabled types. If false, only channels the bot has already been added to will be synced.
+        description: Whether to automatically join channels. If false, only channels the bot has already been added to will be synced.
       include_public_channels:
         type: boolean
         default: true

--- a/airbyte-integrations/connectors/source-slack/manifest.yaml
+++ b/airbyte-integrations/connectors/source-slack/manifest.yaml
@@ -142,7 +142,13 @@ definitions:
             - type: "WaitTimeFromHeader"
               header: "Retry-After"
         request_parameters:
-          types: "{{ 'public_channel,private_channel' if config['include_private_channels'] == true else 'public_channel' }}"
+          types: >-
+            {{
+              ','.join(
+                (['public_channel'] if config.get('include_public_channels', True) or config.get('include_shared_channels', True) else []) +
+                (['private_channel'] if config.get('include_private_channels', False) else [])
+              )
+            }}
       record_selector:
         $ref: "#/definitions/selector"
       paginator:
@@ -413,11 +419,21 @@ spec:
         default: true
         title: Join all channels
         description: Whether to join all channels or to sync data only from channels the bot is already in.  If false, you''ll need to manually add the bot to all the channels from which you''d like to sync messages.
+      include_public_channels:
+        type: boolean
+        default: true
+        title: Include standard public channels
+        description: Whether to include standard public channels (within your workspace only). Defaults to true.
+      include_shared_channels:
+        type: boolean
+        default: true
+        title: Include externally shared channels
+        description: Whether to include channels shared with external Slack workspaces. Defaults to true.
       include_private_channels:
         type: boolean
         default: false
         title: Include private channels
-        description: Whether to read information from private channels that the bot is already in.  If false, only public channels will be read.  If true, the bot must be manually added to private channels.
+        description: Whether to include private channels the bot has been manually added to.
       channel_filter:
         type: array
         default: []
@@ -440,11 +456,6 @@ spec:
         examples:
           - ext-*
           - archived-channel
-      include_external_channels:
-        type: boolean
-        default: true
-        title: Include external shared channels
-        description: Whether to include external shared channels (shared with other Slack workspaces) in the sync. Defaults to true for backward compatibility.
       credentials:
         title: Authentication mechanism
         description: Choose how to authenticate into Slack

--- a/airbyte-integrations/connectors/source-slack/manifest.yaml
+++ b/airbyte-integrations/connectors/source-slack/manifest.yaml
@@ -417,7 +417,7 @@ spec:
       join_channels:
         type: boolean
         default: true
-        title: Join all channels
+        title: Join channels
         description: Whether to join all channels or to sync data only from channels the bot is already in.  If false, you''ll need to manually add the bot to all the channels from which you''d like to sync messages.
       include_public_channels:
         type: boolean

--- a/airbyte-integrations/connectors/source-slack/manifest.yaml
+++ b/airbyte-integrations/connectors/source-slack/manifest.yaml
@@ -425,7 +425,7 @@ spec:
           type: string
           minLength: 0
         title: Channel name filter
-        description: A list of channel names (without leading '#') to sync. Supports fnmatch wildcards (e.g. 'acme-*'). Empty list means no filter.
+        description: A list of channel names (without leading '#') to sync. Supports wildcard patterns (e.g. 'acme-*'). Empty list means no filter.
         examples:
           - channel_one
           - acme-*
@@ -436,7 +436,7 @@ spec:
           type: string
           minLength: 0
         title: Channel name exclude filter
-        description: A list of channel names (without leading '#') to exclude from syncing. Supports fnmatch wildcards (e.g. 'ext-*'). Exclusions take precedence over channel_filter.
+        description: A list of channel names (without leading '#') to exclude from syncing. Supports wildcard patterns (e.g. 'ext-*'). Exclusions take precedence over channel_filter.
         examples:
           - ext-*
           - archived-channel

--- a/airbyte-integrations/connectors/source-slack/manifest.yaml
+++ b/airbyte-integrations/connectors/source-slack/manifest.yaml
@@ -440,11 +440,11 @@ spec:
         examples:
           - ext-*
           - archived-channel
-      join_external_channels:
+      include_external_channels:
         type: boolean
-        default: false
-        title: Join external shared channels
-        description: Whether to automatically join external shared channels (is_ext_shared=true). Requires join_channels to be false; use this to target only external channels specifically.
+        default: true
+        title: Include external shared channels
+        description: Whether to include external shared channels (shared with other Slack workspaces) in the sync. Defaults to true for backward compatibility.
       credentials:
         title: Authentication mechanism
         description: Choose how to authenticate into Slack

--- a/airbyte-integrations/connectors/source-slack/manifest.yaml
+++ b/airbyte-integrations/connectors/source-slack/manifest.yaml
@@ -418,7 +418,7 @@ spec:
         type: boolean
         default: true
         title: Join channels
-        description: Whether to join all channels or to sync data only from channels the bot is already in.  If false, you''ll need to manually add the bot to all the channels from which you''d like to sync messages.
+        description: Whether to automatically join channels of the enabled types. If false, only channels the bot has already been added to will be synced.
       include_public_channels:
         type: boolean
         default: true

--- a/airbyte-integrations/connectors/source-slack/metadata.yaml
+++ b/airbyte-integrations/connectors/source-slack/metadata.yaml
@@ -41,12 +41,6 @@ data:
   releases:
     rolloutConfiguration:
       enableProgressiveRollout: false
-    migrationDocumentationUrl: https://docs.airbyte.com/integrations/sources/slack-migrations
-    changelog:
-      - version: 3.1.12
-        date: "2025-03-05"
-        pullRequestNumber: 74321
-        subject: Add channel exclude filter, wildcard pattern support in channel filters, and include_external_channels option
     breakingChanges:
       3.0.0:
         message: This update fixes a bug that prevented incremental syncs from progressing for some connections containing the `threads` stream. Affected users should perform a stream refresh. See the [Slack Migration Guide](https://docs.airbyte.com/integrations/sources/slack-migrations) for instructions on identifying impacted connections and refreshing the stream.

--- a/airbyte-integrations/connectors/source-slack/metadata.yaml
+++ b/airbyte-integrations/connectors/source-slack/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: c2281cee-86f9-4a86-bb48-d23286b4c7bd
-  dockerImageTag: 3.1.11
+  dockerImageTag: 3.1.12
   dockerRepository: airbyte/source-slack
   documentationUrl: https://docs.airbyte.com/integrations/sources/slack
   externalDocumentationUrls:
@@ -41,6 +41,12 @@ data:
   releases:
     rolloutConfiguration:
       enableProgressiveRollout: false
+    migrationDocumentationUrl: https://docs.airbyte.com/integrations/sources/slack-migrations
+    changelog:
+      - version: 3.1.12
+        date: "2025-03-05"
+        pullRequestNumber: 74321
+        subject: Add channel exclude filter, wildcard pattern support in channel filters, and include_external_channels option
     breakingChanges:
       3.0.0:
         message: This update fixes a bug that prevented incremental syncs from progressing for some connections containing the `threads` stream. Affected users should perform a stream refresh. See the [Slack Migration Guide](https://docs.airbyte.com/integrations/sources/slack-migrations) for instructions on identifying impacted connections and refreshing the stream.

--- a/airbyte-integrations/connectors/source-slack/unit_tests/test_components.py
+++ b/airbyte-integrations/connectors/source-slack/unit_tests/test_components.py
@@ -21,9 +21,9 @@ def test_channel_members_extractor(token_config, components_module):
     response_mock = MagicMock()
     members_data = {"members": ["U023BECGF", "U061F7AUR", "W012A3CDE"]}
     response_mock.content = json.dumps(members_data).encode("utf-8")
-    records = components_module.ChannelMembersExtractor(
-        config=token_config, parameters={}, field_path=["members"]
-    ).extract_records(response=response_mock)
+    records = components_module.ChannelMembersExtractor(config=token_config, parameters={}, field_path=["members"]).extract_records(
+        response=response_mock
+    )
     assert records == [
         {"member_id": "U023BECGF"},
         {"member_id": "U061F7AUR"},
@@ -39,9 +39,7 @@ def test_join_channels(token_config, requests_mock, joined_channel, components_m
     token = token_config["credentials"]["api_token"]
     authenticator = TokenAuthenticator(token)
     channel_filter = token_config["channel_filter"]
-    stream = components_module.JoinChannelsStream(
-        authenticator=authenticator, channel_filter=channel_filter
-    )
+    stream = components_module.JoinChannelsStream(authenticator=authenticator, channel_filter=channel_filter)
     records = stream.read_records(
         sync_mode=SyncMode.full_refresh,
         stream_slice={"channel": "C061EG9SL", "channel_name": "general"},
@@ -61,9 +59,7 @@ def get_channels_retriever_instance(token_config, components_module):
             parameters={},
         ),
         record_selector=RecordSelector(
-            extractor=DpathExtractor(
-                field_path=["channels"], config=token_config, parameters={}
-            ),
+            extractor=DpathExtractor(field_path=["channels"], config=token_config, parameters={}),
             config=token_config,
             parameters={},
             schema_normalization=None,
@@ -81,10 +77,7 @@ def test_join_channels_should_join_to_channel(token_config, components_module):
 def test_join_channels_make_join_channel_slice(token_config, components_module):
     retriever = get_channels_retriever_instance(token_config, components_module)
     expected_slice = {"channel": "C061EG9SL", "channel_name": "general"}
-    assert (
-        retriever.make_join_channel_slice({"id": "C061EG9SL", "name": "general"})
-        == expected_slice
-    )
+    assert retriever.make_join_channel_slice({"id": "C061EG9SL", "name": "general"}) == expected_slice
 
 
 @pytest.mark.parametrize(
@@ -103,8 +96,7 @@ def test_join_channels_make_join_channel_slice(token_config, components_module):
         ),
         (
             {"ok": False, "error": "missing_scope", "needed": "channels:write"},
-            "Unable to joined channel: good-reads. Reason: {'ok': False, 'error': "
-            "'missing_scope', 'needed': 'channels:write'}",
+            "Unable to joined channel: good-reads. Reason: {'ok': False, 'error': 'missing_scope', 'needed': 'channels:write'}",
         ),
     ),
     ids=["successful_join_to_channel", "failed_join_to_channel"],
@@ -118,9 +110,7 @@ def test_join_channel_read(
     log_message,
     components_module,
 ):
-    mocked_request = requests_mock.post(
-        url="https://slack.com/api/conversations.join", json=join_response
-    )
+    mocked_request = requests_mock.post(url="https://slack.com/api/conversations.join", json=join_response)
     requests_mock.get(
         url="https://slack.com/api/conversations.list",
         json={
@@ -229,9 +219,7 @@ def test_join_channel_read(
         "exclude_takes_precedence",
     ],
 )
-def test_is_channel_included(
-    token_config, components_module, config_overrides, record, expected
-):
+def test_is_channel_included(token_config, components_module, config_overrides, record, expected):
     # Start with empty filters to avoid interference from base config's channel_filter
     config = {
         **token_config,
@@ -293,18 +281,13 @@ def test_is_channel_included(
     ),
     ids=["no_state", "old_format_state", "new_format_state"],
 )
-def test_threads_state_migration(
-    token_config, threads_stream_state, expected_parent_state
-):
+def test_threads_state_migration(token_config, threads_stream_state, expected_parent_state):
     stream = get_stream_by_name(
         "threads",
         token_config,
         StateBuilder().with_stream_state("threads", threads_stream_state).build(),
     )
-    assert (
-        stream.cursor.state.get("parent_state", {}).get("channel_messages", None)
-        == expected_parent_state
-    )
+    assert stream.cursor.state.get("parent_state", {}).get("channel_messages", None) == expected_parent_state
 
 
 @pytest.mark.parametrize(
@@ -365,13 +348,9 @@ def tesadfst_threads_and_messages_api_budget(
     token_config,
     requests_mock,
 ):
-    stream = get_stream_by_name(
-        "threads", oauth_config if config == "oauth" else token_config
-    )
+    stream = get_stream_by_name("threads", oauth_config if config == "oauth" else token_config)
     retriever = stream._stream_partition_generator._partition_factory._retriever
-    assert len(retriever.requester._http_client._api_budget._policies) == (
-        1 if config == "oauth" else 0
-    )
+    assert len(retriever.requester._http_client._api_budget._policies) == (1 if config == "oauth" else 0)
     if config == "oauth":
         assert isinstance(
             retriever.requester._http_client._api_budget._policies[0],
@@ -396,16 +375,8 @@ def tesadfst_threads_and_messages_api_budget(
         [{"json": {"messages": messages}}, {"json": {"messages": []}}],
     )
 
-    list(
-        record
-        for partition in stream.generate_partitions()
-        for record in partition.read()
-    )
+    list(record for partition in stream.generate_partitions() for record in partition.read())
 
-    assert len(retriever.requester._http_client._api_budget._policies) == (
-        1 if config == "oauth" else 0
-    )
+    assert len(retriever.requester._http_client._api_budget._policies) == (1 if config == "oauth" else 0)
     if config == "oauth":
-        assert isinstance(
-            retriever.requester._http_client._api_budget._policies[0], expected_policy
-        )
+        assert isinstance(retriever.requester._http_client._api_budget._policies[0], expected_policy)

--- a/airbyte-integrations/connectors/source-slack/unit_tests/test_components.py
+++ b/airbyte-integrations/connectors/source-slack/unit_tests/test_components.py
@@ -67,12 +67,12 @@ def test_join_channels_make_join_channel_slice(token_config, components_module):
     "join_response, log_message",
     (
         (
-            {"ok": True, "channel": {"is_member": True, "id": "channel 2", "name": "test channel"}},
-            "Successfully joined channel: test channel",
+            {"ok": True, "channel": {"is_member": True, "id": "good-reads", "name": "good-reads"}},
+            "Successfully joined channel: good-reads",
         ),
         (
             {"ok": False, "error": "missing_scope", "needed": "channels:write"},
-            "Unable to joined channel: test channel. Reason: {'ok': False, 'error': " "'missing_scope', 'needed': 'channels:write'}",
+            "Unable to joined channel: good-reads. Reason: {'ok': False, 'error': " "'missing_scope', 'needed': 'channels:write'}",
         ),
     ),
     ids=["successful_join_to_channel", "failed_join_to_channel"],
@@ -81,14 +81,67 @@ def test_join_channel_read(requests_mock, token_config, joined_channel, caplog, 
     mocked_request = requests_mock.post(url="https://slack.com/api/conversations.join", json=join_response)
     requests_mock.get(
         url="https://slack.com/api/conversations.list",
-        json={"channels": [{"is_member": True, "id": "channel 1"}, {"is_member": False, "id": "channel 2", "name": "test channel"}]},
+        json={"channels": [
+            {"is_member": True, "id": "airbyte-for-beginners", "name": "airbyte-for-beginners"},
+            {"is_member": False, "id": "good-reads", "name": "good-reads"},
+        ]},
     )
 
     retriever = get_channels_retriever_instance(token_config, components_module)
     assert len(list(retriever.read_records(records_schema={}))) == 2
     assert mocked_request.called
-    assert mocked_request.last_request._request.body == b'{"channel": "channel 2"}'
+    assert mocked_request.last_request._request.body == b'{"channel": "good-reads"}'
     assert log_message in caplog.text
+
+
+@pytest.mark.parametrize(
+    "config_overrides, record, expected",
+    (
+        # Default: all public channels included
+        ({}, {"name": "general", "is_ext_shared": False, "is_private": False}, True),
+        # include_public_channels=False: standard public channels excluded
+        ({"include_public_channels": False}, {"name": "general", "is_ext_shared": False, "is_private": False}, False),
+        # include_public_channels=False: external shared channels still included
+        ({"include_public_channels": False}, {"name": "ext-acme", "is_ext_shared": True, "is_private": False}, True),
+        # include_shared_channels=False: external shared channels excluded
+        ({"include_shared_channels": False}, {"name": "ext-acme", "is_ext_shared": True, "is_private": False}, False),
+        # include_shared_channels=False: standard public channels still included
+        ({"include_shared_channels": False}, {"name": "general", "is_ext_shared": False, "is_private": False}, True),
+        # channel_filter whitelist with exact match
+        ({"channel_filter": ["acme", "globetech"]}, {"name": "acme", "is_ext_shared": False, "is_private": False}, True),
+        # channel_filter whitelist no match
+        ({"channel_filter": ["acme"]}, {"name": "random", "is_ext_shared": False, "is_private": False}, False),
+        # channel_filter with wildcard
+        ({"channel_filter": ["acme-*"]}, {"name": "acme-sales", "is_ext_shared": False, "is_private": False}, True),
+        # channel_filter with wildcard no match
+        ({"channel_filter": ["acme-*"]}, {"name": "globetech-sales", "is_ext_shared": False, "is_private": False}, False),
+        # channel_exclude_filter blacklist
+        ({"channel_exclude_filter": ["random"]}, {"name": "random", "is_ext_shared": False, "is_private": False}, False),
+        # channel_exclude_filter with wildcard
+        ({"channel_exclude_filter": ["ext-*"]}, {"name": "ext-acme", "is_ext_shared": True, "is_private": False}, False),
+        # exclude takes precedence over include
+        ({"channel_filter": ["acme"], "channel_exclude_filter": ["acme"]}, {"name": "acme", "is_ext_shared": False, "is_private": False}, False),
+    ),
+    ids=[
+        "default_public_included",
+        "no_public_channels",
+        "no_public_channels_but_shared_included",
+        "no_shared_channels",
+        "no_shared_channels_but_public_included",
+        "whitelist_exact_match",
+        "whitelist_no_match",
+        "wildcard_match",
+        "wildcard_no_match",
+        "blacklist_exact",
+        "blacklist_wildcard",
+        "exclude_takes_precedence",
+    ],
+)
+def test_is_channel_included(token_config, components_module, config_overrides, record, expected):
+    # Start with empty filters to avoid interference from base config's channel_filter
+    config = {**token_config, "channel_filter": [], "channel_exclude_filter": [], **config_overrides}
+    retriever = get_channels_retriever_instance(token_config, components_module)
+    assert retriever.is_channel_included(config, record) is expected
 
 
 @pytest.mark.parametrize(

--- a/airbyte-integrations/connectors/source-slack/unit_tests/test_components.py
+++ b/airbyte-integrations/connectors/source-slack/unit_tests/test_components.py
@@ -8,7 +8,10 @@ import pytest
 from airbyte_cdk.models import SyncMode
 from airbyte_cdk.sources.declarative.extractors import DpathExtractor, RecordSelector
 from airbyte_cdk.sources.declarative.requesters import HttpRequester
-from airbyte_cdk.sources.streams.call_rate import MovingWindowCallRatePolicy, UnlimitedCallRatePolicy
+from airbyte_cdk.sources.streams.call_rate import (
+    MovingWindowCallRatePolicy,
+    UnlimitedCallRatePolicy,
+)
 from airbyte_cdk.sources.streams.http.requests_native_auth import TokenAuthenticator
 from airbyte_cdk.test.state_builder import StateBuilder
 from unit_tests.conftest import get_stream_by_name, oauth_config, token_config
@@ -18,19 +21,31 @@ def test_channel_members_extractor(token_config, components_module):
     response_mock = MagicMock()
     members_data = {"members": ["U023BECGF", "U061F7AUR", "W012A3CDE"]}
     response_mock.content = json.dumps(members_data).encode("utf-8")
-    records = components_module.ChannelMembersExtractor(config=token_config, parameters={}, field_path=["members"]).extract_records(
-        response=response_mock
-    )
-    assert records == [{"member_id": "U023BECGF"}, {"member_id": "U061F7AUR"}, {"member_id": "W012A3CDE"}]
+    records = components_module.ChannelMembersExtractor(
+        config=token_config, parameters={}, field_path=["members"]
+    ).extract_records(response=response_mock)
+    assert records == [
+        {"member_id": "U023BECGF"},
+        {"member_id": "U061F7AUR"},
+        {"member_id": "W012A3CDE"},
+    ]
 
 
 def test_join_channels(token_config, requests_mock, joined_channel, components_module):
-    mocked_request = requests_mock.post(url="https://slack.com/api/conversations.join", json={"ok": True, "channel": joined_channel})
+    mocked_request = requests_mock.post(
+        url="https://slack.com/api/conversations.join",
+        json={"ok": True, "channel": joined_channel},
+    )
     token = token_config["credentials"]["api_token"]
     authenticator = TokenAuthenticator(token)
     channel_filter = token_config["channel_filter"]
-    stream = components_module.JoinChannelsStream(authenticator=authenticator, channel_filter=channel_filter)
-    records = stream.read_records(sync_mode=SyncMode.full_refresh, stream_slice={"channel": "C061EG9SL", "channel_name": "general"})
+    stream = components_module.JoinChannelsStream(
+        authenticator=authenticator, channel_filter=channel_filter
+    )
+    records = stream.read_records(
+        sync_mode=SyncMode.full_refresh,
+        stream_slice={"channel": "C061EG9SL", "channel_name": "general"},
+    )
     assert not list(records)
     assert mocked_request.called
 
@@ -39,10 +54,16 @@ def get_channels_retriever_instance(token_config, components_module):
     return components_module.ChannelsRetriever(
         config=token_config,
         requester=HttpRequester(
-            name="channels", path="conversations.list", url_base="https://slack.com/api/", config=token_config, parameters={}
+            name="channels",
+            path="conversations.list",
+            url_base="https://slack.com/api/",
+            config=token_config,
+            parameters={},
         ),
         record_selector=RecordSelector(
-            extractor=DpathExtractor(field_path=["channels"], config=token_config, parameters={}),
+            extractor=DpathExtractor(
+                field_path=["channels"], config=token_config, parameters={}
+            ),
             config=token_config,
             parameters={},
             schema_normalization=None,
@@ -60,31 +81,58 @@ def test_join_channels_should_join_to_channel(token_config, components_module):
 def test_join_channels_make_join_channel_slice(token_config, components_module):
     retriever = get_channels_retriever_instance(token_config, components_module)
     expected_slice = {"channel": "C061EG9SL", "channel_name": "general"}
-    assert retriever.make_join_channel_slice({"id": "C061EG9SL", "name": "general"}) == expected_slice
+    assert (
+        retriever.make_join_channel_slice({"id": "C061EG9SL", "name": "general"})
+        == expected_slice
+    )
 
 
 @pytest.mark.parametrize(
     "join_response, log_message",
     (
         (
-            {"ok": True, "channel": {"is_member": True, "id": "good-reads", "name": "good-reads"}},
+            {
+                "ok": True,
+                "channel": {
+                    "is_member": True,
+                    "id": "good-reads",
+                    "name": "good-reads",
+                },
+            },
             "Successfully joined channel: good-reads",
         ),
         (
             {"ok": False, "error": "missing_scope", "needed": "channels:write"},
-            "Unable to joined channel: good-reads. Reason: {'ok': False, 'error': " "'missing_scope', 'needed': 'channels:write'}",
+            "Unable to joined channel: good-reads. Reason: {'ok': False, 'error': "
+            "'missing_scope', 'needed': 'channels:write'}",
         ),
     ),
     ids=["successful_join_to_channel", "failed_join_to_channel"],
 )
-def test_join_channel_read(requests_mock, token_config, joined_channel, caplog, join_response, log_message, components_module):
-    mocked_request = requests_mock.post(url="https://slack.com/api/conversations.join", json=join_response)
+def test_join_channel_read(
+    requests_mock,
+    token_config,
+    joined_channel,
+    caplog,
+    join_response,
+    log_message,
+    components_module,
+):
+    mocked_request = requests_mock.post(
+        url="https://slack.com/api/conversations.join", json=join_response
+    )
     requests_mock.get(
         url="https://slack.com/api/conversations.list",
-        json={"channels": [
-            {"is_member": True, "id": "airbyte-for-beginners", "name": "airbyte-for-beginners"},
-            {"is_member": False, "id": "good-reads", "name": "good-reads"},
-        ]},
+        json={
+            "channels": [
+                {
+                    "is_member": True,
+                    "id": "airbyte-for-beginners",
+                    "name": "airbyte-for-beginners",
+                },
+                {"is_member": False, "id": "good-reads", "name": "good-reads"},
+            ]
+        },
     )
 
     retriever = get_channels_retriever_instance(token_config, components_module)
@@ -100,27 +148,71 @@ def test_join_channel_read(requests_mock, token_config, joined_channel, caplog, 
         # Default: all public channels included
         ({}, {"name": "general", "is_ext_shared": False, "is_private": False}, True),
         # include_public_channels=False: standard public channels excluded
-        ({"include_public_channels": False}, {"name": "general", "is_ext_shared": False, "is_private": False}, False),
+        (
+            {"include_public_channels": False},
+            {"name": "general", "is_ext_shared": False, "is_private": False},
+            False,
+        ),
         # include_public_channels=False: external shared channels still included
-        ({"include_public_channels": False}, {"name": "ext-acme", "is_ext_shared": True, "is_private": False}, True),
+        (
+            {"include_public_channels": False},
+            {"name": "ext-acme", "is_ext_shared": True, "is_private": False},
+            True,
+        ),
         # include_shared_channels=False: external shared channels excluded
-        ({"include_shared_channels": False}, {"name": "ext-acme", "is_ext_shared": True, "is_private": False}, False),
+        (
+            {"include_shared_channels": False},
+            {"name": "ext-acme", "is_ext_shared": True, "is_private": False},
+            False,
+        ),
         # include_shared_channels=False: standard public channels still included
-        ({"include_shared_channels": False}, {"name": "general", "is_ext_shared": False, "is_private": False}, True),
+        (
+            {"include_shared_channels": False},
+            {"name": "general", "is_ext_shared": False, "is_private": False},
+            True,
+        ),
         # channel_filter whitelist with exact match
-        ({"channel_filter": ["acme", "globetech"]}, {"name": "acme", "is_ext_shared": False, "is_private": False}, True),
+        (
+            {"channel_filter": ["acme", "globetech"]},
+            {"name": "acme", "is_ext_shared": False, "is_private": False},
+            True,
+        ),
         # channel_filter whitelist no match
-        ({"channel_filter": ["acme"]}, {"name": "random", "is_ext_shared": False, "is_private": False}, False),
+        (
+            {"channel_filter": ["acme"]},
+            {"name": "random", "is_ext_shared": False, "is_private": False},
+            False,
+        ),
         # channel_filter with wildcard
-        ({"channel_filter": ["acme-*"]}, {"name": "acme-sales", "is_ext_shared": False, "is_private": False}, True),
+        (
+            {"channel_filter": ["acme-*"]},
+            {"name": "acme-sales", "is_ext_shared": False, "is_private": False},
+            True,
+        ),
         # channel_filter with wildcard no match
-        ({"channel_filter": ["acme-*"]}, {"name": "globetech-sales", "is_ext_shared": False, "is_private": False}, False),
+        (
+            {"channel_filter": ["acme-*"]},
+            {"name": "globetech-sales", "is_ext_shared": False, "is_private": False},
+            False,
+        ),
         # channel_exclude_filter blacklist
-        ({"channel_exclude_filter": ["random"]}, {"name": "random", "is_ext_shared": False, "is_private": False}, False),
+        (
+            {"channel_exclude_filter": ["random"]},
+            {"name": "random", "is_ext_shared": False, "is_private": False},
+            False,
+        ),
         # channel_exclude_filter with wildcard
-        ({"channel_exclude_filter": ["ext-*"]}, {"name": "ext-acme", "is_ext_shared": True, "is_private": False}, False),
+        (
+            {"channel_exclude_filter": ["ext-*"]},
+            {"name": "ext-acme", "is_ext_shared": True, "is_private": False},
+            False,
+        ),
         # exclude takes precedence over include
-        ({"channel_filter": ["acme"], "channel_exclude_filter": ["acme"]}, {"name": "acme", "is_ext_shared": False, "is_private": False}, False),
+        (
+            {"channel_filter": ["acme"], "channel_exclude_filter": ["acme"]},
+            {"name": "acme", "is_ext_shared": False, "is_private": False},
+            False,
+        ),
     ),
     ids=[
         "default_public_included",
@@ -137,9 +229,16 @@ def test_join_channel_read(requests_mock, token_config, joined_channel, caplog, 
         "exclude_takes_precedence",
     ],
 )
-def test_is_channel_included(token_config, components_module, config_overrides, record, expected):
+def test_is_channel_included(
+    token_config, components_module, config_overrides, record, expected
+):
     # Start with empty filters to avoid interference from base config's channel_filter
-    config = {**token_config, "channel_filter": [], "channel_exclude_filter": [], **config_overrides}
+    config = {
+        **token_config,
+        "channel_filter": [],
+        "channel_exclude_filter": [],
+        **config_overrides,
+    }
     retriever = get_channels_retriever_instance(token_config, components_module)
     assert retriever.is_channel_included(config, record) is expected
 
@@ -157,15 +256,33 @@ def test_is_channel_included(token_config, components_module, config_overrides, 
             {
                 "states": [
                     {
-                        "partition": {"float_ts": "1683104542.931169", "parent_slice": {"channel": "C04KX3KEZ54", "parent_slice": {}}},
+                        "partition": {
+                            "float_ts": "1683104542.931169",
+                            "parent_slice": {
+                                "channel": "C04KX3KEZ54",
+                                "parent_slice": {},
+                            },
+                        },
                         "cursor": {"float_ts": "1753263869"},
                     },
                     {
-                        "partition": {"float_ts": "1683104590.931169", "parent_slice": {"channel": "C04KX3KEZ54", "parent_slice": {}}},
+                        "partition": {
+                            "float_ts": "1683104590.931169",
+                            "parent_slice": {
+                                "channel": "C04KX3KEZ54",
+                                "parent_slice": {},
+                            },
+                        },
                         "cursor": {"float_ts": "1753263870"},
                     },
                     {
-                        "partition": {"float_ts": "1683104590.931169", "parent_slice": {"channel": "C04KX3KEZ54", "parent_slice": {}}},
+                        "partition": {
+                            "float_ts": "1683104590.931169",
+                            "parent_slice": {
+                                "channel": "C04KX3KEZ54",
+                                "parent_slice": {},
+                            },
+                        },
                         "cursor": {"float_ts": "1753263849"},
                     },
                 ]
@@ -176,9 +293,18 @@ def test_is_channel_included(token_config, components_module, config_overrides, 
     ),
     ids=["no_state", "old_format_state", "new_format_state"],
 )
-def test_threads_state_migration(token_config, threads_stream_state, expected_parent_state):
-    stream = get_stream_by_name("threads", token_config, StateBuilder().with_stream_state("threads", threads_stream_state).build())
-    assert stream.cursor.state.get("parent_state", {}).get("channel_messages", None) == expected_parent_state
+def test_threads_state_migration(
+    token_config, threads_stream_state, expected_parent_state
+):
+    stream = get_stream_by_name(
+        "threads",
+        token_config,
+        StateBuilder().with_stream_state("threads", threads_stream_state).build(),
+    )
+    assert (
+        stream.cursor.state.get("parent_state", {}).get("channel_messages", None)
+        == expected_parent_state
+    )
 
 
 @pytest.mark.parametrize(
@@ -188,7 +314,11 @@ def test_threads_state_migration(token_config, threads_stream_state, expected_pa
             429,
             [
                 # first call rate limited
-                {"headers": {"Retry-After": "1"}, "text": "rate limited", "status_code": 429},
+                {
+                    "headers": {"Retry-After": "1"},
+                    "text": "rate limited",
+                    "status_code": 429,
+                },
                 # refreshed limits on second call
                 {"json": {"messages": []}, "status_code": 200},
             ],
@@ -199,7 +329,11 @@ def test_threads_state_migration(token_config, threads_stream_state, expected_pa
             429,
             [
                 # first call rate limited
-                {"headers": {"Retry-After": "1"}, "text": "rate limited", "status_code": 429},
+                {
+                    "headers": {"Retry-After": "1"},
+                    "text": "rate limited",
+                    "status_code": 429,
+                },
                 # refreshed limits on second call
                 {"json": {"messages": []}, "status_code": 200},
             ],
@@ -216,16 +350,33 @@ def test_threads_state_migration(token_config, threads_stream_state, expected_pa
             UnlimitedCallRatePolicy,
         ),
     ),
-    ids=["rate_limited_oauth_policy", "no_rate_limits_token_policy", "no_rate_limits_policy"],
+    ids=[
+        "rate_limited_oauth_policy",
+        "no_rate_limits_token_policy",
+        "no_rate_limits_policy",
+    ],
 )
 def tesadfst_threads_and_messages_api_budget(
-    response_status_code, api_response, config, expected_policy, oauth_config, token_config, requests_mock
+    response_status_code,
+    api_response,
+    config,
+    expected_policy,
+    oauth_config,
+    token_config,
+    requests_mock,
 ):
-    stream = get_stream_by_name("threads", oauth_config if config == "oauth" else token_config)
+    stream = get_stream_by_name(
+        "threads", oauth_config if config == "oauth" else token_config
+    )
     retriever = stream._stream_partition_generator._partition_factory._retriever
-    assert len(retriever.requester._http_client._api_budget._policies) == (1 if config == "oauth" else 0)
+    assert len(retriever.requester._http_client._api_budget._policies) == (
+        1 if config == "oauth" else 0
+    )
     if config == "oauth":
-        assert isinstance(retriever.requester._http_client._api_budget._policies[0], UnlimitedCallRatePolicy)
+        assert isinstance(
+            retriever.requester._http_client._api_budget._policies[0],
+            UnlimitedCallRatePolicy,
+        )
 
     messages = [{"ts": 1577866844}, {"ts": 1577877406}]
 
@@ -245,8 +396,16 @@ def tesadfst_threads_and_messages_api_budget(
         [{"json": {"messages": messages}}, {"json": {"messages": []}}],
     )
 
-    list(record for partition in stream.generate_partitions() for record in partition.read())
+    list(
+        record
+        for partition in stream.generate_partitions()
+        for record in partition.read()
+    )
 
-    assert len(retriever.requester._http_client._api_budget._policies) == (1 if config == "oauth" else 0)
+    assert len(retriever.requester._http_client._api_budget._policies) == (
+        1 if config == "oauth" else 0
+    )
     if config == "oauth":
-        assert isinstance(retriever.requester._http_client._api_budget._policies[0], expected_policy)
+        assert isinstance(
+            retriever.requester._http_client._api_budget._policies[0], expected_policy
+        )

--- a/docs/integrations/sources/slack.md
+++ b/docs/integrations/sources/slack.md
@@ -183,6 +183,7 @@ These two streams are effectively limited to **one request per minute**. Conside
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:-----------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 3.1.12 | 2026-03-05 | [74321](https://github.com/airbytehq/airbyte/pull/74321) | Add channel exclude filter, wildcard pattern support in channel filters, and external channel toggle |
 | 3.1.11 | 2026-02-24 | [73948](https://github.com/airbytehq/airbyte/pull/73948) | Update dependencies |
 | 3.1.10 | 2026-02-17 | [73564](https://github.com/airbytehq/airbyte/pull/73564) | Update dependencies |
 | 3.1.9 | 2026-02-10 | [73208](https://github.com/airbytehq/airbyte/pull/73208) | Update dependencies |


### PR DESCRIPTION
## Why?

The existing channel configuration has two limitations:
1. `channel_filter` (whitelist) only supports exact name matching — no wildcard patterns
2. No way to exclude channels by name or type without enumerating every channel to include
3. No way to sync only a specific type of channel (e.g. only externally shared channels)

## What?

Five new config options:

- **`include_public_channels`** (default `true`): whether to include standard public channels
- **`include_shared_channels`** (default `true`): whether to include externally shared channels (shared with other Slack workspaces)
- **`channel_exclude_filter`** (default `[]`): blacklist of channel names/patterns to exclude; takes precedence over `channel_filter`
- Wildcard pattern support (e.g. `acme-*`) in both `channel_filter` and `channel_exclude_filter`

`include_private_channels` is unchanged.

## How?

- Channel inclusion logic moved from manifest `RecordFilter` into `ChannelsRetriever.is_channel_included()` to support wildcard matching via `fnmatch`
- Manifest `types` API parameter now dynamically built from `include_public_channels`, `include_shared_channels`, and `include_private_channels`
- All new options default to backward-compatible values

## Example use cases

- Sync only externally shared channels: `include_public_channels=false`, `include_shared_channels=true`, `join_channels=true`
- Exclude noisy channels: `channel_exclude_filter=["random", "general", "ext-*"]`
- Sync only specific teams: `channel_filter=["acme-*", "globetech-*"]`

## AI PR Review Justification

### Backwards Compatibility

The switch from exact string matching to `fnmatch` wildcard matching in `channel_filter` is fully backward-compatible. Slack channel names can only contain lowercase letters, numbers, hyphens (`-`), and underscores (`_`). The special `fnmatch` characters (`*`, `?`, `[`, `]`) are not valid in Slack channel names and cannot appear in any existing `channel_filter` values. Therefore, all existing exact-match filters will continue to behave identically.

### Behavioral Changes

The behavioral changes (moving filter logic to Python, dynamic `types` parameter) are intentional and required to support wildcard matching — which cannot be expressed in a manifest `RecordFilter` Jinja condition. All new config options default to backward-compatible values, so existing syncs are completely unaffected.