### PR TITLE
docs: set External Secrets Management to products: cloud-teams

### DIFF
--- a/docs/platform/operating-airbyte/external-secrets.md
+++ b/docs/platform/operating-airbyte/external-secrets.md
@@ -1,5 +1,5 @@
 ---
-products: standard, plus, pro, enterprise-flex
+products: all
 sidebar_label: External Secret Management
 ---
 
@@ -10,15 +10,10 @@ import TabItem from '@theme/TabItem';
 
 This guide provides step-by-step instructions for configuring external secrets management with Airbyte. External secrets management allows Airbyte to securely store and manage connection credentials in your cloud provider's secrets manager (AWS Secrets Manager, Azure Key Vault, or Google Cloud Secret Manager) instead of storing them in Airbyte's internal database.
 
-:::info
-External secrets management is available for Airbyte Standard, Plus, Pro, and Enterprise Flex customers.
-:::
-
 ---
 
 ## Prerequisites
 
-- Airbyte organization on a Standard, Plus, Pro, or Enterprise Flex plan
 - Active account with your chosen cloud provider (AWS, Azure, or GCP)
 - Appropriate permissions to create and manage IAM roles/policies or service principals
 - Access to your cloud provider's secrets management service

--- a/docs/platform/operating-airbyte/external-secrets.md
+++ b/docs/platform/operating-airbyte/external-secrets.md
@@ -10,10 +10,15 @@ import TabItem from '@theme/TabItem';
 
 This guide provides step-by-step instructions for configuring external secrets management with Airbyte. External secrets management allows Airbyte to securely store and manage connection credentials in your cloud provider's secrets manager (AWS Secrets Manager, Azure Key Vault, or Google Cloud Secret Manager) instead of storing them in Airbyte's internal database.
 
+:::info
+External secrets management is available for Airbyte Pro and Enterprise Flex customers.
+:::
+
 ---
 
 ## Prerequisites
 
+- Airbyte organization on a Pro or Enterprise Flex plan
 - Active account with your chosen cloud provider (AWS, Azure, or GCP)
 - Appropriate permissions to create and manage IAM roles/policies or service principals
 - Access to your cloud provider's secrets management service

--- a/docs/platform/operating-airbyte/external-secrets.md
+++ b/docs/platform/operating-airbyte/external-secrets.md
@@ -1,5 +1,5 @@
 ---
-products: pro, enterprise-flex
+products: standard, plus, pro, enterprise-flex
 sidebar_label: External Secret Management
 ---
 
@@ -11,14 +11,14 @@ import TabItem from '@theme/TabItem';
 This guide provides step-by-step instructions for configuring external secrets management with Airbyte. External secrets management allows Airbyte to securely store and manage connection credentials in your cloud provider's secrets manager (AWS Secrets Manager, Azure Key Vault, or Google Cloud Secret Manager) instead of storing them in Airbyte's internal database.
 
 :::info
-External secrets management is available for Airbyte Pro and Enterprise Flex customers.
+External secrets management is available for Airbyte Standard, Plus, Pro, and Enterprise Flex customers.
 :::
 
 ---
 
 ## Prerequisites
 
-- Airbyte organization on a Pro or Enterprise Flex plan
+- Airbyte organization on a Standard, Plus, Pro, or Enterprise Flex plan
 - Active account with your chosen cloud provider (AWS, Azure, or GCP)
 - Appropriate permissions to create and manage IAM roles/policies or service principals
 - Access to your cloud provider's secrets management service

--- a/docs/platform/operating-airbyte/external-secrets.md
+++ b/docs/platform/operating-airbyte/external-secrets.md
@@ -1,5 +1,5 @@
 ---
-products: all
+products: cloud
 sidebar_label: External Secret Management
 ---
 

--- a/docs/platform/operating-airbyte/external-secrets.md
+++ b/docs/platform/operating-airbyte/external-secrets.md
@@ -1,5 +1,5 @@
 ---
-products: cloud
+products: cloud-teams
 sidebar_label: External Secret Management
 ---
 


### PR DESCRIPTION
## What

Updates the External Secrets Management documentation page to use the correct `products` metadata key (`cloud-teams`) so that **Pro and Enterprise Flex** badges appear enabled, while Standard, Plus, Core, and Self-Managed Enterprise badges appear grayed out.

This is a follow-up to #75173, which moved the page from Enterprise Flex to the Security section.

## How

Updated `docs/platform/operating-airbyte/external-secrets.md`:
1. Frontmatter `products` field: `pro, enterprise-flex` → `cloud-teams` (enables Pro and Enterprise Flex via [Cloud tier inheritance](https://docs.airbyte.com/community/contributing-to-airbyte/writing-docs#product-badges); Standard and Plus remain grayed out)

The info callout and plan prerequisite are preserved unchanged.

## Review guide

1. `docs/platform/operating-airbyte/external-secrets.md` — single-line diff changing the frontmatter `products` value.

### Human review checklist
- [ ] Confirm `cloud-teams` is the correct metadata key for Pro + Enterprise Flex (per the [product badges docs](https://docs.airbyte.com/community/contributing-to-airbyte/writing-docs#product-badges))
- [ ] Verify on the Vercel preview that the badges render correctly (Pro and Enterprise Flex highlighted, others grayed out)

## User Impact

The External Secret Management page will display Pro and Enterprise Flex badges as enabled. Standard, Plus, Core, and Self-Managed Enterprise badges will appear grayed out.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/f4ade1b2b39c49b49137a0f6810853d6
Requested by: @matteogp