### PR TITLE
ci: add /good-bot and /bad-bot slash commands

### DIFF
--- a/.github/workflows/bad-bot-command.yml
+++ b/.github/workflows/bad-bot-command.yml
@@ -40,7 +40,7 @@ jobs:
           private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
 
       - name: Run Bot Feedback
-        uses: aaronsteers/devin-action@v0.2.0
+        uses: aaronsteers/devin-action@main
         with:
           comment-id: ${{ inputs.comment-id }}
           issue-number: ${{ inputs.pr }}

--- a/.github/workflows/bad-bot-command.yml
+++ b/.github/workflows/bad-bot-command.yml
@@ -1,0 +1,57 @@
+name: Bad Bot Feedback Command
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: "PR or issue number"
+        required: false
+      comment-id:
+        description: "Comment ID"
+        required: false
+      repo:
+        description: "Repo (passed by slash command dispatcher)"
+        required: false
+      gitref:
+        description: "Git ref (passed by slash command dispatcher)"
+        required: false
+
+run-name: "Bad Bot Feedback for #${{ inputs.pr }}"
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  bot-feedback:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Authenticate as GitHub App
+        uses: actions/create-github-app-token@v2
+        id: get-app-token
+        with:
+          owner: "airbytehq"
+          repositories: "airbyte"
+          app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
+          private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
+
+      - name: Run Bot Feedback
+        uses: aaronsteers/devin-action@v0.2.0
+        with:
+          comment-id: ${{ inputs.comment-id }}
+          issue-number: ${{ inputs.pr }}
+          playbook-macro: "!slash_command_feedback"
+          devin-token: ${{ secrets.DEVIN_AI_API_KEY }}
+          github-token: ${{ steps.get-app-token.outputs.token }}
+          start-message: "📝 Recording negative feedback for triage..."
+          extra-context: |
+            ## Slash Command Context
+
+            The feedback type is: `bad-bot`
+            Repository: `airbytehq/airbyte`
+          tags: |
+            bot-feedback

--- a/.github/workflows/good-bot-command.yml
+++ b/.github/workflows/good-bot-command.yml
@@ -40,7 +40,7 @@ jobs:
           private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
 
       - name: Run Bot Feedback
-        uses: aaronsteers/devin-action@v0.2.0
+        uses: aaronsteers/devin-action@main
         with:
           comment-id: ${{ inputs.comment-id }}
           issue-number: ${{ inputs.pr }}

--- a/.github/workflows/good-bot-command.yml
+++ b/.github/workflows/good-bot-command.yml
@@ -1,0 +1,57 @@
+name: Good Bot Feedback Command
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: "PR or issue number"
+        required: false
+      comment-id:
+        description: "Comment ID"
+        required: false
+      repo:
+        description: "Repo (passed by slash command dispatcher)"
+        required: false
+      gitref:
+        description: "Git ref (passed by slash command dispatcher)"
+        required: false
+
+run-name: "Good Bot Feedback for #${{ inputs.pr }}"
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  bot-feedback:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Authenticate as GitHub App
+        uses: actions/create-github-app-token@v2
+        id: get-app-token
+        with:
+          owner: "airbytehq"
+          repositories: "airbyte"
+          app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
+          private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
+
+      - name: Run Bot Feedback
+        uses: aaronsteers/devin-action@v0.2.0
+        with:
+          comment-id: ${{ inputs.comment-id }}
+          issue-number: ${{ inputs.pr }}
+          playbook-macro: "!slash_command_feedback"
+          devin-token: ${{ secrets.DEVIN_AI_API_KEY }}
+          github-token: ${{ steps.get-app-token.outputs.token }}
+          start-message: "🎉 Recording positive feedback..."
+          extra-context: |
+            ## Slash Command Context
+
+            The feedback type is: `good-bot`
+            Repository: `airbytehq/airbyte`
+          tags: |
+            bot-feedback

--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -69,6 +69,8 @@ jobs:
             build-connector-images
             force-merge
             format-fix
+            good-bot
+            bad-bot
             poe
             publish-connectors-prerelease
             publish-java-cdk


### PR DESCRIPTION
## What

Adds `/good-bot` and `/bad-bot` slash commands to the airbyte repo, allowing anyone to quickly give positive or negative feedback on Devin's work directly from issue or PR comments.

Part of a multi-repo change:
- **Playbook**: Companion PR in `airbytehq/ai-skills` adds the `slash_command_feedback` playbook that these commands invoke
- **Other repos**: Matching PRs in `airbytehq/oncall` and `airbytehq/airbyte-internal-issues` add the same commands there

## How

1. **`slash-commands.yml`** — Registers `good-bot` and `bad-bot` in the slash command dispatcher's command list. Since this repo uses `dispatch-type: workflow`, each command maps to a `{command}-command.yml` workflow file.
2. **`good-bot-command.yml`** — New workflow dispatched by `/good-bot`. Invokes `aaronsteers/devin-action@main` with the `!slash_command_feedback` playbook macro, passing `good-bot` as the feedback type via `extra-context`.
3. **`bad-bot-command.yml`** — Same structure, passes `bad-bot` as the feedback type.

Both workflows follow the existing pattern used by other AI command workflows in this repo (authenticate as Octavia Bot → invoke devin-action).

## Review guide

1. `.github/workflows/slash-commands.yml` — two lines added to the commands list
2. `.github/workflows/good-bot-command.yml` — new workflow for positive feedback
3. `.github/workflows/bad-bot-command.yml` — new workflow for negative feedback

**Key things to verify:**
- The `ai-skills` companion PR with the `!slash_command_feedback` playbook must be merged first, otherwise these commands will fail at runtime
- Workflow filenames match the command names (required by `dispatch-type: workflow`)
- Secrets (`OCTAVIA_BOT_APP_ID`, `OCTAVIA_BOT_PRIVATE_KEY`, `DEVIN_AI_API_KEY`) are already configured in this repo

## User Impact

Users can type `/good-bot` or `/bad-bot` in any issue or PR comment to submit feedback on Devin's work. Feedback is routed to `#hydra-feedback` in Slack. No impact on existing commands.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

## Updates since last revision

- Updated `devin-action` pin from `@v0.2.0` to `@main` to match the convention used by newer workflows in this repo (e.g. `ai-create-docs-pr-command.yml`, `ai-prove-fix-command.yml`).

---

Requested by: @aaronsteers
[Link to Devin session](https://app.devin.ai/sessions/e2070dd5d9c64a2fb45a42025b32a2b7)