### PR TITLE
feat: add session reuse to all AI slash command workflows

### DIFF
--- a/.github/workflows/ai-canary-prerelease-command.yml
+++ b/.github/workflows/ai-canary-prerelease-command.yml
@@ -67,7 +67,7 @@ jobs:
           playbook-macro: "!canary_prerelease"
           devin-token: ${{ secrets.DEVIN_AI_API_KEY }}
           github-token: ${{ steps.get-app-token.outputs.token }}
-          reuse-slash-command-session: 'true'
+          reuse-slash-command-session: "true"
           start-message: "🐤 **AI Canary Prerelease session starting...** Rolling out to 5-10 connections, watching results, and reporting findings. [View playbook](https://github.com/airbytehq/oncall/blob/main/prompts/playbooks/canary_prerelease.md)"
           tags: |
             ai-oncall

--- a/.github/workflows/ai-canary-prerelease-command.yml
+++ b/.github/workflows/ai-canary-prerelease-command.yml
@@ -67,7 +67,7 @@ jobs:
           playbook-macro: "!canary_prerelease"
           devin-token: ${{ secrets.DEVIN_AI_API_KEY }}
           github-token: ${{ steps.get-app-token.outputs.token }}
-          reuse-devin-session: same-slash-command
+          reuse-slash-command-session: 'true'
           start-message: "🐤 **AI Canary Prerelease session starting...** Rolling out to 5-10 connections, watching results, and reporting findings. [View playbook](https://github.com/airbytehq/oncall/blob/main/prompts/playbooks/canary_prerelease.md)"
           tags: |
             ai-oncall

--- a/.github/workflows/ai-canary-prerelease-command.yml
+++ b/.github/workflows/ai-canary-prerelease-command.yml
@@ -67,6 +67,7 @@ jobs:
           playbook-macro: "!canary_prerelease"
           devin-token: ${{ secrets.DEVIN_AI_API_KEY }}
           github-token: ${{ steps.get-app-token.outputs.token }}
+          reuse-devin-session: same-slash-command
           start-message: "🐤 **AI Canary Prerelease session starting...** Rolling out to 5-10 connections, watching results, and reporting findings. [View playbook](https://github.com/airbytehq/oncall/blob/main/prompts/playbooks/canary_prerelease.md)"
           tags: |
             ai-oncall

--- a/.github/workflows/ai-create-docs-pr-command.yml
+++ b/.github/workflows/ai-create-docs-pr-command.yml
@@ -143,6 +143,7 @@ jobs:
           playbook-macro: "!connectordocs"
           devin-token: ${{ secrets.DEVIN_AI_API_KEY }}
           github-token: ${{ steps.get-app-token.outputs.token }}
+          reuse-devin-session: same-slash-command
           start-message: ${{ steps.context.outputs.start-message }}
           extra-context: ${{ steps.context.outputs.extra-context }}
           tags: |

--- a/.github/workflows/ai-create-docs-pr-command.yml
+++ b/.github/workflows/ai-create-docs-pr-command.yml
@@ -143,7 +143,7 @@ jobs:
           playbook-macro: "!connectordocs"
           devin-token: ${{ secrets.DEVIN_AI_API_KEY }}
           github-token: ${{ steps.get-app-token.outputs.token }}
-          reuse-devin-session: same-slash-command
+          reuse-slash-command-session: 'true'
           start-message: ${{ steps.context.outputs.start-message }}
           extra-context: ${{ steps.context.outputs.extra-context }}
           tags: |

--- a/.github/workflows/ai-create-docs-pr-command.yml
+++ b/.github/workflows/ai-create-docs-pr-command.yml
@@ -143,7 +143,7 @@ jobs:
           playbook-macro: "!connectordocs"
           devin-token: ${{ secrets.DEVIN_AI_API_KEY }}
           github-token: ${{ steps.get-app-token.outputs.token }}
-          reuse-slash-command-session: 'true'
+          reuse-slash-command-session: "true"
           start-message: ${{ steps.context.outputs.start-message }}
           extra-context: ${{ steps.context.outputs.extra-context }}
           tags: |

--- a/.github/workflows/ai-docs-review-command.yml
+++ b/.github/workflows/ai-docs-review-command.yml
@@ -184,7 +184,7 @@ jobs:
           github-token: ${{ steps.get-app-token.outputs.token }}
           playbook-macro: "!connectordocs_pr_review"
           prompt-text: "The pull request to review is ${{ inputs.pr }}."
-          reuse-devin-session: same-slash-command
+          reuse-slash-command-session: 'true'
           start-message: "AI Docs Review session starting... Analyzing connector changes and preparing documentation recommendations."
           tags: |
             area/documentation

--- a/.github/workflows/ai-docs-review-command.yml
+++ b/.github/workflows/ai-docs-review-command.yml
@@ -176,7 +176,7 @@ jobs:
 
       - name: Start AI documentation recommendation session
         if: steps.validate.outputs.valid == 'true' && steps.pr-files.outputs.has_connector_changes == 'true'
-        uses: aaronsteers/devin-action@0d74d6d9ff1b16ada5966dc31af53a9d155759f4 # Pinned to specific commit for security
+        uses: aaronsteers/devin-action@main
         with:
           comment-id: ${{ inputs.comment-id }}
           issue-number: ${{ inputs.pr }}
@@ -184,6 +184,7 @@ jobs:
           github-token: ${{ steps.get-app-token.outputs.token }}
           playbook-macro: "!connectordocs_pr_review"
           prompt-text: "The pull request to review is ${{ inputs.pr }}."
+          reuse-devin-session: same-slash-command
           start-message: "AI Docs Review session starting... Analyzing connector changes and preparing documentation recommendations."
           tags: |
             area/documentation

--- a/.github/workflows/ai-docs-review-command.yml
+++ b/.github/workflows/ai-docs-review-command.yml
@@ -184,7 +184,7 @@ jobs:
           github-token: ${{ steps.get-app-token.outputs.token }}
           playbook-macro: "!connectordocs_pr_review"
           prompt-text: "The pull request to review is ${{ inputs.pr }}."
-          reuse-slash-command-session: 'true'
+          reuse-slash-command-session: "true"
           start-message: "AI Docs Review session starting... Analyzing connector changes and preparing documentation recommendations."
           tags: |
             area/documentation

--- a/.github/workflows/ai-prove-fix-command.yml
+++ b/.github/workflows/ai-prove-fix-command.yml
@@ -67,7 +67,7 @@ jobs:
           playbook-macro: "!prove_fix"
           devin-token: ${{ secrets.DEVIN_AI_API_KEY }}
           github-token: ${{ steps.get-app-token.outputs.token }}
-          reuse-devin-session: same-slash-command
+          reuse-slash-command-session: 'true'
           start-message: "🔍 **AI Prove Fix session starting...** Running readiness checks and testing against customer connections. [View playbook](https://github.com/airbytehq/oncall/blob/main/prompts/playbooks/prove_fix.md)"
           tags: |
             ai-oncall

--- a/.github/workflows/ai-prove-fix-command.yml
+++ b/.github/workflows/ai-prove-fix-command.yml
@@ -67,7 +67,7 @@ jobs:
           playbook-macro: "!prove_fix"
           devin-token: ${{ secrets.DEVIN_AI_API_KEY }}
           github-token: ${{ steps.get-app-token.outputs.token }}
-          reuse-slash-command-session: 'true'
+          reuse-slash-command-session: "true"
           start-message: "🔍 **AI Prove Fix session starting...** Running readiness checks and testing against customer connections. [View playbook](https://github.com/airbytehq/oncall/blob/main/prompts/playbooks/prove_fix.md)"
           tags: |
             ai-oncall

--- a/.github/workflows/ai-prove-fix-command.yml
+++ b/.github/workflows/ai-prove-fix-command.yml
@@ -67,6 +67,7 @@ jobs:
           playbook-macro: "!prove_fix"
           devin-token: ${{ secrets.DEVIN_AI_API_KEY }}
           github-token: ${{ steps.get-app-token.outputs.token }}
+          reuse-devin-session: same-slash-command
           start-message: "🔍 **AI Prove Fix session starting...** Running readiness checks and testing against customer connections. [View playbook](https://github.com/airbytehq/oncall/blob/main/prompts/playbooks/prove_fix.md)"
           tags: |
             ai-oncall

--- a/.github/workflows/ai-release-watch-command.yml
+++ b/.github/workflows/ai-release-watch-command.yml
@@ -67,7 +67,7 @@ jobs:
           playbook-macro: "!release_watch"
           devin-token: ${{ secrets.DEVIN_AI_API_KEY }}
           github-token: ${{ steps.get-app-token.outputs.token }}
-          reuse-slash-command-session: 'true'
+          reuse-slash-command-session: "true"
           start-message: "👁️ **AI Release Watch session starting...** Monitoring rollout and tracking sync success rates. [View playbook](https://github.com/airbytehq/oncall/blob/main/prompts/playbooks/release_watch.md)"
           tags: |
             ai-oncall

--- a/.github/workflows/ai-release-watch-command.yml
+++ b/.github/workflows/ai-release-watch-command.yml
@@ -67,7 +67,7 @@ jobs:
           playbook-macro: "!release_watch"
           devin-token: ${{ secrets.DEVIN_AI_API_KEY }}
           github-token: ${{ steps.get-app-token.outputs.token }}
-          reuse-devin-session: same-slash-command
+          reuse-slash-command-session: 'true'
           start-message: "👁️ **AI Release Watch session starting...** Monitoring rollout and tracking sync success rates. [View playbook](https://github.com/airbytehq/oncall/blob/main/prompts/playbooks/release_watch.md)"
           tags: |
             ai-oncall

--- a/.github/workflows/ai-release-watch-command.yml
+++ b/.github/workflows/ai-release-watch-command.yml
@@ -67,6 +67,7 @@ jobs:
           playbook-macro: "!release_watch"
           devin-token: ${{ secrets.DEVIN_AI_API_KEY }}
           github-token: ${{ steps.get-app-token.outputs.token }}
+          reuse-devin-session: same-slash-command
           start-message: "👁️ **AI Release Watch session starting...** Monitoring rollout and tracking sync success rates. [View playbook](https://github.com/airbytehq/oncall/blob/main/prompts/playbooks/release_watch.md)"
           tags: |
             ai-oncall

--- a/.github/workflows/ai-review-command.yml
+++ b/.github/workflows/ai-review-command.yml
@@ -97,6 +97,7 @@ jobs:
           playbook-macro: "!pr_ai_review"
           devin-token: ${{ secrets.DEVIN_AI_API_KEY }}
           github-token: ${{ steps.get-app-token.outputs.token }}
+          reuse-devin-session: same-slash-command
           start-message: |
             **AI PR Review** starting...
 

--- a/.github/workflows/ai-review-command.yml
+++ b/.github/workflows/ai-review-command.yml
@@ -97,7 +97,7 @@ jobs:
           playbook-macro: "!pr_ai_review"
           devin-token: ${{ secrets.DEVIN_AI_API_KEY }}
           github-token: ${{ steps.get-app-token.outputs.token }}
-          reuse-slash-command-session: 'true'
+          reuse-slash-command-session: "true"
           start-message: |
             **AI PR Review** starting...
 

--- a/.github/workflows/ai-review-command.yml
+++ b/.github/workflows/ai-review-command.yml
@@ -97,7 +97,7 @@ jobs:
           playbook-macro: "!pr_ai_review"
           devin-token: ${{ secrets.DEVIN_AI_API_KEY }}
           github-token: ${{ steps.get-app-token.outputs.token }}
-          reuse-devin-session: same-slash-command
+          reuse-slash-command-session: 'true'
           start-message: |
             **AI PR Review** starting...
 


### PR DESCRIPTION
## What

Enables session deduplication for all AI slash command workflows. When the same slash command (e.g. `/ai-prove-fix`) is re-triggered on the same PR/issue, the existing Devin session is reused instead of creating a new one.

Companion PRs:
- **Upstream (must merge first):** [aaronsteers/devin-action#40](https://github.com/aaronsteers/devin-action/pull/40) — adds the `reuse-slash-command-session` and `reuse-initial-devin-session` boolean inputs to the action
- **Oncall repo:** [airbytehq/oncall#11558](https://github.com/airbytehq/oncall/pull/11558) (same change for oncall workflows)
- Relates to [airbytehq/airbyte-ops-mcp#461](https://github.com/airbytehq/airbyte-ops-mcp/issues/461)

## How

Adds `reuse-slash-command-session: "true"` to every `devin-action` invocation across 6 workflow files. The upstream action handles all the logic:
1. Extracts the slash command from the triggering comment (first word)
2. Searches previous comments on the same issue/PR for one starting with the same command
3. If a prior Devin session URL is found → injects a message into that session
4. If not found → creates a new session (first invocation)
5. If injection fails → hard fail (no fallback)

The upstream action exposes two independent boolean inputs (`reuse-slash-command-session` and `reuse-initial-devin-session`) that can be combined, with initial-session checked first. This PR only sets `reuse-slash-command-session: "true"`.

## Review guide

1. **`ai-docs-review-command.yml`** — Most notable change: also moves from a pinned commit (`@0d74d6d9...`) to `@main`. The original pinning comment said "Pinned to specific commit for security." This is necessary because the pinned commit doesn't have the new input, but the security tradeoff should be acknowledged.
2. All other workflow files — single-line addition of `reuse-slash-command-session: "true"`, no other changes.

**Key review items:**
- [ ] Confirm [devin-action#40](https://github.com/aaronsteers/devin-action/pull/40) is merged before merging this PR (otherwise the input won't exist and will be silently ignored by GitHub Actions)
- [ ] Verify the unpinning of `ai-docs-review-command.yml` from a specific commit to `@main` is acceptable from a security standpoint
- [ ] Confirm all 6 AI command workflows in this repo are covered (canary-prerelease, create-docs-pr, docs-review, prove-fix, release-watch, review)

## User Impact

When a user re-runs the same slash command on a PR/issue (e.g. types `/ai-prove-fix` a second time), the message is sent to the already-running Devin session instead of spinning up a new one. This reduces session sprawl and keeps context in one place.

No change in behavior for first-time invocations.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Reverting removes the `reuse-slash-command-session` input, which causes the action to fall back to its default behavior (`"false"`) — always creating new sessions. No data loss or side effects.

---

Link to Devin session: https://app.devin.ai/sessions/03d66d4a51f5498f8940e053df065539
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/74374" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
