### PR TITLE
docs: fix broken links in docs

### DIFF
--- a/docs/integrations/destinations/duckdb.md
+++ b/docs/integrations/destinations/duckdb.md
@@ -46,7 +46,7 @@ Each table will contain 3 columns:
 
 ### Normalization
 
-If you set [Normalization](https://docs.airbyte.com/understanding-airbyte/basic-normalization/), source data will be normalized to a tabular form. Let's say you have a source such as GitHub with nested JSONs; the Normalization ensures you end up with tables and columns. Suppose you have a many-to-many relationship between the users and commits. Normalization will create separate tables for it. The end state is the [third normal form](https://en.wikipedia.org/wiki/Third_normal_form) (3NF).
+If you set [Normalization](https://docs.airbyte.com/using-airbyte/core-concepts/typing-deduping), source data will be normalized to a tabular form. Let's say you have a source such as GitHub with nested JSONs; the Normalization ensures you end up with tables and columns. Suppose you have a many-to-many relationship between the users and commits. Normalization will create separate tables for it. The end state is the [third normal form](https://en.wikipedia.org/wiki/Third_normal_form) (3NF).
 
 #### Performance consideration
 

--- a/docs/integrations/sources/fullstory.md
+++ b/docs/integrations/sources/fullstory.md
@@ -64,7 +64,7 @@ GET https://api.fullstory.com/segments/v1
 
 ## Performance considerations
 
-FullStory [API reference](https://api.fullstory.com) has v1 at present. The connector as default uses v1.
+FullStory [API reference](https://developer.fullstory.com) has v1 at present. The connector as default uses v1.
 
 ## Changelog
 

--- a/docs/integrations/sources/omnisend.md
+++ b/docs/integrations/sources/omnisend.md
@@ -2,7 +2,7 @@
 
 ## Sync overview
 
-This source can sync data from the [Omnisend API](https://api-docs.omnisend.com/reference/intro). At present this connector only supports full refresh syncs meaning that each time you use the connector it will sync all available records from scratch. Please use cautiously if you expect your API to have a lot of records.
+This source can sync data from the [Omnisend API](https://api-docs.omnisend.com/reference). At present this connector only supports full refresh syncs meaning that each time you use the connector it will sync all available records from scratch. Please use cautiously if you expect your API to have a lot of records.
 
 ## This Source Supports the Following Streams
 

--- a/docs/integrations/sources/xero.md
+++ b/docs/integrations/sources/xero.md
@@ -48,7 +48,7 @@ For the OAuth client credentials, please follow [instructions](https://developer
 
 ## Supported sync modes
 
-The Xero source connector supports the following [sync modes](https://docs.airbyte.com/understanding-airbyte/connections/connection-sync-modes):
+The Xero source connector supports the following [sync modes](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes):
 
 - [Full Refresh - Overwrite](https://docs.airbyte.com/understanding-airbyte/connections/full-refresh-overwrite/)
 - [Full Refresh - Append](https://docs.airbyte.com/understanding-airbyte/connections/full-refresh-append)

--- a/docs/release_notes/august_2022.md
+++ b/docs/release_notes/august_2022.md
@@ -8,7 +8,7 @@ This page includes new features and improvements to the Airbyte Cloud and Airbyt
 
 - Added reserved keywords for schema names by fixing the quotation logic in normalization. [#14683](https://github.com/airbytehq/airbyte/pull/14683)
 
-- Added [documentation](https://docs.airbyte.com/cloud/managing-airbyte-cloud/review-sync-summary) about the data displayed in sync log summaries. [#15181](https://github.com/airbytehq/airbyte/pull/15181)
+- Added [documentation](https://docs.airbyte.com/cloud/managing-airbyte-cloud/review-connection-timeline) about the data displayed in sync log summaries. [#15181](https://github.com/airbytehq/airbyte/pull/15181)
 
 - Added OAuth login to Airbyte Cloud, which allows you to sign in using your Google login credentials. [#15414](https://github.com/airbytehq/airbyte/pull/15414)
 


### PR DESCRIPTION
## Summary

Fixes 5 broken links across the documentation, addressing #33874.

cc @natikgadzhi for review as requested in the issue.

- `docs/release_notes/august_2022.md`: Updated dead link to `review-sync-summary` to the current `review-connection-timeline` page
- `docs/integrations/destinations/duckdb.md`: Updated dead link to `understanding-airbyte/basic-normalization/` to the current `using-airbyte/core-concepts/typing-deduping` page
- `docs/integrations/sources/xero.md`: Updated dead link to `understanding-airbyte/connections/connection-sync-modes` to the current `platform/using-airbyte/core-concepts/sync-modes` page
- `docs/integrations/sources/omnisend.md`: Fixed 404 link to Omnisend API docs (`/reference/intro` -> `/reference`)
- `docs/integrations/sources/fullstory.md`: Fixed 404 link to FullStory API reference (`api.fullstory.com` -> `developer.fullstory.com`)

## Test plan

- [ ] Verify each replacement URL resolves (all were confirmed via HTTP status check before submitting)