### PR TITLE
feat: migrate source-zendesk-chat and source-monday to scopes array

### DIFF
--- a/airbyte-integrations/connectors/source-monday/manifest.yaml
+++ b/airbyte-integrations/connectors/source-monday/manifest.yaml
@@ -455,7 +455,16 @@ spec:
             type: string
             path_in_connector_config: ["credentials", "client_secret"]
       oauth_connector_input_specification:
-        scope: me:read boards:read workspaces:read users:read account:read updates:read assets:read tags:read teams:read
+        scopes:
+          - me:read
+          - boards:read
+          - workspaces:read
+          - users:read
+          - account:read
+          - updates:read
+          - assets:read
+          - tags:read
+          - teams:read
         consent_url: https://auth.monday.com/oauth2/authorize?{{client_id_param}}&{{redirect_uri_param}}&{{scope_param}}&{{state_param}}&subdomain={{subdomain}}
         access_token_url: https://auth.monday.com/oauth2/token?{{client_id_param}}&{{client_secret_param}}&{{auth_code_param}}&{{redirect_uri_param}}
         extract_output: ["access_token"]

--- a/airbyte-integrations/connectors/source-zendesk-chat/manifest.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-chat/manifest.yaml
@@ -683,7 +683,9 @@ spec:
             type: string
             path_in_connector_config: ["credentials", "client_secret"]
       oauth_connector_input_specification:
-        scope: read chat
+        scopes:
+          - read
+          - chat
         consent_url: https://{{subdomain}}.zendesk.com/oauth2/chat/authorizations/new?response_type=code&{{client_id_param}}&{{redirect_uri_param}}&{{scope_param}}&{{state_param}}
         access_token_url: https://{{subdomain}}.zendesk.com/oauth2/chat/token?grant_type=authorization_code&{{client_id_param}}&{{client_secret_param}}&{{auth_code_param}}&{{redirect_uri_param}}&{{scope_param}}
         extract_output: ["access_token", "refresh_token"]


### PR DESCRIPTION
## Summary
- Canary connectors for the scopes array feature
- `source-zendesk-chat`: `scope: "read chat"` → `scopes: ["read", "chat"]`
- `source-monday`: `scope: "me:read boards:read ..."` → `scopes: ["me:read", "boards:read", ...]` (9 scopes)
- Template URLs (`{{scope_param}}`) unchanged — backward compatible via platform back-population

## Context
Phase 2 of the OAuth Scopes Array PRD. These two connectors serve as canaries to validate the scopes array feature end-to-end.

## Dependencies
- airbytehq/airbyte-python-cdk#934 (schema)
- airbytehq/airbyte-platform-internal#18705 (platform processing)

## Test plan
- [ ] OAuth flow for source-zendesk-chat produces correct consent URL with scopes
- [ ] OAuth flow for source-monday produces correct consent URL with scopes
- [ ] No change in behavior — scopes array joined with space produces same URL as old scope string

Generated with [Claude Code](https://claude.com/claude-code)