### PR TITLE
ci: Add 'prompts' to allowed semantic PR title types

### DIFF
--- a/.github/workflows/semantic-pr-check.yml
+++ b/.github/workflows/semantic-pr-check.yml
@@ -53,6 +53,7 @@ jobs:
             feat
             fix
             perf
+            prompts
             refactor
             release
             revert


### PR DESCRIPTION
## What

Adds `prompts` as a new allowed semantic PR title type. This type covers changes to AI/LLM prompts, agent instructions, playbooks, and skill definitions — content that doesn't fit neatly into `docs`, `ci`, `feat`, or `fix`.

Part of a cross-repo rollout adding `prompts` to all Airbyte repositories that enforce semantic PR titles.

## How

Adds `prompts` to the `types` list in the `amannn/action-semantic-pull-request` configuration, in alphabetical order.

## Review guide

1. `.github/workflows/semantic-pr-check.yml` — single line addition

## User Impact

Contributors can now use `prompts:` as a PR title prefix (e.g., `prompts: Update triage playbook instructions`). Previously this would fail the semantic PR title check.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Requested by: @aaronsteers
[Link to Devin session](https://app.devin.ai/sessions/1559b22d46df416e816ad743d46edb60)