### PR TITLE
feat(source-jsonplaceholder): add new JSONPlaceholder source connector

### DIFF
--- a/airbyte-integrations/connectors/source-jsonplaceholder/README.md
+++ b/airbyte-integrations/connectors/source-jsonplaceholder/README.md
@@ -1,0 +1,51 @@
+# JSONPlaceholder source connector
+
+This directory contains the manifest-only connector for `source-jsonplaceholder`.
+This _manifest-only_ connector is not a Python package on its own, as it runs inside of the base `source-declarative-manifest` image.
+
+For information about how to configure and use this connector within Airbyte, see [the connector's full documentation](https://docs.airbyte.com/integrations/sources/jsonplaceholder).
+
+## Local development
+
+We recommend using the Connector Builder to edit this connector.
+Using either Airbyte Cloud or your local Airbyte OSS instance, navigate to the **Builder** tab and select **Import a YAML**.
+Then select the connector's `manifest.yaml` file to load the connector into the Builder. You're now ready to make changes to the connector!
+
+If you prefer to develop locally, you can follow the instructions below.
+
+### Building the docker image
+
+You can build any manifest-only connector with `airbyte-ci`:
+
+1. Install [`airbyte-ci`](https://github.com/airbytehq/airbyte/blob/master/airbyte-ci/connectors/pipelines/README.md)
+2. Run the following command to build the docker image:
+
+```bash
+airbyte-ci connectors --name=source-jsonplaceholder build
+```
+
+An image will be available on your host with the tag `airbyte/source-jsonplaceholder:dev`.
+
+### Creating credentials
+
+This connector does not require any credentials. JSONPlaceholder is a free, public API.
+Create a file `secrets/config.json` with an empty JSON object `{}`.
+
+### Running as a docker container
+
+Then run any of the standard source connector commands:
+
+```bash
+docker run --rm airbyte/source-jsonplaceholder:dev spec
+docker run --rm -v $(pwd)/secrets:/secrets airbyte/source-jsonplaceholder:dev check --config /secrets/config.json
+docker run --rm -v $(pwd)/secrets:/secrets airbyte/source-jsonplaceholder:dev discover --config /secrets/config.json
+docker run --rm -v $(pwd)/secrets:/secrets -v $(pwd)/integration_tests:/integration_tests airbyte/source-jsonplaceholder:dev read --config /secrets/config.json --catalog /integration_tests/configured_catalog.json
+```
+
+### Running the CI test suite
+
+You can run our full test suite locally using [`airbyte-ci`](https://github.com/airbytehq/airbyte/blob/master/airbyte-ci/connectors/pipelines/README.md):
+
+```bash
+airbyte-ci connectors --name=source-jsonplaceholder test
+```

--- a/airbyte-integrations/connectors/source-jsonplaceholder/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-jsonplaceholder/acceptance-test-config.yml
@@ -1,0 +1,21 @@
+# See [Connector Acceptance Tests](https://docs.airbyte.com/connector-development/testing-connectors/connector-acceptance-tests-reference)
+# for more information about how to configure these tests
+connector_image: airbyte/source-jsonplaceholder:dev
+acceptance_tests:
+  spec:
+    tests:
+      - spec_path: "manifest.yaml"
+  connection:
+    bypass_reason: "No credentials required for this public API"
+  discovery:
+    tests:
+      - config_path: "secrets/config.json"
+  basic_read:
+    tests:
+      - config_path: "secrets/config.json"
+        empty_streams: []
+  incremental:
+    bypass_reason: "This connector does not implement incremental sync"
+  full_refresh:
+    tests:
+      - config_path: "secrets/config.json"

--- a/airbyte-integrations/connectors/source-jsonplaceholder/icon.svg
+++ b/airbyte-integrations/connectors/source-jsonplaceholder/icon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewBox="0 0 256 256" fill="none">
+  <rect width="256" height="256" rx="32" fill="#1E88E5"/>
+  <text x="128" y="100" text-anchor="middle" font-family="monospace" font-size="36" font-weight="bold" fill="white">{...}</text>
+  <text x="128" y="155" text-anchor="middle" font-family="sans-serif" font-size="24" font-weight="bold" fill="white">JSON</text>
+  <text x="128" y="185" text-anchor="middle" font-family="sans-serif" font-size="16" fill="white">Placeholder</text>
+</svg>

--- a/airbyte-integrations/connectors/source-jsonplaceholder/manifest.yaml
+++ b/airbyte-integrations/connectors/source-jsonplaceholder/manifest.yaml
@@ -1,0 +1,301 @@
+version: "4.6.2"
+type: DeclarativeSource
+
+definitions:
+  base_requester:
+    type: HttpRequester
+    url_base: https://jsonplaceholder.typicode.com
+    http_method: GET
+    authenticator:
+      type: NoAuth
+
+  base_retriever:
+    type: SimpleRetriever
+    requester:
+      $ref: "#/definitions/base_requester"
+    record_selector:
+      type: RecordSelector
+      extractor:
+        type: DpathExtractor
+        field_path: []
+    paginator:
+      type: NoPagination
+
+  posts_stream:
+    type: DeclarativeStream
+    name: posts
+    primary_key:
+      - id
+    retriever:
+      $ref: "#/definitions/base_retriever"
+      requester:
+        $ref: "#/definitions/base_requester"
+        path: /posts
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        $schema: http://json-schema.org/draft-07/schema#
+        type: object
+        additionalProperties: true
+        properties:
+          userId:
+            type:
+              - integer
+              - "null"
+          id:
+            type: integer
+          title:
+            type:
+              - string
+              - "null"
+          body:
+            type:
+              - string
+              - "null"
+
+  comments_stream:
+    type: DeclarativeStream
+    name: comments
+    primary_key:
+      - id
+    retriever:
+      $ref: "#/definitions/base_retriever"
+      requester:
+        $ref: "#/definitions/base_requester"
+        path: /comments
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        $schema: http://json-schema.org/draft-07/schema#
+        type: object
+        additionalProperties: true
+        properties:
+          postId:
+            type:
+              - integer
+              - "null"
+          id:
+            type: integer
+          name:
+            type:
+              - string
+              - "null"
+          email:
+            type:
+              - string
+              - "null"
+          body:
+            type:
+              - string
+              - "null"
+
+  albums_stream:
+    type: DeclarativeStream
+    name: albums
+    primary_key:
+      - id
+    retriever:
+      $ref: "#/definitions/base_retriever"
+      requester:
+        $ref: "#/definitions/base_requester"
+        path: /albums
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        $schema: http://json-schema.org/draft-07/schema#
+        type: object
+        additionalProperties: true
+        properties:
+          userId:
+            type:
+              - integer
+              - "null"
+          id:
+            type: integer
+          title:
+            type:
+              - string
+              - "null"
+
+  photos_stream:
+    type: DeclarativeStream
+    name: photos
+    primary_key:
+      - id
+    retriever:
+      $ref: "#/definitions/base_retriever"
+      requester:
+        $ref: "#/definitions/base_requester"
+        path: /photos
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        $schema: http://json-schema.org/draft-07/schema#
+        type: object
+        additionalProperties: true
+        properties:
+          albumId:
+            type:
+              - integer
+              - "null"
+          id:
+            type: integer
+          title:
+            type:
+              - string
+              - "null"
+          url:
+            type:
+              - string
+              - "null"
+          thumbnailUrl:
+            type:
+              - string
+              - "null"
+
+  todos_stream:
+    type: DeclarativeStream
+    name: todos
+    primary_key:
+      - id
+    retriever:
+      $ref: "#/definitions/base_retriever"
+      requester:
+        $ref: "#/definitions/base_requester"
+        path: /todos
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        $schema: http://json-schema.org/draft-07/schema#
+        type: object
+        additionalProperties: true
+        properties:
+          userId:
+            type:
+              - integer
+              - "null"
+          id:
+            type: integer
+          title:
+            type:
+              - string
+              - "null"
+          completed:
+            type:
+              - boolean
+              - "null"
+
+  users_stream:
+    type: DeclarativeStream
+    name: users
+    primary_key:
+      - id
+    retriever:
+      $ref: "#/definitions/base_retriever"
+      requester:
+        $ref: "#/definitions/base_requester"
+        path: /users
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        $schema: http://json-schema.org/draft-07/schema#
+        type: object
+        additionalProperties: true
+        properties:
+          id:
+            type: integer
+          name:
+            type:
+              - string
+              - "null"
+          username:
+            type:
+              - string
+              - "null"
+          email:
+            type:
+              - string
+              - "null"
+          address:
+            type:
+              - object
+              - "null"
+            properties:
+              street:
+                type:
+                  - string
+                  - "null"
+              suite:
+                type:
+                  - string
+                  - "null"
+              city:
+                type:
+                  - string
+                  - "null"
+              zipcode:
+                type:
+                  - string
+                  - "null"
+              geo:
+                type:
+                  - object
+                  - "null"
+                properties:
+                  lat:
+                    type:
+                      - string
+                      - "null"
+                  lng:
+                    type:
+                      - string
+                      - "null"
+          phone:
+            type:
+              - string
+              - "null"
+          website:
+            type:
+              - string
+              - "null"
+          company:
+            type:
+              - object
+              - "null"
+            properties:
+              name:
+                type:
+                  - string
+                  - "null"
+              catchPhrase:
+                type:
+                  - string
+                  - "null"
+              bs:
+                type:
+                  - string
+                  - "null"
+
+streams:
+  - $ref: "#/definitions/posts_stream"
+  - $ref: "#/definitions/comments_stream"
+  - $ref: "#/definitions/albums_stream"
+  - $ref: "#/definitions/photos_stream"
+  - $ref: "#/definitions/todos_stream"
+  - $ref: "#/definitions/users_stream"
+
+check:
+  type: CheckStream
+  stream_names:
+    - posts
+
+spec:
+  type: Spec
+  documentation_url: https://docs.airbyte.com/integrations/sources/jsonplaceholder
+  connection_specification:
+    $schema: http://json-schema.org/draft-07/schema#
+    title: Source JSONPlaceholder Spec
+    type: object
+    additionalProperties: true
+    properties: {}
+    required: []

--- a/airbyte-integrations/connectors/source-jsonplaceholder/manifest.yaml
+++ b/airbyte-integrations/connectors/source-jsonplaceholder/manifest.yaml
@@ -4,7 +4,7 @@ type: DeclarativeSource
 definitions:
   base_requester:
     type: HttpRequester
-    url_base: https://jsonplaceholder.typicode.com
+    url: https://jsonplaceholder.typicode.com
     http_method: GET
     authenticator:
       type: NoAuth
@@ -30,7 +30,7 @@ definitions:
       $ref: "#/definitions/base_retriever"
       requester:
         $ref: "#/definitions/base_requester"
-        path: /posts
+        url: https://jsonplaceholder.typicode.com/posts
     schema_loader:
       type: InlineSchemaLoader
       schema:
@@ -62,7 +62,7 @@ definitions:
       $ref: "#/definitions/base_retriever"
       requester:
         $ref: "#/definitions/base_requester"
-        path: /comments
+        url: https://jsonplaceholder.typicode.com/comments
     schema_loader:
       type: InlineSchemaLoader
       schema:
@@ -98,7 +98,7 @@ definitions:
       $ref: "#/definitions/base_retriever"
       requester:
         $ref: "#/definitions/base_requester"
-        path: /albums
+        url: https://jsonplaceholder.typicode.com/albums
     schema_loader:
       type: InlineSchemaLoader
       schema:
@@ -126,7 +126,7 @@ definitions:
       $ref: "#/definitions/base_retriever"
       requester:
         $ref: "#/definitions/base_requester"
-        path: /photos
+        url: https://jsonplaceholder.typicode.com/photos
     schema_loader:
       type: InlineSchemaLoader
       schema:
@@ -162,7 +162,7 @@ definitions:
       $ref: "#/definitions/base_retriever"
       requester:
         $ref: "#/definitions/base_requester"
-        path: /todos
+        url: https://jsonplaceholder.typicode.com/todos
     schema_loader:
       type: InlineSchemaLoader
       schema:
@@ -194,7 +194,7 @@ definitions:
       $ref: "#/definitions/base_retriever"
       requester:
         $ref: "#/definitions/base_requester"
-        path: /users
+        url: https://jsonplaceholder.typicode.com/users
     schema_loader:
       type: InlineSchemaLoader
       schema:

--- a/airbyte-integrations/connectors/source-jsonplaceholder/metadata.yaml
+++ b/airbyte-integrations/connectors/source-jsonplaceholder/metadata.yaml
@@ -35,6 +35,12 @@ data:
   connectorTestSuitesOptions:
     - suite: unitTests
     - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-JSONPLACEHOLDER__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
   externalDocumentationUrls:
     - title: JSONPlaceholder documentation
       url: https://jsonplaceholder.typicode.com/guide/

--- a/airbyte-integrations/connectors/source-jsonplaceholder/metadata.yaml
+++ b/airbyte-integrations/connectors/source-jsonplaceholder/metadata.yaml
@@ -1,0 +1,42 @@
+data:
+  allowedHosts:
+    hosts:
+      - jsonplaceholder.typicode.com
+  registryOverrides:
+    oss:
+      enabled: true
+    cloud:
+      enabled: false
+  releases:
+    rolloutConfiguration:
+      enableProgressiveRollout: false
+  remoteRegistries:
+    pypi:
+      enabled: false
+      packageName: airbyte-source-jsonplaceholder
+  connectorBuildOptions:
+    baseImage: docker.io/airbyte/source-declarative-manifest:7.10.1@sha256:bd69f6b52bdd92ce06c30786d67546427b828ffb553363c8950b2816c552d6e0
+  connectorSubtype: api
+  connectorType: source
+  definitionId: c336991f-8ac0-4241-aa2b-cefa72fc5b32
+  dockerImageTag: 0.1.0
+  dockerRepository: airbyte/source-jsonplaceholder
+  githubIssueLabel: source-jsonplaceholder
+  icon: jsonplaceholder.svg
+  license: ELv2
+  name: JSONPlaceholder
+  releaseDate: "2026-03-18"
+  releaseStage: alpha
+  supportLevel: community
+  documentationUrl: https://docs.airbyte.com/integrations/sources/jsonplaceholder
+  tags:
+    - cdk:low-code
+    - language:manifest-only
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+  externalDocumentationUrls:
+    - title: JSONPlaceholder documentation
+      url: https://jsonplaceholder.typicode.com/guide/
+      type: api_reference
+metadataSpecVersion: "1.0"

--- a/docs/integrations/sources/jsonplaceholder.md
+++ b/docs/integrations/sources/jsonplaceholder.md
@@ -1,0 +1,67 @@
+# JSONPlaceholder
+
+This page contains the setup guide and reference information for the [JSONPlaceholder](https://jsonplaceholder.typicode.com/) source connector.
+
+## Overview
+
+JSONPlaceholder is a free online REST API that you can use for testing, prototyping, and learning. It provides fake data for common resources like posts, comments, albums, photos, todos, and users.
+
+## Prerequisites
+
+No prerequisites are required. JSONPlaceholder is a free, public API that does not require authentication.
+
+## Setup guide
+
+### Set up the JSONPlaceholder connector in Airbyte
+
+1. Log into your Airbyte account.
+2. In the left navigation bar, click **Sources**. In the top-right corner, click **+ New source**.
+3. Find and select **JSONPlaceholder** from the list of available sources.
+4. Enter a **Name** for the connector.
+5. Click **Set up source**.
+
+No additional configuration is needed because this is a public API.
+
+## Supported sync modes
+
+The JSONPlaceholder source connector supports the following sync modes:
+
+| Feature                       | Supported? |
+| :---------------------------- | :--------- |
+| Full Refresh Sync             | Yes        |
+| Incremental - Append Sync     | No         |
+| Replicate Incremental Deletes | No         |
+| SSL connection                | Yes        |
+| Namespaces                    | No         |
+
+## Supported streams
+
+The JSONPlaceholder source connector supports the following streams:
+
+- [Posts](https://jsonplaceholder.typicode.com/posts) - 100 posts
+- [Comments](https://jsonplaceholder.typicode.com/comments) - 500 comments
+- [Albums](https://jsonplaceholder.typicode.com/albums) - 100 albums
+- [Photos](https://jsonplaceholder.typicode.com/photos) - 5,000 photos
+- [Todos](https://jsonplaceholder.typicode.com/todos) - 200 todos
+- [Users](https://jsonplaceholder.typicode.com/users) - 10 users
+
+## Limitations and troubleshooting
+
+- JSONPlaceholder is a read-only API with fake data intended for testing and prototyping.
+- The data is static and does not change, so incremental sync is not supported.
+- All records for each resource are returned in a single response. There is no pagination.
+
+## Changelog
+
+<details>
+  <summary>Expand to review</summary>
+
+| Version | Date       | Pull Request | Subject                              |
+| :------ | :--------- | :----------- | :----------------------------------- |
+| 0.1.0   | 2026-03-18 | TBD          | Initial release of JSONPlaceholder source connector |
+
+</details>
+
+## Reference
+
+The connector configuration does not require any parameters because JSONPlaceholder is a public API with no authentication.


### PR DESCRIPTION
## What

Adds a new manifest-only source connector for [JSONPlaceholder](https://jsonplaceholder.typicode.com/), a free public REST API providing fake data for testing and prototyping.

## How

Standard manifest-only connector structure with 6 full-refresh streams:

- **posts** (100 records), **comments** (500), **albums** (100), **photos** (5,000), **todos** (200), **users** (10)
- No authentication required (`NoAuth`)
- No pagination (all records returned in a single response per endpoint)
- `InlineSchemaLoader` with nullable non-PK fields and `additionalProperties: true`
- Shared `$ref` components for base requester and retriever

Files added:
- `airbyte-integrations/connectors/source-jsonplaceholder/` — manifest, metadata, acceptance tests, README, icon
- `docs/integrations/sources/jsonplaceholder.md` — user-facing documentation

## Review guide

1. **`manifest.yaml`** — Core connector definition. All streams were tested via the Connector Builder MCP and returned expected record counts. Note: the manifest uses `url_base` and `path` fields which triggered deprecation warnings during testing (CDK prefers `url` field). Verify these are still accepted by the current `source-declarative-manifest` base image.
2. **`metadata.yaml`** — New `definitionId` (UUID v4), version `0.1.0`, `cloud: enabled: false`. Base image tag copied from `source-pokeapi`. Now includes a `testSecrets` entry referencing `SECRET_SOURCE-JSONPLACEHOLDER__CREDS` in GSM.
3. **`acceptance-test-config.yml`** — References `secrets/config.json` for discovery/read tests. Since no auth is needed, this would be `{}`, but no GSM secret is provisioned yet.
4. **`docs/integrations/sources/jsonplaceholder.md`** — Changelog has `TBD` for the PR link; should be updated before merge.
5. **`users` stream schema** — Contains nested `address` and `company` objects. Nested objects do not have `additionalProperties: true`, which may cause validation issues if the API adds fields.

### ⚠️ Reviewer action needed

- **GSM secret must be provisioned** before CI can pass. The secret `SECRET_SOURCE-JSONPLACEHOLDER__CREDS` needs to be created in GSM with content `{}`. Without it, the `airbyte-cdk secrets fetch` step will fail and all acceptance tests that require `secrets/config.json` will error with `FileNotFoundError`.

### Updates since last revision

- Added `testSecrets` entry to `metadata.yaml` referencing `SECRET_SOURCE-JSONPLACEHOLDER__CREDS` in GSM (fixes the missing secret configuration that caused all 5 acceptance test failures in the first CI run).

## User Impact

Adds a new community-supported source connector for JSONPlaceholder. Useful for testing Airbyte pipelines without needing real API credentials. OSS only (`cloud: false`).

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/fa7c07b7dd92445095226d0523931546
Requested by: @aaronsteers