### PR TITLE
fix(source-zendesk-support): Add HTTPAPIBudget with rate limit headers

### DIFF
--- a/airbyte-integrations/connectors/source-zendesk-support/manifest.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-support/manifest.yaml
@@ -1269,12 +1269,27 @@ streams:
   # - $ref: "#/definitions/account_attributes_stream"
   # - $ref: "#/definitions/attribute_definitions_stream"
 
+# Rate limits: https://developer.zendesk.com/api-reference/ticketing/account-configuration/usage_limits/
 # Zendesk Support offers four tiers of rate limits:
 # - Team: 200 req/min (3.3 req/sec)
 # - Professional: 400 req/min (6.7 req/sec)
 # - Enterprise: 700 req/min (11.7 req/sec)
 # - High Volume API add-on: 2500 req/min (41.7 req/sec)
-#
+# Headers: RateLimit-Limit, RateLimit-Remaining, RateLimit-Reset, Retry-After
+# Returns HTTP 429 when rate limited.
+api_budget:
+  type: HTTPAPIBudget
+  policies:
+    - type: MovingWindowCallRatePolicy
+      rates:
+        - limit: 200
+          interval: PT1M
+      matchers: []
+  ratelimit_reset_header: "Retry-After"
+  ratelimit_remaining_header: "RateLimit-Remaining"
+  status_codes_for_ratelimit_hit:
+    - 429
+
 # We use defer to a level of 3 because we assume by default that customers are on the Team tier, but
 # customers can specify a higher concurrency level as needed up to the theoretical max rate limit.
 concurrency_level:

--- a/airbyte-integrations/connectors/source-zendesk-support/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-support/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 79c1aa37-dae3-42ae-b333-d1c105477715
-  dockerImageTag: 5.1.5
+  dockerImageTag: 5.1.6-rc.1
   dockerRepository: airbyte/source-zendesk-support
   documentationUrl: https://docs.airbyte.com/integrations/sources/zendesk-support
   githubIssueLabel: source-zendesk-support
@@ -31,7 +31,7 @@ data:
   releaseStage: generally_available
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
     breakingChanges:
       1.0.0:
         message: "`cursor_field` for `Tickets` stream is changed to `generated_timestamp`"

--- a/docs/integrations/sources/zendesk-support.md
+++ b/docs/integrations/sources/zendesk-support.md
@@ -193,7 +193,7 @@ The connector includes a `num_workers` configuration parameter (default: 3, max:
 
 | Version     | Date       | Pull Request                                             | Subject                                                                                                                                                                                                                            |
 |:------------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 5.1.6-rc.1 | 2026-03-07 | [](https://github.com/airbytehq/airbyte/pull/) | Add HTTPAPIBudget with rate limit headers for Zendesk Support API |
+| 5.1.6-rc.1 | 2026-03-07 | [74352](https://github.com/airbytehq/airbyte/pull/74352) | Add HTTPAPIBudget with rate limit headers for Zendesk Support API |
 | 5.1.5 | 2026-02-24 | [45667](https://github.com/airbytehq/airbyte/issues/45667) | Add missing SLA fields (`sla`, `group_sla`, `status`, `deleted`) to `ticket_metric_events` schema |
 | 5.1.4 | 2026-02-24 | [73911](https://github.com/airbytehq/airbyte/pull/73911) | Update dependencies |
 | 5.1.3 | 2026-02-17 | [73508](https://github.com/airbytehq/airbyte/pull/73508) | Update dependencies |

--- a/docs/integrations/sources/zendesk-support.md
+++ b/docs/integrations/sources/zendesk-support.md
@@ -178,6 +178,8 @@ The connector is restricted by normal Zendesk [requests limitation](https://deve
 
 The Zendesk connector ideally should not run into Zendesk API limitations under normal usage. [Create an issue](https://github.com/airbytehq/airbyte/issues) if you see any rate limit issues that are not automatically retried successfully.
 
+The connector includes a `num_workers` configuration parameter (default: 3, max: 40) that controls the number of concurrent threads used during syncing. The default is conservative for Team-tier accounts (200 req/min). You can increase this value for higher-tier plans. For more details, see the [Zendesk rate limits documentation](https://developer.zendesk.com/api-reference/ticketing/account-configuration/usage_limits/).
+
 ### Troubleshooting
 
 - Check out common troubleshooting issues for the Zendesk Support source connector on our [Airbyte Forum](https://github.com/airbytehq/airbyte/discussions).
@@ -191,6 +193,7 @@ The Zendesk connector ideally should not run into Zendesk API limitations under 
 
 | Version     | Date       | Pull Request                                             | Subject                                                                                                                                                                                                                            |
 |:------------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 5.1.6-rc.1 | 2026-03-07 | [](https://github.com/airbytehq/airbyte/pull/) | Add HTTPAPIBudget with rate limit headers for Zendesk Support API |
 | 5.1.5 | 2026-02-24 | [45667](https://github.com/airbytehq/airbyte/issues/45667) | Add missing SLA fields (`sla`, `group_sla`, `status`, `deleted`) to `ticket_metric_events` schema |
 | 5.1.4 | 2026-02-24 | [73911](https://github.com/airbytehq/airbyte/pull/73911) | Update dependencies |
 | 5.1.3 | 2026-02-17 | [73508](https://github.com/airbytehq/airbyte/pull/73508) | Update dependencies |


### PR DESCRIPTION
## What

Adds `HTTPAPIBudget` rate limiting configuration to `source-zendesk-support`, per the implementation guidelines in [airbytehq/airbyte-internal-issues#15262](https://github.com/airbytehq/airbyte-internal-issues/issues/15262). Resolves [airbytehq/airbyte-internal-issues#15330](https://github.com/airbytehq/airbyte-internal-issues/issues/15330).

This connector already had `concurrency_level` and `num_workers` configured — this PR adds the missing `api_budget` block, version bump with RC suffix, and progressive rollout enablement.

## How

- **manifest.yaml**: Added `api_budget` with `MovingWindowCallRatePolicy` at 200 req/min (Zendesk Team tier default), `Retry-After` and `RateLimit-Remaining` headers, and 429 status code handling.
- **metadata.yaml**: Version bump `5.1.5` → `5.1.6-rc.1`, flipped `enableProgressiveRollout` to `true`.
- **docs**: Added `num_workers` documentation in the rate limiting section and changelog entry.

## Review guide

1. `airbyte-integrations/connectors/source-zendesk-support/manifest.yaml` — the `api_budget` block (lines ~1280–1291)
2. `airbyte-integrations/connectors/source-zendesk-support/metadata.yaml` — version + rollout config
3. `docs/integrations/sources/zendesk-support.md` — docs update

**⚠️ Items for reviewer attention:**
- **Changelog PR link is empty** — needs to be backfilled with the actual PR number.
- **Budget vs max_concurrency mismatch**: The `api_budget` is 200 req/min (~3.3 req/sec) based on Team tier, but `max_concurrency` is already set to 40. A user on Team tier setting `num_workers` high would immediately saturate the budget. Verify the CDK properly throttles workers against the budget, and consider whether this pairing is sensible.
- **`ratelimit_reset_header: "Retry-After"`**: Zendesk documents both `Retry-After` (seconds to wait) and `RateLimit-Reset` (timestamp). Confirm `Retry-After` is the correct choice for the CDK's expected header semantics.

## User Impact

No user-visible behavior change for default configurations. The connector will now proactively respect Zendesk rate limits via `HTTPAPIBudget` instead of only reacting to 429 responses, which should reduce rate limit errors. Progressive rollout ensures gradual deployment.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

[Devin session](https://app.devin.ai/sessions/ad8d2fb295ae424da050b07fe35b7d58) | Requested by @sophiecuiy