### PR TITLE
chore(destination-postgres): bump version 3.0.11 → 3.0.12

### DIFF
--- a/airbyte-integrations/connectors/destination-postgres/gradle.properties
+++ b/airbyte-integrations/connectors/destination-postgres/gradle.properties
@@ -1,4 +1,4 @@
-cdkVersion=1.0.2
+cdkVersion=1.0.6
 # our testcontainer has issues with too much concurrency.
 # 4 threads seems to be the sweet spot.
 testExecutionConcurrency=4

--- a/airbyte-integrations/connectors/destination-postgres/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-postgres/metadata.yaml
@@ -6,7 +6,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 25c5221d-dce2-4163-ade9-739ef790f503
-  dockerImageTag: 3.0.11
+  dockerImageTag: 3.0.12
   dockerRepository: airbyte/destination-postgres
   documentationUrl: https://docs.airbyte.com/integrations/destinations/postgres
   githubIssueLabel: destination-postgres

--- a/docs/integrations/destinations/postgres.md
+++ b/docs/integrations/destinations/postgres.md
@@ -298,6 +298,7 @@ This destination supports [namespaces](https://docs.airbyte.com/platform/using-a
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                                                                                                |
 |:--------|:-----------|:-----------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 3.0.12  | 2026-03-17 | [74824](https://github.com/airbytehq/airbyte/pull/74824)   | Drop temp table after successful upsert to prevent duplicate records in dedup+truncate mode (CDK 1.0.6) |
 | 3.0.11  | 2026-02-25 | | Upgrade CDK to 1.0.2 and base image to 2.0.4 for CVE patches |
 | 3.0.10  | 2026-02-04 | [72858](https://github.com/airbytehq/airbyte/pull/72858)   | Upgrade CDK to 0.2.8                                                                                                                                                                   |
 | 3.0.9   | 2026-01-28 | [72292](https://github.com/airbytehq/airbyte/pull/72292)   | Upgrade CDK to 0.2.0                                                                                                                                                                   |


### PR DESCRIPTION
## What

Release destination-postgres 3.0.12 to pick up the bulk-cdk-core-load fix from [#74715](https://github.com/airbytehq/airbyte/pull/74715), which drops the temp table after a successful upsert to prevent duplicate records in dedup+truncate mode. This is the same CDK bump applied to destination-snowflake in [#74824](https://github.com/airbytehq/airbyte/pull/74824).

## How

- Bump `cdkVersion` in `gradle.properties` from 1.0.2 → 1.0.6
- Bump `dockerImageTag` in `metadata.yaml` from 3.0.11 → 3.0.12
- Add changelog entry in `docs/integrations/destinations/postgres.md`

## Review guide

1. `airbyte-integrations/connectors/destination-postgres/gradle.properties` — CDK version bump
2. `airbyte-integrations/connectors/destination-postgres/metadata.yaml` — connector version bump
3. `docs/integrations/destinations/postgres.md` — new changelog row

### Reviewer checklist

- [ ] Verify that CDK versions 1.0.3–1.0.5 don't introduce unintended behavioral changes for Postgres (the jump skips several intermediate versions)
- [ ] Confirm the changelog PR link is acceptable (currently references #74824, the Snowflake equivalent — could alternatively reference this PR or the underlying fix #74715)

## User Impact

Users syncing to Postgres in dedup+truncate mode will no longer see duplicate records across successive syncs once this version is deployed.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Reverting pins the connector back to 3.0.11 (CDK 1.0.2), which still has the duplicate-records bug in the dedup-truncate path. No data loss or schema corruption.

Link to Devin session: https://app.devin.ai/sessions/e915c37ea8a14ed898f4347b79a0283b
Requested by: @benmoriceau