### PR TITLE
derive reduce_range from failing slice

### DIFF
--- a/airbyte-integrations/connectors/source-iterable/source_iterable/slice_generators.py
+++ b/airbyte-integrations/connectors/source-iterable/source_iterable/slice_generators.py
@@ -145,15 +145,20 @@ class AdjustableSliceGenerator(SliceGenerator):
         RANGE_REDUCE_FACTOR (2 times).
         Returns updated slice to try again.
         """
-        self._current_range = int(max(self._current_range / self.RANGE_REDUCE_FACTOR, self.INITIAL_RANGE_DAYS))
         start_date = self._prev_start_date
-        end_date = min(self._end_date, start_date + (pendulum.Duration(days=self._current_range)))
+        # Derive reduction from the actual failing slice duration, not
+        # _current_range which may be much larger than the real slice
+        # (e.g. _current_range=30 days but _end_date caps the slice to hours).
+        actual_end = min(self._end_date, start_date + pendulum.Duration(days=self._current_range))
+        actual_duration = (actual_end - start_date).total_seconds() / 86400
+        self._current_range = actual_duration / self.RANGE_REDUCE_FACTOR
+        end_date = start_date + pendulum.Duration(days=self._current_range)
         self._start_date = end_date
         return StreamSlice(start_date=start_date, end_date=end_date)
 
     def __next__(self) -> StreamSlice:
         """
-        Generates next slice based on prevouis slice processing result. All the
+        Generates next slice based on previous slice processing result. All the
         next slice range calculations should be done after calling adjust_range
         and reduce_range methods.
         """

--- a/airbyte-integrations/connectors/source-iterable/unit_tests/test_slice_generator.py
+++ b/airbyte-integrations/connectors/source-iterable/unit_tests/test_slice_generator.py
@@ -102,4 +102,98 @@ def test_reduce_range():
     next(slice_generator)
     reduced_slice = slice_generator.reduce_range()
     assert reduced_slice.start_date == datetime(2022, 1, 1)
-    assert reduced_slice.end_date == datetime(2022, 1, 31)
+    # 30-day window halved by RANGE_REDUCE_FACTOR (2) = 15 days
+    assert reduced_slice.end_date == datetime(2022, 1, 16)
+
+
+def test_reduce_range_actually_shrinks_slice_within_small_window():
+    """With a 6-hour window, reduce_range should produce a smaller slice."""
+    start = pendulum.parse("2026-03-09 18:00:00")
+    end = pendulum.parse("2026-03-10 00:00:00")  # 6 hours
+
+    gen = AdjustableSliceGenerator(start_date=start, end_date=end)
+    first_slice = next(gen)
+
+    assert first_slice.start_date == start
+    assert first_slice.end_date == end
+    first_duration = (first_slice.end_date - first_slice.start_date).total_seconds()
+
+    reduced_slice = gen.reduce_range()
+    reduced_duration = (reduced_slice.end_date - reduced_slice.start_date).total_seconds()
+
+    assert reduced_duration < first_duration, (
+        f"reduce_range() did not shrink the slice! "
+        f"Original: {first_duration}s, Reduced: {reduced_duration}s"
+    )
+
+
+def test_repeated_reduce_range_produces_progressively_smaller_slices():
+    """6 calls to reduce_range should produce 6 progressively smaller slices."""
+    start = pendulum.parse("2026-03-09 18:00:00")
+    end = pendulum.parse("2026-03-10 00:00:00")  # 6 hours
+
+    gen = AdjustableSliceGenerator(start_date=start, end_date=end)
+    next(gen)
+
+    durations = []
+    for _ in range(6):
+        reduced = gen.reduce_range()
+        duration = (reduced.end_date - reduced.start_date).total_seconds()
+        durations.append(duration)
+
+    for i in range(1, len(durations)):
+        assert durations[i] < durations[i - 1], (
+            f"Retry {i+1} did not shrink vs retry {i}: "
+            f"{durations[i]}s >= {durations[i-1]}s"
+        )
+
+
+def test_reduce_range_with_5_minute_window():
+    """Even a 5-minute sync window should be reducible."""
+    start = pendulum.parse("2026-03-09 22:30:00")
+    end = pendulum.parse("2026-03-09 22:35:00")
+
+    gen = AdjustableSliceGenerator(start_date=start, end_date=end)
+    first_slice = next(gen)
+    assert first_slice.end_date == end
+
+    reduced = gen.reduce_range()
+    reduced_duration = (reduced.end_date - reduced.start_date).total_seconds()
+    assert reduced_duration < 5 * 60, (
+        f"reduce_range() could not shrink a 5-minute window! "
+        f"Reduced duration: {reduced_duration}s"
+    )
+
+
+def test_reduce_range_slices_stay_within_bounds():
+    """Reduced slices should stay within the original window."""
+    start = pendulum.parse("2026-03-09 20:00:00")
+    end = pendulum.parse("2026-03-09 22:00:00")  # 2 hours
+
+    gen = AdjustableSliceGenerator(start_date=start, end_date=end)
+    next(gen)
+
+    for _ in range(6):
+        reduced = gen.reduce_range()
+        assert reduced.start_date == start
+        assert reduced.end_date <= end
+        assert reduced.end_date > reduced.start_date
+
+
+def test_reduce_range_after_adjust_does_not_expand():
+    """When adjust_range set _current_range small, reduce_range should not expand it."""
+    start = pendulum.parse("2026-03-09 00:00:00")
+    end = pendulum.parse("2026-03-09 12:00:00")  # 12 hours
+
+    gen = AdjustableSliceGenerator(start_date=start, end_date=end)
+    next(gen)
+
+    gen.adjust_range(pendulum.Duration(minutes=30))
+
+    reduced = gen.reduce_range()
+    reduced_duration_days = (reduced.end_date - reduced.start_date).total_seconds() / 86400
+
+    assert reduced_duration_days <= 0.5, (
+        f"reduce_range() produced a {reduced_duration_days}-day slice "
+        f"after adjust_range set _current_range to {gen._current_range}"
+    )


### PR DESCRIPTION
## What
Fix `AdjustableSliceGenerator.reduce_range()` being a no-op when the sync window is smaller than 30 days, causing `ChunkedEncodingError: Reached maximum number of retries: 6` on high-volume streams like `email_send`.

When the connector runs on a frequent schedule (e.g. every 5 minutes), the sync window is far smaller than the 30-day floor in `reduce_range()`. The `min(_end_date, start + 30 days)` cap always resolves to `_end_date`, so all 6 retries use the identical slice and the sync fails.

## How
Changed `reduce_range()` to compute the actual failing slice duration (which may be capped by `_end_date`) and halve that, instead of halving `_current_range` (which could be 30 days while the real slice is minutes/hours).

```python
# Before: floors at 30 days, never effective for small windows
self._current_range = int(max(self._current_range / self.RANGE_REDUCE_FACTOR, self.INITIAL_RANGE_DAYS))
end_date = min(self._end_date, start_date + Duration(days=self._current_range))

# After: halves the actual slice duration
actual_end = min(self._end_date, start_date + Duration(days=self._current_range))
actual_duration = (actual_end - start_date).total_seconds() / 86400
self._current_range = actual_duration / self.RANGE_REDUCE_FACTOR
end_date = start_date + Duration(days=self._current_range)
```

## Review guide
1. `source_iterable/slice_generators.py`: the fix in reduce_range()
2. `unit_tests/test_slice_generator.py`: updated existing assertion + 5 new tests

## User Impact
Connectors using `IterableExportStreamAdjustableRange` streams (email_send, email_click, email_open, etc.) will no longer fail with `ChunkedEncodingError` when a send spike occurs during a small sync window. Retries now progressively shrink the slice until the API can serve it. No change to the happy path — adjust_range() and __next__() are unmodified.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌
