### PR TITLE
chore(source-pokeapi): bump version 0.3.50 → 0.3.51 to test ops CLI publish pipeline

### DIFF
--- a/airbyte-integrations/connectors/source-pokeapi/metadata.yaml
+++ b/airbyte-integrations/connectors/source-pokeapi/metadata.yaml
@@ -22,7 +22,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 6371b14b-bc68-4236-bfbd-468e8df8e968
-  dockerImageTag: 0.3.50
+  dockerImageTag: 0.3.51
   dockerRepository: airbyte/source-pokeapi
   githubIssueLabel: source-pokeapi
   icon: pokeapi.svg

--- a/docs/integrations/sources/pokeapi.md
+++ b/docs/integrations/sources/pokeapi.md
@@ -39,7 +39,7 @@ The PokéAPI uses the same [JSONSchema](https://json-schema.org/understanding-js
 
 | Version | Date       | Pull Request                                             | Subject                                         |
 | :------ | :--------- | :------------------------------------------------------- | :---------------------------------------------- |
-| 0.3.51 | 2026-03-13 | [74817](https://github.com/airbytehq/airbyte/pull/74817) | Patch version bump to test ops CLI publish pipeline |
+| 0.3.51 | 2026-03-13 | [74819](https://github.com/airbytehq/airbyte/pull/74819) | Patch version bump to test ops CLI publish pipeline |
 | 0.3.50 | 2026-02-24 | [73837](https://github.com/airbytehq/airbyte/pull/73837) | Update dependencies |
 | 0.3.49 | 2026-02-10 | [73196](https://github.com/airbytehq/airbyte/pull/73196) | Update dependencies |
 | 0.3.48 | 2026-02-02 | [72538](https://github.com/airbytehq/airbyte/pull/72538) | Promoting release candidate 0.3.48-rc.1 to a main version. |

--- a/docs/integrations/sources/pokeapi.md
+++ b/docs/integrations/sources/pokeapi.md
@@ -39,6 +39,7 @@ The PokéAPI uses the same [JSONSchema](https://json-schema.org/understanding-js
 
 | Version | Date       | Pull Request                                             | Subject                                         |
 | :------ | :--------- | :------------------------------------------------------- | :---------------------------------------------- |
+| 0.3.51 | 2026-03-13 | [74817](https://github.com/airbytehq/airbyte/pull/74817) | Patch version bump to test ops CLI publish pipeline |
 | 0.3.50 | 2026-02-24 | [73837](https://github.com/airbytehq/airbyte/pull/73837) | Update dependencies |
 | 0.3.49 | 2026-02-10 | [73196](https://github.com/airbytehq/airbyte/pull/73196) | Update dependencies |
 | 0.3.48 | 2026-02-02 | [72538](https://github.com/airbytehq/airbyte/pull/72538) | Promoting release candidate 0.3.48-rc.1 to a main version. |

--- a/docs/integrations/sources/pokeapi.md
+++ b/docs/integrations/sources/pokeapi.md
@@ -39,7 +39,7 @@ The PokéAPI uses the same [JSONSchema](https://json-schema.org/understanding-js
 
 | Version | Date       | Pull Request                                             | Subject                                         |
 | :------ | :--------- | :------------------------------------------------------- | :---------------------------------------------- |
-| 0.3.51 | 2026-03-13 | [74819](https://github.com/airbytehq/airbyte/pull/74819) | Patch version bump to test ops CLI publish pipeline |
+| 0.3.51 | 2026-03-13 | [74819](https://github.com/airbytehq/airbyte/pull/74819) | Patch version bump (publish test) |
 | 0.3.50 | 2026-02-24 | [73837](https://github.com/airbytehq/airbyte/pull/73837) | Update dependencies |
 | 0.3.49 | 2026-02-10 | [73196](https://github.com/airbytehq/airbyte/pull/73196) | Update dependencies |
 | 0.3.48 | 2026-02-02 | [72538](https://github.com/airbytehq/airbyte/pull/72538) | Promoting release candidate 0.3.48-rc.1 to a main version. |


### PR DESCRIPTION
## What

Patch version bump for `source-pokeapi` (0.3.50 → 0.3.51) with no functional changes. This is a deliberate rerelease to exercise and validate the new ops CLI-based publish pipeline end-to-end on a real manifest-only connector.

This is one of two test PRs (the other being source-faker). Between the two, at least one should produce a successful publish.

## How

- Bumped `dockerImageTag` in `metadata.yaml` from 0.3.50 to 0.3.51
- Added changelog entry in `docs/integrations/sources/pokeapi.md`

## Review guide

1. `airbyte-integrations/connectors/source-pokeapi/metadata.yaml` — single-line version bump
2. `docs/integrations/sources/pokeapi.md` — changelog entry (note: PR number in changelog may not match actual PR number)

## User Impact

No user-facing changes. The published connector image is functionally identical to 0.3.50.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Link to Devin run: https://app.devin.ai/sessions/f900274cb0884bf99e399b1c40c48067
Requested by: AJ Steers (@aaronsteers)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/74819" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
