### PR TITLE
docs: move External Secrets Manager page from Enterprise Flex to Security, add Pro support

### DIFF
--- a/docs/platform/operating-airbyte/external-secrets.md
+++ b/docs/platform/operating-airbyte/external-secrets.md
@@ -1,5 +1,5 @@
 ---
-products: enterprise-flex
+products: pro, enterprise-flex
 sidebar_label: External Secret Management
 ---
 
@@ -8,17 +8,17 @@ import TabItem from '@theme/TabItem';
 
 # External Secret Management
 
-This guide provides step-by-step instructions for configuring external secrets management with Airbyte Enterprise Flex. External secrets management allows Airbyte to securely store and manage connection credentials in your cloud provider's secrets manager (AWS Secrets Manager, Azure Key Vault, or Google Cloud Secret Manager) instead of storing them in Airbyte's internal database.
+This guide provides step-by-step instructions for configuring external secrets management with Airbyte. External secrets management allows Airbyte to securely store and manage connection credentials in your cloud provider's secrets manager (AWS Secrets Manager, Azure Key Vault, or Google Cloud Secret Manager) instead of storing them in Airbyte's internal database.
 
 :::info
-External secrets management is available for Airbyte Enterprise Flex customers.
+External secrets management is available for Airbyte Pro and Enterprise Flex customers.
 :::
 
 ---
 
 ## Prerequisites
 
-- Airbyte organization on an Enterprise Flex plan
+- Airbyte organization on a Pro or Enterprise Flex plan
 - Active account with your chosen cloud provider (AWS, Azure, or GCP)
 - Appropriate permissions to create and manage IAM roles/policies or service principals
 - Access to your cloud provider's secrets management service

--- a/docusaurus/sidebar-platform.js
+++ b/docusaurus/sidebar-platform.js
@@ -463,7 +463,6 @@ module.exports = {
           },
           items: [
             "enterprise-flex/getting-started",
-            "enterprise-flex/external-secrets",
             "enterprise-flex/data-plane",
             "enterprise-flex/data-plane-util",
           ],
@@ -526,6 +525,10 @@ module.exports = {
             {
               type: "doc",
               id: "operating-airbyte/privatelink",
+            },
+            {
+              type: "doc",
+              id: "operating-airbyte/external-secrets",
             },
           ],
         },


### PR DESCRIPTION
## What

Moves the External Secrets Manager documentation page from the **Enterprise Flex** section to the **Security** section in the sidebar, and adds **Pro** as a supported product tier.

## How

- Renamed/moved `docs/platform/enterprise-flex/external-secrets.md` → `docs/platform/operating-airbyte/external-secrets.md`
- Updated `docusaurus/sidebar-platform.js` to remove the entry from the Enterprise Flex category and add it under the Security category
- Updated frontmatter `products` from `enterprise-flex` to `pro, enterprise-flex`
- Updated three content references (intro paragraph, info callout, prerequisites) to mention both Pro and Enterprise Flex

## Review guide

1. `docusaurus/sidebar-platform.js` — sidebar restructuring (entry removed from Enterprise Flex, added to Security)
2. `docs/platform/operating-airbyte/external-secrets.md` — file move + frontmatter and content updates for Pro support

**Please verify:**
- The `products: pro, enterprise-flex` frontmatter format is correct for multi-product pages
- No other docs or versioned docs link to the old `enterprise-flex/external-secrets` path (grep found none, but a build check would be more thorough)

## User Impact

- The External Secret Management page now appears under **Security** in the docs sidebar instead of under **Enterprise Flex**
- Pro customers will see this page as applicable to their product tier

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/f4ade1b2b39c49b49137a0f6810853d6
Requested by: @matteogp