### PR TITLE
ci: add docs slash commands to PR welcome messages

### DIFF
--- a/.github/pr-welcome-community.md
+++ b/.github/pr-welcome-community.md
@@ -19,6 +19,8 @@ As needed or by request, Airbyte Maintainers can execute the following slash com
 - `/build-connector-images` - Builds and publishes a pre-release docker image for the modified connector(s).
 - `/publish-connectors-prerelease` - Publishes pre-release connector builds (tagged as `{version}-preview.{git-sha}`) for all modified connectors in the PR.
 - `/ai-review` - AI-powered PR review for connector safety and quality gates.
+- `/ai-docs-review` - AI-powered documentation review for PRs with connector changes.
+- `/ai-create-docs-pr` - Creates a documentation PR for connector changes.
 - `/force-merge reason="<A_GOOD_REASON>"` - Force merges the PR using admin privileges, bypassing CI checks. Requires a reason.
 
 ### Tips for Working with CI

--- a/.github/pr-welcome-internal.md
+++ b/.github/pr-welcome-internal.md
@@ -16,6 +16,9 @@ Airbyte Maintainers (that's you!) can execute the following slash commands on yo
   - `/ai-prove-fix` - Runs prerelease readiness checks, including testing against customer connections.
   - `/ai-canary-prerelease` - Rolls out prerelease to 5-10 connections for canary testing.
   - `/ai-review` - AI-powered PR review for connector safety and quality gates.
+- 📝 AI Documentation:
+  - `/ai-docs-review` - AI-powered documentation review for PRs with connector changes.
+  - `/ai-create-docs-pr` - Creates a documentation PR for connector changes, stacked on the current PR.
 - 🚀 Connector Releases:
   - `/publish-connectors-prerelease` - Publishes pre-release connector builds (tagged as `{version}-preview.{git-sha}`) for all modified connectors in the PR.
   - `/bump-progressive-rollout-version` - Bumps connector version with an RC suffix (`2.16.10-rc.1`) for progressive rollouts (`enableProgressiveRollout: true`).


### PR DESCRIPTION
## What

Adds the `/ai-docs-review` and `/ai-create-docs-pr` slash commands to both the internal and community PR welcome messages. These commands already exist in the [slash command dispatcher](https://github.com/airbytehq/airbyte/blob/master/.github/workflows/slash-commands.yml) and have corresponding workflows, but were not listed in the welcome messages shown to PR authors.

## How

Added entries for the two documentation slash commands to:
- `.github/pr-welcome-internal.md` — grouped under a new "📝 AI Documentation" category
- `.github/pr-welcome-community.md` — added inline with other AI commands

## Review guide
1. `.github/pr-welcome-internal.md` — new "AI Documentation" section with both commands
2. `.github/pr-welcome-community.md` — two new lines added alongside existing AI commands

## User Impact

PR authors (both internal and community) will now see the documentation slash commands listed in the welcome message when they open a PR, improving discoverability of these tools.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Link to Devin session: https://app.devin.ai/sessions/e48cbe9703b94b5bb4c002dd76b8ee82
Requested by: @ian-at-airbyte
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/74368" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
