### PR TITLE
docs(ai-agents): add Claude Code skills documentation page

### DIFF
--- a/docs/ai-agents/README.md
+++ b/docs/ai-agents/README.md
@@ -26,4 +26,6 @@ The Agent engine is new and growing. Airbyte is actively seeking feedback. Expec
 
 <CardWithIcon title="Connectors" description="Browse our catalog of connectors, copy code samples, and start powering your agents." ctaText="Connectors" ctaLink="/ai-agents/connectors/" icon="fa-python" />
 
+<CardWithIcon title="Claude Code skills" description="Install skills that teach Claude Code how to set up and operate Airbyte's agent connectors." ctaText="Skills" ctaLink="/ai-agents/skills/" icon="fa-wand-magic-sparkles" />
+
 </Grid>

--- a/docs/ai-agents/skills/readme.md
+++ b/docs/ai-agents/skills/readme.md
@@ -77,6 +77,6 @@ For reference, examine the structure of the skills in the [airbyte-agent-connect
 
 ## Requirements
 
-- Python 3.11 or later
+- Python 3.13 or later
 - [uv](https://github.com/astral-sh/uv) for package management
 - [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview)

--- a/docs/ai-agents/skills/readme.md
+++ b/docs/ai-agents/skills/readme.md
@@ -1,0 +1,82 @@
+---
+sidebar_position: 7
+---
+
+# Claude Code skills
+
+Airbyte provides [Claude Code skills](https://docs.anthropic.com/en/docs/claude-code/skills) for the [Agent Engine](../). Skills are reusable instruction sets that teach Claude Code how to set up and operate Airbyte's agent connectors. When you install a skill, Claude gains the context it needs to help you configure connectors, write integration code, and troubleshoot issues without you having to explain Airbyte's APIs from scratch.
+
+## What skills do
+
+A skill is a structured document that Claude Code reads when you invoke it. It contains setup instructions, code examples, authentication patterns, and API usage guidance. When you ask Claude for help with a task the skill covers, Claude follows the skill's instructions to guide you through the process.
+
+For example, the `airbyte-agent-connectors` skill teaches Claude how to:
+
+- Set up agent connectors in Platform Mode or OSS Mode
+- Configure authentication for different services
+- Use the entity-action API pattern that all connectors share
+- Integrate connectors with agent frameworks like Pydantic AI and LangChain
+- Configure the MCP server for Claude Desktop and Claude Code
+
+## Available skills
+
+Skills are maintained in the [airbyte-agent-connectors](https://github.com/airbytehq/airbyte-agent-connectors/tree/main/skills) repository. Refer to that repository for the latest list of available skills and their documentation.
+
+## Install a skill
+
+You can install skills from the Claude Code plugin marketplace or manually from the repository.
+
+### Install from the plugin marketplace
+
+In Claude Code, add the plugin repository:
+
+```text
+/plugin marketplace add airbytehq/airbyte-agent-connectors
+```
+
+Then install the skill you want. For example, to install the agent connectors skill:
+
+```text
+/plugin install airbyte-agent-connectors@airbyte-agent-connectors
+```
+
+### Install manually
+
+Clone the skill files into your project's `.claude/skills` directory:
+
+```bash
+mkdir -p .claude/skills
+git clone --depth 1 https://github.com/airbytehq/airbyte-agent-connectors.git /tmp/airbyte-skills
+cp -r /tmp/airbyte-skills/skills/airbyte-agent-connectors .claude/skills/
+rm -rf /tmp/airbyte-skills
+```
+
+## Use a skill
+
+After installing, invoke the skill in Claude Code by typing its name as a slash command. For example:
+
+```text
+/airbyte-agent-connectors
+```
+
+You can also ask Claude directly and it uses the skill's knowledge automatically. Try prompts like:
+
+- "Set up a Stripe connector in Platform Mode"
+- "Connect to GitHub using OSS Mode"
+- "Configure Airbyte MCP tools"
+
+## Build your own skills
+
+You can create custom skills that extend or complement the ones Airbyte provides. Skills are markdown files that follow the [Claude Code skill format](https://docs.anthropic.com/en/docs/claude-code/skills). Place your skill files in your project's `.claude/skills` directory.
+
+For reference, examine the structure of the skills in the [airbyte-agent-connectors repository](https://github.com/airbytehq/airbyte-agent-connectors/tree/main/skills). Each skill contains:
+
+- A `SKILL.md` file with instructions that Claude reads
+- A `README.md` file with human-readable documentation
+- A `references/` directory with detailed reference material
+
+## Requirements
+
+- Python 3.11 or later
+- [uv](https://github.com/astral-sh/uv) for package management
+- [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview)


### PR DESCRIPTION
## What

Adds a new documentation page under the Agent Engine section that describes Airbyte's Claude Code skills — reusable instruction sets that teach Claude Code how to set up and operate agent connectors. Also adds a navigation card to the Agent Engine landing page.

This was requested to give users a clear entry point into the [skills directory](https://github.com/airbytehq/airbyte-agent-connectors/tree/main/skills) from the published docs. The page intentionally avoids listing specific skills or connectors, since these change frequently.

A companion PR updates the `airbyte-agent-connectors` repo README to link back to this published page.

## How

- New file `docs/ai-agents/skills/readme.md` with `sidebar_position: 7` (after the existing MCP Server section at position 6).
- Added a `CardWithIcon` entry on the Agent Engine landing page (`docs/ai-agents/README.md`) linking to the new skills page.

## Review guide

1. `docs/ai-agents/skills/readme.md` — the new page. Covers what skills are, installation (marketplace and manual), usage, and pointers to building custom skills.
2. `docs/ai-agents/README.md` — one new `CardWithIcon` line added to the second grid.

### Things to verify
- Does the `fa-wand-magic-sparkles` icon render correctly in `CardWithIcon`? The existing cards use `fa-cloud`, `fa-lock`, `fa-python` — confirm this icon is available in the icon set.
- Check the Vercel preview to confirm the page renders and the sidebar ordering is correct.

## User Impact

Users visiting the Agent Engine docs now see a "Claude Code skills" card on the landing page and can navigate to a dedicated page with installation and usage instructions.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/5cd8525606b34e76bb24e36f3c4d50df
Requested by: @ian-at-airbyte
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/74901" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
