### PR TITLE
docs: update in-app support agent section on getting-support page

### DIFF
--- a/docs/community/getting-support.md
+++ b/docs/community/getting-support.md
@@ -8,9 +8,11 @@ If you can't find an answer to your question in the docs, Airbyte has different 
 
 ## For Airbyte Enterprise and Cloud
 
-### In-app support agent (beta)
+### In-app support agent
 
-Airbyte Cloud includes an AI-powered support agent accessible directly within the app. Look for the chat button in the bottom-right corner of the screen. The support agent can help answer questions about your workspace, connections, and common troubleshooting scenarios. It has context about your current workspace, making it easier to get relevant assistance immediately, without creating a support ticket.
+**The in-app support agent is available 24/7 for Airbyte Enterprise and Cloud customers, and can help with basic troubleshooting anytime.**
+
+Airbyte Cloud includes an AI-powered support agent accessible directly within the app. Look for the chat button in the bottom-right corner of the screen. The support agent can help answer questions about your workspace, connections, and common troubleshooting scenarios. It has context about your current workspace, making it easier to get relevant assistance immediately. The agent can also create Zendesk tickets with additional connection information for the Airbyte support team if further help is needed.
 
 ### Support center
 


### PR DESCRIPTION
## What

Updates the "In-app support agent" section on the [Getting Support](https://docs.airbyte.com/community/getting-support) page to reflect that the feature is out of beta and to clarify its capabilities.

## How

Three changes to `docs/community/getting-support.md`:
1. Removed "(beta)" from the "In-app support agent" heading
2. Added a bold callout stating the agent is available 24/7 for Enterprise and Cloud customers for basic troubleshooting
3. Added a sentence noting the agent can create Zendesk tickets with additional connection information for the Airbyte support team

Also removed the previous clause "without creating a support ticket" since the agent now supports ticket creation.

## Review guide
1. `docs/community/getting-support.md` — only file changed; review the new wording for accuracy

**Key items for reviewer:**
- Confirm the 24/7 availability claim is accurate for the current product
- Confirm the Zendesk ticket creation description matches actual agent behavior
- Confirm "(beta)" removal is appropriate

## User Impact

Users visiting the Getting Support docs page will see updated information reflecting that the in-app support agent is generally available (not beta), available around the clock, and can escalate to Zendesk tickets.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/091247adf7cf452a8ea1073096240cd2
Requested by: @katmarkham