### PR TITLE
ci(connector-ci-checks): replace poe get-version with ops CLI local connector info

### DIFF
--- a/.github/workflows/connector-ci-checks.yml
+++ b/.github/workflows/connector-ci-checks.yml
@@ -471,43 +471,30 @@ jobs:
       # Runs alongside existing pre-release checks to validate the new ops CLI path.
       # continue-on-error: true ensures this does not block the CI pipeline.
       # Tracking: https://github.com/airbytehq/airbyte-ops-mcp/issues/504
-      - name: "[Ops Registry Soft Launch] Detect connector language"
-        if: matrix.connector
-        id: connector-language
-        continue-on-error: true
-        working-directory: airbyte-integrations/connectors/${{ matrix.connector }}
-        run: |
-          LANGUAGE="$(poe -qq get-language)"
-          echo "language=${LANGUAGE}" | tee -a $GITHUB_OUTPUT
-          if [[ "${LANGUAGE}" == "java" ]]; then
-            echo "is-jvm=true" | tee -a $GITHUB_OUTPUT
-          else
-            echo "is-jvm=false" | tee -a $GITHUB_OUTPUT
-          fi
-
       - name: "[Ops Registry Soft Launch] Get connector metadata"
-        if: matrix.connector && steps.connector-language.outcome == 'success' && steps.connector-language.outputs.is-jvm != 'true'
+        if: matrix.connector
         id: connector-metadata
         continue-on-error: true
-        env:
-          CONNECTOR_DIR: airbyte-integrations/connectors/${{ matrix.connector }}
         run: |
           set -euo pipefail
-          CONNECTOR_VERSION="$(poe -qq --root "${CONNECTOR_DIR}" get-version)"
+          # Uses ops CLI to get connector info; writes to GITHUB_OUTPUT automatically in CI
+          airbyte-ops local connector info ${{ matrix.connector }}
+          # Also compute docker-image for downstream steps
+          CONNECTOR_DIR="airbyte-integrations/connectors/${{ matrix.connector }}"
           DOCKER_REPO=$(yq -r '.data.dockerRepository' "${CONNECTOR_DIR}/metadata.yaml")
-          echo "connector-version=${CONNECTOR_VERSION}" | tee -a $GITHUB_OUTPUT
+          CONNECTOR_VERSION=$(yq -r '.data.dockerImageTag' "${CONNECTOR_DIR}/metadata.yaml")
           echo "docker-image=${DOCKER_REPO}:${CONNECTOR_VERSION}" | tee -a $GITHUB_OUTPUT
 
       - name: "[Ops Registry Soft Launch] Build connector Docker image"
-        if: matrix.connector && steps.connector-metadata.outcome == 'success'
+        if: matrix.connector && steps.connector-metadata.outcome == 'success' && steps.connector-metadata.outputs.connector_language != 'java'
         continue-on-error: true
         working-directory: airbyte-integrations/connectors/${{ matrix.connector }}
         run: >
           airbyte-cdk image build
-          --tag ${{ steps.connector-metadata.outputs.connector-version }}
+          --tag ${{ steps.connector-metadata.outputs.connector_version }}
 
       - name: "[Ops Registry Soft Launch] Generate and Validate Registry Artifacts (ops CLI)"
-        if: matrix.connector && steps.connector-metadata.outcome == 'success'
+        if: matrix.connector && steps.connector-metadata.outcome == 'success' && steps.connector-metadata.outputs.connector_language != 'java'
         continue-on-error: true
         shell: bash
         env:
@@ -520,11 +507,11 @@ jobs:
           --with-validate
 
       - name: "[Ops Registry Soft Launch] Upload Registry CI Artifacts"
-        if: matrix.connector && steps.connector-metadata.outcome == 'success'
+        if: matrix.connector && steps.connector-metadata.outcome == 'success' && steps.connector-metadata.outputs.connector_language != 'java'
         continue-on-error: true
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: registry-artifacts-${{ matrix.connector }}-${{ steps.connector-metadata.outputs.connector-version }}
+          name: registry-artifacts-${{ matrix.connector }}-${{ steps.connector-metadata.outputs.connector_version }}
           path: ./registry-artifacts/
           retention-days: 7
           if-no-files-found: ignore


### PR DESCRIPTION
## What

Fixes soft launch step failures for manifest-only connectors (`source-stripe`, `source-zendesk-support`, etc.) where `poe get-version` and `poe get-language` fail because these connectors lack a `pyproject.toml`.

Tracking: https://github.com/airbytehq/airbyte-ops-mcp/issues/504

## How

- Removed the separate "Detect connector language" step that used `poe -qq get-language`
- Replaced `poe -qq get-version` with `airbyte-ops local connector info`, which reads version and language from `metadata.yaml` and works for **all** connector types (manifest-only, Python, Java)
- The ops CLI automatically writes `connector_version`, `connector_language`, etc. to `$GITHUB_OUTPUT` when running in CI
- Added `connector_language != 'java'` guards on Docker build, artifact generation, and upload steps (replacing the previous `is-jvm` check from the removed step)

**Output key change**: Step output keys changed from hyphenated (`connector-version`) to underscored (`connector_version`) to match the ops CLI output format. All downstream references were updated.

## Review guide

1. `.github/workflows/connector-ci-checks.yml` — the only file changed. Focus on:
   - The consolidated metadata step (lines ~474–486): verify `airbyte-ops local connector info` is available (installed earlier in the job via `uv tool install airbyte-internal-ops`)
   - The `connector_language != 'java'` conditions on downstream steps: verify this matches the ops CLI's actual output for JVM connectors
   - The output key rename from `connector-version` → `connector_version` is consistent across all references

**Note**: All soft launch steps retain `continue-on-error: true`, so even if something is incorrect, it cannot block CI. This is a non-blocking soft launch path.

## User Impact

No user-facing impact. This fixes internal CI soft launch steps that were silently failing for manifest-only connectors. All steps remain non-blocking (`continue-on-error: true`).

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Link to Devin run: https://app.devin.ai/sessions/f900274cb0884bf99e399b1c40c48067
Requested by: AJ Steers (@aaronsteers)