### PR TITLE
fix(iceberg): defer identifier field update when replacing columns in schema evolution

### DIFF
--- a/airbyte-cdk/bulk/core/load/changelog.md
+++ b/airbyte-cdk/bulk/core/load/changelog.md
@@ -9,7 +9,7 @@ The Load CDK provides functionality for destination connectors including stream-
 
 | Version | Date       | Pull Request | Subject                                                                                         |
 |---------|------------|--------------|-------------------------------------------------------------------------------------------------|
-| 1.0.5   | 2026-03-10 | [#74XXX](https://github.com/airbytehq/airbyte/pull/74XXX) | Fix schema evolution: defer identifier field update when replacing columns to avoid Iceberg conflict. |
+| 1.0.5   | 2026-03-10 | [#74723](https://github.com/airbytehq/airbyte/pull/74723) | Fix schema evolution: defer identifier field update when replacing columns to avoid Iceberg conflict. |
 | 1.0.4   | 2026-03-05 | [#74328](https://github.com/airbytehq/airbyte/pull/74328) | Fix iceberg dedup: map PK NumberType to StringType instead of DecimalType for identifier field compatibility. |
 | 1.0.3   | 2026-03-05 | [#74272](https://github.com/airbytehq/airbyte/pull/74272) | Fix iceberg dedup.                                                                              |
 | 1.0.2   | 2026-02-24 | | Bump bulk-cdk-core-base to 1.0.1 to pick up CVE fixes (CVE-2021-47621, CVE-2022-36944).         |

--- a/airbyte-cdk/bulk/core/load/changelog.md
+++ b/airbyte-cdk/bulk/core/load/changelog.md
@@ -9,6 +9,7 @@ The Load CDK provides functionality for destination connectors including stream-
 
 | Version | Date       | Pull Request | Subject                                                                                         |
 |---------|------------|--------------|-------------------------------------------------------------------------------------------------|
+| 1.0.5   | 2026-03-10 | [#74XXX](https://github.com/airbytehq/airbyte/pull/74XXX) | Fix schema evolution: defer identifier field update when replacing columns to avoid Iceberg conflict. |
 | 1.0.4   | 2026-03-05 | [#74328](https://github.com/airbytehq/airbyte/pull/74328) | Fix iceberg dedup: map PK NumberType to StringType instead of DecimalType for identifier field compatibility. |
 | 1.0.3   | 2026-03-05 | [#74272](https://github.com/airbytehq/airbyte/pull/74272) | Fix iceberg dedup.                                                                              |
 | 1.0.2   | 2026-02-24 | | Bump bulk-cdk-core-base to 1.0.1 to pick up CVE fixes (CVE-2021-47621, CVE-2022-36944).         |

--- a/airbyte-cdk/bulk/core/load/version.properties
+++ b/airbyte-cdk/bulk/core/load/version.properties
@@ -1,1 +1,1 @@
-version=1.0.4
+version=1.0.5

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/IcebergTableSynchronizer.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/IcebergTableSynchronizer.kt
@@ -94,6 +94,7 @@ class IcebergTableSynchronizer(
         // 2) Update types => find a supertype for each changed column
         val columnsToReplaceInSecondCommit =
             mutableMapOf<String, org.apache.iceberg.types.Types.NestedField>()
+        val replacedColumns = mutableSetOf<String>()
 
         diff.updatedDataTypes.forEach { columnName ->
             val existingField =
@@ -134,6 +135,7 @@ class IcebergTableSynchronizer(
                         update.deleteColumn(columnName)
                         update.addColumn(columnName, incomingField.type())
                     }
+                    replacedColumns.add(columnName)
                 }
             }
         }
@@ -188,8 +190,17 @@ class IcebergTableSynchronizer(
         }
 
         // 5) Update identifier fields
-        if (diff.identifierFieldsChanged) {
-            val updatedIdentifierFields = incomingSchema.identifierFieldNames().toList()
+        // Iceberg's requireColumn() fails for columns pending deletion (even if they're
+        // being re-added in the same update). When replaced columns are also identifier
+        // fields, we must defer the identifier field update to a follow-up commit.
+        val updatedIdentifierFields =
+            if (diff.identifierFieldsChanged) incomingSchema.identifierFieldNames().toList()
+            else emptyList()
+        val hasReplacedIdentifierFields =
+            replacedColumns.any { it in updatedIdentifierFields.toSet() }
+
+        if (diff.identifierFieldsChanged && !hasReplacedIdentifierFields) {
+            // No conflict: can update identifier fields in the same update
             updatedIdentifierFields.forEach { update.requireColumn(it) }
             update.setIdentifierFields(updatedIdentifierFields)
         }
@@ -211,6 +222,12 @@ class IcebergTableSynchronizer(
                 addUpdate.addColumn(null, columnName, field.type())
             }
 
+            // If identifier fields were deferred, handle them now (columns have been re-added)
+            if (hasReplacedIdentifierFields) {
+                updatedIdentifierFields.forEach { addUpdate.requireColumn(it) }
+                addUpdate.setIdentifierFields(updatedIdentifierFields)
+            }
+
             // Commit or defer the add operation based on columnTypeChangeBehavior
             val finalSchema = addUpdate.apply()
             return if (columnTypeChangeBehavior.commitImmediately) {
@@ -218,6 +235,25 @@ class IcebergTableSynchronizer(
                 SchemaUpdateResult(finalSchema, pendingUpdates = emptyList())
             } else {
                 SchemaUpdateResult(finalSchema, pendingUpdates = listOf(addUpdate))
+            }
+        }
+
+        // If replaced columns are also identifier fields, commit column replacements first,
+        // then handle identifier fields in a follow-up update.
+        if (hasReplacedIdentifierFields) {
+            update.commit()
+            table.refresh()
+
+            val identifierUpdate = table.updateSchema().allowIncompatibleChanges()
+            updatedIdentifierFields.forEach { identifierUpdate.requireColumn(it) }
+            identifierUpdate.setIdentifierFields(updatedIdentifierFields)
+
+            val newSchema = identifierUpdate.apply()
+            return if (columnTypeChangeBehavior.commitImmediately) {
+                identifierUpdate.commit()
+                SchemaUpdateResult(newSchema, pendingUpdates = emptyList())
+            } else {
+                SchemaUpdateResult(newSchema, pendingUpdates = listOf(identifierUpdate))
             }
         }
 

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/test/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/IcebergTableSynchronizerTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/test/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/IcebergTableSynchronizerTest.kt
@@ -421,4 +421,56 @@ class IcebergTableSynchronizerTest {
         assertThat(schema).isSameAs(mockNewSchema)
         assertThat(pendingUpdates).hasSize(1)
     }
+
+    @Test
+    fun `test overwrite with replaced column as identifier field defers identifier update`() {
+        // Simulates the scenario where a PK column's type changes (e.g. Double -> String)
+        // and the column is also an identifier field. Iceberg's requireColumn() fails for
+        // columns pending deletion, so we must commit the column replacement first, then
+        // handle identifier fields in a follow-up update.
+        val existingSchema =
+            buildSchema(Types.NestedField.required(1, "pk_col", Types.DoubleType.get()))
+        val incomingSchema =
+            buildSchema(
+                Types.NestedField.required(1, "pk_col", Types.StringType.get()),
+                identifierFields = setOf(1)
+            )
+
+        every { mockTable.schema() } returns existingSchema
+
+        // After the first commit (column replacement), table.updateSchema() returns a new mock
+        val mockIdentifierUpdateSchema = mockk<UpdateSchema>(relaxed = true)
+        val mockIdentifierNewSchema = mockk<Schema>(relaxed = true)
+        every { mockIdentifierUpdateSchema.apply() } returns mockIdentifierNewSchema
+
+        // First call returns mockUpdateSchema, second call (after commit+refresh) returns
+        // the identifier update mock.
+        every { mockTable.updateSchema().allowIncompatibleChanges() } returnsMany
+            listOf(mockUpdateSchema, mockIdentifierUpdateSchema)
+
+        val (schema, pendingUpdates) =
+            synchronizer.maybeApplySchemaChanges(
+                mockTable,
+                incomingSchema,
+                ColumnTypeChangeBehavior.OVERWRITE
+            )
+
+        // First update: delete + add column (committed immediately due to deferred identifiers)
+        verify { mockUpdateSchema.deleteColumn("pk_col") }
+        verify { mockUpdateSchema.addColumn("pk_col", Types.StringType.get()) }
+        verify { mockUpdateSchema.commit() }
+
+        // Table is refreshed after the first commit
+        verify { mockTable.refresh() }
+
+        // Second update: identifier fields handled in a follow-up
+        verify { mockIdentifierUpdateSchema.requireColumn("pk_col") }
+        verify { mockIdentifierUpdateSchema.setIdentifierFields(listOf("pk_col")) }
+        // OVERWRITE mode doesn't commit immediately — returns as pending
+        verify(exactly = 0) { mockIdentifierUpdateSchema.commit() }
+
+        assertThat(schema).isSameAs(mockIdentifierNewSchema)
+        assertThat(pendingUpdates).hasSize(1)
+        assertThat(pendingUpdates.first()).isSameAs(mockIdentifierUpdateSchema)
+    }
 }


### PR DESCRIPTION
## What

Fixes `IllegalArgumentException: Cannot update a column that will be deleted: column1` when schema evolution replaces a column that is also an identifier field.

This was observed when deploying [#74328](https://github.com/airbytehq/airbyte/pull/74328) (PK NumberType→StringType mapping). The existing Iceberg table had `column1` as `DoubleType`, and the new schema had it as `StringType` (PK). The schema evolution tried to `deleteColumn` + `addColumn` + `requireColumn` in the same `UpdateSchema` operation, but Iceberg's `requireColumn()` resolves the column name against the **old** schema and finds the field pending deletion.

## How

In `IcebergTableSynchronizer.maybeApplySchemaChanges()`:

1. Track which columns are being replaced (deleted + re-added) via a `replacedColumns` set
2. Check if any replaced columns are also in the incoming identifier field set
3. If so, **commit the column replacement first**, refresh the table, then handle `requireColumn` + `setIdentifierFields` in a follow-up `UpdateSchema` operation
4. Also handle the same conflict in the `requireSeparateCommitsForColumnReplace` path (used by BigLake)

This follows the same pattern already used by `requireSeparateCommitsForColumnReplace` for splitting incompatible operations across commits.

## Review guide

1. `IcebergTableSynchronizer.kt` — core fix. Key areas:
   - Line 97: new `replacedColumns` tracking set
   - Lines 192–206: deferred identifier field logic (the decision point)
   - Lines 225–229: handling for the `requireSeparateCommitsForColumnReplace` path
   - Lines 241–258: the new intermediate-commit path for standard OVERWRITE mode — **this is the most important block to review**. Note that this introduces an eager commit of the column replacement in OVERWRITE mode (which normally defers commits to the caller). This matches the existing pattern on line 214 for `requireSeparateCommitsForColumnReplace`.
2. `IcebergTableSynchronizerTest.kt` — new test verifying the two-phase commit behavior with mocks
3. `version.properties` / `changelog.md` — version bump 1.0.4 → 1.0.5 (changelog has placeholder `#74XXX` to be updated)


## User Impact

**Positive:** Fixes the crash when syncing to Iceberg destinations with PK columns that have changed types (e.g., from the NumberType→StringType fix in [#74328](https://github.com/airbytehq/airbyte/pull/74328)).

**Potential concern:** In OVERWRITE mode (used by `isSingleGenerationTruncate()` aka full refresh), column type replacements for identifier fields are now committed during `start()` (in the first `computeOrExecuteSchemaUpdate()` call) rather than being deferred until `teardown()`. If a sync fails partway through, the table schema will reflect the new column type even though no data was successfully written. However:
- This behavior already exists for `requireSeparateCommitsForColumnReplace` (BigLake)
- The table is still queryable (Iceberg is ACID-compliant)
- The next sync will succeed and write the correct data

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Reverting will restore the previous behavior but re-introduce the `Cannot update a column that will be deleted` crash for PK type changes.

---

**Devin Session:** https://app.devin.ai/sessions/9bc57a1832ff418a9afe589894fd36e8  
**Requested by:** @benmoriceau