### PR TITLE
chore(source-facebook-marketing): extend v5.0.0 upgrade deadline to 2026-04-10

### DIFF
--- a/airbyte-integrations/connectors/source-facebook-marketing/metadata.yaml
+++ b/airbyte-integrations/connectors/source-facebook-marketing/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: e7778cfc-e97c-4458-9ecb-b4f2bba8946c
-  dockerImageTag: 5.2.1
+  dockerImageTag: 5.2.2
   dockerRepository: airbyte/source-facebook-marketing
   documentationUrl: https://docs.airbyte.com/integrations/sources/facebook-marketing
   externalDocumentationUrls:
@@ -74,7 +74,7 @@ data:
               - "ad_creatives"
       5.0.0:
         message: "This update includes multiple breaking schema changes: (1) Custom Insights streams now use level-based primary keys — when `level` is set to `adset`, `campaign`, or `account`, the primary key will use `adset_id`, `campaign_id`, or just `account_id` respectively, instead of always using `ad_id`. (2) The deprecated `7d_view` and `28d_view` attribution window columns have been removed from all Ads Insights streams, as Meta stopped returning data for these windows on January 12, 2026. (3) The `wish_bid` field has been removed from Ads Insights streams. All users should refresh their source schema and reset affected streams after upgrading. For more information, see the [migration guide](https://docs.airbyte.com/integrations/sources/facebook-marketing-migrations)."
-        upgradeDeadline: "2026-03-20"
+        upgradeDeadline: "2026-04-10"
   suggestedStreams:
     streams:
       - ads_insights

--- a/airbyte-integrations/connectors/source-facebook-marketing/pyproject.toml
+++ b/airbyte-integrations/connectors/source-facebook-marketing/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "5.2.1"
+version = "5.2.2"
 name = "source-facebook-marketing"
 description = "Source implementation for Facebook Marketing."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/docs/integrations/sources/facebook-marketing.md
+++ b/docs/integrations/sources/facebook-marketing.md
@@ -441,7 +441,7 @@ Facebook’s Ads Insights API dynamically aggregates and filters metrics. Purcha
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                                                                                                                                                                                                                           |
 |:-----------|:-----------|:---------------------------------------------------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 5.2.2 | 2026-03-17 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Extend upgrade deadline for version 5.0.0 breaking changes to 2026-04-10 |
+| 5.2.2 | 2026-03-17 | [75130](https://github.com/airbytehq/airbyte/pull/75130) | Extend upgrade deadline for version 5.0.0 breaking changes to 2026-04-10 |
 | 5.2.1 | 2026-03-09 | [74147](https://github.com/airbytehq/airbyte/pull/74147) | Add calendar-aligned time periods (daily/weekly/monthly) to InsightConfig |
 | 5.2.0 | 2026-03-05 | [72835](https://github.com/airbytehq/airbyte/pull/72835) | Add ad_creatives_from_ads stream as alternative to ad_creatives |
 | 5.1.1 | 2026-03-03 | [74255](https://github.com/airbytehq/airbyte/pull/74255) | update upgradeDeadline for the v5.0.0 |

--- a/docs/integrations/sources/facebook-marketing.md
+++ b/docs/integrations/sources/facebook-marketing.md
@@ -441,6 +441,7 @@ Facebook’s Ads Insights API dynamically aggregates and filters metrics. Purcha
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                                                                                                                                                                                                                           |
 |:-----------|:-----------|:---------------------------------------------------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 5.2.2 | 2026-03-17 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Extend upgrade deadline for version 5.0.0 breaking changes to 2026-04-10 |
 | 5.2.1 | 2026-03-09 | [74147](https://github.com/airbytehq/airbyte/pull/74147) | Add calendar-aligned time periods (daily/weekly/monthly) to InsightConfig |
 | 5.2.0 | 2026-03-05 | [72835](https://github.com/airbytehq/airbyte/pull/72835) | Add ad_creatives_from_ads stream as alternative to ad_creatives |
 | 5.1.1 | 2026-03-03 | [74255](https://github.com/airbytehq/airbyte/pull/74255) | update upgradeDeadline for the v5.0.0 |


### PR DESCRIPTION
## What
Extends the upgrade deadline for the source-facebook-marketing v5.0.0 breaking changes from `2026-03-20` to `2026-04-10` (3 additional weeks).

## How
- Updated `upgradeDeadline` for the `5.0.0` breaking change entry in `metadata.yaml`
- Bumped connector version from `5.2.1` → `5.2.2` in `metadata.yaml` and `pyproject.toml`
- Added changelog entry in docs

## Review guide
1. `airbyte-integrations/connectors/source-facebook-marketing/metadata.yaml` — deadline and version changes
2. `airbyte-integrations/connectors/source-facebook-marketing/pyproject.toml` — version bump
3. `docs/integrations/sources/facebook-marketing.md` — changelog entry

## User Impact
Users on versions older than 5.0.0 get an additional 3 weeks (until April 10, 2026) to upgrade before the deadline.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/d8d3a949423e4fdb959d9a311e444980
Requested by: @darynaishchenko