### PR TITLE
ci: replace legacy stale metadata check with ops CLI unpublished connector audit

### DIFF
--- a/.github/workflows/resolve-stale-metadata.yml
+++ b/.github/workflows/resolve-stale-metadata.yml
@@ -40,10 +40,10 @@ jobs:
         shell: bash
         # TODO: GitHub Step Summary output should be handled internally by the ops CLI.
         #   See: https://github.com/airbytehq/airbyte-ops-mcp/issues/473
-        run: |
-          uvx --from airbyte-internal-ops \
-            airbyte-ops local connector list \
-            --repo-path "${{ github.workspace }}" \
-            --unpublished \
-            --store coral:prod \
+        run: >
+          uvx --from airbyte-internal-ops
+            airbyte-ops local connector list
+            --repo-path "${{ github.workspace }}"
+            --unpublished
+            --store coral:prod
             --assert-none

--- a/.github/workflows/resolve-stale-metadata.yml
+++ b/.github/workflows/resolve-stale-metadata.yml
@@ -39,26 +39,12 @@ jobs:
           GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
         shell: bash
         # TK-TODO: Revert to GA version of airbyte-internal-ops before merging. # IGNORE:TK
+        # TODO: GitHub Step Summary output should be handled internally by the ops CLI.
+        #   See: https://github.com/airbytehq/airbyte-ops-mcp/issues/473
         run: |
-          set +e  # Don't exit on error so we can capture the exit code
           uvx --from "airbyte-internal-ops @ git+https://github.com/airbytehq/airbyte-ops-mcp@main" \
             airbyte-ops local connector list \
             --repo-path "${{ github.workspace }}" \
             --unpublished \
             --store coral:prod \
-            --assert-none \
-            2>&1 | tee /tmp/unpublished-report.txt
-          EXIT_CODE=${PIPESTATUS[0]}
-
-          # Write results to GitHub Step Summary for visibility
-          echo '## Unpublished Connector Versions Check' >> $GITHUB_STEP_SUMMARY
-          if [ "$EXIT_CODE" -ne 0 ]; then
-            echo '⚠️ **Unpublished connector versions detected:**' >> $GITHUB_STEP_SUMMARY
-          else
-            echo '✅ All connector versions are published.' >> $GITHUB_STEP_SUMMARY
-          fi
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          cat /tmp/unpublished-report.txt >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-
-          exit $EXIT_CODE
+            --assert-none

--- a/.github/workflows/resolve-stale-metadata.yml
+++ b/.github/workflows/resolve-stale-metadata.yml
@@ -38,8 +38,6 @@ jobs:
         env:
           GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
         shell: bash
-        # TODO: GitHub Step Summary output should be handled internally by the ops CLI.
-        #   See: https://github.com/airbytehq/airbyte-ops-mcp/issues/473
         run: >
           uvx --from airbyte-internal-ops
             airbyte-ops local connector list

--- a/.github/workflows/resolve-stale-metadata.yml
+++ b/.github/workflows/resolve-stale-metadata.yml
@@ -38,11 +38,10 @@ jobs:
         env:
           GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
         shell: bash
-        # TK-TODO: Revert to GA version of airbyte-internal-ops before merging. # IGNORE:TK
         # TODO: GitHub Step Summary output should be handled internally by the ops CLI.
         #   See: https://github.com/airbytehq/airbyte-ops-mcp/issues/473
         run: |
-          uvx --from "airbyte-internal-ops @ git+https://github.com/airbytehq/airbyte-ops-mcp@main" \
+          uvx --from airbyte-internal-ops \
             airbyte-ops local connector list \
             --repo-path "${{ github.workspace }}" \
             --unpublished \

--- a/.github/workflows/resolve-stale-metadata.yml
+++ b/.github/workflows/resolve-stale-metadata.yml
@@ -30,30 +30,35 @@ jobs:
         with:
           ref: ${{ github.event.inputs.gitref || github.ref }}
 
-      - name: Set up Python
-        uses: actions/setup-python@9322b3ca74000aeb2c01eb777b646334015ddd72 # v5.6.0
-        with:
-          python-version: "3.11"
-          check-latest: true
-          update-environment: true
+      - name: Install uv
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
 
-      - name: Install Poetry
-        uses: snok/install-poetry@d526ede1e27960b7b181a5ac53044f552afdaa38 # v1.4.1
-        with:
-          version: latest
-          virtualenvs-create: true
-          virtualenvs-in-project: true
-
-      - name: Install metadata_service
-        working-directory: airbyte-ci/connectors/metadata_service/lib
-        run: poetry install
-
-      - name: Run stale metadata report task
+      - name: Check for unpublished connector versions
+        continue-on-error: true
         env:
           GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
-          SLACK_TOKEN: ${{ secrets.SLACK_BOT_TOKEN_AIRBYTE_TEAM }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        working-directory: airbyte-ci/connectors/metadata_service/lib
         shell: bash
+        # TK-TODO: Revert to GA version of airbyte-internal-ops before merging. # IGNORE:TK
         run: |
-          poetry run metadata_service publish-stale-metadata-report prod-airbyte-cloud-connector-metadata-service
+          set +e  # Don't exit on error so we can capture the exit code
+          uvx --from "airbyte-internal-ops @ git+https://github.com/airbytehq/airbyte-ops-mcp@main" \
+            airbyte-ops local connector list \
+            --repo-path "${{ github.workspace }}" \
+            --unpublished \
+            --store coral:prod \
+            --assert-none \
+            2>&1 | tee /tmp/unpublished-report.txt
+          EXIT_CODE=${PIPESTATUS[0]}
+
+          # Write results to GitHub Step Summary for visibility
+          echo '## Unpublished Connector Versions Check' >> $GITHUB_STEP_SUMMARY
+          if [ "$EXIT_CODE" -ne 0 ]; then
+            echo '⚠️ **Unpublished connector versions detected:**' >> $GITHUB_STEP_SUMMARY
+          else
+            echo '✅ All connector versions are published.' >> $GITHUB_STEP_SUMMARY
+          fi
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          cat /tmp/unpublished-report.txt >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+          exit $EXIT_CODE


### PR DESCRIPTION
## What

Replaces the legacy Poetry-based `metadata_service publish-stale-metadata-report` command in `resolve-stale-metadata.yml` with the new `airbyte-internal-ops` CLI invoked via `uvx`. This is one of several PRs splitting out the migration from legacy `metadata_service`/`airbyte-ci` tooling to the new ops CLI (see [original combined PR #74100](https://github.com/airbytehq/airbyte/pull/74100)).

Related ops CLI PR (merged): [airbytehq/airbyte-ops-mcp#417](https://github.com/airbytehq/airbyte-ops-mcp/pull/417)
Tracking issue for future escalation improvements: [airbytehq/airbyte-ops-mcp#430](https://github.com/airbytehq/airbyte-ops-mcp/issues/430)

## How

- Removes Python 3.11 + Poetry + `metadata_service` package installation (4 steps → 1 `setup-uv` step)
- Replaces `poetry run metadata_service publish-stale-metadata-report` with `uvx --from airbyte-internal-ops airbyte-ops local connector list --unpublished --store coral:prod --assert-none`
- The new command compares each connector's local `dockerImageTag` in `metadata.yaml` against the versioned metadata blob on GCS, and exits non-zero if any are missing
- Uses `continue-on-error: true` so the workflow stays green even when unpublished connectors are found (step shows as orange warning in Actions UI)
- Removes `SLACK_TOKEN` and `GITHUB_TOKEN` env vars (no longer needed)

## Updates since last revision

- **Now uses GA PyPI package**: `uvx --from airbyte-internal-ops` references the published PyPI release.
- **Simplified to single command**: Removed all shell-based GitHub Step Summary logic per reviewer feedback. The step is now just the `uvx` command with `continue-on-error: true`.
- **GitHub Step Summary now supported**: [airbytehq/airbyte-ops-mcp#473](https://github.com/airbytehq/airbyte-ops-mcp/issues/473) has been merged and released — the ops CLI now detects CI and writes to `$GITHUB_STEP_SUMMARY` internally, so this workflow will produce Step Summary output without any additional shell logic.
- **Uses YAML folded scalar (`>`)**: Run block uses `>` instead of `|` with backslash continuations for cleaner formatting.

## Review guide

1. `.github/workflows/resolve-stale-metadata.yml` — the only file changed

**⚠️ Key behavioral changes to verify:**
- **No more Slack alerts**: The old command posted a table to Slack when stale connectors were found. The new command does not notify Slack. ([airbytehq/airbyte-ops-mcp#430](https://github.com/airbytehq/airbyte-ops-mcp/issues/430) tracks re-evaluating escalation strategy.)
- **Exit code change**: Old command always exited 0 (even with stale connectors). New command exits 1 via `--assert-none`, but `continue-on-error: true` prevents workflow failure.
- **No grace period**: The old check tolerated recently-modified connectors. The new `--unpublished` check does not — could produce false positives during active publish runs.

**Human review checklist:**
- [ ] Verify that the published `airbyte-internal-ops` PyPI package includes the `local connector list --unpublished` command with `--store` and `--assert-none` flags
- [ ] Confirm acceptable that Slack notifications are removed (only Actions UI pass/fail + Step Summary for now)
- [ ] Consider whether false positives during active publish runs are tolerable given `continue-on-error: true`

## User Impact

No direct user impact. This workflow runs on a cron schedule (every 2 hours) and is an internal audit tool. The only change visible to maintainers is that stale connector detection now appears as a pass/fail step in the GitHub Actions UI (with Step Summary details) instead of a Slack message.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Link to Devin run: https://app.devin.ai/sessions/f900274cb0884bf99e399b1c40c48067
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---


<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/74384" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._

> [!NOTE]
> **Auto-merge may have been disabled. Please check the PR status to confirm.**