### PR TITLE
ci(connector-ci-checks): remove JVM connector guard from pre-release checks

### DIFF
--- a/.github/workflows/connector-ci-checks.yml
+++ b/.github/workflows/connector-ci-checks.yml
@@ -502,21 +502,8 @@ jobs:
         if: matrix.connector
         run: uv tool install "airbyte-cdk[dev]"
 
-      - name: Detect connector language
-        if: matrix.connector
-        id: connector-language
-        working-directory: airbyte-integrations/connectors/${{ matrix.connector }}
-        run: |
-          LANGUAGE="$(poe -qq get-language)"
-          echo "language=${LANGUAGE}" | tee -a $GITHUB_OUTPUT
-          if [[ "${LANGUAGE}" == "java" ]]; then
-            echo "is-jvm=true" | tee -a $GITHUB_OUTPUT
-          else
-            echo "is-jvm=false" | tee -a $GITHUB_OUTPUT
-          fi
-
       - name: Get connector metadata
-        if: matrix.connector && steps.connector-language.outputs.is-jvm != 'true'
+        if: matrix.connector
         id: connector-metadata
         working-directory: airbyte-integrations/connectors/${{ matrix.connector }}
         run: |

--- a/.github/workflows/connector-ci-checks.yml
+++ b/.github/workflows/connector-ci-checks.yml
@@ -530,7 +530,6 @@ jobs:
           --metadata-file "${CONNECTOR_DIR}/metadata.yaml"
           --docker-image "${{ steps.connector-metadata.outputs.docker-image }}"
           --output-dir ./registry-artifacts
-          --with-validate
 
       - name: Upload Registry CI Artifacts
         if: matrix.connector && steps.connector-metadata.outcome == 'success'

--- a/.github/workflows/connector-ci-checks.yml
+++ b/.github/workflows/connector-ci-checks.yml
@@ -530,6 +530,7 @@ jobs:
           --metadata-file "${CONNECTOR_DIR}/metadata.yaml"
           --docker-image "${{ steps.connector-metadata.outputs.docker-image }}"
           --output-dir ./registry-artifacts
+          --with-validate
 
       - name: Upload Registry CI Artifacts
         if: matrix.connector && steps.connector-metadata.outcome == 'success'

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -487,7 +487,8 @@ jobs:
             registry connector-version artifacts generate \
             --metadata-file "airbyte-integrations/connectors/${{ matrix.connector }}/metadata.yaml" \
             --docker-image "${DOCKER_IMAGE}" \
-            --output-dir ./registry-artifacts
+            --output-dir ./registry-artifacts \
+            --with-validate
 
       - name: "[Ops Registry Soft Launch] Upload Registry CI Artifacts"
         if: steps.generate-registry-artifacts-ops-cli.outcome == 'success'
@@ -514,7 +515,8 @@ jobs:
             --name "${{ matrix.connector }}" \
             --version "${{ steps.connector-metadata.outputs.docker-image-tag }}" \
             --artifacts-dir ./registry-artifacts \
-            --store "${REGISTRY_STORE}"
+            --store "${REGISTRY_STORE}" \
+            --with-validate
 
   generate_connector_registry:
     name: Generate connector registry

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -487,8 +487,7 @@ jobs:
             registry connector-version artifacts generate \
             --metadata-file "airbyte-integrations/connectors/${{ matrix.connector }}/metadata.yaml" \
             --docker-image "${DOCKER_IMAGE}" \
-            --output-dir ./registry-artifacts \
-            --with-validate
+            --output-dir ./registry-artifacts
 
       - name: "[Ops Registry Soft Launch] Upload Registry CI Artifacts"
         if: steps.generate-registry-artifacts-ops-cli.outcome == 'success'
@@ -515,8 +514,7 @@ jobs:
             --name "${{ matrix.connector }}" \
             --version "${{ steps.connector-metadata.outputs.docker-image-tag }}" \
             --artifacts-dir ./registry-artifacts \
-            --store "${REGISTRY_STORE}" \
-            --with-validate
+            --store "${REGISTRY_STORE}"
 
   generate_connector_registry:
     name: Generate connector registry


### PR DESCRIPTION
## What

The "Detect connector language" step and `is-jvm != 'true'` condition were causing all pre-release checks (metadata extraction, Docker build, artifact generation) to be silently skipped for Java/Kotlin connectors. All connector types should go through the same pipeline.

## How

- Removed the "Detect connector language" step entirely from `connector-ci-checks.yml` (no longer needed)
- Simplified the `if` condition on "Get connector metadata" from `matrix.connector && steps.connector-language.outputs.is-jvm != 'true'` to just `matrix.connector`
- Downstream steps (Docker build, artifact generation, upload) already gate on `steps.connector-metadata.outcome == 'success'`

## Review guide

1. `.github/workflows/connector-ci-checks.yml` — Removed "Detect connector language" step (14 lines), simplified `if` condition on "Get connector metadata"

### Human review checklist
- [ ] Confirm JVM connectors should go through Docker build (`airbyte-cdk image build`) — if this fails for JVM connectors, artifact generation and upload steps will be skipped (they gate on `connector-metadata.outcome`, not the build step)
- [ ] Verify no other steps reference `connector-language` or `is-jvm` outputs

## User Impact

JVM connectors will now go through the same pre-release checks as Python and manifest-only connectors in CI, rather than being silently skipped.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Requested by: @aaronsteers
Link to Devin run: https://app.devin.ai/sessions/f900274cb0884bf99e399b1c40c48067