### PR TITLE
ci(connector-ci-checks): rename soft launch job to 'Build and Verify Artifacts'

### DIFF
--- a/.github/workflows/connector-ci-checks.yml
+++ b/.github/workflows/connector-ci-checks.yml
@@ -473,7 +473,7 @@ jobs:
       matrix: ${{ fromJson(needs.generate-matrix.outputs.connectors-matrix) }}
       max-parallel: 10
       fail-fast: false
-    name: "[Ops Registry Soft Launch] Build and Verify Artifacts (${{ matrix.connector || 'No-Op' }})"
+    name: "Build and Verify Artifacts (${{ matrix.connector || 'No-Op' }})"
     runs-on: ubuntu-24.04
     continue-on-error: true
     steps:


### PR DESCRIPTION
## What

Removes the `[Ops Registry Soft Launch]` prefix from the artifact build/verify job name now that the soft launch validation is complete and all 4 connector types pass successfully.

## How

Single string change in the job `name` field:
- Before: `[Ops Registry Soft Launch] Build and Verify Artifacts ({connector})`
- After: `Build and Verify Artifacts ({connector})`

## Review guide

1. `.github/workflows/connector-ci-checks.yml` — one-line name change at line 476.

## User Impact

CI job names in GitHub Actions will appear shorter and cleaner. No functional change.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Requested by: @aaronsteers
[Link to Devin run](https://app.devin.ai/sessions/f900274cb0884bf99e399b1c40c48067)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/74816" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
