### PR TITLE
ci: replace uvx with uv tool install for cleaner step logs

### DIFF
--- a/.github/workflows/generate-connector-registries.yml
+++ b/.github/workflows/generate-connector-registries.yml
@@ -177,10 +177,13 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
 
+      - name: Install Ops CLI
+        run: uv tool install airbyte-internal-ops
+
       - name: Compile Registries
         env:
           GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
         shell: bash
         run: >
-          uvx airbyte-internal-ops
+          airbyte-ops
           registry store compile --store "${REGISTRY_STORE}" --with-secrets-mask

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -473,6 +473,10 @@ jobs:
       # Runs alongside the legacy Poetry-based registry entry generation above.
       # continue-on-error: true ensures this does not block the publish pipeline.
       # Tracking: https://github.com/airbytehq/airbyte-ops-mcp/issues/504
+      - name: Install Ops CLI
+        continue-on-error: true
+        run: uv tool install airbyte-internal-ops
+
       - name: "[Ops Registry Soft Launch] Generate Registry Artifacts (ops CLI)"
         id: generate-registry-artifacts-ops-cli
         continue-on-error: true
@@ -483,7 +487,7 @@ jobs:
           echo "Generating registry artifacts for ${{ matrix.connector }}"
           DOCKER_REPOSITORY=$(yq -r '.data.dockerRepository' "airbyte-integrations/connectors/${{ matrix.connector }}/metadata.yaml")
           DOCKER_IMAGE="${DOCKER_REPOSITORY}:${{ steps.connector-metadata.outputs.docker-image-tag }}"
-          uvx airbyte-internal-ops \
+          airbyte-ops \
             registry connector-version artifacts generate \
             --metadata-file "airbyte-integrations/connectors/${{ matrix.connector }}/metadata.yaml" \
             --docker-image "${DOCKER_IMAGE}" \
@@ -510,7 +514,7 @@ jobs:
           REGISTRY_STORE: "coral:dev/soft-launch-trial"
         run: |
           echo "Publishing registry artifacts for ${{ matrix.connector }}"
-          uvx airbyte-internal-ops \
+          airbyte-ops \
             registry connector-version artifacts publish \
             --name "${{ matrix.connector }}" \
             --version "${{ steps.connector-metadata.outputs.docker-image-tag }}" \

--- a/.github/workflows/resolve-stale-metadata.yml
+++ b/.github/workflows/resolve-stale-metadata.yml
@@ -33,13 +33,15 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
 
+      - name: Install Ops CLI
+        run: uv tool install airbyte-internal-ops
+
       - name: Check for unpublished connector versions
         continue-on-error: true
         env:
           GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
         shell: bash
         run: >
-          uvx --from airbyte-internal-ops
           airbyte-ops local connector list
           --repo-path "${{ github.workspace }}"
           --unpublished

--- a/.github/workflows/resolve-stale-metadata.yml
+++ b/.github/workflows/resolve-stale-metadata.yml
@@ -34,6 +34,7 @@ jobs:
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
 
       - name: Install Ops CLI
+        continue-on-error: true
         run: uv tool install airbyte-internal-ops
 
       - name: Check for unpublished connector versions


### PR DESCRIPTION
## What

Replaces inline `uvx airbyte-internal-ops` / `uvx --from airbyte-internal-ops` invocations with a dedicated `uv tool install airbyte-internal-ops` step + direct `airbyte-ops` CLI calls. This keeps package download/install noise in its own collapsible step instead of polluting the first ~30 lines of every ops CLI step log.

This aligns these workflows with `connector-ci-checks.yml`, which already uses this pattern.

## How

In each of the 3 affected workflows:
1. Added a new `Install Ops CLI` step: `uv tool install airbyte-internal-ops`
2. Replaced `uvx airbyte-internal-ops` / `uvx --from airbyte-internal-ops` with plain `airbyte-ops`

## Review guide

1. `.github/workflows/generate-connector-registries.yml` — soft launch compile job
2. `.github/workflows/publish_connectors.yml` — soft launch generate + publish steps (2 call sites)
3. `.github/workflows/resolve-stale-metadata.yml` — unpublished connector audit step

**Things to verify:**
- In `resolve-stale-metadata.yml`, the YAML folded scalar (`>`) still produces the correct single-line command after removing the `uvx --from` prefix line
- In `publish_connectors.yml`, the install step has `continue-on-error: true` to stay consistent with the other soft launch steps — if install fails, subsequent steps fail too (all also `continue-on-error`)
- In `generate-connector-registries.yml`, the install step does **not** have `continue-on-error` because the job itself already has `continue-on-error: true` at the job level

## User Impact

No user-facing impact. CI logs for ops CLI steps will be cleaner — install output is isolated in its own collapsible step.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Link to Devin run: https://app.devin.ai/sessions/f900274cb0884bf99e399b1c40c48067
Requested by: AJ Steers (@aaronsteers)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/74821" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
