### PR TITLE
fix(source-paypal-transaction): Add HTTPAPIBudget, concurrency_level, and num_workers configuration

### DIFF
--- a/airbyte-integrations/connectors/source-paypal-transaction/manifest.yaml
+++ b/airbyte-integrations/connectors/source-paypal-transaction/manifest.yaml
@@ -471,6 +471,26 @@ streams:
   - $ref: "#/definitions/streams/search_invoices"
   - $ref: "#/definitions/streams/list_payments"
 
+# Rate limits: https://developer.paypal.com/api/rest/reference/rate-limiting/
+# PayPal REST API enforces rate limits per endpoint.
+# General: ~30 requests per minute for some endpoints, varies by API.
+# Returns HTTP 429 when rate limited.
+api_budget:
+  type: HTTPAPIBudget
+  policies:
+    - type: MovingWindowCallRatePolicy
+      rates:
+        - limit: 30
+          interval: PT1M
+      matchers: []
+  status_codes_for_ratelimit_hit:
+    - 429
+
+concurrency_level:
+  type: ConcurrencyLevel
+  default_concurrency: "{{ config.get('num_workers', 3) }}"
+  max_concurrency: 12
+
 spec:
   type: Spec
   connection_specification:
@@ -560,6 +580,18 @@ spec:
         minimum: 1
         maximum: 31
         order: 7
+      num_workers:
+        type: integer
+        title: Number of Concurrent Workers
+        description: >-
+          The number of worker threads to use for the sync. Higher values can
+          speed up syncs but may hit rate limits. PayPal API rate limits vary
+          by endpoint. More info at
+          https://developer.paypal.com/api/rest/reference/rate-limiting/
+        default: 3
+        minimum: 2
+        maximum: 12
+        order: 8
     additionalProperties: true
 
 metadata:

--- a/airbyte-integrations/connectors/source-paypal-transaction/metadata.yaml
+++ b/airbyte-integrations/connectors/source-paypal-transaction/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: d913b0f2-cc51-4e55-a44c-8ba1697b9239
-  dockerImageTag: 2.6.27
+  dockerImageTag: 2.6.28-rc.1
   dockerRepository: airbyte/source-paypal-transaction
   documentationUrl: https://docs.airbyte.com/integrations/sources/paypal-transaction
   githubIssueLabel: source-paypal-transaction
@@ -40,6 +40,8 @@ data:
           and the key for the balances stream change to "as_of_time". The upgrade
           is safe, but rolling back is not.'
         upgradeDeadline: "2023-09-18"
+    rolloutConfiguration:
+      enableProgressiveRollout: true
   suggestedStreams:
     streams:
       - transactions

--- a/docs/integrations/sources/paypal-transaction.md
+++ b/docs/integrations/sources/paypal-transaction.md
@@ -266,7 +266,7 @@ The connector includes a `num_workers` configuration parameter (default: 3, max:
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                      |
 | :------ | :--------- | :------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------- |
-| 2.6.28-rc.1 | 2026-03-07 | [70860](https://github.com/airbytehq/airbyte/pull/70860) | Add HTTPAPIBudget, concurrency_level, and num_workers configuration |
+| 2.6.28-rc.1 | 2026-03-07 | [74348](https://github.com/airbytehq/airbyte/pull/74348) | Add HTTPAPIBudget, concurrency_level, and num_workers configuration |
 | 2.6.27 | 2026-03-03 | [73875](https://github.com/airbytehq/airbyte/pull/73875) | Update dependencies |
 | 2.6.26 | 2026-02-26 | [74027](https://github.com/airbytehq/airbyte/pull/74027) | Fix INVALID_DATE_TIME_FORMAT error on disputes stream by using 3-digit milliseconds |
 | 2.6.25 | 2026-02-17 | [73574](https://github.com/airbytehq/airbyte/pull/73574) | Update dependencies |

--- a/docs/integrations/sources/paypal-transaction.md
+++ b/docs/integrations/sources/paypal-transaction.md
@@ -248,6 +248,8 @@ The below table contains the configuraiton parameters available for this connect
 - `page_size`: The number of records per page is differs per stream. `source-paypal-transaction` sets maximum allowed page size for each stream by default.
 - `requests_per_minute`: The maximum limit is 50 requests per minute from IP address to all endpoint (API Server restriction).
 
+The connector includes a `num_workers` configuration parameter (default: 3, max: 12) that controls the number of concurrent threads used during syncing. You can increase this value to speed up syncs, but be mindful of the rate limits. For more details, see the [PayPal API rate limiting documentation](https://developer.paypal.com/api/rest/reference/rate-limiting/).
+
 ## Data type map
 
 | Integration Type | Airbyte Type |
@@ -264,6 +266,7 @@ The below table contains the configuraiton parameters available for this connect
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                      |
 | :------ | :--------- | :------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------- |
+| 2.6.28-rc.1 | 2026-03-07 | [70860](https://github.com/airbytehq/airbyte/pull/70860) | Add HTTPAPIBudget, concurrency_level, and num_workers configuration |
 | 2.6.27 | 2026-03-03 | [73875](https://github.com/airbytehq/airbyte/pull/73875) | Update dependencies |
 | 2.6.26 | 2026-02-26 | [74027](https://github.com/airbytehq/airbyte/pull/74027) | Fix INVALID_DATE_TIME_FORMAT error on disputes stream by using 3-digit milliseconds |
 | 2.6.25 | 2026-02-17 | [73574](https://github.com/airbytehq/airbyte/pull/73574) | Update dependencies |


### PR DESCRIPTION
## What

Add HTTPAPIBudget rate limiting, concurrency configuration, and a user-configurable `num_workers` parameter to source-paypal-transaction, per the implementation guidelines in [airbytehq/airbyte-internal-issues#15262](https://github.com/airbytehq/airbyte-internal-issues/issues/15262). Resolves [airbytehq/airbyte-internal-issues#15311](https://github.com/airbytehq/airbyte-internal-issues/issues/15311).

## How

- **manifest.yaml**: Added `api_budget` (HTTPAPIBudget with MovingWindowCallRatePolicy at 30 req/min, 429 status code handling), `concurrency_level` (default from `config.num_workers` defaulting to 3, max 12), and `num_workers` spec property (integer, min 2, max 12).
- **metadata.yaml**: Bumped version to `2.6.28-rc.1` and enabled progressive rollout.
- **docs**: Added `num_workers` documentation and changelog entry.

## Review guide

1. `airbyte-integrations/connectors/source-paypal-transaction/manifest.yaml` — core changes: api_budget, concurrency_level, num_workers spec
2. `airbyte-integrations/connectors/source-paypal-transaction/metadata.yaml` — version bump + progressive rollout
3. `docs/integrations/sources/paypal-transaction.md` — docs and changelog

**⚠️ Items requiring reviewer attention:**
- The `api_budget` rate limit is set to **30 req/min**, but the existing Performance Considerations section already states the API limit is **50 requests per minute**. The 30/min value may be too conservative or the two numbers should at least be reconciled.
- The changelog entry incorrectly links to PR `#70860` (which is the mailchimp PR) instead of this PR's actual number. This needs to be corrected.
- No `ratelimit_reset_header` or `ratelimit_remaining_header` is configured. Verify whether PayPal returns standard rate limit headers that should be configured.

## User Impact

Users gain a new `num_workers` config parameter to control sync concurrency. The connector will now respect PayPal API rate limits via HTTPAPIBudget, reducing 429 errors. Progressive rollout is enabled so this will deploy gradually.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

[Devin session](https://app.devin.ai/sessions/ad8d2fb295ae424da050b07fe35b7d58) | Requested by @sophiecuiy