### PR TITLE
feat(source-bing-ads): increase default concurrency to 40 for rate limit testing

### DIFF
--- a/airbyte-integrations/connectors/source-bing-ads/manifest.yaml
+++ b/airbyte-integrations/connectors/source-bing-ads/manifest.yaml
@@ -17473,8 +17473,8 @@ schemas:
 
 concurrency_level:
   type: ConcurrencyLevel
-  default_concurrency: 2
-  max_concurrency: 10
+  default_concurrency: 40
+  max_concurrency: 40
 
 spec:
   type: Spec

--- a/airbyte-integrations/connectors/source-bing-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-bing-ads/metadata.yaml
@@ -16,7 +16,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 47f25999-dd5e-4636-8c39-e7cea2453331
-  dockerImageTag: 2.23.14
+  dockerImageTag: 2.23.15-rc.1
   dockerRepository: airbyte/source-bing-ads
   documentationUrl: https://docs.airbyte.com/integrations/sources/bing-ads
   externalDocumentationUrls:
@@ -44,7 +44,7 @@ data:
   releaseStage: generally_available
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
     breakingChanges:
       1.0.0:
         message: Version 1.0.0 removes the primary keys from the geographic performance report streams. This will prevent the connector from losing data in the incremental append+dedup sync mode because of deduplication and incorrect primary keys. A data reset and schema refresh of all the affected streams is required for the changes to take effect.

--- a/docs/integrations/sources/bing-ads.md
+++ b/docs/integrations/sources/bing-ads.md
@@ -319,6 +319,7 @@ The Bing Ads API limits the number of requests for all Microsoft Advertising cli
 
 | Version     | Date       | Pull Request                                                                                                                     | Subject                                                                                                                                                                |
 |:------------|:-----------|:---------------------------------------------------------------------------------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 2.23.15-rc.1 | 2026-03-11 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Increase default concurrency from 2 to 40 to test rate limit behavior |
 | 2.23.14 | 2026-03-10 | [74483](https://github.com/airbytehq/airbyte/pull/74483) | Update dependencies |
 | 2.23.13 | 2026-03-03 | [73654](https://github.com/airbytehq/airbyte/pull/73654) | Use streaming decompression in BingAdsGzipCsvDecoder to prevent OOM on large accounts |
 | 2.23.12 | 2026-03-03 | [73829](https://github.com/airbytehq/airbyte/pull/73829) | Update dependencies |


### PR DESCRIPTION
## What

Increases the default concurrency for `source-bing-ads` from 2 to 40 to intentionally stress-test rate limit behavior during syncs. This is an RC release with progressive rollout enabled to safely observe the impact on a subset of connections before wider deployment.

## How

- **`manifest.yaml`**: Changed `default_concurrency` from `2` → `40` and `max_concurrency` from `10` → `40`
- **`metadata.yaml`**: Bumped version to `2.23.15-rc.1` and enabled `enableProgressiveRollout: true`
- **`bing-ads.md`**: Added changelog entry

## Review guide

1. `airbyte-integrations/connectors/source-bing-ads/manifest.yaml` — concurrency change (lines 17474-17477)
2. `airbyte-integrations/connectors/source-bing-ads/metadata.yaml` — RC version + progressive rollout enablement

**Key context:** Bing Ads does not publish API rate limits (error code 117 / `CallRateExceeded` is the only signal). The connector has **no `api_budget`** and no explicit 429/rate-limit handling in the manifest — it relies on the SDK's built-in retry behavior. This PR is designed to surface what happens when concurrency is pushed well beyond the previous conservative default.

## User Impact

- Connections rolled into the progressive rollout will run with 40 concurrent workers instead of 2, which is expected to trigger `CallRateExceeded` errors from the Bing Ads API
- The goal is to observe sync behavior under rate limiting — this is **not** intended as a permanent production setting
- Progressive rollout limits blast radius to a small percentage of connections initially

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Link to Devin session: https://app.devin.ai/sessions/fb11bb6801b6457b84645a812a6e3ab4
Requested by: @sophiecuiy
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/74745" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._