### PR TITLE
DO NOT MERGE fix(source-hubspot): remove AddFieldsFromEndpointTransformation from campaigns stream

### DIFF
--- a/airbyte-integrations/connectors/source-hubspot/BEHAVIOR.md
+++ b/airbyte-integrations/connectors/source-hubspot/BEHAVIOR.md
@@ -101,20 +101,16 @@ into character-bounded chunks.
 
 ---
 
-## 6. Per-Record API Enrichment (Campaigns and Marketing Emails)
+## 6. Per-Record API Enrichment (Marketing Emails)
 
-Two streams make **additional API calls during record transformation** to enrich each record:
+The marketing emails stream makes **additional API calls during record transformation** to enrich
+each record:
 
-- **Campaigns:** HubSpot's campaign list endpoint (`/email/public/v1/campaigns`) only returns a
-  summary with `id`, `appId`, `appName`, and `lastUpdatedTime`. To get full campaign details
-  (subject, counters, etc.), the connector makes a separate GET request to
-  `/email/public/v1/campaigns/{id}` for each record. This is a limitation of HubSpot's email campaign
-  API which has no "list with full details" endpoint.
 - **Marketing Emails:** HubSpot's v3 email API separates content data and performance statistics into
   different endpoints. For every email record, the connector makes a GET request to
   `/marketing/v3/emails/{emailId}/statistics` to fetch performance metrics.
 
-**Why this matters:** Unlike the association extractor (which batches per page), these enrichments make one extra HTTP call per individual record. A sync of 50,000 campaigns means 50,000 additional API calls on top of the pagination calls. This is the most API-intensive pattern in the connector and the most likely to hit rate limits on large accounts.
+**Why this matters:** Unlike the association extractor (which batches per page), this enrichment makes one extra HTTP call per individual record. A sync of many marketing emails means an equal number of additional API calls on top of the pagination calls. This is one of the most API-intensive patterns in the connector and likely to hit rate limits on large accounts.
 
 ---
 

--- a/airbyte-integrations/connectors/source-hubspot/components.py
+++ b/airbyte-integrations/connectors/source-hubspot/components.py
@@ -177,34 +177,6 @@ class HubspotPropertyHistoryExtractor(RecordExtractor):
 
 
 @dataclass
-class AddFieldsFromEndpointTransformation(RecordTransformation):
-    """
-    Makes request to provided endpoint and updates record with retrieved data.
-
-    requester: Requester
-    record_selector: HttpSelector
-    """
-
-    requester: Requester
-    record_selector: HttpSelector
-
-    def transform(
-        self,
-        record: Dict[str, Any],
-        config: Optional[Config] = None,
-        stream_state: Optional[StreamState] = None,
-        stream_slice: Optional[StreamSlice] = None,
-    ) -> None:
-        additional_data_response = self.requester.send_request(
-            stream_slice=StreamSlice(partition={"parent_id": record["id"]}, cursor_slice={})
-        )
-        additional_data = self.record_selector.select_records(response=additional_data_response, stream_state={}, records_schema={})
-
-        for data in additional_data:
-            record.update(data)
-
-
-@dataclass
 class MarketingEmailStatisticsTransformation(RecordTransformation):
     """
     Custom transformation for HubSpot Marketing Emails that fetches statistics from the v3 API.

--- a/airbyte-integrations/connectors/source-hubspot/manifest.yaml
+++ b/airbyte-integrations/connectors/source-hubspot/manifest.yaml
@@ -1081,19 +1081,6 @@ definitions:
       schema:
         $ref: "#/schemas/campaigns"
     transformations:
-      - type: CustomTransformation
-        class_name: source_declarative_manifest.components.AddFieldsFromEndpointTransformation
-        requester:
-          $ref: "#/definitions/base_requester"
-          path: "/email/public/v1/campaigns/{{ stream_slice['parent_id'] }}"
-        record_selector:
-          type: RecordSelector
-          extractor:
-            type: DpathExtractor
-            field_path: []
-        $parameters:
-          # Requester and Selector require stream name as a param.
-          name: campaigns
       - type: DpathFlattenFields
         field_path:
           - counters


### PR DESCRIPTION
## What
Removes the `AddFieldsFromEndpointTransformation` custom component from the campaigns stream in source-hubspot.

## How
- **`components.py`**: Deleted the `AddFieldsFromEndpointTransformation` class (a `RecordTransformation` that made a per-record HTTP request to `/email/public/v1/campaigns/{id}` and merged the response into each campaign record).
- **`manifest.yaml`**: Removed the `CustomTransformation` entry referencing this class from the campaigns stream's `transformations` list. The `DpathFlattenFields` transformation on `counters` is preserved.
- **`BEHAVIOR.md`**: Updated Section 6 ("Per-Record API Enrichment") to remove the campaigns-specific documentation, since that enrichment no longer exists. The section now only documents the marketing emails per-record enrichment.

## Review guide
1. `manifest.yaml` — confirm the transformation block removal is clean and the remaining `DpathFlattenFields` on `counters` still applies correctly. Note: `counters` was a field returned by the per-campaign detail endpoint that is now removed — **verify whether `DpathFlattenFields` on `counters` is still meaningful or becomes a no-op**.
2. `components.py` — confirm the class deletion is clean with no orphaned imports (all remaining imports are used by other classes).
3. `BEHAVIOR.md` — confirm the updated Section 6 accurately reflects the remaining per-record enrichment (marketing emails only) and reads coherently.

## User Impact
The campaigns stream will **no longer enrich records** with data fetched from the individual campaign detail endpoint (`/email/public/v1/campaigns/{id}`). Fields that were previously merged from that endpoint will no longer appear in the stream output. This is a schema-level change for downstream consumers.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚

---
Link to Devin session: https://app.devin.ai/sessions/5a02e3769ad4491584c51ee12bd09794
Requested by: @brianjlai