### PR TITLE
ci: notify sonar on replication version publish

### DIFF
--- a/.github/workflows/notify-on-replication-version-change.yml
+++ b/.github/workflows/notify-on-replication-version-change.yml
@@ -101,6 +101,12 @@ jobs:
               continue
             fi
 
+            # Only notify for stable releases (strict X.Y.Z semver)
+            if ! [[ "$CURRENT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "Skipping $CONNECTOR_NAME (non-stable version: $CURRENT_VERSION)"
+              continue
+            fi
+
             echo "Version changed for $CONNECTOR_NAME: ${PREVIOUS_VERSION:-<new>} -> $CURRENT_VERSION"
             CHANGES=$(echo "$CHANGES" | jq -c --arg name "$CONNECTOR_NAME" --arg version "$CURRENT_VERSION" '. + [{"connector": $name, "version": $version}]')
           done <<< "$CHANGED_FILES"

--- a/.github/workflows/notify-on-replication-version-change.yml
+++ b/.github/workflows/notify-on-replication-version-change.yml
@@ -6,9 +6,13 @@ on:
     types: [completed]
     branches: [master]
 
+permissions:
+  contents: read
+  actions: read
+
 concurrency:
   group: ${{ github.workflow }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   notify-version-change:
@@ -26,13 +30,15 @@ jobs:
         id: published-connectors
         env:
           GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
         run: |
           set -euo pipefail
 
           # Query the publish workflow run's jobs to find which source connectors
           # had their registry entries published successfully.
           # Job names follow the pattern: "Publish connector registry entries (source-xyz)"
-          PUBLISHED=$(gh api "repos/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}/jobs" \
+          PUBLISHED=$(gh api "repos/$REPO/actions/runs/$WORKFLOW_RUN_ID/jobs" \
             --paginate \
             --jq '[.jobs[]
               | select(.name | startswith("Publish connector registry entries (source-"))
@@ -47,10 +53,10 @@ jobs:
 
       - name: Detect dockerImageTag changes for published connectors
         id: detect-changes
+        env:
+          PUBLISHED: ${{ steps.published-connectors.outputs.published }}
         run: |
           set -euo pipefail
-
-          PUBLISHED='${{ steps.published-connectors.outputs.published }}'
           CHANGES="[]"
 
           if [[ "$PUBLISHED" == "[]" ]]; then
@@ -115,12 +121,12 @@ jobs:
         if: fromJSON(steps.detect-changes.outputs.changes)[0] != null
         env:
           GH_TOKEN: ${{ steps.get-app-token.outputs.token }}
+          CHANGES: ${{ steps.detect-changes.outputs.changes }}
         run: |
           set -euo pipefail
 
-          CHANGES='${{ steps.detect-changes.outputs.changes }}'
           echo "Dispatching to airbytehq/sonar with changes: $CHANGES"
 
           jq -n --argjson changes "$CHANGES" \
-            '{"event_type": "replication-version-changed", "client_payload": {"changes": $changes}}' \
+            '{"event_type": "replication-version-changed", "client_payload": $changes}' \
           | gh api repos/airbytehq/sonar/dispatches --method POST --input -

--- a/.github/workflows/notify-on-replication-version-change.yml
+++ b/.github/workflows/notify-on-replication-version-change.yml
@@ -1,0 +1,126 @@
+name: Notify Sonar on Source Connector Version Change
+
+on:
+  workflow_run:
+    workflows: ["Publish Connectors"]
+    types: [completed]
+    branches: [master]
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  notify-version-change:
+    name: Detect version changes and notify Sonar
+    if: github.event.workflow_run.event == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 2
+
+      - name: Get successfully published source connectors
+        id: published-connectors
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          # Query the publish workflow run's jobs to find which source connectors
+          # had their registry entries published successfully.
+          # Job names follow the pattern: "Publish connector registry entries (source-xyz)"
+          PUBLISHED=$(gh api "repos/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}/jobs" \
+            --paginate \
+            --jq '[.jobs[]
+              | select(.name | startswith("Publish connector registry entries (source-"))
+              | select(.conclusion == "success")
+              | .name
+              | capture("\\((?<connector>source-[^)]+)\\)")
+              | .connector
+            ]')
+
+          echo "Successfully published source connectors: $PUBLISHED"
+          echo "published=$PUBLISHED" >> "$GITHUB_OUTPUT"
+
+      - name: Detect dockerImageTag changes for published connectors
+        id: detect-changes
+        run: |
+          set -euo pipefail
+
+          PUBLISHED='${{ steps.published-connectors.outputs.published }}'
+          CHANGES="[]"
+
+          if [[ "$PUBLISHED" == "[]" ]]; then
+            echo "No source connectors were successfully published."
+            echo "changes=$CHANGES" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          CHANGED_FILES=$(git diff --name-only HEAD~1 HEAD -- 'airbyte-integrations/connectors/source-*/metadata.yaml') || true
+
+          if [[ -z "$CHANGED_FILES" ]]; then
+            echo "No source connector metadata.yaml files changed."
+            echo "changes=$CHANGES" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          while IFS= read -r file; do
+            if [[ ! -f "$file" ]]; then
+              echo "Skipping $file (deleted in HEAD)"
+              continue
+            fi
+
+            CONNECTOR_NAME=$(echo "$file" | cut -d'/' -f3)
+
+            # Only include connectors that were successfully published
+            if ! echo "$PUBLISHED" | jq -e --arg name "$CONNECTOR_NAME" 'index($name) != null' > /dev/null 2>&1; then
+              echo "Skipping $CONNECTOR_NAME (not in successfully published list)"
+              continue
+            fi
+
+            CURRENT_VERSION=$(grep -E '^\s*dockerImageTag:' "$file" | head -n1 | awk '{print $2}' | tr -d '"')
+
+            PREVIOUS_VERSION=$(git show HEAD~1:"$file" 2>/dev/null | grep -E '^\s*dockerImageTag:' | head -n1 | awk '{print $2}' | tr -d '"') || true
+
+            if [[ -z "$CURRENT_VERSION" ]]; then
+              echo "Skipping $file (no dockerImageTag found)"
+              continue
+            fi
+
+            if [[ "$CURRENT_VERSION" == "$PREVIOUS_VERSION" ]]; then
+              echo "Skipping $file (dockerImageTag unchanged: $CURRENT_VERSION)"
+              continue
+            fi
+
+            echo "Version changed for $CONNECTOR_NAME: ${PREVIOUS_VERSION:-<new>} -> $CURRENT_VERSION"
+            CHANGES=$(echo "$CHANGES" | jq -c --arg name "$CONNECTOR_NAME" --arg version "$CURRENT_VERSION" '. + [{"connector": $name, "version": $version}]')
+          done <<< "$CHANGED_FILES"
+
+          echo "changes=$CHANGES" >> "$GITHUB_OUTPUT"
+
+      - name: Authenticate as GitHub App
+        if: fromJSON(steps.detect-changes.outputs.changes)[0] != null
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
+        id: get-app-token
+        with:
+          owner: "airbytehq"
+          repositories: "sonar"
+          app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
+          private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
+
+      - name: Dispatch to Sonar
+        if: fromJSON(steps.detect-changes.outputs.changes)[0] != null
+        env:
+          GH_TOKEN: ${{ steps.get-app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+
+          CHANGES='${{ steps.detect-changes.outputs.changes }}'
+          echo "Dispatching to airbytehq/sonar with changes: $CHANGES"
+
+          jq -n --argjson changes "$CHANGES" \
+            '{"event_type": "replication-version-changed", "client_payload": {"changes": $changes}}' \
+          | gh api repos/airbytehq/sonar/dispatches --method POST --input -


### PR DESCRIPTION
## What

Resolves [airbytehq/airbyte-internal-issues#15962](https://github.com/airbytehq/airbyte-internal-issues/issues/15962)

Adds a workflow that notifies sonar when source connector replication versions are successfully published, so sonar can automatically validate and update its `x-airbyte-replication-version` annotations.

This is part of the [replication version pinning initiative](https://gist.github.com/ChristoGrab/bacffc056408bce185ee8be5fcc43296). The receiving workflow on the sonar side was merged in [airbytehq/sonar#3035](https://github.com/airbytehq/sonar/pull/3035).

## How

New workflow: `.github/workflows/notify-on-replication-version-change.yml`

Triggers via `workflow_run` after the **"Publish Connectors"** workflow completes on `master`. Steps:

1. **Get published connectors** — Queries the publish run's jobs API for source connectors where "Publish connector registry entries (source-xyz)" succeeded
2. **Detect version changes** — Cross-references published connectors with `git diff HEAD~1` on `metadata.yaml` files to find actual `dockerImageTag` changes
3. **Dispatch to sonar** — Sends a `repository_dispatch` (`replication-version-changed`) to `airbytehq/sonar` with the changed connectors as a flat JSON array

Using `workflow_run` instead of `push` trigger ensures we only notify sonar after connectors are actually published to Docker + registry, not just when versions are bumped in code.

**Payload format** (matches sonar's expected `client_payload` shape):
```json
[{"connector": "source-stripe", "version": "5.15.21"}, ...]
```

**Auth:** Uses `OCTAVIA_BOT_APP_ID` / `OCTAVIA_BOT_PRIVATE_KEY` for cross-repo dispatch to sonar.

## Review guide

1. `.github/workflows/notify-on-replication-version-change.yml` — the only file

### Human review checklist

> **This workflow cannot be tested in PR CI** — it only fires on `workflow_run` events from the "Publish Connectors" workflow on `master`. First real validation happens after merge.

- [x] **Workflow name match**: Verify `"Publish Connectors"` exactly matches the `name:` field in the publish connectors workflow YAML. A mismatch means this workflow will silently never trigger.
- [x] **Job name pattern**: The jq regex `capture("\\((?<connector>source-[^)]+)\\)")` depends on publish jobs being named `"Publish connector registry entries (source-xyz)"`. Verify this matches the actual job naming pattern.
- [x] **Secrets availability**: Confirm `OCTAVIA_BOT_APP_ID` and `OCTAVIA_BOT_PRIVATE_KEY` are available as repo secrets (these are the non-hoard variants used in the airbyte monorepo).
- [x] **`fetch-depth: 2` + `HEAD~1`**: Assumes squash merges to master. If merge commits land, the diff comparison could miss changes.

## User Impact

No direct user impact. This is CI infrastructure that enables automated replication version tracking in sonar. When a source connector publishes a new version, sonar will be automatically notified to validate and update its version annotations.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Reverting removes the notification workflow. Sonar's validation workflow has a fallback `workflow_dispatch` trigger and drift detection, so it continues to function independently (just without automatic dispatch from airbyte).

---

[Devin session](https://app.devin.ai/sessions/6213218c598643409ab6477c922e5178) | Requested by: Christo Grabowski