### PR TITLE
fix(source-quickbooks): Add error handler for 401 to retry with refreshed OAuth token instead of failing

### DIFF
--- a/airbyte-integrations/connectors/source-quickbooks/manifest.yaml
+++ b/airbyte-integrations/connectors/source-quickbooks/manifest.yaml
@@ -48,6 +48,15 @@ definitions:
           request_headers:
             Accept: application/json
             User-Agent: airbyte-connector
+          error_handler:
+            type: DefaultErrorHandler
+            response_filters:
+            - type: HttpResponseFilter
+              action: REFRESH_TOKEN_THEN_RETRY
+              http_codes:
+              - 401
+              failure_type: transient_error
+              error_message: Access token is expired.
         record_selector:
           type: RecordSelector
           extractor:
@@ -222,6 +231,15 @@ definitions:
           request_headers:
             Accept: application/json
             User-Agent: airbyte-connector
+          error_handler:
+            type: DefaultErrorHandler
+            response_filters:
+            - type: HttpResponseFilter
+              action: REFRESH_TOKEN_THEN_RETRY
+              http_codes:
+              - 401
+              failure_type: transient_error
+              error_message: Access token is expired.
         record_selector:
           type: RecordSelector
           extractor:
@@ -477,6 +495,15 @@ definitions:
           request_headers:
             Accept: application/json
             User-Agent: airbyte-connector
+          error_handler:
+            type: DefaultErrorHandler
+            response_filters:
+            - type: HttpResponseFilter
+              action: REFRESH_TOKEN_THEN_RETRY
+              http_codes:
+              - 401
+              failure_type: transient_error
+              error_message: Access token is expired.
         record_selector:
           type: RecordSelector
           extractor:
@@ -827,6 +854,15 @@ definitions:
           request_headers:
             Accept: application/json
             User-Agent: airbyte-connector
+          error_handler:
+            type: DefaultErrorHandler
+            response_filters:
+            - type: HttpResponseFilter
+              action: REFRESH_TOKEN_THEN_RETRY
+              http_codes:
+              - 401
+              failure_type: transient_error
+              error_message: Access token is expired.
         record_selector:
           type: RecordSelector
           extractor:
@@ -1031,6 +1067,15 @@ definitions:
           request_headers:
             Accept: application/json
             User-Agent: airbyte-connector
+          error_handler:
+            type: DefaultErrorHandler
+            response_filters:
+            - type: HttpResponseFilter
+              action: REFRESH_TOKEN_THEN_RETRY
+              http_codes:
+              - 401
+              failure_type: transient_error
+              error_message: Access token is expired.
         record_selector:
           type: RecordSelector
           extractor:
@@ -1168,6 +1213,15 @@ definitions:
           request_headers:
             Accept: application/json
             User-Agent: airbyte-connector
+          error_handler:
+            type: DefaultErrorHandler
+            response_filters:
+            - type: HttpResponseFilter
+              action: REFRESH_TOKEN_THEN_RETRY
+              http_codes:
+              - 401
+              failure_type: transient_error
+              error_message: Access token is expired.
         record_selector:
           type: RecordSelector
           extractor:
@@ -1557,6 +1611,15 @@ definitions:
           request_headers:
             Accept: application/json
             User-Agent: airbyte-connector
+          error_handler:
+            type: DefaultErrorHandler
+            response_filters:
+            - type: HttpResponseFilter
+              action: REFRESH_TOKEN_THEN_RETRY
+              http_codes:
+              - 401
+              failure_type: transient_error
+              error_message: Access token is expired.
         record_selector:
           type: RecordSelector
           extractor:
@@ -1913,6 +1976,15 @@ definitions:
           request_headers:
             Accept: application/json
             User-Agent: airbyte-connector
+          error_handler:
+            type: DefaultErrorHandler
+            response_filters:
+            - type: HttpResponseFilter
+              action: REFRESH_TOKEN_THEN_RETRY
+              http_codes:
+              - 401
+              failure_type: transient_error
+              error_message: Access token is expired.
         record_selector:
           type: RecordSelector
           extractor:
@@ -2050,6 +2122,15 @@ definitions:
           request_headers:
             Accept: application/json
             User-Agent: airbyte-connector
+          error_handler:
+            type: DefaultErrorHandler
+            response_filters:
+            - type: HttpResponseFilter
+              action: REFRESH_TOKEN_THEN_RETRY
+              http_codes:
+              - 401
+              failure_type: transient_error
+              error_message: Access token is expired.
         record_selector:
           type: RecordSelector
           extractor:
@@ -2339,6 +2420,15 @@ definitions:
           request_headers:
             Accept: application/json
             User-Agent: airbyte-connector
+          error_handler:
+            type: DefaultErrorHandler
+            response_filters:
+            - type: HttpResponseFilter
+              action: REFRESH_TOKEN_THEN_RETRY
+              http_codes:
+              - 401
+              failure_type: transient_error
+              error_message: Access token is expired.
         record_selector:
           type: RecordSelector
           extractor:
@@ -2542,6 +2632,15 @@ definitions:
           request_headers:
             Accept: application/json
             User-Agent: airbyte-connector
+          error_handler:
+            type: DefaultErrorHandler
+            response_filters:
+            - type: HttpResponseFilter
+              action: REFRESH_TOKEN_THEN_RETRY
+              http_codes:
+              - 401
+              failure_type: transient_error
+              error_message: Access token is expired.
         record_selector:
           type: RecordSelector
           extractor:
@@ -2980,6 +3079,15 @@ definitions:
           request_headers:
             Accept: application/json
             User-Agent: airbyte-connector
+          error_handler:
+            type: DefaultErrorHandler
+            response_filters:
+            - type: HttpResponseFilter
+              action: REFRESH_TOKEN_THEN_RETRY
+              http_codes:
+              - 401
+              failure_type: transient_error
+              error_message: Access token is expired.
         record_selector:
           type: RecordSelector
           extractor:
@@ -3534,6 +3642,15 @@ definitions:
           request_headers:
             Accept: application/json
             User-Agent: airbyte-connector
+          error_handler:
+            type: DefaultErrorHandler
+            response_filters:
+            - type: HttpResponseFilter
+              action: REFRESH_TOKEN_THEN_RETRY
+              http_codes:
+              - 401
+              failure_type: transient_error
+              error_message: Access token is expired.
         record_selector:
           type: RecordSelector
           extractor:
@@ -3734,6 +3851,15 @@ definitions:
           request_headers:
             Accept: application/json
             User-Agent: airbyte-connector
+          error_handler:
+            type: DefaultErrorHandler
+            response_filters:
+            - type: HttpResponseFilter
+              action: REFRESH_TOKEN_THEN_RETRY
+              http_codes:
+              - 401
+              failure_type: transient_error
+              error_message: Access token is expired.
         record_selector:
           type: RecordSelector
           extractor:
@@ -4054,6 +4180,15 @@ definitions:
           request_headers:
             Accept: application/json
             User-Agent: airbyte-connector
+          error_handler:
+            type: DefaultErrorHandler
+            response_filters:
+            - type: HttpResponseFilter
+              action: REFRESH_TOKEN_THEN_RETRY
+              http_codes:
+              - 401
+              failure_type: transient_error
+              error_message: Access token is expired.
         record_selector:
           type: RecordSelector
           extractor:
@@ -4178,6 +4313,15 @@ definitions:
           request_headers:
             Accept: application/json
             User-Agent: airbyte-connector
+          error_handler:
+            type: DefaultErrorHandler
+            response_filters:
+            - type: HttpResponseFilter
+              action: REFRESH_TOKEN_THEN_RETRY
+              http_codes:
+              - 401
+              failure_type: transient_error
+              error_message: Access token is expired.
         record_selector:
           type: RecordSelector
           extractor:
@@ -4474,6 +4618,15 @@ definitions:
           request_headers:
             Accept: application/json
             User-Agent: airbyte-connector
+          error_handler:
+            type: DefaultErrorHandler
+            response_filters:
+            - type: HttpResponseFilter
+              action: REFRESH_TOKEN_THEN_RETRY
+              http_codes:
+              - 401
+              failure_type: transient_error
+              error_message: Access token is expired.
         record_selector:
           type: RecordSelector
           extractor:
@@ -4922,6 +5075,15 @@ definitions:
           request_headers:
             Accept: application/json
             User-Agent: airbyte-connector
+          error_handler:
+            type: DefaultErrorHandler
+            response_filters:
+            - type: HttpResponseFilter
+              action: REFRESH_TOKEN_THEN_RETRY
+              http_codes:
+              - 401
+              failure_type: transient_error
+              error_message: Access token is expired.
         record_selector:
           type: RecordSelector
           extractor:
@@ -5316,6 +5478,15 @@ definitions:
           request_headers:
             Accept: application/json
             User-Agent: airbyte-connector
+          error_handler:
+            type: DefaultErrorHandler
+            response_filters:
+            - type: HttpResponseFilter
+              action: REFRESH_TOKEN_THEN_RETRY
+              http_codes:
+              - 401
+              failure_type: transient_error
+              error_message: Access token is expired.
         record_selector:
           type: RecordSelector
           extractor:
@@ -5665,6 +5836,15 @@ definitions:
           request_headers:
             Accept: application/json
             User-Agent: airbyte-connector
+          error_handler:
+            type: DefaultErrorHandler
+            response_filters:
+            - type: HttpResponseFilter
+              action: REFRESH_TOKEN_THEN_RETRY
+              http_codes:
+              - 401
+              failure_type: transient_error
+              error_message: Access token is expired.
         record_selector:
           type: RecordSelector
           extractor:
@@ -6102,6 +6282,15 @@ definitions:
           request_headers:
             Accept: application/json
             User-Agent: airbyte-connector
+          error_handler:
+            type: DefaultErrorHandler
+            response_filters:
+            - type: HttpResponseFilter
+              action: REFRESH_TOKEN_THEN_RETRY
+              http_codes:
+              - 401
+              failure_type: transient_error
+              error_message: Access token is expired.
         record_selector:
           type: RecordSelector
           extractor:
@@ -6230,6 +6419,15 @@ definitions:
           request_headers:
             Accept: application/json
             User-Agent: airbyte-connector
+          error_handler:
+            type: DefaultErrorHandler
+            response_filters:
+            - type: HttpResponseFilter
+              action: REFRESH_TOKEN_THEN_RETRY
+              http_codes:
+              - 401
+              failure_type: transient_error
+              error_message: Access token is expired.
         record_selector:
           type: RecordSelector
           extractor:
@@ -6406,6 +6604,15 @@ definitions:
           request_headers:
             Accept: application/json
             User-Agent: airbyte-connector
+          error_handler:
+            type: DefaultErrorHandler
+            response_filters:
+            - type: HttpResponseFilter
+              action: REFRESH_TOKEN_THEN_RETRY
+              http_codes:
+              - 401
+              failure_type: transient_error
+              error_message: Access token is expired.
         record_selector:
           type: RecordSelector
           extractor:
@@ -6593,6 +6800,15 @@ definitions:
           request_headers:
             Accept: application/json
             User-Agent: airbyte-connector
+          error_handler:
+            type: DefaultErrorHandler
+            response_filters:
+            - type: HttpResponseFilter
+              action: REFRESH_TOKEN_THEN_RETRY
+              http_codes:
+              - 401
+              failure_type: transient_error
+              error_message: Access token is expired.
         record_selector:
           type: RecordSelector
           extractor:
@@ -6741,6 +6957,15 @@ definitions:
           request_headers:
             Accept: application/json
             User-Agent: airbyte-connector
+          error_handler:
+            type: DefaultErrorHandler
+            response_filters:
+            - type: HttpResponseFilter
+              action: REFRESH_TOKEN_THEN_RETRY
+              http_codes:
+              - 401
+              failure_type: transient_error
+              error_message: Access token is expired.
         record_selector:
           type: RecordSelector
           extractor:
@@ -6925,6 +7150,15 @@ definitions:
           request_headers:
             Accept: application/json
             User-Agent: airbyte-connector
+          error_handler:
+            type: DefaultErrorHandler
+            response_filters:
+            - type: HttpResponseFilter
+              action: REFRESH_TOKEN_THEN_RETRY
+              http_codes:
+              - 401
+              failure_type: transient_error
+              error_message: Access token is expired.
         record_selector:
           type: RecordSelector
           extractor:
@@ -7089,6 +7323,15 @@ definitions:
           request_headers:
             Accept: application/json
             User-Agent: airbyte-connector
+          error_handler:
+            type: DefaultErrorHandler
+            response_filters:
+            - type: HttpResponseFilter
+              action: REFRESH_TOKEN_THEN_RETRY
+              http_codes:
+              - 401
+              failure_type: transient_error
+              error_message: Access token is expired.
         record_selector:
           type: RecordSelector
           extractor:
@@ -7352,6 +7595,15 @@ definitions:
           request_headers:
             Accept: application/json
             User-Agent: airbyte-connector
+          error_handler:
+            type: DefaultErrorHandler
+            response_filters:
+            - type: HttpResponseFilter
+              action: REFRESH_TOKEN_THEN_RETRY
+              http_codes:
+              - 401
+              failure_type: transient_error
+              error_message: Access token is expired.
         record_selector:
           type: RecordSelector
           extractor:
@@ -7637,6 +7889,15 @@ streams:
       request_headers:
         Accept: application/json
         User-Agent: airbyte-connector
+      error_handler:
+        type: DefaultErrorHandler
+        response_filters:
+        - type: HttpResponseFilter
+          action: REFRESH_TOKEN_THEN_RETRY
+          http_codes:
+          - 401
+          failure_type: transient_error
+          error_message: Access token is expired.
     record_selector:
       type: RecordSelector
       extractor:
@@ -7811,6 +8072,15 @@ streams:
       request_headers:
         Accept: application/json
         User-Agent: airbyte-connector
+      error_handler:
+        type: DefaultErrorHandler
+        response_filters:
+        - type: HttpResponseFilter
+          action: REFRESH_TOKEN_THEN_RETRY
+          http_codes:
+          - 401
+          failure_type: transient_error
+          error_message: Access token is expired.
     record_selector:
       type: RecordSelector
       extractor:
@@ -8066,6 +8336,15 @@ streams:
       request_headers:
         Accept: application/json
         User-Agent: airbyte-connector
+      error_handler:
+        type: DefaultErrorHandler
+        response_filters:
+        - type: HttpResponseFilter
+          action: REFRESH_TOKEN_THEN_RETRY
+          http_codes:
+          - 401
+          failure_type: transient_error
+          error_message: Access token is expired.
     record_selector:
       type: RecordSelector
       extractor:
@@ -8416,6 +8695,15 @@ streams:
       request_headers:
         Accept: application/json
         User-Agent: airbyte-connector
+      error_handler:
+        type: DefaultErrorHandler
+        response_filters:
+        - type: HttpResponseFilter
+          action: REFRESH_TOKEN_THEN_RETRY
+          http_codes:
+          - 401
+          failure_type: transient_error
+          error_message: Access token is expired.
     record_selector:
       type: RecordSelector
       extractor:
@@ -8620,6 +8908,15 @@ streams:
       request_headers:
         Accept: application/json
         User-Agent: airbyte-connector
+      error_handler:
+        type: DefaultErrorHandler
+        response_filters:
+        - type: HttpResponseFilter
+          action: REFRESH_TOKEN_THEN_RETRY
+          http_codes:
+          - 401
+          failure_type: transient_error
+          error_message: Access token is expired.
     record_selector:
       type: RecordSelector
       extractor:
@@ -8757,6 +9054,15 @@ streams:
       request_headers:
         Accept: application/json
         User-Agent: airbyte-connector
+      error_handler:
+        type: DefaultErrorHandler
+        response_filters:
+        - type: HttpResponseFilter
+          action: REFRESH_TOKEN_THEN_RETRY
+          http_codes:
+          - 401
+          failure_type: transient_error
+          error_message: Access token is expired.
     record_selector:
       type: RecordSelector
       extractor:
@@ -9146,6 +9452,15 @@ streams:
       request_headers:
         Accept: application/json
         User-Agent: airbyte-connector
+      error_handler:
+        type: DefaultErrorHandler
+        response_filters:
+        - type: HttpResponseFilter
+          action: REFRESH_TOKEN_THEN_RETRY
+          http_codes:
+          - 401
+          failure_type: transient_error
+          error_message: Access token is expired.
     record_selector:
       type: RecordSelector
       extractor:
@@ -9502,6 +9817,15 @@ streams:
       request_headers:
         Accept: application/json
         User-Agent: airbyte-connector
+      error_handler:
+        type: DefaultErrorHandler
+        response_filters:
+        - type: HttpResponseFilter
+          action: REFRESH_TOKEN_THEN_RETRY
+          http_codes:
+          - 401
+          failure_type: transient_error
+          error_message: Access token is expired.
     record_selector:
       type: RecordSelector
       extractor:
@@ -9639,6 +9963,15 @@ streams:
       request_headers:
         Accept: application/json
         User-Agent: airbyte-connector
+      error_handler:
+        type: DefaultErrorHandler
+        response_filters:
+        - type: HttpResponseFilter
+          action: REFRESH_TOKEN_THEN_RETRY
+          http_codes:
+          - 401
+          failure_type: transient_error
+          error_message: Access token is expired.
     record_selector:
       type: RecordSelector
       extractor:
@@ -9928,6 +10261,15 @@ streams:
       request_headers:
         Accept: application/json
         User-Agent: airbyte-connector
+      error_handler:
+        type: DefaultErrorHandler
+        response_filters:
+        - type: HttpResponseFilter
+          action: REFRESH_TOKEN_THEN_RETRY
+          http_codes:
+          - 401
+          failure_type: transient_error
+          error_message: Access token is expired.
     record_selector:
       type: RecordSelector
       extractor:
@@ -10131,6 +10473,15 @@ streams:
       request_headers:
         Accept: application/json
         User-Agent: airbyte-connector
+      error_handler:
+        type: DefaultErrorHandler
+        response_filters:
+        - type: HttpResponseFilter
+          action: REFRESH_TOKEN_THEN_RETRY
+          http_codes:
+          - 401
+          failure_type: transient_error
+          error_message: Access token is expired.
     record_selector:
       type: RecordSelector
       extractor:
@@ -10569,6 +10920,15 @@ streams:
       request_headers:
         Accept: application/json
         User-Agent: airbyte-connector
+      error_handler:
+        type: DefaultErrorHandler
+        response_filters:
+        - type: HttpResponseFilter
+          action: REFRESH_TOKEN_THEN_RETRY
+          http_codes:
+          - 401
+          failure_type: transient_error
+          error_message: Access token is expired.
     record_selector:
       type: RecordSelector
       extractor:
@@ -11123,6 +11483,15 @@ streams:
       request_headers:
         Accept: application/json
         User-Agent: airbyte-connector
+      error_handler:
+        type: DefaultErrorHandler
+        response_filters:
+        - type: HttpResponseFilter
+          action: REFRESH_TOKEN_THEN_RETRY
+          http_codes:
+          - 401
+          failure_type: transient_error
+          error_message: Access token is expired.
     record_selector:
       type: RecordSelector
       extractor:
@@ -11323,6 +11692,15 @@ streams:
       request_headers:
         Accept: application/json
         User-Agent: airbyte-connector
+      error_handler:
+        type: DefaultErrorHandler
+        response_filters:
+        - type: HttpResponseFilter
+          action: REFRESH_TOKEN_THEN_RETRY
+          http_codes:
+          - 401
+          failure_type: transient_error
+          error_message: Access token is expired.
     record_selector:
       type: RecordSelector
       extractor:
@@ -11643,6 +12021,15 @@ streams:
       request_headers:
         Accept: application/json
         User-Agent: airbyte-connector
+      error_handler:
+        type: DefaultErrorHandler
+        response_filters:
+        - type: HttpResponseFilter
+          action: REFRESH_TOKEN_THEN_RETRY
+          http_codes:
+          - 401
+          failure_type: transient_error
+          error_message: Access token is expired.
     record_selector:
       type: RecordSelector
       extractor:
@@ -11767,6 +12154,15 @@ streams:
       request_headers:
         Accept: application/json
         User-Agent: airbyte-connector
+      error_handler:
+        type: DefaultErrorHandler
+        response_filters:
+        - type: HttpResponseFilter
+          action: REFRESH_TOKEN_THEN_RETRY
+          http_codes:
+          - 401
+          failure_type: transient_error
+          error_message: Access token is expired.
     record_selector:
       type: RecordSelector
       extractor:
@@ -12063,6 +12459,15 @@ streams:
       request_headers:
         Accept: application/json
         User-Agent: airbyte-connector
+      error_handler:
+        type: DefaultErrorHandler
+        response_filters:
+        - type: HttpResponseFilter
+          action: REFRESH_TOKEN_THEN_RETRY
+          http_codes:
+          - 401
+          failure_type: transient_error
+          error_message: Access token is expired.
     record_selector:
       type: RecordSelector
       extractor:
@@ -12511,6 +12916,15 @@ streams:
       request_headers:
         Accept: application/json
         User-Agent: airbyte-connector
+      error_handler:
+        type: DefaultErrorHandler
+        response_filters:
+        - type: HttpResponseFilter
+          action: REFRESH_TOKEN_THEN_RETRY
+          http_codes:
+          - 401
+          failure_type: transient_error
+          error_message: Access token is expired.
     record_selector:
       type: RecordSelector
       extractor:
@@ -12905,6 +13319,15 @@ streams:
       request_headers:
         Accept: application/json
         User-Agent: airbyte-connector
+      error_handler:
+        type: DefaultErrorHandler
+        response_filters:
+        - type: HttpResponseFilter
+          action: REFRESH_TOKEN_THEN_RETRY
+          http_codes:
+          - 401
+          failure_type: transient_error
+          error_message: Access token is expired.
     record_selector:
       type: RecordSelector
       extractor:
@@ -13254,6 +13677,15 @@ streams:
       request_headers:
         Accept: application/json
         User-Agent: airbyte-connector
+      error_handler:
+        type: DefaultErrorHandler
+        response_filters:
+        - type: HttpResponseFilter
+          action: REFRESH_TOKEN_THEN_RETRY
+          http_codes:
+          - 401
+          failure_type: transient_error
+          error_message: Access token is expired.
     record_selector:
       type: RecordSelector
       extractor:
@@ -13691,6 +14123,15 @@ streams:
       request_headers:
         Accept: application/json
         User-Agent: airbyte-connector
+      error_handler:
+        type: DefaultErrorHandler
+        response_filters:
+        - type: HttpResponseFilter
+          action: REFRESH_TOKEN_THEN_RETRY
+          http_codes:
+          - 401
+          failure_type: transient_error
+          error_message: Access token is expired.
     record_selector:
       type: RecordSelector
       extractor:
@@ -13819,6 +14260,15 @@ streams:
       request_headers:
         Accept: application/json
         User-Agent: airbyte-connector
+      error_handler:
+        type: DefaultErrorHandler
+        response_filters:
+        - type: HttpResponseFilter
+          action: REFRESH_TOKEN_THEN_RETRY
+          http_codes:
+          - 401
+          failure_type: transient_error
+          error_message: Access token is expired.
     record_selector:
       type: RecordSelector
       extractor:
@@ -13995,6 +14445,15 @@ streams:
       request_headers:
         Accept: application/json
         User-Agent: airbyte-connector
+      error_handler:
+        type: DefaultErrorHandler
+        response_filters:
+        - type: HttpResponseFilter
+          action: REFRESH_TOKEN_THEN_RETRY
+          http_codes:
+          - 401
+          failure_type: transient_error
+          error_message: Access token is expired.
     record_selector:
       type: RecordSelector
       extractor:
@@ -14182,6 +14641,15 @@ streams:
       request_headers:
         Accept: application/json
         User-Agent: airbyte-connector
+      error_handler:
+        type: DefaultErrorHandler
+        response_filters:
+        - type: HttpResponseFilter
+          action: REFRESH_TOKEN_THEN_RETRY
+          http_codes:
+          - 401
+          failure_type: transient_error
+          error_message: Access token is expired.
     record_selector:
       type: RecordSelector
       extractor:
@@ -14330,6 +14798,15 @@ streams:
       request_headers:
         Accept: application/json
         User-Agent: airbyte-connector
+      error_handler:
+        type: DefaultErrorHandler
+        response_filters:
+        - type: HttpResponseFilter
+          action: REFRESH_TOKEN_THEN_RETRY
+          http_codes:
+          - 401
+          failure_type: transient_error
+          error_message: Access token is expired.
     record_selector:
       type: RecordSelector
       extractor:
@@ -14514,6 +14991,15 @@ streams:
       request_headers:
         Accept: application/json
         User-Agent: airbyte-connector
+      error_handler:
+        type: DefaultErrorHandler
+        response_filters:
+        - type: HttpResponseFilter
+          action: REFRESH_TOKEN_THEN_RETRY
+          http_codes:
+          - 401
+          failure_type: transient_error
+          error_message: Access token is expired.
     record_selector:
       type: RecordSelector
       extractor:
@@ -14678,6 +15164,15 @@ streams:
       request_headers:
         Accept: application/json
         User-Agent: airbyte-connector
+      error_handler:
+        type: DefaultErrorHandler
+        response_filters:
+        - type: HttpResponseFilter
+          action: REFRESH_TOKEN_THEN_RETRY
+          http_codes:
+          - 401
+          failure_type: transient_error
+          error_message: Access token is expired.
     record_selector:
       type: RecordSelector
       extractor:
@@ -14941,6 +15436,15 @@ streams:
       request_headers:
         Accept: application/json
         User-Agent: airbyte-connector
+      error_handler:
+        type: DefaultErrorHandler
+        response_filters:
+        - type: HttpResponseFilter
+          action: REFRESH_TOKEN_THEN_RETRY
+          http_codes:
+          - 401
+          failure_type: transient_error
+          error_message: Access token is expired.
     record_selector:
       type: RecordSelector
       extractor:

--- a/airbyte-integrations/connectors/source-quickbooks/manifest.yaml
+++ b/airbyte-integrations/connectors/source-quickbooks/manifest.yaml
@@ -52,7 +52,7 @@ definitions:
             type: DefaultErrorHandler
             response_filters:
             - type: HttpResponseFilter
-              action: REFRESH_TOKEN_THEN_RETRY
+              action: RETRY
               http_codes:
               - 401
               failure_type: transient_error
@@ -235,7 +235,7 @@ definitions:
             type: DefaultErrorHandler
             response_filters:
             - type: HttpResponseFilter
-              action: REFRESH_TOKEN_THEN_RETRY
+              action: RETRY
               http_codes:
               - 401
               failure_type: transient_error
@@ -499,7 +499,7 @@ definitions:
             type: DefaultErrorHandler
             response_filters:
             - type: HttpResponseFilter
-              action: REFRESH_TOKEN_THEN_RETRY
+              action: RETRY
               http_codes:
               - 401
               failure_type: transient_error
@@ -858,7 +858,7 @@ definitions:
             type: DefaultErrorHandler
             response_filters:
             - type: HttpResponseFilter
-              action: REFRESH_TOKEN_THEN_RETRY
+              action: RETRY
               http_codes:
               - 401
               failure_type: transient_error
@@ -1071,7 +1071,7 @@ definitions:
             type: DefaultErrorHandler
             response_filters:
             - type: HttpResponseFilter
-              action: REFRESH_TOKEN_THEN_RETRY
+              action: RETRY
               http_codes:
               - 401
               failure_type: transient_error
@@ -1217,7 +1217,7 @@ definitions:
             type: DefaultErrorHandler
             response_filters:
             - type: HttpResponseFilter
-              action: REFRESH_TOKEN_THEN_RETRY
+              action: RETRY
               http_codes:
               - 401
               failure_type: transient_error
@@ -1615,7 +1615,7 @@ definitions:
             type: DefaultErrorHandler
             response_filters:
             - type: HttpResponseFilter
-              action: REFRESH_TOKEN_THEN_RETRY
+              action: RETRY
               http_codes:
               - 401
               failure_type: transient_error
@@ -1980,7 +1980,7 @@ definitions:
             type: DefaultErrorHandler
             response_filters:
             - type: HttpResponseFilter
-              action: REFRESH_TOKEN_THEN_RETRY
+              action: RETRY
               http_codes:
               - 401
               failure_type: transient_error
@@ -2126,7 +2126,7 @@ definitions:
             type: DefaultErrorHandler
             response_filters:
             - type: HttpResponseFilter
-              action: REFRESH_TOKEN_THEN_RETRY
+              action: RETRY
               http_codes:
               - 401
               failure_type: transient_error
@@ -2424,7 +2424,7 @@ definitions:
             type: DefaultErrorHandler
             response_filters:
             - type: HttpResponseFilter
-              action: REFRESH_TOKEN_THEN_RETRY
+              action: RETRY
               http_codes:
               - 401
               failure_type: transient_error
@@ -2636,7 +2636,7 @@ definitions:
             type: DefaultErrorHandler
             response_filters:
             - type: HttpResponseFilter
-              action: REFRESH_TOKEN_THEN_RETRY
+              action: RETRY
               http_codes:
               - 401
               failure_type: transient_error
@@ -3083,7 +3083,7 @@ definitions:
             type: DefaultErrorHandler
             response_filters:
             - type: HttpResponseFilter
-              action: REFRESH_TOKEN_THEN_RETRY
+              action: RETRY
               http_codes:
               - 401
               failure_type: transient_error
@@ -3646,7 +3646,7 @@ definitions:
             type: DefaultErrorHandler
             response_filters:
             - type: HttpResponseFilter
-              action: REFRESH_TOKEN_THEN_RETRY
+              action: RETRY
               http_codes:
               - 401
               failure_type: transient_error
@@ -3855,7 +3855,7 @@ definitions:
             type: DefaultErrorHandler
             response_filters:
             - type: HttpResponseFilter
-              action: REFRESH_TOKEN_THEN_RETRY
+              action: RETRY
               http_codes:
               - 401
               failure_type: transient_error
@@ -4184,7 +4184,7 @@ definitions:
             type: DefaultErrorHandler
             response_filters:
             - type: HttpResponseFilter
-              action: REFRESH_TOKEN_THEN_RETRY
+              action: RETRY
               http_codes:
               - 401
               failure_type: transient_error
@@ -4317,7 +4317,7 @@ definitions:
             type: DefaultErrorHandler
             response_filters:
             - type: HttpResponseFilter
-              action: REFRESH_TOKEN_THEN_RETRY
+              action: RETRY
               http_codes:
               - 401
               failure_type: transient_error
@@ -4622,7 +4622,7 @@ definitions:
             type: DefaultErrorHandler
             response_filters:
             - type: HttpResponseFilter
-              action: REFRESH_TOKEN_THEN_RETRY
+              action: RETRY
               http_codes:
               - 401
               failure_type: transient_error
@@ -5079,7 +5079,7 @@ definitions:
             type: DefaultErrorHandler
             response_filters:
             - type: HttpResponseFilter
-              action: REFRESH_TOKEN_THEN_RETRY
+              action: RETRY
               http_codes:
               - 401
               failure_type: transient_error
@@ -5482,7 +5482,7 @@ definitions:
             type: DefaultErrorHandler
             response_filters:
             - type: HttpResponseFilter
-              action: REFRESH_TOKEN_THEN_RETRY
+              action: RETRY
               http_codes:
               - 401
               failure_type: transient_error
@@ -5840,7 +5840,7 @@ definitions:
             type: DefaultErrorHandler
             response_filters:
             - type: HttpResponseFilter
-              action: REFRESH_TOKEN_THEN_RETRY
+              action: RETRY
               http_codes:
               - 401
               failure_type: transient_error
@@ -6286,7 +6286,7 @@ definitions:
             type: DefaultErrorHandler
             response_filters:
             - type: HttpResponseFilter
-              action: REFRESH_TOKEN_THEN_RETRY
+              action: RETRY
               http_codes:
               - 401
               failure_type: transient_error
@@ -6423,7 +6423,7 @@ definitions:
             type: DefaultErrorHandler
             response_filters:
             - type: HttpResponseFilter
-              action: REFRESH_TOKEN_THEN_RETRY
+              action: RETRY
               http_codes:
               - 401
               failure_type: transient_error
@@ -6608,7 +6608,7 @@ definitions:
             type: DefaultErrorHandler
             response_filters:
             - type: HttpResponseFilter
-              action: REFRESH_TOKEN_THEN_RETRY
+              action: RETRY
               http_codes:
               - 401
               failure_type: transient_error
@@ -6804,7 +6804,7 @@ definitions:
             type: DefaultErrorHandler
             response_filters:
             - type: HttpResponseFilter
-              action: REFRESH_TOKEN_THEN_RETRY
+              action: RETRY
               http_codes:
               - 401
               failure_type: transient_error
@@ -6961,7 +6961,7 @@ definitions:
             type: DefaultErrorHandler
             response_filters:
             - type: HttpResponseFilter
-              action: REFRESH_TOKEN_THEN_RETRY
+              action: RETRY
               http_codes:
               - 401
               failure_type: transient_error
@@ -7154,7 +7154,7 @@ definitions:
             type: DefaultErrorHandler
             response_filters:
             - type: HttpResponseFilter
-              action: REFRESH_TOKEN_THEN_RETRY
+              action: RETRY
               http_codes:
               - 401
               failure_type: transient_error
@@ -7327,7 +7327,7 @@ definitions:
             type: DefaultErrorHandler
             response_filters:
             - type: HttpResponseFilter
-              action: REFRESH_TOKEN_THEN_RETRY
+              action: RETRY
               http_codes:
               - 401
               failure_type: transient_error
@@ -7599,7 +7599,7 @@ definitions:
             type: DefaultErrorHandler
             response_filters:
             - type: HttpResponseFilter
-              action: REFRESH_TOKEN_THEN_RETRY
+              action: RETRY
               http_codes:
               - 401
               failure_type: transient_error
@@ -7893,7 +7893,7 @@ streams:
         type: DefaultErrorHandler
         response_filters:
         - type: HttpResponseFilter
-          action: REFRESH_TOKEN_THEN_RETRY
+          action: RETRY
           http_codes:
           - 401
           failure_type: transient_error
@@ -8076,7 +8076,7 @@ streams:
         type: DefaultErrorHandler
         response_filters:
         - type: HttpResponseFilter
-          action: REFRESH_TOKEN_THEN_RETRY
+          action: RETRY
           http_codes:
           - 401
           failure_type: transient_error
@@ -8340,7 +8340,7 @@ streams:
         type: DefaultErrorHandler
         response_filters:
         - type: HttpResponseFilter
-          action: REFRESH_TOKEN_THEN_RETRY
+          action: RETRY
           http_codes:
           - 401
           failure_type: transient_error
@@ -8699,7 +8699,7 @@ streams:
         type: DefaultErrorHandler
         response_filters:
         - type: HttpResponseFilter
-          action: REFRESH_TOKEN_THEN_RETRY
+          action: RETRY
           http_codes:
           - 401
           failure_type: transient_error
@@ -8912,7 +8912,7 @@ streams:
         type: DefaultErrorHandler
         response_filters:
         - type: HttpResponseFilter
-          action: REFRESH_TOKEN_THEN_RETRY
+          action: RETRY
           http_codes:
           - 401
           failure_type: transient_error
@@ -9058,7 +9058,7 @@ streams:
         type: DefaultErrorHandler
         response_filters:
         - type: HttpResponseFilter
-          action: REFRESH_TOKEN_THEN_RETRY
+          action: RETRY
           http_codes:
           - 401
           failure_type: transient_error
@@ -9456,7 +9456,7 @@ streams:
         type: DefaultErrorHandler
         response_filters:
         - type: HttpResponseFilter
-          action: REFRESH_TOKEN_THEN_RETRY
+          action: RETRY
           http_codes:
           - 401
           failure_type: transient_error
@@ -9821,7 +9821,7 @@ streams:
         type: DefaultErrorHandler
         response_filters:
         - type: HttpResponseFilter
-          action: REFRESH_TOKEN_THEN_RETRY
+          action: RETRY
           http_codes:
           - 401
           failure_type: transient_error
@@ -9967,7 +9967,7 @@ streams:
         type: DefaultErrorHandler
         response_filters:
         - type: HttpResponseFilter
-          action: REFRESH_TOKEN_THEN_RETRY
+          action: RETRY
           http_codes:
           - 401
           failure_type: transient_error
@@ -10265,7 +10265,7 @@ streams:
         type: DefaultErrorHandler
         response_filters:
         - type: HttpResponseFilter
-          action: REFRESH_TOKEN_THEN_RETRY
+          action: RETRY
           http_codes:
           - 401
           failure_type: transient_error
@@ -10477,7 +10477,7 @@ streams:
         type: DefaultErrorHandler
         response_filters:
         - type: HttpResponseFilter
-          action: REFRESH_TOKEN_THEN_RETRY
+          action: RETRY
           http_codes:
           - 401
           failure_type: transient_error
@@ -10924,7 +10924,7 @@ streams:
         type: DefaultErrorHandler
         response_filters:
         - type: HttpResponseFilter
-          action: REFRESH_TOKEN_THEN_RETRY
+          action: RETRY
           http_codes:
           - 401
           failure_type: transient_error
@@ -11487,7 +11487,7 @@ streams:
         type: DefaultErrorHandler
         response_filters:
         - type: HttpResponseFilter
-          action: REFRESH_TOKEN_THEN_RETRY
+          action: RETRY
           http_codes:
           - 401
           failure_type: transient_error
@@ -11696,7 +11696,7 @@ streams:
         type: DefaultErrorHandler
         response_filters:
         - type: HttpResponseFilter
-          action: REFRESH_TOKEN_THEN_RETRY
+          action: RETRY
           http_codes:
           - 401
           failure_type: transient_error
@@ -12025,7 +12025,7 @@ streams:
         type: DefaultErrorHandler
         response_filters:
         - type: HttpResponseFilter
-          action: REFRESH_TOKEN_THEN_RETRY
+          action: RETRY
           http_codes:
           - 401
           failure_type: transient_error
@@ -12158,7 +12158,7 @@ streams:
         type: DefaultErrorHandler
         response_filters:
         - type: HttpResponseFilter
-          action: REFRESH_TOKEN_THEN_RETRY
+          action: RETRY
           http_codes:
           - 401
           failure_type: transient_error
@@ -12463,7 +12463,7 @@ streams:
         type: DefaultErrorHandler
         response_filters:
         - type: HttpResponseFilter
-          action: REFRESH_TOKEN_THEN_RETRY
+          action: RETRY
           http_codes:
           - 401
           failure_type: transient_error
@@ -12920,7 +12920,7 @@ streams:
         type: DefaultErrorHandler
         response_filters:
         - type: HttpResponseFilter
-          action: REFRESH_TOKEN_THEN_RETRY
+          action: RETRY
           http_codes:
           - 401
           failure_type: transient_error
@@ -13323,7 +13323,7 @@ streams:
         type: DefaultErrorHandler
         response_filters:
         - type: HttpResponseFilter
-          action: REFRESH_TOKEN_THEN_RETRY
+          action: RETRY
           http_codes:
           - 401
           failure_type: transient_error
@@ -13681,7 +13681,7 @@ streams:
         type: DefaultErrorHandler
         response_filters:
         - type: HttpResponseFilter
-          action: REFRESH_TOKEN_THEN_RETRY
+          action: RETRY
           http_codes:
           - 401
           failure_type: transient_error
@@ -14127,7 +14127,7 @@ streams:
         type: DefaultErrorHandler
         response_filters:
         - type: HttpResponseFilter
-          action: REFRESH_TOKEN_THEN_RETRY
+          action: RETRY
           http_codes:
           - 401
           failure_type: transient_error
@@ -14264,7 +14264,7 @@ streams:
         type: DefaultErrorHandler
         response_filters:
         - type: HttpResponseFilter
-          action: REFRESH_TOKEN_THEN_RETRY
+          action: RETRY
           http_codes:
           - 401
           failure_type: transient_error
@@ -14449,7 +14449,7 @@ streams:
         type: DefaultErrorHandler
         response_filters:
         - type: HttpResponseFilter
-          action: REFRESH_TOKEN_THEN_RETRY
+          action: RETRY
           http_codes:
           - 401
           failure_type: transient_error
@@ -14645,7 +14645,7 @@ streams:
         type: DefaultErrorHandler
         response_filters:
         - type: HttpResponseFilter
-          action: REFRESH_TOKEN_THEN_RETRY
+          action: RETRY
           http_codes:
           - 401
           failure_type: transient_error
@@ -14802,7 +14802,7 @@ streams:
         type: DefaultErrorHandler
         response_filters:
         - type: HttpResponseFilter
-          action: REFRESH_TOKEN_THEN_RETRY
+          action: RETRY
           http_codes:
           - 401
           failure_type: transient_error
@@ -14995,7 +14995,7 @@ streams:
         type: DefaultErrorHandler
         response_filters:
         - type: HttpResponseFilter
-          action: REFRESH_TOKEN_THEN_RETRY
+          action: RETRY
           http_codes:
           - 401
           failure_type: transient_error
@@ -15168,7 +15168,7 @@ streams:
         type: DefaultErrorHandler
         response_filters:
         - type: HttpResponseFilter
-          action: REFRESH_TOKEN_THEN_RETRY
+          action: RETRY
           http_codes:
           - 401
           failure_type: transient_error
@@ -15440,7 +15440,7 @@ streams:
         type: DefaultErrorHandler
         response_filters:
         - type: HttpResponseFilter
-          action: REFRESH_TOKEN_THEN_RETRY
+          action: RETRY
           http_codes:
           - 401
           failure_type: transient_error

--- a/airbyte-integrations/connectors/source-quickbooks/metadata.yaml
+++ b/airbyte-integrations/connectors/source-quickbooks/metadata.yaml
@@ -9,7 +9,7 @@ data:
     baseImage: docker.io/airbyte/source-declarative-manifest:6.51.0@sha256:890b109f243b8b9406f23ea7522de41025f7b3e87f6fc9710bc1e521213a276f
   connectorType: source
   definitionId: cf9c4355-b171-4477-8f2d-6c5cc5fc8b7e
-  dockerImageTag: 4.1.8
+  dockerImageTag: 4.1.9
   dockerRepository: airbyte/source-quickbooks
   githubIssueLabel: source-quickbooks
   icon: quickbooks.svg

--- a/airbyte-integrations/connectors/source-quickbooks/metadata.yaml
+++ b/airbyte-integrations/connectors/source-quickbooks/metadata.yaml
@@ -6,7 +6,7 @@ data:
       - oauth.platform.intuit.com
   connectorSubtype: api
   connectorBuildOptions:
-    baseImage: docker.io/airbyte/source-declarative-manifest:7.13.0@sha256:949b0f3efefbd66e6222f279f36b2fb1c796b06e0e712b1a80124b49769862c4
+    baseImage: docker.io/airbyte/source-declarative-manifest:6.51.0@sha256:890b109f243b8b9406f23ea7522de41025f7b3e87f6fc9710bc1e521213a276f
   connectorType: source
   definitionId: cf9c4355-b171-4477-8f2d-6c5cc5fc8b7e
   dockerImageTag: 4.1.9

--- a/airbyte-integrations/connectors/source-quickbooks/metadata.yaml
+++ b/airbyte-integrations/connectors/source-quickbooks/metadata.yaml
@@ -6,7 +6,7 @@ data:
       - oauth.platform.intuit.com
   connectorSubtype: api
   connectorBuildOptions:
-    baseImage: docker.io/airbyte/source-declarative-manifest:6.51.0@sha256:890b109f243b8b9406f23ea7522de41025f7b3e87f6fc9710bc1e521213a276f
+    baseImage: docker.io/airbyte/source-declarative-manifest:7.13.0@sha256:949b0f3efefbd66e6222f279f36b2fb1c796b06e0e712b1a80124b49769862c4
   connectorType: source
   definitionId: cf9c4355-b171-4477-8f2d-6c5cc5fc8b7e
   dockerImageTag: 4.1.9

--- a/docs/integrations/sources/quickbooks.md
+++ b/docs/integrations/sources/quickbooks.md
@@ -108,6 +108,7 @@ This Source is capable of syncing the following [Streams](https://developer.intu
 
 | Version     | Date       | Pull Request                                             | Subject                                                            |
 |:------------|:-----------|:---------------------------------------------------------| :----------------------------------------------------------------- |
+| 4.1.9 | 2026-03-12 | [74774](https://github.com/airbytehq/airbyte/pull/74774) | Add error handler for 401 to refresh OAuth token instead of failing sync |
 | 4.1.8 | 2025-05-24 | [60468](https://github.com/airbytehq/airbyte/pull/60468) | Update dependencies |
 | 4.1.7 | 2025-05-10 | [60170](https://github.com/airbytehq/airbyte/pull/60170) | Update dependencies |
 | 4.1.6 | 2025-05-03 | [59500](https://github.com/airbytehq/airbyte/pull/59500) | Update dependencies |


### PR DESCRIPTION
## What

When a QuickBooks OAuth access token expires mid-sync, the CDK's default error mapping classifies the HTTP 401 as a `config_error` with `ResponseAction.FAIL`. This prevents platform auto-retry, causing the sync to fail immediately. The next scheduled sync succeeds hours later once the token is refreshed — but the gap in data freshness is unacceptable.

Tracked in: https://github.com/airbytehq/oncall/issues/11635

## How

Adds a `DefaultErrorHandler` with an `HttpResponseFilter` to every `HttpRequester` in the QuickBooks manifest (all 28 streams × 2 = 56 blocks in both `definitions` and `streams` sections). The filter intercepts HTTP 401 responses and maps them to `RETRY` with `transient_error`, overriding the CDK's default `FAIL / config_error` classification.

On retry, the CDK's `OAuthAuthenticator.get_access_token()` checks `token_has_expired()` — since the token has already expired by the time the 401 occurred, it automatically refreshes the token before retrying the request.

**No base image change.** The base image remains at `source-declarative-manifest:6.51.0` (CDK v6.x). An earlier revision attempted to bump to CDK v7.x to use `REFRESH_TOKEN_THEN_RETRY`, but this caused sync crashes and refresh token invalidation in the customer's workspace (all 7 connections failed). The `RETRY` action on CDK 6.x achieves the same result for token-expiration 401s without requiring a major CDK version bump.

Version bumped from `4.1.8` → `4.1.9` with changelog entry.

## Updates since last revision

- **Reverted base image** from `source-declarative-manifest:7.13.0` back to `6.51.0`. The CDK 6→7 bump caused all connections in a customer workspace to crash with "Sync process exited without reporting status", followed by refresh token invalidation.
- **Changed action** from `REFRESH_TOKEN_THEN_RETRY` to `RETRY`. `RETRY` is supported on CDK 6.x and works for token-expiration 401s because the CDK's `OAuthAuthenticator` automatically refreshes expired tokens on retry.

## Review guide

1. `airbyte-integrations/connectors/source-quickbooks/manifest.yaml` — the identical 9-line `error_handler` block is added to each of the 56 `HttpRequester` blocks (28 in `definitions` + 28 in `streams`). Spot-check a few insertions to confirm correct indentation and placement (should be a sibling of `request_headers`, `path`, `http_method` within the `requester`).
2. `airbyte-integrations/connectors/source-quickbooks/metadata.yaml` — version bump `4.1.8` → `4.1.9` only. Base image is **unchanged** from master (`source-declarative-manifest:6.51.0`).
3. `docs/integrations/sources/quickbooks.md` — changelog entry added.

**Key items for reviewer attention:**
- **`RETRY` vs `REFRESH_TOKEN_THEN_RETRY`**: The `RETRY` action does NOT force-refresh the token — it relies on the CDK's `OAuthAuthenticator.get_access_token()` detecting the expired token and refreshing it before the retry. This works for token-expiration 401s but would not help if the 401 is caused by something other than an expired token where the CDK still thinks the token is valid. Verify this is acceptable for the QuickBooks use case.
- **Both `definitions` and `streams` sections modified**: The manifest duplicates all stream definitions in both sections. Confirm whether both require the change or if only `streams` is needed at runtime.
- **Retry exhaustion behavior**: With `DefaultErrorHandler` default `max_retries: 5`, if credentials are truly revoked (not just expired), the connector will attempt 5 retries before ultimately failing. Confirm this is acceptable.
- **No automated test coverage**: Acceptance tests are disabled for this connector (`connectorTestSuitesOptions` is commented out in `metadata.yaml`). The change can only be fully validated by a real 401 during an OAuth-authenticated sync.

## User Impact

Syncs that previously failed due to OAuth token expiration mid-sync (HTTP 401 classified as `config_error`, no retry) will now automatically retry with a refreshed token. Users no longer need to wait for the next scheduled sync to recover from token expiration.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Reverting restores the previous behavior where 401s fail immediately as `config_error`. No state, schema, or base image changes involved.

---

Link to Devin session: https://app.devin.ai/sessions/74967759df5f4a8ca54f0036527e1279
Requested by: @gyairbyte
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/74774" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
