### PR TITLE
docs(source-facebook-pages): improve documentation accuracy and completeness

### DIFF
--- a/docs/integrations/sources/facebook-pages.md
+++ b/docs/integrations/sources/facebook-pages.md
@@ -1,67 +1,55 @@
 # Facebook Pages
 
-This page contains the setup guide and reference information for the Facebook Pages source connector.
+This page contains the setup guide and reference information for the [Facebook Pages](https://www.facebook.com/business/pages) source connector.
+
+This connector uses [version 24.0](https://developers.facebook.com/docs/graph-api/changelog/version24.0) of the Facebook Graph API.
 
 ## Prerequisites
 
-To set up the Facebook Pages source connector with Airbyte, you'll need to create your Facebook Application and use both long-lived Page access token and Facebook Page ID.
-
-:::note
-The Facebook Pages source connector is currently only compatible with v24 of the Facebook Graph API.
-:::
+- A [Facebook Developer Account](https://developers.facebook.com/async/registration/)
+- A [Facebook App](https://developers.facebook.com/apps/)
+- A Facebook Page you manage
+- A long-lived Page access token with the following permissions:
+  - `pages_read_engagement`
+  - `pages_read_user_content`
+  - `pages_show_list`
+  - `read_insights`
 
 ## Setup guide
 
-### Step 1: Set up Facebook Pages
+### Generate a long-lived Page access token
 
-1. Create a Facebook Developer Account. Follow [these instructions](https://developers.facebook.com/async/registration/) to create one.
-2. Create a [Facebook App](https://developers.facebook.com/apps/). Choose "Company" as the purpose of the app. Fill out the remaining fields to create your app, then follow along the "Connect a User Page" section.
-3. Connect a User [Page](https://developers.facebook.com/tools/explorer/) using the Graph API Explorer. Choose your app in the `Meta App` field. Choose your Page in the `User or Page` field. Add the following permissions:
-   - pages_read_engagement
-   - pages_read_user_content
-   - pages_show_list
-   - read_insights
-4. Click Generate Access Token and follow instructions.
+1. Go to the [Graph API Explorer](https://developers.facebook.com/tools/explorer/).
+2. Select your app in the **Meta App** field.
+3. Select your Page in the **User or Page** field.
+4. Under **Permissions**, add the following:
+   - `pages_read_engagement`
+   - `pages_read_user_content`
+   - `pages_show_list`
+   - `read_insights`
+5. Click **Generate Access Token** and follow the prompts to authorize.
+6. [Exchange the short-lived token for a long-lived User access token](https://developers.facebook.com/docs/facebook-login/guides/access-tokens/get-long-lived#get-a-long-lived-user-access-token).
+7. [Exchange the long-lived User access token for a long-lived Page token](https://developers.facebook.com/docs/facebook-login/guides/access-tokens/get-long-lived#long-lived-page-token). Long-lived Page tokens do not expire.
 
-After all the steps, it should look something like this:
+### Set up the connector in Airbyte
 
-![](/.gitbook/assets/facebook-pages-1.png)
+1. Select **Facebook Pages** as your source type.
+2. Enter your **Page Access Token** (the long-lived Page token from the previous section).
+3. Enter your **Page ID**. If your Page URL is `https://www.facebook.com/MyPageName`, the Page ID is `MyPageName`. You can also find your numeric Page ID in your Page's **About** section.
+4. (Optional) Set **Page Size** to control the number of records per API request for the `post` and `post_insights` streams. The default is 100. Reduce this value if you encounter "Please reduce the amount of data you're asking for" errors.
 
-5. [Generate](https://developers.facebook.com/docs/facebook-login/guides/access-tokens/get-long-lived#get-a-long-lived-user-access-token) Long-Lived User Access Token.
-6. [Generate](https://developers.facebook.com/docs/facebook-login/guides/access-tokens/get-long-lived#long-lived-page-token) Long-Lived Page Token.
+### Using your own OAuth app
 
-### Step 2: Set up the Facebook Pages connector in Airbyte
+If you prefer to use your own OAuth app instead of Airbyte's, follow the [Meta documentation to create an app](https://developers.facebook.com/docs/development/create-an-app/).
 
-### For Airbyte Cloud:
-
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
-2. In the left navigation bar, click **Sources**. In the top-right corner, click **+ New source**.
-3. On the Set up the source page, enter the name for the Facebook Pages connector and select **Facebook Pages** from the Source type dropdown.
-4. Fill in Page Access Token with Long-Lived Page Token
-5. Fill in Page ID (if you have a page URL such as `https://www.facebook.com/Test-1111111111`, the ID would be `Test-1111111111`)
-6. (Optional) Set **Page Size** to control the number of records per page for the `post` and `post_insights` streams. The default is 100. Decrease this value if you encounter "Please reduce the amount of data you're asking for" errors.
-
-### For Airbyte OSS
-
-1. Navigate to the Airbyte Open Source dashboard.
-2. Set the name for your source.
-3. On the Set up the source page, enter the name for the Facebook Pages connector and select **Facebook Pages** from the Source type dropdown.
-4. Fill in Page Access Token with Long-Lived Page Token
-5. Fill in Page ID (if you have a page URL such as `https://www.facebook.com/Test-1111111111`, the ID would be `Test-1111111111`)
-6. (Optional) Set **Page Size** to control the number of records per page for the `post` and `post_insights` streams. The default is 100. Decrease this value if you encounter "Please reduce the amount of data you're asking for" errors.
-
-### Creating your own OAuth App
-
-Follow this [Facebook documentation](https://developers.facebook.com/docs/development/create-an-app/) to create an OAuth App.
-
-Required permissions for your OAuth App to sync data using the Facebook Pages source connector:
+Your app needs the following permissions:
 
 - `pages_read_engagement`
 - `pages_read_user_content`
 - `pages_show_list`
 - `read_insights`
 
-If you encounter permission errors for specific Page fields, see [Meta's Permissions Reference](https://developers.facebook.com/docs/permissions) for additional permissions you might need. As a rule it's best to request the lowest number of permissions you can to function normally.
+If you encounter permission errors for specific Page fields, see [Meta's Permissions Reference](https://developers.facebook.com/docs/permissions) for additional permissions.
 
 ## Supported sync modes
 
@@ -70,40 +58,43 @@ The Facebook Pages source connector supports the following [sync modes](https://
 - [Full Refresh - Overwrite](https://docs.airbyte.com/understanding-airbyte/connections/full-refresh-overwrite/)
 - [Full Refresh - Append](https://docs.airbyte.com/understanding-airbyte/connections/full-refresh-append)
 
-## Supported Streams
+## Supported streams
 
-- [Page](https://developers.facebook.com/docs/graph-api/reference/v24.0/page/#overview)
-- [Post](https://developers.facebook.com/docs/graph-api/reference/v24.0/page/feed)
-- [Page Insights](https://developers.facebook.com/docs/graph-api/reference/v24.0/page/insights)
-- [Post Insights](https://developers.facebook.com/docs/graph-api/reference/v24.0/insights)
+- [Page](https://developers.facebook.com/docs/graph-api/reference/v24.0/page/#overview) - Metadata and properties for the Facebook Page.
+- [Post](https://developers.facebook.com/docs/graph-api/reference/v24.0/page/feed) - Posts from the Page's feed, including status updates, links, photos, and videos.
+- [Page Insights](https://developers.facebook.com/docs/graph-api/reference/v24.0/page/insights) - Aggregated metrics for the Page, such as total actions, post engagements, and fan growth.
+- [Post Insights](https://developers.facebook.com/docs/graph-api/reference/v24.0/insights) - Per-post metrics, such as media views, clicks, and reactions.
 
-## Limitations & Troubleshooting
+## Limitations and troubleshooting
+
+### Page Insights requires 100 or more page likes
+
+The Facebook Graph API only returns Page Insights data for Pages with 100 or more likes. If your Page has fewer than 100 likes, the `page_insights` stream returns no data.
+
+### Insights data retention
+
+The Facebook Graph API retains insights data for up to two years. Data older than two years is not available. When querying by date range, only 90 days of insights data can be retrieved per request.
+
+### Upcoming metric deprecations
+
+Meta periodically deprecates Page Insights and Post Insights metrics. See [Meta's deprecated metrics page](https://developers.facebook.com/docs/platforminsights/page/deprecated-metrics/) for the full list. If deprecated metrics affect streams this connector syncs, those metrics return errors from the API.
 
 ### "Please reduce the amount of data you're asking for" error
 
-This error occurs when the Facebook Graph API considers the total response data too large. There are two ways to resolve it:
+This error occurs when the Facebook Graph API considers the response data too large. To resolve it:
 
-- **Remove fields from the request via the Schema Tab.** Go to your connection's Schema Tab and deselect fields you don't need for the affected stream. This reduces the number of fields included in API requests. Supported streams: `page`, `post`.
-- **Reduce page size.** Set the **Page Size** configuration parameter to a lower value (e.g., 25 or 50). This reduces the number of records fetched per API request. Supported streams: `post`, `post_insights`.
+- **Remove fields from the request.** Go to your connection's **Schema** tab and deselect fields you don't need for the affected stream. This reduces the number of fields included in API requests. Applies to the `page` and `post` streams.
+- **Reduce page size.** Set the **Page Size** configuration parameter to a lower value, such as 25 or 50. This reduces the number of records fetched per API request. Applies to the `post` and `post_insights` streams.
 
 ### Product catalogs field not available
 
-Starting from version 2.0.4, the `product_catalogs` field is no longer synced in the Page stream and will always be `null`. This is because the Facebook Graph API only returns product catalogs that are owned directly by the Page, not catalogs owned by a Business. Since most product catalogs are now created as Business-owned catalogs (Page-owned catalogs are a legacy feature), and this connector uses Page access tokens, the `product_catalogs` field would not return meaningful data for most users.
+Starting from version 2.0.4, the `product_catalogs` field is no longer synced in the Page stream and always returns `null`. The Facebook Graph API only returns product catalogs owned directly by the Page, not catalogs owned by a Business. Because most product catalogs are now Business-owned (Page-owned catalogs are a legacy feature), this field does not return meaningful data for most users.
 
-## Data type map
+### Rate limiting
 
-| Integration Type | Airbyte Type | Notes |
-| :--------------- | :----------- | :---- |
-| `string`         | `string`     |       |
-| `number`         | `number`     |       |
-| `array`          | `array`      |       |
-| `object`         | `object`     |       |
+Facebook rate limits Page API requests to 4,800 calls per authenticated user per 24 hours. Short-lived tokens generated from Facebook Apps are throttled more aggressively, making them impractical for use with Airbyte. Use a long-lived Page token as described in the [setup guide](#generate-a-long-lived-page-access-token) to avoid excessive rate limiting.
 
-## Performance considerations
-
-Facebook heavily throttles API tokens generated from Facebook Apps by default, making it infeasible to use such a token for syncs with Airbyte. To be able to use this connector without your syncs taking days due to rate limiting, follow the instructions in the Setup Guide above to generate a Long-Lived Page Token.
-
-See Facebook's [documentation on rate limiting](https://developers.facebook.com/docs/graph-api/overview/rate-limiting) for more information on requesting a quota upgrade.
+For more information, see Facebook's [rate limiting documentation](https://developers.facebook.com/docs/graph-api/overview/rate-limiting).
 
 ## Changelog
 
@@ -112,7 +103,7 @@ See Facebook's [documentation on rate limiting](https://developers.facebook.com/
 
 | Version | Date       | Pull Request                                                   | Subject                                                                                                                                                                |
 |:--------|:-----------|:---------------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 2.1.0 | 2026-02-09 | [72949](https://github.com/airbytehq/airbyte/pull/72949) | Use QueryProperties with JsonSchemaPropertySelector to limit API field requests to user-selected fields; add configurable page_size for post and post_insights streams |
+| 2.1.0   | 2026-03-02 | [72949](https://github.com/airbytehq/airbyte/pull/72949)  | Use QueryProperties with JsonSchemaPropertySelector to limit API field requests to user-selected fields; add configurable page_size for post and post_insights streams |
 | 2.0.4 | 2026-01-29 | [72253](https://github.com/airbytehq/airbyte/pull/72253) | Remove product_catalogs from fields request parameter |
 | 2.0.3 | 2025-12-01 | [70248](https://github.com/airbytehq/airbyte/pull/70248) | Use correct pagination parameter name (`limit` instead of `page_size`) |
 | 2.0.2 | 2025-12-01 | [70258](https://github.com/airbytehq/airbyte/pull/70258) | Use Post stream for check, handle 400 error in Page stream |
@@ -124,7 +115,7 @@ See Facebook's [documentation on rate limiting](https://developers.facebook.com/
 | 1.1.1 | 2025-05-03 | [53787](https://github.com/airbytehq/airbyte/pull/53787) | Update dependencies |
 | 1.1.0 | 2025-04-30 | [59126](https://github.com/airbytehq/airbyte/pull/59126) | Re-enable in cloud and update versions |
 | 1.0.32 | 2025-02-01 | [52793](https://github.com/airbytehq/airbyte/pull/52793) | Update dependencies |
-| 1.0.31  | 2025-01-27 | [52122](https://github.com/airbytehq/airbyte/pull/52122/files) | Upgrade Facebook API to v21.0                                                                                                                                          |
+| 1.0.31  | 2025-01-27 | [52122](https://github.com/airbytehq/airbyte/pull/52122)       | Upgrade Facebook API to v21.0                                                                                                                                          |
 | 1.0.30  | 2025-01-25 | [52373](https://github.com/airbytehq/airbyte/pull/52373)       | Update dependencies                                                                                                                                                    |
 | 1.0.29  | 2025-01-18 | [51637](https://github.com/airbytehq/airbyte/pull/51637)       | Update dependencies                                                                                                                                                    |
 | 1.0.28  | 2025-01-11 | [51056](https://github.com/airbytehq/airbyte/pull/51056)       | Update dependencies                                                                                                                                                    |
@@ -162,12 +153,12 @@ See Facebook's [documentation on rate limiting](https://developers.facebook.com/
 | 0.2.3   | 2023-02-23 | [23395](https://github.com/airbytehq/airbyte/pull/23395)       | Parse datetime to rfc3339                                                                                                                                              |
 | 0.2.2   | 2023-02-10 | [22804](https://github.com/airbytehq/airbyte/pull/22804)       | Retry 500 errors                                                                                                                                                       |
 | 0.2.1   | 2022-12-29 | [20925](https://github.com/airbytehq/airbyte/pull/20925)       | Fix tests; modify expected records                                                                                                                                     |
-| 0.2.0   | 2022-11-24 | [19788](https://github.com/airbytehq/airbyte/pull/19788)       | Migrate lo low-code; Beta certification; Upgrade Facebook API to v.15                                                                                                  |
+| 0.2.0   | 2022-11-24 | [19788](https://github.com/airbytehq/airbyte/pull/19788)       | Migrate to low-code; Beta certification; Upgrade Facebook API to v15                                                                                                   |
 | 0.1.6   | 2021-12-22 | [9032](https://github.com/airbytehq/airbyte/pull/9032)         | Remove deprecated field `live_encoders` from Page stream                                                                                                               |
-| 0.1.5   | 2021-11-26 | [8267](https://github.com/airbytehq/airbyte/pull/8267)         | updated all empty objects in schemas for Page and Post streams                                                                                                         |
+| 0.1.5   | 2021-11-26 | [8267](https://github.com/airbytehq/airbyte/pull/8267)         | Update all empty objects in schemas for Page and Post streams                                                                                                          |
 | 0.1.4   | 2021-11-26 | [](https://github.com/airbytehq/airbyte/pull/)                 | Remove unsupported insights_export field from Pages request                                                                                                            |
 | 0.1.3   | 2021-10-28 | [7440](https://github.com/airbytehq/airbyte/pull/7440)         | Generate Page token from config access token                                                                                                                           |
-| 0.1.2   | 2021-10-18 | [7128](https://github.com/airbytehq/airbyte/pull/7128)         | Upgrade Facebook API to v.12                                                                                                                                           |
+| 0.1.2   | 2021-10-18 | [7128](https://github.com/airbytehq/airbyte/pull/7128)         | Upgrade Facebook API to v12                                                                                                                                            |
 | 0.1.1   | 2021-09-30 | [6438](https://github.com/airbytehq/airbyte/pull/6438)         | Annotate Oauth2 flow initialization parameters in connector specification                                                                                              |
 | 0.1.0   | 2021-09-01 | [5158](https://github.com/airbytehq/airbyte/pull/5158)         | Initial Release                                                                                                                                                        |
 


### PR DESCRIPTION
## Documentation Confidence Assessment

**Overall Confidence: 3/5** *capped: zero-score dimension (Triggering Context)*

| Dimension | Score | Rationale |
|-----------|-------|-----------|
| Code Comprehension | 4/5 | Low-code connector with custom Python components; manifest.yaml is declarative and behavior is verifiable from source. |
| API Documentation Quality | 4/5 | Comprehensive Facebook Graph API docs with auth guides, rate limits, and changelogs; 4 external doc URLs in metadata. |
| Change Scope & Risk | 3/5 | 133 lines changed (62 added, 71 removed); new troubleshooting sections, stream descriptions, and structural reorganization. |
| Existing Doc Maturity | 3/5 | 163-line doc with basic setup and stream coverage but missing troubleshooting depth and stream descriptions. |
| Connector Sensitivity | 4/5 | Community connector with moderate usage (ql=300, sl=100). |
| Triggering Context | 0/5 | Triggered standalone via Slack command with no specific PR or issue context. |

### What I Verified vs. What I Inferred

- **Verified from code**: API version v24.0, four streams (Page, Post, Page Insights, Post Insights), required permissions (pages_read_engagement, pages_read_user_content, pages_show_list, read_insights), QueryProperties + JsonSchemaPropertySelector for field filtering, configurable page_size for post and post_insights streams, product_catalogs field removal in v2.0.4
- **Verified from API docs**: Rate limit of 4,800 calls per 24h per authenticated user, long-lived Page tokens do not expire, Page Insights requires 100+ likes, insights data retained for 2 years with 90-day query windows, deprecated metrics page URL
- **Inferred**: The exact impact of upcoming metric deprecations on this connector's specific streams (documented as a general warning with link to Meta's page)

### Areas of Concern

- The deprecated metrics URL (https://developers.facebook.com/docs/platforminsights/page/deprecated-metrics/) should be verified as current and accessible.
- The 4,800 calls/24h rate limit is documented for Page-level rate limiting; different rate limit tiers may apply depending on app review status.

---

## What

Improves the Facebook Pages source connector documentation by fixing inaccuracies, filling documentation gaps, removing outdated content, and restructuring for clarity.

## How

**Corrections (Priority 1):**
- Fixed v2.1.0 changelog date from 2026-02-09 to 2026-03-02 (actual merge date of PR [72949](https://github.com/airbytehq/airbyte/pull/72949))
- Fixed broken changelog link for v1.0.31 (had `/files` suffix in URL)
- Fixed changelog typos: "Migrate lo low-code" → "Migrate to low-code", "v.15" → "v15", "v.12" → "v12"

**Additions (Priority 2):**
- Added "Page Insights requires 100 or more page likes" limitation
- Added "Insights data retention" section (2-year limit, 90-day query window)
- Added "Upcoming metric deprecations" section with link to Meta's deprecated metrics page
- Added descriptions to each supported stream explaining what data they contain
- Added explicit rate limiting details (4,800 calls/user/24h) with explanation of why long-lived tokens matter

**Removals (Priority 3):**
- Removed "Data type map" section (trivial 1:1 type mapping that added no value)
- Removed duplicate Cloud/OSS setup tabs, consolidated into single unified section
- Removed legacy `.gitbook` screenshot reference

**Restructuring:**
- Moved rate limiting from separate "Performance considerations" section into "Limitations and troubleshooting"
- Restructured prerequisites as scannable bullet list
- Normalized heading case to sentence case

## Review Guide

- Verify the three new limitation subsections (100-like minimum, 2-year retention, metric deprecations) against current Facebook API behavior
- Confirm v2.1.0 changelog date correction matches the merge date of PR [72949](https://github.com/airbytehq/airbyte/pull/72949)
- Verify the deprecated metrics URL is valid and current
- Confirm removal of the Data type map section is acceptable

---

> **Note**: I am an AI assistant (Devin) and have proposed these documentation updates based on a review of the connector source code and third-party API documentation. Reviewers may merge, modify, or close this PR as they see fit.

---
[Devin session](https://app.devin.ai/sessions/954b2353f3dc4f08a824932672d2ca26)
Requested by: @ian-at-airbyte