### PR TITLE
fix(destination-pinecone): Add logging to check and write operations and fix __init__ bug

### DIFF
--- a/airbyte-integrations/connectors/destination-pinecone/destination_pinecone/destination.py
+++ b/airbyte-integrations/connectors/destination-pinecone/destination_pinecone/destination.py
@@ -44,16 +44,30 @@ class DestinationPinecone(Destination):
         except Exception as e:
             return AirbyteConnectionStatus(status=Status.FAILED, message=str(e))
 
+    def _log(self, level, message: str) -> AirbyteMessage:
+        from airbyte_protocol.models.airbyte_protocol import AirbyteLogMessage, Level
+
+        return AirbyteMessage(type="LOG", log=AirbyteLogMessage(level=level, message=message))
+
     def write(
         self, config: Mapping[str, Any], configured_catalog: ConfiguredAirbyteCatalog, input_messages: Iterable[AirbyteMessage]
     ) -> Iterable[AirbyteMessage]:
+        from airbyte_protocol.models.airbyte_protocol import Level
+
+        yield self._log(Level.INFO, "Starting Pinecone destination write...")
         try:
+            yield self._log(Level.INFO, "Parsing configuration...")
             config_model = ConfigModel.parse_obj(config)
+
+            yield self._log(Level.INFO, "Initializing embedder and indexer...")
             self._init_indexer(config_model)
+
+            yield self._log(Level.INFO, "Creating writer and starting sync...")
             writer = Writer(
                 config_model.processing, self.indexer, self.embedder, batch_size=BATCH_SIZE, omit_raw_text=config_model.omit_raw_text
             )
             yield from writer.write(configured_catalog, input_messages)
+            yield self._log(Level.INFO, "Write operation completed.")
         except Exception as e:
             yield AirbyteMessage(
                 type=Type.TRACE,
@@ -69,20 +83,34 @@ class DestinationPinecone(Destination):
             )
 
     def check(self, logger: logging.Logger, config: Mapping[str, Any]) -> AirbyteConnectionStatus:
+        logger.info("Starting Pinecone destination check...")
         try:
+            logger.info("Parsing configuration...")
             parsed_config = ConfigModel.parse_obj(config)
+
+            logger.info("Initializing embedder and indexer...")
             init_status = self._init_indexer(parsed_config)
             if init_status and init_status.status == Status.FAILED:
                 logger.error(f"Initialization failed with message: {init_status.message}")
-                return init_status  # Return the failure status immediately if initialization fails
+                return init_status
 
-            checks = [self.embedder.check(), self.indexer.check(), DocumentProcessor.check_config(parsed_config.processing)]
+            logger.info("Running embedder check...")
+            embedder_check_result = self.embedder.check()
+
+            logger.info("Running indexer check...")
+            indexer_check_result = self.indexer.check()
+
+            logger.info("Running document processor config check...")
+            processor_check_result = DocumentProcessor.check_config(parsed_config.processing)
+
+            checks = [embedder_check_result, indexer_check_result, processor_check_result]
             errors = [error for error in checks if error is not None]
             if len(errors) > 0:
                 error_message = "\n".join(errors)
                 logger.error(f"Configuration check failed: {error_message}")
                 return AirbyteConnectionStatus(status=Status.FAILED, message=error_message)
             else:
+                logger.info("Configuration check succeeded.")
                 return AirbyteConnectionStatus(status=Status.SUCCEEDED)
         except Exception as e:
             logger.error(f"Exception during configuration check: {str(e)}")

--- a/airbyte-integrations/connectors/destination-pinecone/destination_pinecone/destination.py
+++ b/airbyte-integrations/connectors/destination-pinecone/destination_pinecone/destination.py
@@ -60,7 +60,10 @@ class DestinationPinecone(Destination):
             config_model = ConfigModel.parse_obj(config)
 
             yield self._log(Level.INFO, "Initializing embedder and indexer...")
-            self._init_indexer(config_model)
+            init_status = self._init_indexer(config_model)
+            if init_status and init_status.status == Status.FAILED:
+                yield self._log(Level.ERROR, f"Initialization failed: {init_status.message}")
+                return
 
             yield self._log(Level.INFO, "Creating writer and starting sync...")
             writer = Writer(

--- a/airbyte-integrations/connectors/destination-pinecone/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-pinecone/metadata.yaml
@@ -13,7 +13,7 @@ data:
   connectorSubtype: vectorstore
   connectorType: destination
   definitionId: 3d2b6f84-7f0d-4e3f-a5e5-7c7d4b50eabd
-  dockerImageTag: 0.1.47
+  dockerImageTag: 0.1.48
   dockerRepository: airbyte/destination-pinecone
   documentationUrl: https://docs.airbyte.com/integrations/destinations/pinecone
   githubIssueLabel: destination-pinecone

--- a/airbyte-integrations/connectors/destination-pinecone/pyproject.toml
+++ b/airbyte-integrations/connectors/destination-pinecone/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "airbyte-destination-pinecone"
-version = "0.1.47"
+version = "0.1.48"
 description = "Airbyte destination implementation for Pinecone."
 authors = ["Airbyte <contact@airbyte.io>"]
 license = "ELv2"

--- a/docs/integrations/destinations/pinecone.md
+++ b/docs/integrations/destinations/pinecone.md
@@ -96,6 +96,7 @@ This destination supports [namespaces](https://docs.airbyte.com/platform/using-a
 
 | Version | Date       | Pull Request                                              | Subject                                                                                                                      |
 | :------ | :--------- | :-------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------- |
+| 0.1.48 | 2026-03-17 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Add logging to check and write operations and fix `__init__` bug |
 | 0.1.47 | 2026-03-17 | [75136](https://github.com/airbytehq/airbyte/pull/75136) | Emit TRACE error instead of LOG on write failure for proper error surfacing |
 | 0.1.46 | 2025-10-21 | [68334](https://github.com/airbytehq/airbyte/pull/68334) | Update dependencies |
 | 0.1.45 | 2025-10-14 | [61096](https://github.com/airbytehq/airbyte/pull/61096) | Update dependencies |
@@ -141,8 +142,8 @@ This destination supports [namespaces](https://docs.airbyte.com/platform/using-a
 | 0.1.5 | 2024-06-25 | [40430](https://github.com/airbytehq/airbyte/pull/40430) | Update dependencies |
 | 0.1.4 | 2024-06-22 | [40150](https://github.com/airbytehq/airbyte/pull/40150) | Update dependencies |
 | 0.1.3 | 2024-06-06 | [39148](https://github.com/airbytehq/airbyte/pull/39148) | [autopull] Upgrade base image to v1.2.2 |
-| 0.1.2   | 2023-05-17 | [38336](https://github.com/airbytehq/airbyte/pull/38336) | Fix for regression: Custom namespaces not created automatically |
-| 0.1.1   | 2023-05-14 | [38151](https://github.com/airbytehq/airbyte/pull/38151) | Add airbyte source tag for attribution |
+| 0.1.2 | 2023-05-17 | [38336](https://github.com/airbytehq/airbyte/pull/38336) | Fix for regression: Custom namespaces not created automatically |
+| 0.1.1 | 2023-05-14 | [38151](https://github.com/airbytehq/airbyte/pull/38151) | Add airbyte source tag for attribution |
 | 0.1.0   | 2023-05-06 | [#37756](https://github.com/airbytehq/airbyte/pull/37756) | Add support for Pinecone Serverless                                                                                          |
 | 0.0.24  | 2023-04-15 | [#37333](https://github.com/airbytehq/airbyte/pull/37333) | Update CDK & pytest version to fix security vulnerabilities.                                                                 |
 | 0.0.23  | 2023-03-22 | [#35911](https://github.com/airbytehq/airbyte/pull/35911) | Bump versions to latest, resolves test failures.                                                                             |

--- a/docs/integrations/destinations/pinecone.md
+++ b/docs/integrations/destinations/pinecone.md
@@ -96,7 +96,7 @@ This destination supports [namespaces](https://docs.airbyte.com/platform/using-a
 
 | Version | Date       | Pull Request                                              | Subject                                                                                                                      |
 | :------ | :--------- | :-------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------- |
-| 0.1.48 | 2026-03-17 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Add logging to check and write operations and fix `__init__` bug |
+| 0.1.48 | 2026-03-17 | [75170](https://github.com/airbytehq/airbyte/pull/75170) | Add logging to check and write operations and fix `__init__` bug |
 | 0.1.47 | 2026-03-17 | [75136](https://github.com/airbytehq/airbyte/pull/75136) | Emit TRACE error instead of LOG on write failure for proper error surfacing |
 | 0.1.46 | 2025-10-21 | [68334](https://github.com/airbytehq/airbyte/pull/68334) | Update dependencies |
 | 0.1.45 | 2025-10-14 | [61096](https://github.com/airbytehq/airbyte/pull/61096) | Update dependencies |


### PR DESCRIPTION
## What

Addresses an issue where the Pinecone destination connector's "check" operation was hanging without any logs being printed, making it difficult to diagnose where the hang was occurring. Also fixes a bug in `PineconeIndexer.__init__` where exceptions were being silently swallowed.

Related: https://github.com/airbytehq/oncall/issues/10270

Recreates on a fresh branch: https://github.com/airbytehq/airbyte/pull/70202 (closed — was reviewed and approved by @girarda, with review feedback from @aaronsteers incorporated). This PR also addresses a [Devin Review finding](https://github.com/airbytehq/airbyte/pull/70202#discussion_r2947949244) on the original PR that `write()` silently discarded `_init_indexer` failure status.

## How

**Logging improvements (`destination.py`):**
- Added `_log()` helper for yielding `AirbyteMessage` log entries from generator methods
- Added `logger.info()` progress logs in `check()` before each step (config parsing, embedder/indexer init, individual checks)
- Added yielded INFO log messages in `write()` before each step
- Split the check calls into individual variables so each step can be logged independently

**Bug fix (`indexer.py`):**
- Added `PineconeIndexerInitError` custom exception
- `__init__` now catches `PineconeException` and re-raises as `PineconeIndexerInitError` with exception chaining (`from e`)
- Previously, the code returned `AirbyteConnectionStatus` from `__init__`, which Python silently ignores — leaving the indexer in a broken state with no error surfaced

**Bug fix (`destination.py` — `write()`):**
- `write()` now checks the return value of `_init_indexer()` and exits early with an error log if initialization failed
- Previously, `write()` ignored the failure status, causing a downstream `AttributeError` on `self.indexer` that masked the actual Pinecone init error
- This mirrors the existing pattern already present in `check()`

## Review guide

1. `indexer.py` — Verify the `PineconeIndexerInitError` exception and re-raise properly chains to `_init_indexer()`'s `except Exception` handler in `destination.py`
2. `destination.py` — Review the `write()` init failure handling (lines 63-66): on failure it yields an ERROR log and returns early, but does *not* emit a TRACE error. Confirm this is acceptable vs. falling through to the TRACE error path in the outer `except`.
3. `destination.py` — The `_log()` helper and `write()` use inline imports for `Level`/`AirbyteLogMessage` from `airbyte_protocol.models`. Review whether these should be moved to the top-level imports instead.

### Human review checklist
- [ ] Verify `write()` init failure path (LOG + return) surfaces enough info to the platform vs. emitting a TRACE error
- [ ] Confirm `PineconeIndexerInitError` → `_init_indexer` `except Exception` → `AirbyteConnectionStatus(FAILED)` chain works end-to-end
- [ ] Review logging verbosity for production appropriateness
- [ ] Confirm inline imports in `_log()` / `write()` are acceptable style for this codebase

## User Impact

- Users will see progress logs during check and write operations, making it easier to diagnose hangs
- If `PineconeGRPC()` initialization fails, users will now see a proper error instead of silent failure
- If indexer/embedder init fails during `write()`, the actual error message is now surfaced instead of a confusing `AttributeError`

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/20eeff534b464d4ba5f05f524d56af16
Requested by: @bernielomax