### PR TITLE
ci(connector-ci-checks): add Java + Gradle setup to soft launch job for JVM connectors

### DIFF
--- a/.github/workflows/connector-ci-checks.yml
+++ b/.github/workflows/connector-ci-checks.yml
@@ -490,6 +490,19 @@ jobs:
         if: matrix.connector
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
 
+      # Java deps (needed for JVM connector Docker image builds via Gradle)
+      - uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
+        if: matrix.connector
+        with:
+          distribution: zulu
+          java-version: 21
+          cache: gradle
+
+      - uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1 # v4.4.4
+        if: matrix.connector
+        with:
+          gradle-version: "8.14"
+
       - name: Install Poe
         if: matrix.connector
         run: uv tool install poethepoet

--- a/.github/workflows/connector-ci-checks.yml
+++ b/.github/workflows/connector-ci-checks.yml
@@ -491,6 +491,7 @@ jobs:
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
 
       # Java deps (needed for JVM connector Docker image builds via Gradle)
+      # TODO: Consider making this conditional on connector language to skip for non-JVM connectors.
       - uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         if: matrix.connector
         with:


### PR DESCRIPTION
## What

The `build-and-verify-artifacts` soft launch job fails for JVM connectors (e.g. `source-postgres`, `destination-databricks`) because the Docker image build step calls `./gradlew distTar` via `airbyte-cdk image build`, which requires Java and Gradle — neither of which were installed in this job.

## How

Adds `actions/setup-java` (Zulu 21, Gradle cache) and `gradle/actions/setup-gradle` (8.14) to the soft launch job, matching the existing setup in `jvm-connectors-test` (lines 150–162).

## Review guide

1. `.github/workflows/connector-ci-checks.yml` — the only change. 13 lines added after the `setup-uv` step.

**Key review point:** Java + Gradle setup runs for _all_ connectors in the matrix unconditionally (gated only on `if: matrix.connector`), not just JVM ones. This adds ~1-2 min setup overhead for Python/manifest-only connectors. This is the simplest approach and matches how other jobs in this file handle it, but worth flagging.

## User Impact

JVM connector soft launch artifact generation will now succeed instead of failing with a Gradle `distTar` error. No user-facing impact — this job has `continue-on-error: true` and does not block CI.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Requested by: @aaronsteers
[Link to Devin run](https://app.devin.ai/sessions/f900274cb0884bf99e399b1c40c48067)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/74815" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
