### PR TITLE
docs: fix broken external links in platform docs

### DIFF
--- a/docs/platform/connector-development/connector-builder-ui/incremental-sync.md
+++ b/docs/platform/connector-development/connector-builder-ui/incremental-sync.md
@@ -197,5 +197,5 @@ Using the "Inject start time / end time into outgoing HTTP request" option in th
 
 To handle these cases, disable injection in the incremental sync form and use the generic parameter section at the bottom of the stream configuration form to freely configure query parameters, headers and properties of the JSON body, by using jinja expressions and [available variables](/platform/connector-development/config-based/understanding-the-yaml-file/reference/#/variables). You can also use these variables as part of the URL path.
 
-For example the [Sendgrid API](https://docs.sendgrid.com/api-reference/e-mail-activity/filter-all-messages) requires setting both start and end time in a `query` parameter.
+For example the [Sendgrid API](https://www.twilio.com/docs/sendgrid/api-reference/email-activity/filter-all-messages) requires setting both start and end time in a `query` parameter.
 For this case, you can use the `stream_interval` variable to configure a query parameter with "key" `query` and "value" `last_event_time BETWEEN TIMESTAMP "{{stream_interval.start_time}}" AND TIMESTAMP "{{stream_interval.end_time}}"` to filter down to the right window in time.

--- a/docs/platform/enterprise-flex/data-plane.md
+++ b/docs/platform/enterprise-flex/data-plane.md
@@ -88,7 +88,7 @@ We require you to install and configure the following Kubernetes tooling:
 <TabItem value="Amazon EKS" label="Amazon EKS" default>
 
 1. Configure your [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html) to connect to your project.
-2. Install [eksctl](https://eksctl.io/introduction/).
+2. Install [eksctl](https://eksctl.io/getting-started/).
 3. Run `eksctl utils write-kubeconfig --cluster=$CLUSTER_NAME` to make the context available to kubectl.
 4. Use `kubectl config get-contexts` to show the available contexts.
 5. Run `kubectl config use-context $EKS_CONTEXT` to access the cluster with kubectl.

--- a/docs/platform/enterprise-setup/implementation-guide.md
+++ b/docs/platform/enterprise-setup/implementation-guide.md
@@ -54,7 +54,7 @@ We require you to install and configure the following Kubernetes tooling:
 <TabItem value="Amazon EKS" label="Amazon EKS" default>
 
 1. Configure your [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html) to connect to your project.
-2. Install [eksctl](https://eksctl.io/introduction/).
+2. Install [eksctl](https://eksctl.io/getting-started/).
 3. Run `eksctl utils write-kubeconfig --cluster=$CLUSTER_NAME` to make the context available to kubectl.
 4. Use `kubectl config get-contexts` to show the available contexts.
 5. Run `kubectl config use-context $EKS_CONTEXT` to access the cluster with kubectl.

--- a/docs/platform/operator-guides/using-the-airflow-airbyte-operator.md
+++ b/docs/platform/operator-guides/using-the-airflow-airbyte-operator.md
@@ -133,6 +133,6 @@ For additional information about using the Airflow and Airbyte together, see the
 - [Using the new Airbyte API to orchestrate Airbyte Cloud with Airflow](https://airbyte.com/blog/orchestrating-airbyte-api-airbyte-cloud-airflow)
 - [A step-by-step guide to setting up and configuring Airbyte and Airflow to work together](https://airbyte.com/tutorials/how-to-use-airflow-and-airbyte-together)
 - [Build an e-commerce Analytics Stack with Airbyte, dbt, Airflow (ADA) and BigQuery](https://github.com/airbytehq/quickstarts/tree/main/airbyte_dbt_airflow_bigquery)
-- [The difference between Airbyte and Airflow](https://airbyte.com/blog/airbyte-vs-airflow)
+- [Using Airflow and Airbyte together](https://airbyte.com/tutorials/how-to-use-airflow-and-airbyte-together)
 - [ETL Pipelines with Airflow: the Good, the Bad and the Ugly](https://airbyte.com/blog/airflow-etl-pipelines)
 - [Automate your Data Scraping with Apache Airflow and Beautiful Soup](https://airbyte.com/tutorials/data-scraping-with-airflow-and-beautiful-soup)

--- a/docs/platform/understanding-airbyte/json-avro-conversion.md
+++ b/docs/platform/understanding-airbyte/json-avro-conversion.md
@@ -28,9 +28,9 @@ The following built-in JSON formats will be mapped to Avro logical types.
 
 | JSON Type | JSON Built-in Format | Avro Type | Avro Logical Type  | Meaning                                                                                                                                                 |
 | --------- | -------------------- | --------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `string`  | `date`               | `int`     | `date`             | Number of epoch days from 1970-01-01 ([reference](https://avro.apache.org/docs/current/spec.html#Date)).                                                |
-| `string`  | `time`               | `long`    | `time-micros`      | Number of microseconds after midnight ([reference](https://avro.apache.org/docs/current/spec.html#Time+%28microsecond+precision%29)).                   |
-| `string`  | `date-time`          | `long`    | `timestamp-micros` | Number of microseconds from `1970-01-01T00:00:00Z` ([reference](https://avro.apache.org/docs/current/spec.html#Timestamp+%28microsecond+precision%29)). |
+| `string`  | `date`               | `int`     | `date`             | Number of epoch days from 1970-01-01 ([reference](https://avro.apache.org/docs/1.12.0/specification/#date)).                                                |
+| `string`  | `time`               | `long`    | `time-micros`      | Number of microseconds after midnight ([reference](https://avro.apache.org/docs/1.12.0/specification/#time-microsecond-precision)).                   |
+| `string`  | `date-time`          | `long`    | `timestamp-micros` | Number of microseconds from `1970-01-01T00:00:00Z` ([reference](https://avro.apache.org/docs/1.12.0/specification/#timestamp-microsecond-precision)). |
 
 In the final Avro schema, these logical type fields will be typed as a union of null and the logical type. The logical type will be stored as UTC, respecting timezone as/applicable. If the incoming data cannot be converted, the field will be nulled, and the failure will be captured in `_airbyte_meta.changes[]`.
 
@@ -405,8 +405,8 @@ Three Airbyte specific fields will be added to each Avro record:
 
 | Field                            | Schema             |                                          Document                                           |
 | :------------------------------- | :----------------- | :-----------------------------------------------------------------------------------------: |
-| `_airbyte_raw_id`                | `uuid`             |                 [link](http://avro.apache.org/docs/current/spec.html#UUID)                  |
-| `_airbyte_extracted_at`          | `timestamp-millis` | [link](http://avro.apache.org/docs/current/spec.html#Timestamp+%28millisecond+precision%29) |
+| `_airbyte_raw_id`                | `uuid`             |                 [link](https://avro.apache.org/docs/1.12.0/specification/#uuid)                  |
+| `_airbyte_extracted_at`          | `timestamp-millis` | [link](https://avro.apache.org/docs/1.12.0/specification/#timestamp-millisecond-precision) |
 | `_airbyte_generation_id`         | `long`             |                     https://github.com/airbytehq/airbyte/issues/17011                       |
 | `_airbyte_meta`                  | `record`           |                                                                                             |
 


### PR DESCRIPTION
## What

Fix 9 broken external URLs across 5 documentation files in `docs/platform/`.

## Changes

| File | Fix | Count |
|------|-----|-------|
| `json-avro-conversion.md` | Update Apache Avro spec links from removed `docs/current/spec.html` to `docs/1.12.0/specification/` | 5 |
| `data-plane.md` | Update `eksctl.io/introduction/` → `eksctl.io/getting-started/` | 1 |
| `implementation-guide.md` | Update `eksctl.io/introduction/` → `eksctl.io/getting-started/` | 1 |
| `incremental-sync.md` | Update SendGrid docs from `docs.sendgrid.com` → `twilio.com/docs/sendgrid` | 1 |
| `using-the-airflow-airbyte-operator.md` | Replace removed blog post with working tutorial link | 1 |

All replacement URLs verified as HTTP 200.

## Related Issue

Contributes to #33874