### PR TITLE
ci(connector-ci-checks): fix poe get-version for manifest-only connectors

### DIFF
--- a/.github/workflows/connector-ci-checks.yml
+++ b/.github/workflows/connector-ci-checks.yml
@@ -518,12 +518,11 @@ jobs:
       - name: Get connector metadata
         if: matrix.connector && steps.connector-language.outputs.is-jvm != 'true'
         id: connector-metadata
-        env:
-          CONNECTOR_DIR: airbyte-integrations/connectors/${{ matrix.connector }}
+        working-directory: airbyte-integrations/connectors/${{ matrix.connector }}
         run: |
           set -euo pipefail
-          CONNECTOR_VERSION="$(poe -qq --root "${CONNECTOR_DIR}" get-version)"
-          DOCKER_REPO=$(yq -r '.data.dockerRepository' "${CONNECTOR_DIR}/metadata.yaml")
+          CONNECTOR_VERSION="$(poe -qq get-version)"
+          DOCKER_REPO=$(yq -r '.data.dockerRepository' metadata.yaml)
           echo "connector-version=${CONNECTOR_VERSION}" | tee -a $GITHUB_OUTPUT
           echo "docker-image=${DOCKER_REPO}:${CONNECTOR_VERSION}" | tee -a $GITHUB_OUTPUT
 


### PR DESCRIPTION
## What

Fixes the `build-and-verify-artifacts` job failing on manifest-only connectors (e.g., `source-stripe`, `source-zendesk-support`) because `poe --root <dir> get-version` cannot find a poe configuration in directories without `pyproject.toml`.

Tracking: https://github.com/airbytehq/airbyte-ops-mcp/issues/504

## How

`poe --root <path>` looks for config **only** in the specified directory. Manifest-only connectors lack `pyproject.toml`, so this fails immediately. However, `poe` invoked *from within* a directory walks **up** the tree and finds the existing fallback at `airbyte-integrations/connectors/poe_tasks.toml`, which includes `manifest-only-connector-tasks.toml`.

The fix replaces `env: CONNECTOR_DIR` + `poe --root` with `working-directory` + `poe -qq get-version`, matching the pattern already used by the "Detect connector language" step directly above.

## Review guide

Single file: `.github/workflows/connector-ci-checks.yml`

- Verify `working-directory` applies to both the `poe` and `yq` commands in the `run` block (it does — GitHub Actions `working-directory` applies to the entire step)
- Confirm the removed `CONNECTOR_DIR` env var wasn't used by anything outside this step's `run` block (it's step-scoped, so it can't be)
- Note: the preceding "Detect connector language" step already uses this same `working-directory` + `poe -qq` pattern, so this change makes both steps consistent

## User Impact

No user-facing impact. Fixes internal CI soft launch steps that were silently failing (`continue-on-error: true` at job level). After this fix, manifest-only connectors will correctly report their version and proceed through Docker build + registry artifact generation.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Reverting restores `--root`, which will continue to fail silently on manifest-only connectors (the pre-existing behavior).

---

Link to Devin run: https://app.devin.ai/sessions/f900274cb0884bf99e399b1c40c48067
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/74811" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
