### PR TITLE
ci: fix YAML folded scalar indentation in resolve-stale-metadata workflow

### DIFF
--- a/.github/workflows/resolve-stale-metadata.yml
+++ b/.github/workflows/resolve-stale-metadata.yml
@@ -40,8 +40,8 @@ jobs:
         shell: bash
         run: >
           uvx --from airbyte-internal-ops
-            airbyte-ops local connector list
-            --repo-path "${{ github.workspace }}"
-            --unpublished
-            --store coral:prod
-            --assert-none
+          airbyte-ops local connector list
+          --repo-path "${{ github.workspace }}"
+          --unpublished
+          --store coral:prod
+          --assert-none


### PR DESCRIPTION
## What

Fixes the `resolve-stale-metadata` workflow which fails with `Provide a command to run with 'uvx <command>'` due to incorrect YAML folded scalar indentation introduced in #74384.

Failed run: https://github.com/airbytehq/airbyte/actions/runs/22862161264

## How

YAML folded scalars (`>`) only fold newlines into spaces when continuation lines have the **same or less** indentation as the first content line. The continuation lines (`airbyte-ops local connector list`, `--repo-path`, etc.) had 4 extra spaces of indentation vs the first line (`uvx --from airbyte-internal-ops`), causing YAML to preserve literal newlines. This meant `uvx` only received `--from airbyte-internal-ops` with no subcommand.

Fix: align all continuation lines to the same indentation as the first content line.

## Review guide

1. `.github/workflows/resolve-stale-metadata.yml` — verify lines 42–47 all share the same indentation level (10 spaces: 8 from YAML block context + 2 content)

## User Impact

The stale metadata check (runs every 2 hours on cron) is currently broken on master. This fix restores it.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Requested by: @aaronsteers
[Link to Devin run](https://app.devin.ai/sessions/f900274cb0884bf99e399b1c40c48067)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/74396" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
