### PR TITLE
fix(destination-pinecone): emit TRACE error instead of LOG on write failure

### DIFF
--- a/airbyte-integrations/connectors/destination-pinecone/destination_pinecone/destination.py
+++ b/airbyte-integrations/connectors/destination-pinecone/destination_pinecone/destination.py
@@ -4,6 +4,8 @@
 
 
 import logging
+import time
+import traceback
 from typing import Any, Iterable, Mapping
 
 from airbyte_cdk.destinations import Destination
@@ -11,9 +13,19 @@ from airbyte_cdk.destinations.vector_db_based.document_processor import Document
 from airbyte_cdk.destinations.vector_db_based.embedder import Embedder, create_from_config
 from airbyte_cdk.destinations.vector_db_based.indexer import Indexer
 from airbyte_cdk.destinations.vector_db_based.writer import Writer
-from airbyte_cdk.models import AirbyteConnectionStatus, AirbyteMessage, ConfiguredAirbyteCatalog, ConnectorSpecification, Status
+from airbyte_cdk.models import (
+    AirbyteConnectionStatus,
+    AirbyteErrorTraceMessage,
+    AirbyteMessage,
+    AirbyteTraceMessage,
+    ConfiguredAirbyteCatalog,
+    ConnectorSpecification,
+    FailureType,
+    Status,
+    TraceType,
+    Type,
+)
 from airbyte_cdk.models.airbyte_protocol import DestinationSyncMode
-from airbyte_protocol.models.airbyte_protocol import AirbyteLogMessage, Level
 from destination_pinecone.config import ConfigModel
 from destination_pinecone.indexer import PineconeIndexer
 
@@ -43,8 +55,18 @@ class DestinationPinecone(Destination):
             )
             yield from writer.write(configured_catalog, input_messages)
         except Exception as e:
-            log_message = AirbyteLogMessage(level=Level.ERROR, message=str(e))
-            yield AirbyteMessage(type="LOG", message=log_message)
+            yield AirbyteMessage(
+                type=Type.TRACE,
+                trace=AirbyteTraceMessage(
+                    type=TraceType.ERROR,
+                    emitted_at=time.time() * 1000,
+                    error=AirbyteErrorTraceMessage(
+                        message=f"Pinecone destination write failed: {e}",
+                        internal_message=traceback.format_exc(),
+                        failure_type=FailureType.system_error,
+                    ),
+                ),
+            )
 
     def check(self, logger: logging.Logger, config: Mapping[str, Any]) -> AirbyteConnectionStatus:
         try:

--- a/airbyte-integrations/connectors/destination-pinecone/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-pinecone/metadata.yaml
@@ -13,7 +13,7 @@ data:
   connectorSubtype: vectorstore
   connectorType: destination
   definitionId: 3d2b6f84-7f0d-4e3f-a5e5-7c7d4b50eabd
-  dockerImageTag: 0.1.46
+  dockerImageTag: 0.1.47
   dockerRepository: airbyte/destination-pinecone
   documentationUrl: https://docs.airbyte.com/integrations/destinations/pinecone
   githubIssueLabel: destination-pinecone

--- a/airbyte-integrations/connectors/destination-pinecone/pyproject.toml
+++ b/airbyte-integrations/connectors/destination-pinecone/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "airbyte-destination-pinecone"
-version = "0.1.46"
+version = "0.1.47"
 description = "Airbyte destination implementation for Pinecone."
 authors = ["Airbyte <contact@airbyte.io>"]
 license = "ELv2"

--- a/docs/integrations/destinations/pinecone.md
+++ b/docs/integrations/destinations/pinecone.md
@@ -84,6 +84,7 @@ This destination supports [namespaces](https://docs.airbyte.com/platform/using-a
 
 | Version | Date       | Pull Request                                              | Subject                                                                                                                      |
 | :------ | :--------- | :-------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------- |
+| 0.1.47 | 2026-03-17 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Emit TRACE error instead of LOG on write failure for proper error surfacing |
 | 0.1.46 | 2025-10-21 | [68334](https://github.com/airbytehq/airbyte/pull/68334) | Update dependencies |
 | 0.1.45 | 2025-10-14 | [61096](https://github.com/airbytehq/airbyte/pull/61096) | Update dependencies |
 | 0.1.44 | 2025-05-17 | [57171](https://github.com/airbytehq/airbyte/pull/57171) | Update dependencies |


### PR DESCRIPTION
## What

Fixes the error handling in `destination-pinecone`'s `write()` method so the platform properly detects sync failures.

Resolves: https://github.com/airbytehq/oncall/issues/11429

## How

The `write()` method's catch-all exception handler was yielding an `AirbyteLogMessage` with `Level.ERROR`. The Airbyte platform does not treat LOG messages as failure signals, so write failures were effectively silent — the sync could appear successful despite an underlying error.

Replaced with an `AirbyteTraceMessage` using `TraceType.ERROR` and `FailureType.system_error`, which is the correct Airbyte protocol mechanism for signaling connector failures. The `internal_message` field includes the full traceback for debugging.

Removed the now-unused `AirbyteLogMessage` / `Level` imports from `airbyte_protocol.models`.

Version bumped to `0.1.47` with changelog entry.

## Review guide

1. `airbyte-integrations/connectors/destination-pinecone/destination_pinecone/destination.py` — core fix.
2. `metadata.yaml`, `pyproject.toml`, `docs/integrations/destinations/pinecone.md` — version bump + changelog.

### Human review checklist

- [ ] **`FailureType.system_error`** is used because this is a broad catch-all handler. If finer-grained classification is desired (e.g., `config_error` for auth failures), that would require restructuring the exception handling.
- [ ] **Exception is not re-raised** after yielding the trace message. This preserves the existing behavior (the old LOG path also swallowed the exception). `destination-couchbase` re-raises after emitting a trace — worth considering whether that pattern should be adopted here as well, though it would be a behavior change beyond the scope of this fix.

## User Impact

Sync failures in `destination-pinecone` will now be properly surfaced to users in the Airbyte UI instead of being silently swallowed as log lines. Users will see actionable error messages when their Pinecone syncs fail.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/f13495eabe91429c82e490a3cd444ddb
Requested by: @bernielomax