### PR TITLE
docs(destination-hubspot): fix changelog, update links, and clarify object terminology

### DIFF
--- a/docs/integrations/destinations/hubspot.md
+++ b/docs/integrations/destinations/hubspot.md
@@ -66,13 +66,13 @@ This is a [data activation](/platform/move-data/elt-data-activation) destination
 
 ## Supported Objects
 
-The HubSpot destination connector supports the following streams:
+The HubSpot destination connector supports writing to the following objects:
 
 - [Companies](https://developers.hubspot.com/docs/api/crm/companies): Upsert on unique field
-- [Contacts](https://developers.hubspot.com/docs/methods/contacts): Upsert on email
+- [Contacts](https://developers.hubspot.com/docs/guides/api/crm/contacts): Upsert on email
 - [Deals](https://developers.hubspot.com/docs/api/crm/deals): Upsert on unique field
 - [Products](https://developers.hubspot.com/docs/api/crm/products): Upsert on unique field
-- [Custom Objects](https://developers.hubspot.com/docs/guides/api/crm/objects/custom-objects): Upsert on unique field
+- [Custom Objects](https://developers.hubspot.com/docs/guides/api/crm/objects/custom-objects): Upsert on unique field. Requires a HubSpot Enterprise subscription.
 
 ## Limitations & Troubleshooting
 
@@ -100,7 +100,7 @@ In order to verify our HubSpot application, HubSpot expects some usage i.e. [mor
 
 ### Scopes for Unsupported Streams
 
-During app the app installation, you might see scopes related to objects we don't support. This is expected as changing scopes might require the users to re-authenticate which is quite disruptive. In order to prevent that, we added scopes on objects we intend to support given user demands.
+During the app installation, you might see scopes related to objects we don't support. This is expected as changing scopes might require the users to re-authenticate which is quite disruptive. In order to prevent that, we added scopes on objects we intend to support given user demands.
 
 ### 403 Forbidden Error
 
@@ -117,7 +117,7 @@ This destination does not support [namespaces](https://docs.airbyte.com/platform
 
 | Version | Date       | Pull Request                                                    | Subject                                   |
 |:--------|:-----------|:----------------------------------------------------------------|:------------------------------------------|
-| 0.0.11  | 2026-03-07 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) | Use Properties API for standard object discovery to fix missing Deal and Company objects |
+| 0.0.11  | 2026-03-07 | [74355](https://github.com/airbytehq/airbyte/pull/74355) | Use Properties API for standard object discovery to fix missing Deal and Company objects |
 | 0.0.10  | 2026-02-09 | [72975](https://github.com/airbytehq/airbyte/pull/72975) | Upgrade CDK to 1.0.1                      |
 | 0.0.9   | 2026-01-26 | [72304](https://github.com/airbytehq/airbyte/pull/72304) | Upgrade CDK to 0.2.0                      |
 | 0.0.8   | 2025-11-05 | [69131](https://github.com/airbytehq/airbyte/pull/69131) | Upgrade to Bulk CDK 0.1.61.               |


### PR DESCRIPTION
This PR targets the following PR:
- #74355

---

## What

Documentation improvements for the destination-hubspot connector, triggered by review of #74355. Fixes a changelog placeholder, a deprecated API link, a typo, and incorrect terminology.

This PR was generated by an AI (Devin) based on a review of recent connector changes. Reviewers may merge, modify, or close this PR as they see fit.

**Requested by:** @ian-at-airbyte
**Devin session:** https://app.devin.ai/sessions/21b36b69cdf645c9abe821be4cdcba8c

## How

Five targeted fixes to `docs/integrations/destinations/hubspot.md`:

1. **Changelog placeholder** — Replaced `[XXXXX](...pull/XXXXX)` with `[74355](...pull/74355)` for the v0.0.11 entry.
2. **Deprecated Contacts link** — Updated the Contacts API link from the deprecated v1 path (`/docs/methods/contacts`) to the current v3 path (`/docs/guides/api/crm/contacts`).
3. **Terminology** — Changed "supports the following streams" to "supports writing to the following objects" since this is a destination, not a source.
4. **Typo** — Fixed "During app the app installation" → "During the app installation".
5. **Custom Objects note** — Added that Custom Objects require a HubSpot Enterprise subscription.

### Docusaurus build

The Docusaurus production build completed successfully (`[SUCCESS] Generated static files in "build"`). The build reports many pre-existing broken anchors across versioned platform docs — none are related to this change.

## Review guide

1. `docs/integrations/destinations/hubspot.md` — the only file changed. All five fixes are small and independently reviewable.

**Items worth verifying:**
- [ ] The new Contacts API URL (`https://developers.hubspot.com/docs/guides/api/crm/contacts`) resolves correctly
- [ ] The HubSpot Enterprise requirement for Custom Objects is still accurate
- [ ] The changelog PR number `74355` matches the parent PR

## User Impact

More accurate documentation for destination-hubspot users. No runtime or configuration changes.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚