### PR TITLE
fix(source-clickhouse): work around ClickHouse JDBC ArrayResultSet.next() off-by-one bug

### DIFF
--- a/airbyte-integrations/connectors/source-clickhouse/metadata.yaml
+++ b/airbyte-integrations/connectors/source-clickhouse/metadata.yaml
@@ -14,7 +14,7 @@ data:
     - suite: acceptanceTests
   connectorType: source
   definitionId: bad83517-5e54-4a3d-9b53-63e85fbd4d7c
-  dockerImageTag: 0.3.0-rc.1
+  dockerImageTag: 0.3.0-rc.2
   dockerRepository: airbyte/source-clickhouse
   documentationUrl: https://docs.airbyte.com/integrations/sources/clickhouse
   githubIssueLabel: source-clickhouse

--- a/airbyte-integrations/connectors/source-clickhouse/src/main/java/io/airbyte/integrations/source/clickhouse/ClickHouseSourceOperations.java
+++ b/airbyte-integrations/connectors/source-clickhouse/src/main/java/io/airbyte/integrations/source/clickhouse/ClickHouseSourceOperations.java
@@ -62,16 +62,18 @@ public class ClickHouseSourceOperations extends JdbcSourceOperations {
    * ArrayResultSet.next() method.
    *
    * <p>
-   * The driver's ArrayResultSet.next() returns true one extra time past the end of the array,
-   * causing a "No current row" SQLException when getString(2) is called on the phantom row.
-   * For ARRAY columns, this override uses Array.getArray() to get a Java Object[] directly,
-   * bypassing the buggy ArrayResultSet entirely. All other types delegate to the parent.
+   * The driver's ArrayResultSet.next() returns true one extra time past the end of the array, causing
+   * a "No current row" SQLException when getString(2) is called on the phantom row. For ARRAY
+   * columns, this override uses Array.getArray() to get a Java Object[] directly, bypassing the buggy
+   * ArrayResultSet entirely. All other types delegate to the parent.
    *
    * @see <a href="https://github.com/airbytehq/airbyte/issues/61419">#61419</a>
    */
   @Override
-  public void copyToJsonField(final ResultSet resultSet, final int colIndex,
-      final ObjectNode json) throws SQLException {
+  public void copyToJsonField(final ResultSet resultSet,
+                              final int colIndex,
+                              final ObjectNode json)
+      throws SQLException {
     final int columnTypeInt = resultSet.getMetaData().getColumnType(colIndex);
     if (columnTypeInt == Types.ARRAY) {
       final String columnName = resultSet.getMetaData().getColumnName(colIndex);

--- a/airbyte-integrations/connectors/source-clickhouse/src/main/java/io/airbyte/integrations/source/clickhouse/ClickHouseSourceOperations.java
+++ b/airbyte-integrations/connectors/source-clickhouse/src/main/java/io/airbyte/integrations/source/clickhouse/ClickHouseSourceOperations.java
@@ -5,9 +5,13 @@
 package io.airbyte.integrations.source.clickhouse;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.airbyte.cdk.db.jdbc.JdbcConstants;
 import io.airbyte.cdk.db.jdbc.JdbcSourceOperations;
 import java.sql.JDBCType;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.sql.Types;
 
 /**
@@ -51,6 +55,35 @@ public class ClickHouseSourceOperations extends JdbcSourceOperations {
 
     // Default to VARCHAR for any other types that unexpectedly return as OTHER
     return JDBCType.VARCHAR;
+  }
+
+  /**
+   * Overrides copyToJsonField to work around an off-by-one bug in the ClickHouse JDBC v2 driver's
+   * ArrayResultSet.next() method.
+   *
+   * <p>
+   * The driver's ArrayResultSet.next() returns true one extra time past the end of the array,
+   * causing a "No current row" SQLException when getString(2) is called on the phantom row.
+   * For ARRAY columns, this override uses Array.getArray() to get a Java Object[] directly,
+   * bypassing the buggy ArrayResultSet entirely. All other types delegate to the parent.
+   *
+   * @see <a href="https://github.com/airbytehq/airbyte/issues/61419">#61419</a>
+   */
+  @Override
+  public void copyToJsonField(final ResultSet resultSet, final int colIndex,
+      final ObjectNode json) throws SQLException {
+    final int columnTypeInt = resultSet.getMetaData().getColumnType(colIndex);
+    if (columnTypeInt == Types.ARRAY) {
+      final String columnName = resultSet.getMetaData().getColumnName(colIndex);
+      final var arrayNode = new ObjectMapper().createArrayNode();
+      final Object[] elements = (Object[]) resultSet.getArray(colIndex).getArray();
+      for (final Object element : elements) {
+        arrayNode.add(element == null ? null : element.toString());
+      }
+      json.set(columnName, arrayNode);
+    } else {
+      super.copyToJsonField(resultSet, colIndex, json);
+    }
   }
 
 }

--- a/airbyte-integrations/connectors/source-clickhouse/src/test/java/io/airbyte/integrations/source/clickhouse/ClickHouseSourceOperationsTest.java
+++ b/airbyte-integrations/connectors/source-clickhouse/src/test/java/io/airbyte/integrations/source/clickhouse/ClickHouseSourceOperationsTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.source.clickhouse;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.airbyte.commons.json.Jsons;
+import java.sql.Array;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.Types;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+class ClickHouseSourceOperationsTest {
+
+  private final ClickHouseSourceOperations ops = new ClickHouseSourceOperations();
+
+  /**
+   * Verifies that copyToJsonField correctly serializes a multi-element integer array. This is the
+   * core regression test for the ClickHouse JDBC v2 ArrayResultSet.next() off-by-one bug (#61419).
+   * Without the workaround, the CDK's default putArray path would iterate through the buggy
+   * ArrayResultSet and throw "No current row" on the phantom extra iteration.
+   */
+  @Test
+  void testCopyToJsonFieldArrayIntegers() throws Exception {
+    final ObjectNode json = (ObjectNode) Jsons.jsonNode(Collections.emptyMap());
+    final ResultSet rs = mockResultSetWithArray("int_arr", new Object[] {1, 2, 3});
+
+    ops.copyToJsonField(rs, 1, json);
+
+    final JsonNode arrayNode = json.get("int_arr");
+    assertTrue(arrayNode.isArray());
+    assertEquals(3, arrayNode.size());
+    assertEquals("1", arrayNode.get(0).asText());
+    assertEquals("2", arrayNode.get(1).asText());
+    assertEquals("3", arrayNode.get(2).asText());
+  }
+
+  /**
+   * Verifies that a single-element array is handled correctly.
+   */
+  @Test
+  void testCopyToJsonFieldArraySingleElement() throws Exception {
+    final ObjectNode json = (ObjectNode) Jsons.jsonNode(Collections.emptyMap());
+    final ResultSet rs = mockResultSetWithArray("single_arr", new Object[] {42});
+
+    ops.copyToJsonField(rs, 1, json);
+
+    final JsonNode arrayNode = json.get("single_arr");
+    assertTrue(arrayNode.isArray());
+    assertEquals(1, arrayNode.size());
+    assertEquals("42", arrayNode.get(0).asText());
+  }
+
+  /**
+   * Verifies that an empty array produces an empty JSON array.
+   */
+  @Test
+  void testCopyToJsonFieldArrayEmpty() throws Exception {
+    final ObjectNode json = (ObjectNode) Jsons.jsonNode(Collections.emptyMap());
+    final ResultSet rs = mockResultSetWithArray("empty_arr", new Object[] {});
+
+    ops.copyToJsonField(rs, 1, json);
+
+    final JsonNode arrayNode = json.get("empty_arr");
+    assertTrue(arrayNode.isArray());
+    assertEquals(0, arrayNode.size());
+  }
+
+  /**
+   * Verifies that null elements within an array are preserved as JSON nulls.
+   */
+  @Test
+  void testCopyToJsonFieldArrayWithNulls() throws Exception {
+    final ObjectNode json = (ObjectNode) Jsons.jsonNode(Collections.emptyMap());
+    final ResultSet rs = mockResultSetWithArray("nullable_arr", new Object[] {"a", null, "c"});
+
+    ops.copyToJsonField(rs, 1, json);
+
+    final JsonNode arrayNode = json.get("nullable_arr");
+    assertTrue(arrayNode.isArray());
+    assertEquals(3, arrayNode.size());
+    assertEquals("a", arrayNode.get(0).asText());
+    assertTrue(arrayNode.get(1).isNull());
+    assertEquals("c", arrayNode.get(2).asText());
+  }
+
+  /**
+   * Verifies that string arrays are serialized correctly.
+   */
+  @Test
+  void testCopyToJsonFieldArrayStrings() throws Exception {
+    final ObjectNode json = (ObjectNode) Jsons.jsonNode(Collections.emptyMap());
+    final ResultSet rs = mockResultSetWithArray("str_arr", new Object[] {"hello", "world"});
+
+    ops.copyToJsonField(rs, 1, json);
+
+    final JsonNode arrayNode = json.get("str_arr");
+    assertTrue(arrayNode.isArray());
+    assertEquals(2, arrayNode.size());
+    assertEquals("hello", arrayNode.get(0).asText());
+    assertEquals("world", arrayNode.get(1).asText());
+  }
+
+  private ResultSet mockResultSetWithArray(final String columnName, final Object[] elements)
+      throws Exception {
+    final ResultSetMetaData metadata = mock(ResultSetMetaData.class);
+    when(metadata.getColumnType(1)).thenReturn(Types.ARRAY);
+    when(metadata.getColumnName(1)).thenReturn(columnName);
+
+    final Array sqlArray = mock(Array.class);
+    when(sqlArray.getArray()).thenReturn(elements);
+
+    final ResultSet rs = mock(ResultSet.class);
+    when(rs.getMetaData()).thenReturn(metadata);
+    when(rs.getArray(1)).thenReturn(sqlArray);
+
+    return rs;
+  }
+
+}

--- a/airbyte-integrations/connectors/source-clickhouse/src/test/java/io/airbyte/integrations/source/clickhouse/ClickHouseSourceOperationsTest.java
+++ b/airbyte-integrations/connectors/source-clickhouse/src/test/java/io/airbyte/integrations/source/clickhouse/ClickHouseSourceOperationsTest.java
@@ -5,7 +5,6 @@
 package io.airbyte.integrations.source.clickhouse;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/airbyte-integrations/connectors/source-clickhouse/src/test/java/io/airbyte/integrations/source/clickhouse/ClickHouseSourceOperationsTest.java
+++ b/airbyte-integrations/connectors/source-clickhouse/src/test/java/io/airbyte/integrations/source/clickhouse/ClickHouseSourceOperationsTest.java
@@ -5,16 +5,20 @@
 package io.airbyte.integrations.source.clickhouse;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.clickhouse.data.ClickHouseColumn;
+import com.clickhouse.jdbc.types.ArrayResultSet;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.airbyte.commons.json.Jsons;
 import java.sql.Array;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
 import java.sql.Types;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
@@ -24,15 +28,45 @@ class ClickHouseSourceOperationsTest {
   private final ClickHouseSourceOperations ops = new ClickHouseSourceOperations();
 
   /**
-   * Verifies that copyToJsonField correctly serializes a multi-element integer array. This is the
-   * core regression test for the ClickHouse JDBC v2 ArrayResultSet.next() off-by-one bug (#61419).
-   * Without the workaround, the CDK's default putArray path would iterate through the buggy
-   * ArrayResultSet and throw "No current row" on the phantom extra iteration.
+   * Proves the off-by-one bug exists in the real ClickHouse JDBC v2 driver's ArrayResultSet.next().
+   * For an N-element array, next() returns true N+1 times instead of N, and the extra iteration
+   * throws "No current row" when any column is read. This test uses the real driver class directly,
+   * not mocks.
+   */
+  @Test
+  void testDriverArrayResultSetBugExists() throws SQLException {
+    final Integer[] data = {10, 20, 30};
+    final ArrayResultSet buggyRs =
+        new ArrayResultSet(data, ClickHouseColumn.parse("v Array(Int32)").get(0));
+
+    // The standard JDBC iteration pattern triggers the bug:
+    // next() returns true a 4th time for a 3-element array, then getString() throws.
+    int count = 0;
+    while (buggyRs.next()) {
+      count++;
+      if (count > data.length) {
+        // On the phantom extra iteration, reading any column throws "No current row"
+        assertThrows(SQLException.class, () -> buggyRs.getString(2),
+            "Expected 'No current row' on phantom iteration #" + count);
+        break;
+      }
+    }
+    assertTrue(count > data.length,
+        "next() should have returned true more than " + data.length + " times (bug proof)");
+  }
+
+  /**
+   * Verifies that copyToJsonField correctly serializes a multi-element integer array by using
+   * Array.getArray() instead of Array.getResultSet(), thus bypassing the driver bug. The mock
+   * provides both getArray() (returns Object[]) and getResultSet() (returns the real buggy
+   * ArrayResultSet). If the workaround were removed and the parent's putArray were used instead, this
+   * test would fail with "No current row".
    */
   @Test
   void testCopyToJsonFieldArrayIntegers() throws Exception {
     final ObjectNode json = (ObjectNode) Jsons.jsonNode(Collections.emptyMap());
-    final ResultSet rs = mockResultSetWithArray("int_arr", new Object[] {1, 2, 3});
+    final ResultSet rs = mockResultSetWithArrayAndBuggyResultSet("int_arr",
+        new Object[] {1, 2, 3}, new Integer[] {1, 2, 3});
 
     ops.copyToJsonField(rs, 1, json);
 
@@ -50,7 +84,8 @@ class ClickHouseSourceOperationsTest {
   @Test
   void testCopyToJsonFieldArraySingleElement() throws Exception {
     final ObjectNode json = (ObjectNode) Jsons.jsonNode(Collections.emptyMap());
-    final ResultSet rs = mockResultSetWithArray("single_arr", new Object[] {42});
+    final ResultSet rs = mockResultSetWithArrayAndBuggyResultSet("single_arr",
+        new Object[] {42}, new Integer[] {42});
 
     ops.copyToJsonField(rs, 1, json);
 
@@ -110,6 +145,37 @@ class ClickHouseSourceOperationsTest {
     assertEquals("world", arrayNode.get(1).asText());
   }
 
+  /**
+   * Creates a mock ResultSet where the Array mock provides both getArray() (Object[] for the
+   * workaround) and getResultSet() (real buggy ArrayResultSet). If the copyToJsonField workaround
+   * were removed, the parent CDK's putArray would call getResultSet() and hit the off-by-one bug.
+   */
+  private ResultSet mockResultSetWithArrayAndBuggyResultSet(final String columnName,
+                                                            final Object[] elements,
+                                                            final Integer[] typedElements)
+      throws Exception {
+    final ResultSetMetaData metadata = mock(ResultSetMetaData.class);
+    when(metadata.getColumnType(1)).thenReturn(Types.ARRAY);
+    when(metadata.getColumnName(1)).thenReturn(columnName);
+
+    // Wire up the real buggy ArrayResultSet so getResultSet() returns the driver's broken impl
+    final ArrayResultSet buggyResultSet =
+        new ArrayResultSet(typedElements, ClickHouseColumn.parse("v Array(Int32)").get(0));
+
+    final Array sqlArray = mock(Array.class);
+    when(sqlArray.getArray()).thenReturn(elements);
+    when(sqlArray.getResultSet()).thenReturn(buggyResultSet);
+
+    final ResultSet rs = mock(ResultSet.class);
+    when(rs.getMetaData()).thenReturn(metadata);
+    when(rs.getArray(1)).thenReturn(sqlArray);
+
+    return rs;
+  }
+
+  /**
+   * Creates a simple mock ResultSet with an Array column (getArray() only, no getResultSet()).
+   */
   private ResultSet mockResultSetWithArray(final String columnName, final Object[] elements)
       throws Exception {
     final ResultSetMetaData metadata = mock(ResultSetMetaData.class);

--- a/docs/integrations/sources/clickhouse.md
+++ b/docs/integrations/sources/clickhouse.md
@@ -80,6 +80,7 @@ Using this feature requires additional configuration, when creating the source. 
 
 | Version | Date       | Pull Request                                                | Subject                                                                                                   |
 |:--------|:-----------|:------------------------------------------------------------|:----------------------------------------------------------------------------------------------------------|
+| 0.3.0-rc.2 | 2026-03-13 | [74806](https://github.com/airbytehq/airbyte/pull/74806) | Work around ClickHouse JDBC v2 driver ArrayResultSet.next() off-by-one bug causing 'No current row' error on Array columns |
 | 0.3.0-rc.1 | 2026-02-03 | [72395](https://github.com/airbytehq/airbyte/pull/72395) | Upgrade ClickHouse JDBC driver to 0.9.5 with custom type mapping |
 | 0.2.6 | 2025-11-03 | [66714](https://github.com/airbytehq/airbyte/pull/66714) | Revert JDBC driver upgrade |
 | 0.2.5 | 2025-09-25 | [66482](https://github.com/airbytehq/airbyte/pull/66482) | Upgrade ClickHouse JDBC driver from 0.3.2-patch10 to 0.9.0 |


### PR DESCRIPTION
## What

Fixes [#61419](https://github.com/airbytehq/airbyte/issues/61419) — `java.sql.SQLException: No current row` when syncing tables with Array columns using the ClickHouse JDBC v2 driver (0.9.5+).

The ClickHouse JDBC v2 driver's `ArrayResultSet.next()` has an off-by-one bug: it returns `true` one extra time past the end of the array, then `getString()` throws `"No current row"`. This bug exists in all v2 driver versions (0.9.5 through 0.9.7) and is unreported upstream. See the [investigation notes in the Devin session](https://app.devin.ai/sessions/951f1c50782d4dcb96172e2d35d1272c) for the full root cause analysis and local reproduction.

## How

Overrides `copyToJsonField` in `ClickHouseSourceOperations` to intercept ARRAY columns. Instead of the CDK's default path (`Array.getResultSet()` → iterate with `next()`/`getString()`), uses `Array.getArray()` which returns a Java `Object[]` directly, bypassing the buggy `ArrayResultSet` entirely. All non-ARRAY types delegate to `super.copyToJsonField()`.

Note: `putArray` in the CDK's `AbstractJdbcCompatibleSourceOperations.kt` is `protected fun` (final in Kotlin), so it cannot be overridden from Java. Overriding `copyToJsonField` is the narrowest available override point.

Bumps connector version to `0.3.0-rc.2` with changelog entry.

## Review guide

1. `ClickHouseSourceOperations.java` — the core fix (`copyToJsonField` override)
2. `ClickHouseSourceOperationsTest.java` — unit tests proving the driver bug and verifying the workaround
3. `metadata.yaml` — version bump to `0.3.0-rc.2`
4. `docs/integrations/sources/clickhouse.md` — changelog entry

### Test strategy

Tests were verified to **fail without the workaround** and **pass with it**:

- **`testDriverArrayResultSetBugExists`**: Constructs a real `com.clickhouse.jdbc.types.ArrayResultSet` from the JDBC driver (no mocks) and proves `next()` returns true one extra time, causing `getString(2)` to throw `SQLException`. This is a direct proof the driver bug exists.
- **`testCopyToJsonFieldArrayIntegers` / `testCopyToJsonFieldArraySingleElement`**: Mocks wire up *both* `getArray()` (workaround path) and `getResultSet()` (backed by the real buggy `ArrayResultSet`). Removing the `copyToJsonField` override causes these tests to fail with the actual `"No current row"` error through the CDK's `putArray` → `ArrayResultSet.getString()` path.
- **`testCopyToJsonFieldArrayEmpty` / `WithNulls` / `Strings`**: Cover edge cases (empty arrays, null elements, string types) using simple mocks.

### Key things to verify
- **`(Object[]) getArray()` cast safety**: Tests use `Object[]` returns, but could the real driver return primitive arrays (e.g. `int[]`) for certain ClickHouse types? This would cause a `ClassCastException` at runtime.
- **`element.toString()` serialization**: The CDK's original path used `arrayResultSet.getString(2)`. Does `toString()` produce equivalent output for all types (especially Decimals, dates, nested arrays)?
- **Nested arrays**: `Array(Array(Int64))` — would `getArray()` return `Object[]` of `Object[]`, and would `toString()` on the inner arrays produce valid JSON?
- **`testDriverArrayResultSetBugExists` maintenance**: This test asserts the driver bug *exists*. It will break if the JDBC dependency is upgraded to a version that fixes the bug — that's intentional, as it signals the workaround can be removed. But reviewers should be aware of this coupling.

## User Impact

Users syncing ClickHouse tables with Array columns on connector version 0.3.0-rc.1 (JDBC 0.9.5) will no longer hit the `"No current row"` error. Array data will be correctly serialized as JSON arrays.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Reverting restores the CDK's default `putArray` path, which will re-expose the JDBC driver bug for Array columns only. Non-array columns are unaffected.

---

Link to Devin session: https://app.devin.ai/sessions/951f1c50782d4dcb96172e2d35d1272c
Requested by: @sophiecuiy
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/74806" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
