### PR TITLE
chore: promote source-zendesk-support 5.1.7-rc.1 to 5.1.7 GA

### DIFF
--- a/airbyte-integrations/connectors/source-zendesk-support/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-support/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 79c1aa37-dae3-42ae-b333-d1c105477715
-  dockerImageTag: 5.1.7-rc.1
+  dockerImageTag: 5.1.7
   dockerRepository: airbyte/source-zendesk-support
   documentationUrl: https://docs.airbyte.com/integrations/sources/zendesk-support
   githubIssueLabel: source-zendesk-support

--- a/docs/integrations/sources/zendesk-support.md
+++ b/docs/integrations/sources/zendesk-support.md
@@ -211,7 +211,7 @@ The connector should not run into Zendesk API limitations under normal usage. [C
 
 | Version     | Date       | Pull Request                                             | Subject                                                                                                                                                                                                                            |
 |:------------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 5.1.7 | 2026-03-12 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Upgrade CDK to 7.8.1.post54 — validates StateDelegatingStream and DeclarativeStream regression fix |
+| 5.1.7 | 2026-03-12 | [74765](https://github.com/airbytehq/airbyte/pull/74765) | Upgrade CDK to 7.8.1.post54 — validates StateDelegatingStream and DeclarativeStream regression fix |
 | 5.1.7-rc.1 | 2026-03-10 | [74398](https://github.com/airbytehq/airbyte/pull/74398) | Pin CDK to 7.8.1.post54 for regression testing of StateDelegatingStream and DeclarativeStream |
 | 5.1.6 | 2026-03-09 | [73686](https://github.com/airbytehq/airbyte/pull/73686) | Add 504 exponential backoff error handling to `ticket_comments` stream and API budget (10 req/min) for all incremental export streams |
 | 5.1.5 | 2026-02-24 | [45667](https://github.com/airbytehq/airbyte/issues/45667) | Add missing SLA fields (`sla`, `group_sla`, `status`, `deleted`) to `ticket_metric_events` schema |

--- a/docs/integrations/sources/zendesk-support.md
+++ b/docs/integrations/sources/zendesk-support.md
@@ -211,6 +211,7 @@ The connector should not run into Zendesk API limitations under normal usage. [C
 
 | Version     | Date       | Pull Request                                             | Subject                                                                                                                                                                                                                            |
 |:------------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 5.1.7 | 2026-03-12 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Upgrade CDK to 7.8.1.post54 — validates StateDelegatingStream and DeclarativeStream regression fix |
 | 5.1.7-rc.1 | 2026-03-10 | [74398](https://github.com/airbytehq/airbyte/pull/74398) | Pin CDK to 7.8.1.post54 for regression testing of StateDelegatingStream and DeclarativeStream |
 | 5.1.6 | 2026-03-09 | [73686](https://github.com/airbytehq/airbyte/pull/73686) | Add 504 exponential backoff error handling to `ticket_comments` stream and API budget (10 req/min) for all incremental export streams |
 | 5.1.5 | 2026-02-24 | [45667](https://github.com/airbytehq/airbyte/issues/45667) | Add missing SLA fields (`sla`, `group_sla`, `status`, `deleted`) to `ticket_metric_events` schema |


### PR DESCRIPTION
## What

Promotes `source-zendesk-support` from `5.1.7-rc.1` to `5.1.7` GA after successful progressive rollout validation of CDK `7.8.1.post54`.

Related: https://github.com/airbytehq/oncall/issues/11103

## How

- Updates `dockerImageTag` in `metadata.yaml` from `5.1.7-rc.1` → `5.1.7`
- Adds changelog entry for the GA release in the connector docs

## Review guide

1. `airbyte-integrations/connectors/source-zendesk-support/metadata.yaml` — version bump only
2. `docs/integrations/sources/zendesk-support.md` — new changelog row (⚠️ note: `*PR_NUMBER_PLACEHOLDER*` needs to be replaced with this PR's number)

## Rollout validation summary

The RC was progressively rolled out across all customer tiers with **0% failure rate**:
- **T2**: 181 actors pinned, 120/121 with successful syncs over 48+ hours
- **T1**: 15/15 actors pinned, 0 failures
- **T0**: 12/12 actors pinned, 0 failures

Rollout finalized (canceled with pins retained) per [approval comment](https://github.com/airbytehq/oncall/issues/11103#issuecomment-4048477719).

## User Impact

No user-facing behavior change. This promotes the already-running RC to the official GA version.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

[Link to Devin Session](https://app.devin.ai/sessions/bb7de8f020274b2589a9fea6807fae99)
Requested by: @agarctfi