### PR TITLE
fix(source-typeform): Add HTTPAPIBudget, concurrency_level, and num_workers configuration

### DIFF
--- a/airbyte-integrations/connectors/source-typeform/manifest.yaml
+++ b/airbyte-integrations/connectors/source-typeform/manifest.yaml
@@ -1810,6 +1810,25 @@ streams:
             format: date-time
         $schema: http://json-schema.org/draft-07/schema#
 
+# Rate limits: https://www.typeform.com/developers/get-started/applications/#rate-limits
+# Typeform API: 2 requests per second per token.
+# Returns HTTP 429 when rate limited.
+api_budget:
+  type: HTTPAPIBudget
+  policies:
+    - type: MovingWindowCallRatePolicy
+      rates:
+        - limit: 2
+          interval: PT1S
+      matchers: []
+  status_codes_for_ratelimit_hit:
+    - 429
+
+concurrency_level:
+  type: ConcurrencyLevel
+  default_concurrency: "{{ config.get('num_workers', 2) }}"
+  max_concurrency: 8
+
 spec:
   type: Spec
   documentation_url: https://docs.airbyte.com/integrations/sources/typeform
@@ -1887,6 +1906,18 @@ spec:
           type: string
         uniqueItems: true
         order: 3
+      num_workers:
+        type: integer
+        title: Number of Concurrent Workers
+        description: >-
+          The number of worker threads to use for the sync. Higher values can
+          speed up syncs but may hit rate limits. Typeform API allows 2
+          requests/second per token. More info at
+          https://www.typeform.com/developers/get-started/applications/#rate-limits
+        default: 2
+        minimum: 2
+        maximum: 8
+        order: 4
   advanced_auth:
     auth_flow_type: oauth2.0
     predicate_key:

--- a/airbyte-integrations/connectors/source-typeform/metadata.yaml
+++ b/airbyte-integrations/connectors/source-typeform/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: e7eff203-90bf-43e5-a240-19ea3056c474
-  dockerImageTag: 1.4.6
+  dockerImageTag: 1.4.7-rc.1
   dockerRepository: airbyte/source-typeform
   documentationUrl: https://docs.airbyte.com/integrations/sources/typeform
   externalDocumentationUrls:
@@ -43,6 +43,8 @@ data:
           mode for this stream, you will need to reset affected connections after
           upgrading to prevent sync failures.
         upgradeDeadline: "2023-09-25"
+    rolloutConfiguration:
+      enableProgressiveRollout: true
   suggestedStreams:
     streams:
       - responses

--- a/docs/integrations/sources/typeform.md
+++ b/docs/integrations/sources/typeform.md
@@ -94,6 +94,8 @@ The connector performs an additional API call to fetch all form IDs in your acco
 
 API rate limits \(2 requests per second\): [https://developer.typeform.com/get-started/\#rate-limits](https://developer.typeform.com/get-started/#rate-limits)
 
+The connector includes a `num_workers` configuration parameter (default: 2, max: 8) that controls the number of concurrent threads used during syncing. You can increase this value to speed up syncs, but be mindful of the rate limits.
+
 ## Changelog
 
 <details>
@@ -101,6 +103,7 @@ API rate limits \(2 requests per second\): [https://developer.typeform.com/get-s
 
 | Version | Date       | Pull Request                                             | Subject                                                                                         |
 |:--------|:-----------|:---------------------------------------------------------|:------------------------------------------------------------------------------------------------|
+| 1.4.7-rc.1 | 2026-03-07 | [](https://github.com/airbytehq/airbyte/pull/) | Add HTTPAPIBudget, concurrency_level, and num_workers configuration |
 | 1.4.6 | 2026-03-03 | [61473](https://github.com/airbytehq/airbyte/pull/61473) | Update dependencies |
 | 1.4.5 | 2026-01-22 | [72261](https://github.com/airbytehq/airbyte/pull/72261) | Update CDK version from 7.0.1 to 7.6.5 |
 | 1.4.4 | 2025-10-22 | [68591](https://github.com/airbytehq/airbyte/pull/68591) | Add `suggestedStreams` |

--- a/docs/integrations/sources/typeform.md
+++ b/docs/integrations/sources/typeform.md
@@ -103,7 +103,7 @@ The connector includes a `num_workers` configuration parameter (default: 2, max:
 
 | Version | Date       | Pull Request                                             | Subject                                                                                         |
 |:--------|:-----------|:---------------------------------------------------------|:------------------------------------------------------------------------------------------------|
-| 1.4.7-rc.1 | 2026-03-07 | [](https://github.com/airbytehq/airbyte/pull/) | Add HTTPAPIBudget, concurrency_level, and num_workers configuration |
+| 1.4.7-rc.1 | 2026-03-07 | [74350](https://github.com/airbytehq/airbyte/pull/74350) | Add HTTPAPIBudget, concurrency_level, and num_workers configuration |
 | 1.4.6 | 2026-03-03 | [61473](https://github.com/airbytehq/airbyte/pull/61473) | Update dependencies |
 | 1.4.5 | 2026-01-22 | [72261](https://github.com/airbytehq/airbyte/pull/72261) | Update CDK version from 7.0.1 to 7.6.5 |
 | 1.4.4 | 2025-10-22 | [68591](https://github.com/airbytehq/airbyte/pull/68591) | Add `suggestedStreams` |


### PR DESCRIPTION
## What

Adds rate limiting (`HTTPAPIBudget`), concurrency configuration, and a user-configurable `num_workers` parameter to `source-typeform`, per the implementation guidelines in [airbytehq/airbyte-internal-issues#15262](https://github.com/airbytehq/airbyte-internal-issues/issues/15262). Resolves [airbytehq/airbyte-internal-issues#15314](https://github.com/airbytehq/airbyte-internal-issues/issues/15314).

## How

- **manifest.yaml**: Added `api_budget` (HTTPAPIBudget with MovingWindowCallRatePolicy at 2 req/s matching [Typeform's documented limit](https://www.typeform.com/developers/get-started/applications/#rate-limits), 429 status code handling), `concurrency_level` (default from `config.num_workers` defaulting to 2, max 8), and `num_workers` spec property (integer, min 2, max 8).
- **metadata.yaml**: Version bump `1.4.6` → `1.4.7-rc.1`, enabled progressive rollout.
- **docs**: Added `num_workers` documentation and changelog entry.

## Review guide

1. `airbyte-integrations/connectors/source-typeform/manifest.yaml` — core changes: `api_budget`, `concurrency_level`, `num_workers` spec
2. `airbyte-integrations/connectors/source-typeform/metadata.yaml` — version bump + progressive rollout
3. `docs/integrations/sources/typeform.md` — docs and changelog

**⚠️ Items requiring reviewer attention:**
- The changelog entry has an **empty PR link** (`[](https://github.com/airbytehq/airbyte/pull/)`) — needs to be backfilled with the actual PR number once known.
- Typeform's rate limit is very low (2 req/s per token). With `max_concurrency: 8`, users could theoretically configure up to 8 workers against a 2 req/s budget. Verify the CDK properly enforces the `api_budget` across concurrent workers to prevent excessive 429s.
- No `ratelimit_reset_header` or `ratelimit_remaining_header` is configured. Verify whether Typeform returns standard rate limit headers that should be configured.

## User Impact

Users gain a new optional `num_workers` config parameter (default: 2) to control sync concurrency. The connector will now respect Typeform API rate limits via HTTPAPIBudget, reducing 429 errors. Progressive rollout is enabled for gradual deployment.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

[Devin session](https://app.devin.ai/sessions/ad8d2fb295ae424da050b07fe35b7d58) | Requested by @sophiecuiy