### PR TITLE
fix(source-sendgrid): Add HTTPAPIBudget, concurrency_level, and num_workers configuration

### DIFF
--- a/airbyte-integrations/connectors/source-sendgrid/manifest.yaml
+++ b/airbyte-integrations/connectors/source-sendgrid/manifest.yaml
@@ -674,6 +674,29 @@ streams:
   - $ref: "#/definitions/streams/campaigns"
   - $ref: "#/definitions/streams/contacts"
 
+# Rate limits: https://docs.sendgrid.com/api-reference/how-to-use-the-sendgrid-v3-api/rate-limits
+# SendGrid v3 API rate limits vary by endpoint.
+# General: most endpoints allow ~50 requests/second.
+# Marketing API: ~600 requests/minute.
+# Headers: X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset
+# Returns HTTP 429 when rate limited.
+api_budget:
+  type: HTTPAPIBudget
+  policies:
+    - type: MovingWindowCallRatePolicy
+      rates:
+        - limit: 50
+          interval: PT1S
+      matchers: []
+  ratelimit_reset_header: "X-RateLimit-Reset"
+  ratelimit_remaining_header: "X-RateLimit-Remaining"
+  status_codes_for_ratelimit_hit:
+    - 429
+
+concurrency_level:
+  type: ConcurrencyLevel
+  default_concurrency: "{{ config.get('num_workers', 5) }}"
+  max_concurrency: 20
 
 spec:
   type: Spec
@@ -702,6 +725,18 @@ spec:
         order: 1
         title: API Key
         airbyte_secret: true
+      num_workers:
+        type: integer
+        title: Number of Concurrent Workers
+        description: >-
+          The number of worker threads to use for the sync. Higher values can
+          speed up syncs but may hit rate limits. SendGrid API allows ~50
+          requests/second for most endpoints. More info at
+          https://docs.sendgrid.com/api-reference/how-to-use-the-sendgrid-v3-api/rate-limits
+        default: 5
+        minimum: 2
+        maximum: 20
+        order: 2
     additionalProperties: true
 
 metadata:

--- a/airbyte-integrations/connectors/source-sendgrid/metadata.yaml
+++ b/airbyte-integrations/connectors/source-sendgrid/metadata.yaml
@@ -10,12 +10,14 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: fbb5fbe2-16ad-4cf4-af7d-ff9d9c316c87
-  dockerImageTag: 1.3.26
+  dockerImageTag: 1.3.27-rc.1
   releases:
     breakingChanges:
       1.0.0:
         message: This release makes several changes that upgrade the Sendgrid connector. The configuration options have been renamed to `api_key` and `start_date`. `start_date` is now required. The `unsubscribe_groups` stream has been removed. It was the same as `suppression_groups`. You can use that and get the same data. The `single_sends` stream has been renamed `singlesend_stats`. This is closer to the data and API. The `segments` stream has been upgraded to use the Sendgrid 2.0 API because the older one has been deprecated. The schema has changed as a result. To ensure a smooth upgrade, please refresh your schemas and reset your data before resuming syncs.
         upgradeDeadline: "2024-04-29"
+    rolloutConfiguration:
+      enableProgressiveRollout: true
   dockerRepository: airbyte/source-sendgrid
   documentationUrl: https://docs.airbyte.com/integrations/sources/sendgrid
   externalDocumentationUrls:

--- a/docs/integrations/sources/sendgrid.md
+++ b/docs/integrations/sources/sendgrid.md
@@ -84,6 +84,8 @@ Expand to see details about Sendgrid connector limitations and troubleshooting.
 
 The connector is restricted by normal Sendgrid [requests limitation](https://docs.sendgrid.com/api-reference/how-to-use-the-sendgrid-v3-api/rate-limits).
 
+The connector includes a `num_workers` configuration parameter (default: 5, max: 20) that controls the number of concurrent threads used during syncing. You can increase this value to speed up syncs, but be mindful of the rate limits.
+
 ### Troubleshooting
 
 #### 403 Forbidden errors
@@ -105,6 +107,7 @@ If you encounter 403 errors, check the following:
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                                                                                                                           |
 |:--------|:-----------| :------------------------------------------------------- |:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1.3.27-rc.1 | 2026-03-07 | [](https://github.com/airbytehq/airbyte/pull/) | Add HTTPAPIBudget, concurrency_level, and num_workers configuration |
 | 1.3.26 | 2026-02-24 | [73950](https://github.com/airbytehq/airbyte/pull/73950) | Update dependencies |
 | 1.3.25 | 2026-02-10 | [73157](https://github.com/airbytehq/airbyte/pull/73157) | Update dependencies |
 | 1.3.24 | 2026-02-03 | [72566](https://github.com/airbytehq/airbyte/pull/72566) | Update dependencies |

--- a/docs/integrations/sources/sendgrid.md
+++ b/docs/integrations/sources/sendgrid.md
@@ -107,7 +107,7 @@ If you encounter 403 errors, check the following:
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                                                                                                                           |
 |:--------|:-----------| :------------------------------------------------------- |:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 1.3.27-rc.1 | 2026-03-07 | [](https://github.com/airbytehq/airbyte/pull/) | Add HTTPAPIBudget, concurrency_level, and num_workers configuration |
+| 1.3.27-rc.1 | 2026-03-07 | [74349](https://github.com/airbytehq/airbyte/pull/74349) | Add HTTPAPIBudget, concurrency_level, and num_workers configuration |
 | 1.3.26 | 2026-02-24 | [73950](https://github.com/airbytehq/airbyte/pull/73950) | Update dependencies |
 | 1.3.25 | 2026-02-10 | [73157](https://github.com/airbytehq/airbyte/pull/73157) | Update dependencies |
 | 1.3.24 | 2026-02-03 | [72566](https://github.com/airbytehq/airbyte/pull/72566) | Update dependencies |


### PR DESCRIPTION
## What

Adds rate limiting (`HTTPAPIBudget`), concurrency configuration, and a user-configurable `num_workers` parameter to `source-sendgrid`, per the implementation guidelines in [airbytehq/airbyte-internal-issues#15262](https://github.com/airbytehq/airbyte-internal-issues/issues/15262). Resolves [airbytehq/airbyte-internal-issues#15312](https://github.com/airbytehq/airbyte-internal-issues/issues/15312).

## How

- **manifest.yaml**: Added `api_budget` (HTTPAPIBudget with MovingWindowCallRatePolicy at 50 req/s, `X-RateLimit-Reset`/`X-RateLimit-Remaining` headers, 429 handling), `concurrency_level` (default from `config.num_workers`, default 5, max 20), and `num_workers` spec property.
- **metadata.yaml**: Version bump `1.3.26` → `1.3.27-rc.1`, enabled progressive rollout.
- **docs**: Added `num_workers` documentation and changelog entry.

## Review guide

1. `airbyte-integrations/connectors/source-sendgrid/manifest.yaml` — core changes
2. `airbyte-integrations/connectors/source-sendgrid/metadata.yaml` — version + rollout config
3. `docs/integrations/sources/sendgrid.md` — docs

**⚠️ Items requiring reviewer attention:**
- The changelog entry has an **empty PR link** (`[](https://github.com/airbytehq/airbyte/pull/)`) — needs to be backfilled with the actual PR number once known.
- A single catch-all rate limit policy of 50 req/s is used. SendGrid's Marketing API has a lower limit (~600 req/min ≈ 10 req/s). Consider whether a more specific policy with a matcher for `/v3/marketing/*` paths is needed.
- Verify that `ratelimit_reset_header` and `ratelimit_remaining_header` are correctly placed at the `api_budget` level in the CDK schema.

## User Impact

Users gain a new optional `num_workers` config parameter (default: 5) to control sync concurrency. The connector will now respect SendGrid API rate limits via HTTPAPIBudget, reducing 429 errors. Progressive rollout is enabled for gradual deployment.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

[Devin session](https://app.devin.ai/sessions/ad8d2fb295ae424da050b07fe35b7d58) | Requested by @sophiecuiy