### PR TITLE
fix(source-woocommerce): Add HTTPAPIBudget, concurrency_level, and num_workers configuration

### DIFF
--- a/airbyte-integrations/connectors/source-woocommerce/manifest.yaml
+++ b/airbyte-integrations/connectors/source-woocommerce/manifest.yaml
@@ -978,6 +978,27 @@ streams:
   - $ref: "#/definitions/streams/tax_classes"
   - $ref: "#/definitions/streams/tax_rates"
 
+# Rate limits: https://woocommerce.github.io/woocommerce-rest-api-docs/#request/response-format
+# WooCommerce REST API rate limits depend on the hosting provider.
+# Default WooCommerce has no built-in rate limiting, but most hosts enforce limits.
+# Common shared hosting: ~2-5 requests/second.
+# Returns HTTP 429 when rate limited by the host.
+api_budget:
+  type: HTTPAPIBudget
+  policies:
+    - type: MovingWindowCallRatePolicy
+      rates:
+        - limit: 5
+          interval: PT1S
+      matchers: []
+  status_codes_for_ratelimit_hit:
+    - 429
+
+concurrency_level:
+  type: ConcurrencyLevel
+  default_concurrency: "{{ config.get('num_workers', 3) }}"
+  max_concurrency: 12
+
 spec:
   type: Spec
   connection_specification:
@@ -1017,6 +1038,18 @@ spec:
         pattern: ^[0-9]{4}-[0-9]{2}-[0-9]{2}$
         examples:
           - "2021-01-01"
+      num_workers:
+        type: integer
+        title: Number of Concurrent Workers
+        description: >-
+          The number of worker threads to use for the sync. Higher values can
+          speed up syncs but may hit rate limits. WooCommerce API rate limits
+          depend on the hosting provider. More info at
+          https://woocommerce.github.io/woocommerce-rest-api-docs/
+        default: 3
+        minimum: 2
+        maximum: 12
+        order: 4
     additionalProperties: true
 
 metadata:

--- a/airbyte-integrations/connectors/source-woocommerce/metadata.yaml
+++ b/airbyte-integrations/connectors/source-woocommerce/metadata.yaml
@@ -8,7 +8,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 2a2552ca-9f78-4c1c-9eb7-4d0dc66d72df
-  dockerImageTag: 0.5.31
+  dockerImageTag: 0.5.32-rc.1
   dockerRepository: airbyte/source-woocommerce
   documentationUrl: https://docs.airbyte.com/integrations/sources/woocommerce
   githubIssueLabel: source-woocommerce
@@ -28,7 +28,7 @@ data:
   releaseStage: generally_available
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
   suggestedStreams:
     streams:
       - orders

--- a/docs/integrations/sources/woocommerce.md
+++ b/docs/integrations/sources/woocommerce.md
@@ -124,7 +124,7 @@ The connector includes a `num_workers` configuration parameter (default: 3, max:
 
 | Version | Date       | Pull Request                                             | Subject                                                                |
 |:--------| :--------- |:---------------------------------------------------------|:-----------------------------------------------------------------------|
-| 0.5.32-rc.1 | 2026-03-07 | [](https://github.com/airbytehq/airbyte/pull/) | Add HTTPAPIBudget, concurrency_level, and num_workers configuration |
+| 0.5.32-rc.1 | 2026-03-07 | [74351](https://github.com/airbytehq/airbyte/pull/74351) | Add HTTPAPIBudget, concurrency_level, and num_workers configuration |
 | 0.5.31 | 2026-02-24 | [73889](https://github.com/airbytehq/airbyte/pull/73889) | Update dependencies |
 | 0.5.30 | 2026-02-10 | [72988](https://github.com/airbytehq/airbyte/pull/72988) | Update dependencies |
 | 0.5.29 | 2026-02-03 | [72658](https://github.com/airbytehq/airbyte/pull/72658) | Update dependencies |

--- a/docs/integrations/sources/woocommerce.md
+++ b/docs/integrations/sources/woocommerce.md
@@ -113,6 +113,8 @@ set [custom rate limits](https://developer.woocommerce.com/2022/11/22/store-api-
 your store. If you set a custom rate limit,
 specify it in seconds in the `maxSecondsBetweenMessages` field in the `metadata.yaml` file. This value should be the
 maximum number of seconds between API calls.
+
+The connector includes a `num_workers` configuration parameter (default: 3, max: 12) that controls the number of concurrent threads used during syncing. You can increase this value to speed up syncs, but be mindful of your store's rate limits.
 </details>
 
 ## Changelog
@@ -122,6 +124,7 @@ maximum number of seconds between API calls.
 
 | Version | Date       | Pull Request                                             | Subject                                                                |
 |:--------| :--------- |:---------------------------------------------------------|:-----------------------------------------------------------------------|
+| 0.5.32-rc.1 | 2026-03-07 | [](https://github.com/airbytehq/airbyte/pull/) | Add HTTPAPIBudget, concurrency_level, and num_workers configuration |
 | 0.5.31 | 2026-02-24 | [73889](https://github.com/airbytehq/airbyte/pull/73889) | Update dependencies |
 | 0.5.30 | 2026-02-10 | [72988](https://github.com/airbytehq/airbyte/pull/72988) | Update dependencies |
 | 0.5.29 | 2026-02-03 | [72658](https://github.com/airbytehq/airbyte/pull/72658) | Update dependencies |


### PR DESCRIPTION
## What

Adds rate limiting (`HTTPAPIBudget`), concurrency configuration, and a user-configurable `num_workers` parameter to `source-woocommerce`, per the implementation guidelines in [airbytehq/airbyte-internal-issues#15262](https://github.com/airbytehq/airbyte-internal-issues/issues/15262). Resolves [airbytehq/airbyte-internal-issues#15315](https://github.com/airbytehq/airbyte-internal-issues/issues/15315).

## How

- **manifest.yaml**: Added `api_budget` (HTTPAPIBudget with MovingWindowCallRatePolicy at 5 req/s, 429 status code handling), `concurrency_level` (default from `config.num_workers` defaulting to 3, max 12), and `num_workers` spec property (integer, min 2, max 12).
- **metadata.yaml**: Version bump `0.5.31` → `0.5.32-rc.1`, flipped `enableProgressiveRollout` from `false` to `true`.
- **docs**: Added `num_workers` documentation and changelog entry.

## Review guide

1. `airbyte-integrations/connectors/source-woocommerce/manifest.yaml` — core changes: `api_budget`, `concurrency_level`, `num_workers` spec
2. `airbyte-integrations/connectors/source-woocommerce/metadata.yaml` — version bump + progressive rollout
3. `docs/integrations/sources/woocommerce.md` — docs and changelog

**⚠️ Items requiring reviewer attention:**
- The changelog entry has an **empty PR link** (`[](https://github.com/airbytehq/airbyte/pull/)`) — needs to be backfilled with the actual PR number.
- WooCommerce has **no built-in rate limiting**; the 5 req/s budget is an estimate for common shared hosting. Verify this is a reasonable default — it may be too conservative for dedicated hosting or too aggressive for restrictive hosts.
- No `ratelimit_reset_header` or `ratelimit_remaining_header` is configured since WooCommerce doesn't document standard rate limit headers. Confirm this is acceptable.

## User Impact

Users gain a new optional `num_workers` config parameter (default: 3) to control sync concurrency. The connector will now respect a 5 req/s rate budget via HTTPAPIBudget, reducing 429 errors on rate-limited hosts. Progressive rollout is enabled for gradual deployment.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

[Devin session](https://app.devin.ai/sessions/ad8d2fb295ae424da050b07fe35b7d58) | Requested by @sophiecuiy