### PR TITLE
Fix NPE caused by unset lastHeartbeatPosition

### DIFF
--- a/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/CdcPartitionReader.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/CdcPartitionReader.kt
@@ -413,7 +413,9 @@ class CdcPartitionReader<T : PartiallyOrdered<T>>(
                 if (currentPosition == null) {
                     return null
                 }
-                val isProgressing = currentPosition.isGreater(lastHeartbeatPosition)
+                val isProgressing =
+                    lastHeartbeatPosition == null ||
+                        currentPosition.isGreater(lastHeartbeatPosition)
                 if (isProgressing) {
                     lastHeartbeatPosition = currentPosition
                     lastHeartbeatTime = now


### PR DESCRIPTION
Fix NPE caused by unset lastHeartbeatPosition.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
