### PR TITLE
ci: extract soft launch steps into parallel 'Build and Verify Artifacts' job

### DIFF
--- a/.github/workflows/connector-ci-checks.yml
+++ b/.github/workflows/connector-ci-checks.yml
@@ -443,11 +443,6 @@ jobs:
         run: |
           uv tool install airbyte-internal-ops
 
-      - name: "[Ops Registry Soft Launch] Install Airbyte CDK"
-        if: matrix.connector
-        continue-on-error: true
-        run: |
-          uv tool install "airbyte-cdk[dev]"
       - name: Run QA Checks
         if: matrix.connector
         # remove "-strict-encrypt" suffix, if present, for parity with the previous version of this workflow
@@ -467,14 +462,49 @@ jobs:
             echo "Skipping CDK pre-release check for non-Python connector."
           fi
 
-      # --- Soft launch: ops CLI artifact generation + validation (parallel validation) ---
-      # Runs alongside existing pre-release checks to validate the new ops CLI path.
-      # continue-on-error: true ensures this does not block the CI pipeline.
-      # Tracking: https://github.com/airbytehq/airbyte-ops-mcp/issues/504
-      - name: "[Ops Registry Soft Launch] Detect connector language"
+  # --- Soft launch: ops CLI artifact generation + validation (parallel job) ---
+  # Runs alongside existing pre-release checks to validate the new ops CLI path.
+  # continue-on-error: true ensures this does not block the CI pipeline.
+  # Tracking: https://github.com/airbytehq/airbyte-ops-mcp/issues/504
+  build-and-verify-artifacts:
+    if: github.event.pull_request.draft == false
+    needs: [generate-matrix]
+    strategy:
+      matrix: ${{ fromJson(needs.generate-matrix.outputs.connectors-matrix) }}
+      max-parallel: 10
+      fail-fast: false
+    name: "[Ops Registry Soft Launch] Build and Verify Artifacts (${{ matrix.connector || 'No-Op' }})"
+    runs-on: ubuntu-24.04
+    continue-on-error: true
+    steps:
+      - name: Checkout Airbyte
+        if: matrix.connector
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          repository: ${{ inputs.repo || github.event.pull_request.head.repo.full_name }}
+          ref: ${{ inputs.gitref || github.head_ref || github.ref_name }}
+          submodules: true
+          fetch-depth: 0
+
+      - name: Install uv
+        if: matrix.connector
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+
+      - name: Install Poe
+        if: matrix.connector
+        run: uv tool install poethepoet
+
+      - name: Install Ops CLI
+        if: matrix.connector
+        run: uv tool install airbyte-internal-ops
+
+      - name: Install Airbyte CDK
+        if: matrix.connector
+        run: uv tool install "airbyte-cdk[dev]"
+
+      - name: Detect connector language
         if: matrix.connector
         id: connector-language
-        continue-on-error: true
         working-directory: airbyte-integrations/connectors/${{ matrix.connector }}
         run: |
           LANGUAGE="$(poe -qq get-language)"
@@ -485,10 +515,9 @@ jobs:
             echo "is-jvm=false" | tee -a $GITHUB_OUTPUT
           fi
 
-      - name: "[Ops Registry Soft Launch] Get connector metadata"
-        if: matrix.connector && steps.connector-language.outcome == 'success' && steps.connector-language.outputs.is-jvm != 'true'
+      - name: Get connector metadata
+        if: matrix.connector && steps.connector-language.outputs.is-jvm != 'true'
         id: connector-metadata
-        continue-on-error: true
         env:
           CONNECTOR_DIR: airbyte-integrations/connectors/${{ matrix.connector }}
         run: |
@@ -498,17 +527,15 @@ jobs:
           echo "connector-version=${CONNECTOR_VERSION}" | tee -a $GITHUB_OUTPUT
           echo "docker-image=${DOCKER_REPO}:${CONNECTOR_VERSION}" | tee -a $GITHUB_OUTPUT
 
-      - name: "[Ops Registry Soft Launch] Build connector Docker image"
+      - name: Build connector Docker image
         if: matrix.connector && steps.connector-metadata.outcome == 'success'
-        continue-on-error: true
         working-directory: airbyte-integrations/connectors/${{ matrix.connector }}
         run: >
           airbyte-cdk image build
           --tag ${{ steps.connector-metadata.outputs.connector-version }}
 
-      - name: "[Ops Registry Soft Launch] Generate and Validate Registry Artifacts (ops CLI)"
+      - name: Generate and Validate Registry Artifacts (ops CLI)
         if: matrix.connector && steps.connector-metadata.outcome == 'success'
-        continue-on-error: true
         shell: bash
         env:
           CONNECTOR_DIR: airbyte-integrations/connectors/${{ matrix.connector }}
@@ -519,9 +546,8 @@ jobs:
           --output-dir ./registry-artifacts
           --with-validate
 
-      - name: "[Ops Registry Soft Launch] Upload Registry CI Artifacts"
+      - name: Upload Registry CI Artifacts
         if: matrix.connector && steps.connector-metadata.outcome == 'success'
-        continue-on-error: true
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: registry-artifacts-${{ matrix.connector }}-${{ steps.connector-metadata.outputs.connector-version }}


### PR DESCRIPTION
## What

Fixes an issue discovered during soft launch monitoring where the `[Ops Registry Soft Launch]` artifact generation/validation steps were **never executing** in real CI runs. When the "Run QA Checks" step failed (e.g., version increment check), GitHub Actions skipped all subsequent steps in the `pre-release-checks` job — including all soft launch steps.

Tracking: https://github.com/airbytehq/airbyte-ops-mcp/issues/504

## How

Extracts the soft launch steps from `pre-release-checks` into a new **parallel** job `build-and-verify-artifacts` that runs alongside pre-release checks rather than sequentially after them. Both jobs depend only on `generate-matrix`.

Key design decisions:
- **Job-level `continue-on-error: true`** replaces per-step `continue-on-error`, keeping the entire job non-blocking.
- **Not added to `connector-ci-checks-summary` `needs`** — this job is intentionally excluded from the aggregate result so it cannot block merges.
- **Own checkout and tool installs** — full isolation from the pre-release-checks job at the cost of duplicated setup (~1-2 min).
- **Simplified step names** — removed `[Ops Registry Soft Launch]` prefix from individual steps since the job name already carries that context: `[Ops Registry Soft Launch] Build and Verify Artifacts (<connector>)`.

## Review guide

1. `.github/workflows/connector-ci-checks.yml` — single file change:
   - **Lines removed from `pre-release-checks`**: Verify the CDK install step and all soft launch steps are cleanly removed with no orphaned references.
   - **New `build-and-verify-artifacts` job**: Verify setup steps are correct and complete (checkout, uv, poe, ops CLI, CDK).
   - **`connector-ci-checks-summary`**: Confirm it does **not** list `build-and-verify-artifacts` in its `needs` — this is intentional.
   - **Condition on "Get connector metadata"**: Changed from `steps.connector-language.outcome == 'success' && ...` to just `steps.connector-language.outputs.is-jvm != 'true'`. Safe because in the new isolated job, the language detection step won't be skipped by unrelated failures.

## User Impact

No user-facing impact. This is a CI-only change that makes soft launch monitoring steps actually execute during connector PR checks. The job is non-blocking (`continue-on-error: true`) so it cannot affect merge eligibility.

Adds ~1-2 minutes of additional CI runner time per modified connector (duplicated setup for the parallel job).

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Reverting restores the soft launch steps to their previous location inside `pre-release-checks` (where they were being skipped — a known issue, but not blocking).

---

Requested by: @aaronsteers
[Devin session](https://app.devin.ai/sessions/f900274cb0884bf99e399b1c40c48067)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/74807" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
