### PR TITLE
fix(iceberg): map PK NumberType to StringType instead of DecimalType

### DIFF
--- a/airbyte-cdk/bulk/core/load/changelog.md
+++ b/airbyte-cdk/bulk/core/load/changelog.md
@@ -9,6 +9,7 @@ The Load CDK provides functionality for destination connectors including stream-
 
 | Version | Date       | Pull Request | Subject                                                                                         |
 |---------|------------|--------------|-------------------------------------------------------------------------------------------------|
+| 1.0.4   | 2026-03-05 | [#74328](https://github.com/airbytehq/airbyte/pull/74328) | Fix iceberg dedup: map PK NumberType to StringType instead of DecimalType for identifier field compatibility. |
 | 1.0.3   | 2026-03-05 | [#74272](https://github.com/airbytehq/airbyte/pull/74272) | Fix iceberg dedup.                                                                              |
 | 1.0.2   | 2026-02-24 | | Bump bulk-cdk-core-base to 1.0.1 to pick up CVE fixes (CVE-2021-47621, CVE-2022-36944).         |
 | 1.0.1   | 2026-02-09 | [#72959](https://github.com/airbytehq/airbyte/pull/72959) | Fix: CVE-2026-25526 (Jinjava dependency bump).                                                  |

--- a/airbyte-cdk/bulk/core/load/version.properties
+++ b/airbyte-cdk/bulk/core/load/version.properties
@@ -1,1 +1,1 @@
-version=1.0.3
+version=1.0.4

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/data/iceberg/parquet/AirbyteTypeToIcebergSchema.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/data/iceberg/parquet/AirbyteTypeToIcebergSchema.kt
@@ -107,13 +107,14 @@ fun ObjectType.toIcebergSchema(primaryKeys: List<List<String>>): Schema {
         // There's no _airbyte_data field, because we flatten the fields.
         // But we should leave the _airbyte_meta field as an actual object.
         val stringifyObjects = name != Meta.COLUMN_NAME_AB_META
-        var icebergType =
-            icebergTypeConverter.convert(field.type, stringifyObjects = stringifyObjects)
-        // Override PK NumberType fields to StringType so they can be used as
-        // Iceberg identifier fields (float/double are disallowed as identifiers).
-        if (isPrimaryKey && field.type is NumberType) {
-            icebergType = Types.StringType.get()
-        }
+        val icebergType =
+            if (isPrimaryKey && field.type is NumberType) {
+                // Override PK NumberType fields to StringType so they can be used as
+                // Iceberg identifier fields (float/double are disallowed as identifiers).
+                Types.StringType.get()
+            } else {
+                icebergTypeConverter.convert(field.type, stringifyObjects = stringifyObjects)
+            }
         fields.add(
             NestedField.of(
                 id,

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/data/iceberg/parquet/AirbyteTypeToIcebergSchema.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/data/iceberg/parquet/AirbyteTypeToIcebergSchema.kt
@@ -67,7 +67,7 @@ class AirbyteTypeToIcebergSchema {
             is BooleanType -> Types.BooleanType.get()
             is DateType -> Types.DateType.get()
             is IntegerType -> Types.LongType.get()
-            is NumberType -> Types.DecimalType.of(38, 18)
+            is NumberType -> Types.DoubleType.get()
             // Schemaless types are converted to string
             is ArrayTypeWithoutSchema,
             is ObjectTypeWithEmptySchema,
@@ -107,8 +107,13 @@ fun ObjectType.toIcebergSchema(primaryKeys: List<List<String>>): Schema {
         // There's no _airbyte_data field, because we flatten the fields.
         // But we should leave the _airbyte_meta field as an actual object.
         val stringifyObjects = name != Meta.COLUMN_NAME_AB_META
-        val icebergType =
+        var icebergType =
             icebergTypeConverter.convert(field.type, stringifyObjects = stringifyObjects)
+        // Override PK NumberType fields to StringType so they can be used as
+        // Iceberg identifier fields (float/double are disallowed as identifiers).
+        if (isPrimaryKey && field.type is NumberType) {
+            icebergType = Types.StringType.get()
+        }
         fields.add(
             NestedField.of(
                 id,

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/data/iceberg/parquet/AirbyteValueToIcebergRecord.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/data/iceberg/parquet/AirbyteValueToIcebergRecord.kt
@@ -65,8 +65,8 @@ class AirbyteValueToIcebergRecord {
             is NullValue -> return null
             is NumberValue ->
                 return when (type.typeId()) {
-                    // NumberType is mapped to DecimalType in Iceberg.
-                    Type.TypeID.DECIMAL -> airbyteValue.value
+                    // PK NumberType fields are mapped to StringType in Iceberg.
+                    Type.TypeID.STRING -> airbyteValue.value.toPlainString()
                     else -> airbyteValue.value.toDouble()
                 }
             is StringValue -> return airbyteValue.value

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/IcebergSuperTypeFinder.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/IcebergSuperTypeFinder.kt
@@ -23,7 +23,7 @@ import org.apache.iceberg.types.Types.*
  */
 @Singleton
 class IcebergSuperTypeFinder(private val icebergTypesComparator: IcebergTypesComparator) {
-    private val unsupportedTypeIds = setOf(BINARY, FIXED, UUID, MAP, TIMESTAMP_NANO)
+    private val unsupportedTypeIds = setOf(BINARY, FIXED, UUID, MAP, DECIMAL, TIMESTAMP_NANO)
 
     /**
      * Returns a supertype for [existingType] and [incomingType] if one exists.
@@ -106,16 +106,6 @@ class IcebergSuperTypeFinder(private val icebergTypesComparator: IcebergTypesCom
         // If both are the same type ID, we just use the existing type
         if (existingTypeId == incomingTypeId) {
             // For timestamps, you'd want to reconcile UTC. This is simplified here.
-            // For decimals, return the wider precision (Iceberg allows widening precision).
-            if (existingTypeId == DECIMAL) {
-                val existingDecimal = existingType as DecimalType
-                val incomingDecimal = incomingType as DecimalType
-                return if (incomingDecimal.precision() > existingDecimal.precision()) {
-                    incomingType
-                } else {
-                    existingType
-                }
-            }
             return existingType
         }
 

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/IcebergTypesComparator.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/IcebergTypesComparator.kt
@@ -222,13 +222,7 @@ class IcebergTypesComparator {
                 // but for this function's purpose, we only check the existing fields.
                 true
             }
-            Type.TypeID.DECIMAL -> {
-                require(existingType is Types.DecimalType && incomingType is Types.DecimalType) {
-                    "Expected DECIMAL types, got $existingType and $incomingType."
-                }
-                existingType.precision() == incomingType.precision() &&
-                    existingType.scale() == incomingType.scale()
-            }
+            Type.TypeID.DECIMAL,
             Type.TypeID.BINARY,
             Type.TypeID.FIXED,
             Type.TypeID.UUID,

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/test/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/IcebergSuperTypeFinderTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/test/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/IcebergSuperTypeFinderTest.kt
@@ -126,30 +126,11 @@ class IcebergSuperTypeFinderTest {
     }
 
     @Test
-    fun testIdenticalDecimalTypes() {
-        val decimalType = Types.DecimalType.of(38, 18)
-        val result = superTypeFinder.findSuperType(decimalType, decimalType, "column_name")
-
-        // Identical decimals => return existing
-        assertThat(result).isSameAs(decimalType)
-    }
-
-    @Test
-    fun testDecimalPrecisionWidening() {
-        val narrowDecimal = Types.DecimalType.of(10, 2)
-        val wideDecimal = Types.DecimalType.of(20, 2)
-
-        val result = superTypeFinder.findSuperType(narrowDecimal, wideDecimal, "column_name")
-        // Wider precision should be returned
-        assertThat(result).isSameAs(wideDecimal)
-    }
-
-    @Test
-    fun testDecimalToIntIsNotAllowed() {
+    fun testDecimalIsUnsupported() {
         val decimalType = Types.DecimalType.of(10, 2)
         val intType = Types.IntegerType.get()
 
-        // Decimal to Int promotion is not allowed by Iceberg
+        // Fails in validateTypeIds => DECIMAL is not supported
         assertThatThrownBy { superTypeFinder.findSuperType(decimalType, intType, "column_name") }
             .isInstanceOf(ConfigErrorException::class.java)
             .hasMessageContaining(

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/test/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/IcebergTypesComparatorTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/test/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/IcebergTypesComparatorTest.kt
@@ -391,7 +391,7 @@ class IcebergTypesComparatorTest {
     }
 
     @Test
-    fun testDecimalTypesEqual() {
+    fun testDecimalTypeIsUnsupported() {
         val existingSchema =
             buildSchema(
                 field("decimal_col", Types.DecimalType.of(10, 2), false),
@@ -401,52 +401,10 @@ class IcebergTypesComparatorTest {
                 field("decimal_col", Types.DecimalType.of(10, 2), false),
             )
 
-        val diff = comparator.compareSchemas(incomingSchema, existingSchema)
-
-        assertThat(diff.newColumns).isEmpty()
-        assertThat(diff.updatedDataTypes).isEmpty()
-        assertThat(diff.removedColumns).isEmpty()
-        assertThat(diff.newlyOptionalColumns).isEmpty()
-    }
-
-    @Test
-    fun testDecimalTypesDifferentPrecision() {
-        val existingSchema =
-            buildSchema(
-                field("decimal_col", Types.DecimalType.of(10, 2), false),
-            )
-        val incomingSchema =
-            buildSchema(
-                field("decimal_col", Types.DecimalType.of(20, 2), false),
-            )
-
-        val diff = comparator.compareSchemas(incomingSchema, existingSchema)
-
-        // Different precision means the type has been updated
-        assertThat(diff.updatedDataTypes).containsExactly("decimal_col")
-        assertThat(diff.newColumns).isEmpty()
-        assertThat(diff.removedColumns).isEmpty()
-        assertThat(diff.newlyOptionalColumns).isEmpty()
-    }
-
-    @Test
-    fun testDecimalTypesDifferentScale() {
-        val existingSchema =
-            buildSchema(
-                field("decimal_col", Types.DecimalType.of(10, 2), false),
-            )
-        val incomingSchema =
-            buildSchema(
-                field("decimal_col", Types.DecimalType.of(10, 5), false),
-            )
-
-        val diff = comparator.compareSchemas(incomingSchema, existingSchema)
-
-        // Different scale means the type has been updated
-        assertThat(diff.updatedDataTypes).containsExactly("decimal_col")
-        assertThat(diff.newColumns).isEmpty()
-        assertThat(diff.removedColumns).isEmpty()
-        assertThat(diff.newlyOptionalColumns).isEmpty()
+        // The code in typesAreEqual() throws for TypeID.DECIMAL
+        assertThatThrownBy { comparator.compareSchemas(incomingSchema, existingSchema) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("Unsupported or unmapped Iceberg type: DECIMAL")
     }
 
     @Test

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/testFixtures/kotlin/io/airbyte/cdk/load/data/icerberg/parquet/AirbyteTypeToIcebergSchemaTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/testFixtures/kotlin/io/airbyte/cdk/load/data/icerberg/parquet/AirbyteTypeToIcebergSchemaTest.kt
@@ -101,7 +101,7 @@ class AirbyteTypeToIcebergSchemaTest {
     @Test
     fun `convert handles NumberType`() {
         assertEquals(
-            Types.DecimalType.of(38, 18),
+            Types.DoubleType.get(),
             converter.convert(NumberType, stringifyObjects = false)
         )
     }
@@ -215,7 +215,7 @@ class AirbyteTypeToIcebergSchemaTest {
     }
 
     @Test
-    fun `toIcebergSchema maps PK NumberType to DecimalType for identifier compatibility`() {
+    fun `toIcebergSchema maps PK NumberType to StringType for identifier compatibility`() {
         val objectType =
             ObjectType(
                 linkedMapOf(
@@ -229,17 +229,17 @@ class AirbyteTypeToIcebergSchemaTest {
         val idColumn = schema.findField("id")
         val amountColumn = schema.findField("amount")
 
-        // PK NumberType field should be DecimalType (for Iceberg identifier compatibility)
+        // PK NumberType field should be StringType (for Iceberg identifier compatibility)
         assertNotNull(idColumn)
         assertFalse(idColumn!!.isOptional)
-        assertEquals(Types.DecimalType.of(38, 18), idColumn.type())
+        assertEquals(Types.StringType.get(), idColumn.type())
 
-        // Non-PK NumberType field should also be DecimalType
+        // Non-PK NumberType field should remain DoubleType
         assertNotNull(amountColumn)
         assertTrue(amountColumn!!.isOptional)
-        assertEquals(Types.DecimalType.of(38, 18), amountColumn.type())
+        assertEquals(Types.DoubleType.get(), amountColumn.type())
 
-        // PK field should be in identifier fields (DecimalType is allowed)
+        // PK field should be in identifier fields (StringType is allowed)
         val identifierFieldIds = schema.identifierFieldIds()
         assertEquals(1, identifierFieldIds.size)
         assertTrue(identifierFieldIds.contains(idColumn.fieldId()))

--- a/airbyte-integrations/connectors/destination-s3-data-lake/gradle.properties
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/gradle.properties
@@ -1,3 +1,3 @@
 testExecutionConcurrency=-1
-cdkVersion=local
+cdkVersion=0.2.8
 JunitMethodExecutionTimeout=10m

--- a/airbyte-integrations/connectors/destination-s3-data-lake/gradle.properties
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/gradle.properties
@@ -1,3 +1,3 @@
 testExecutionConcurrency=-1
-cdkVersion=0.2.8
+cdkVersion=local
 JunitMethodExecutionTimeout=10m

--- a/airbyte-integrations/connectors/destination-s3-data-lake/gradle.properties
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/gradle.properties
@@ -1,3 +1,3 @@
 testExecutionConcurrency=-1
-cdkVersion=0.2.8 
+cdkVersion=0.2.8
 JunitMethodExecutionTimeout=10m

--- a/airbyte-integrations/connectors/destination-s3-data-lake/gradle.properties
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/gradle.properties
@@ -1,3 +1,3 @@
 testExecutionConcurrency=-1
-cdkVersion=0.2.8
+cdkVersion=0.2.8 
 JunitMethodExecutionTimeout=10m


### PR DESCRIPTION
## What

Reverts the universal `NumberType` → `DecimalType(38,18)` mapping introduced in https://github.com/airbytehq/airbyte/pull/74272, which failed when tested against actual destinations (https://github.com/airbytehq/airbyte/pull/74326). Replaces it with a PK-scoped `NumberType` → `StringType` override — the original approach proposed in #74272 before scope expanded to universal DecimalType.

Bumps load CDK version from `1.0.3` → `1.0.4`.

Closes: https://github.com/airbytehq/airbyte/issues/63359

Requested by: @benmoriceau
[Devin session](https://app.devin.ai/sessions/9bc57a1832ff418a9afe589894fd36e8)

## How

1. **`AirbyteTypeToIcebergSchema.kt`** — `convert()` reverts `NumberType` → `DoubleType`. `toIcebergSchema()` adds a PK-specific override using a `val` with conditional: if a field is a primary key and its Airbyte type is `NumberType`, the Iceberg type is `StringType`; otherwise falls through to the normal converter.
2. **`AirbyteValueToIcebergRecord.kt`** — `NumberValue` conversion now checks for `STRING` target type (PK fields) and returns `toPlainString()`; otherwise falls back to `toDouble()`.
3. **`IcebergSuperTypeFinder.kt`** — `DECIMAL` added back to `unsupportedTypeIds`; decimal precision widening logic removed.
4. **`IcebergTypesComparator.kt`** — `DECIMAL` moved back to the unsupported/unmapped branch in `typesAreEqual()`.
5. **`version.properties`** — Load CDK version bumped to `1.0.4`.
6. **Tests** — Updated to reflect `DoubleType` for non-PK NumberType, `StringType` for PK NumberType, and DECIMAL as unsupported.

## Review guide

1. `AirbyteTypeToIcebergSchema.kt` — Core change: revert `convert()` + add PK override in `toIcebergSchema()` (~8 lines)
2. `AirbyteValueToIcebergRecord.kt` — Value conversion: `DECIMAL` → `STRING` branch swap (~2 lines)
3. `IcebergSuperTypeFinder.kt` — Revert: re-add DECIMAL to unsupported, remove widening logic (~12 lines removed)
4. `IcebergTypesComparator.kt` — Revert: DECIMAL back to unsupported (~6 lines removed)
5. `version.properties` — Version bump (1 line)
6. Test files — Expectations updated for StringType/DoubleType and DECIMAL-as-unsupported

**⚠️ Items for reviewer attention:**

- **No integration testing**: This is a CDK-only change. Unit tests pass, but the DecimalType approach also passed unit tests before failing in integration. Recommend testing against an actual S3/GCS Data Lake destination before merging.
- **Schema evolution from DecimalType (post-#74272) → DoubleType/StringType**: Tables synced after #74272 merged will have `DecimalType(38,18)` columns. This PR changes them to `DoubleType` (non-PK) or `StringType` (PK). Iceberg may not allow these type transitions — affected connections may need a full refresh.
- **StringType semantics for numeric PKs**: PK fields with `NumberType` will now be stored as strings. This means lexicographic ordering (e.g., `"9" > "10"`), which is a tradeoff for ID-like fields. This was the approach originally suggested by @tryangul.
- **`toPlainString()` vs `toString()`**: `toPlainString()` avoids scientific notation (e.g., `0.0000001` instead of `1E-7`). Verify this is the desired serialization.

## User Impact

**Positive:**
- Dedup sync mode now works for streams where all/some primary keys are `NumberType` (previously failed with "equality field ids shouldn't be null or empty").
- Preserves analytical query compatibility for non-PK `NumberType` fields (remain `DoubleType`).

**Breaking/Negative:**
- **Schema migration required**: Existing tables synced after #74272 merged (with `DecimalType` columns) will face schema evolution failures or require full refresh when this change is deployed.
- **PK fields lose numeric semantics**: PKs with `NumberType` are now strings. This means:
  - Sorting is lexicographic (not numeric)
  - Joins/filters on these PKs compare strings (e.g., `"9" > "10"` is `false`)
  - Downstream dashboards/queries may need updates if they assume numeric comparison
- **Limited blast radius**: Only affects connections using `NumberType` fields as primary keys. Non-PK `NumberType` fields retain `DoubleType`.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

**Rationale:** Reverting this PR would restore the DecimalType mapping (which is already in master via #74272). However, note that #74272 itself failed integration testing, so reverting may re-introduce that failure. The safe path forward is likely to fix this PR if issues arise, not to revert.

## Updates since last revision

- Refactored to use `val` with conditional expression instead of `var` per reviewer feedback
- Bumped load CDK version to `1.0.4`