### PR TITLE
ci: simplify uvx invocation in resolve-stale-metadata workflow

### DIFF
--- a/.github/workflows/resolve-stale-metadata.yml
+++ b/.github/workflows/resolve-stale-metadata.yml
@@ -39,8 +39,8 @@ jobs:
           GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
         shell: bash
         run: >
-          uvx --from airbyte-internal-ops
-          airbyte-ops local connector list
+          uvx airbyte-internal-ops
+          local connector list
           --repo-path "${{ github.workspace }}"
           --unpublished
           --store coral:prod


### PR DESCRIPTION
## What

Simplifies the `uvx` invocation in `resolve-stale-metadata.yml` by dropping the `--from` flag. The `airbyte-internal-ops` package exposes a same-named CLI entry point, so `uvx airbyte-internal-ops <subcommand>` works directly without `--from`.

## How

- `uvx --from airbyte-internal-ops` → `uvx airbyte-internal-ops`
- `airbyte-ops local connector list` → `local connector list` (the CLI is already invoked by `uvx`, so the redundant command prefix is removed)

The resulting folded command is:
```
uvx airbyte-internal-ops local connector list --repo-path "..." --unpublished --store coral:prod --assert-none
```

## Review guide

1. `.github/workflows/resolve-stale-metadata.yml` — verify the folded scalar produces the correct single-line command after the two substitutions

### Human review checklist

- [ ] Confirm `uvx airbyte-internal-ops local connector list ...` is equivalent to the previous `uvx --from airbyte-internal-ops airbyte-ops local connector list ...` (entry point: `airbyte-internal-ops = "airbyte_ops_mcp.cli.app:main"` in [pyproject.toml](https://github.com/airbytehq/airbyte-ops-mcp/blob/main/pyproject.toml))

## User Impact

No user-facing impact. The stale metadata check (cron every 2 hours) will invoke the same CLI logic with a cleaner command.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Requested by: @aaronsteers
[Link to Devin run](https://app.devin.ai/sessions/f900274cb0884bf99e399b1c40c48067)