### PR TITLE
feat(source-github): add GitHub App authentication support

### DIFF
--- a/airbyte-integrations/connectors/source-github/metadata.yaml
+++ b/airbyte-integrations/connectors/source-github/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: ef69ef6e-aa7f-4af1-a01d-ef775033524e
-  dockerImageTag: 2.1.14
+  dockerImageTag: 2.2.0
   dockerRepository: airbyte/source-github
   documentationUrl: https://docs.airbyte.com/integrations/sources/github
   erdUrl: https://dbdocs.io/airbyteio/source-github?view=relationships

--- a/airbyte-integrations/connectors/source-github/poetry.lock
+++ b/airbyte-integrations/connectors/source-github/poetry.lock
@@ -1679,6 +1679,9 @@ files = [
     {file = "pyjwt-2.11.0.tar.gz", hash = "sha256:35f95c1f0fbe5d5ba6e43f00271c275f7a1a4db1dab27bf708073b75318ea623"},
 ]
 
+[package.dependencies]
+cryptography = {version = ">=3.4.0", optional = true, markers = "extra == \"crypto\""}
+
 [package.extras]
 crypto = ["cryptography (>=3.4.0)"]
 dev = ["coverage[toml] (==7.10.7)", "cryptography (>=3.4.0)", "pre-commit", "pytest (>=8.4.2,<9.0.0)", "sphinx", "sphinx-rtd-theme", "zope.interface"]
@@ -2780,4 +2783,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10,<3.14"
-content-hash = "7082b37f65c8042be4811a100e15c26b974b9cd4917e43a4431539ac2e3f1809"
+content-hash = "020e480cce2b91c5693bb01eef30a7c1bf2b7e42214f128e219a7901e8c851b4"

--- a/airbyte-integrations/connectors/source-github/pyproject.toml
+++ b/airbyte-integrations/connectors/source-github/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "2.1.14"
+version = "2.2.0"
 name = "source-github"
 description = "Source implementation for GitHub."
 authors = [ "Airbyte <contact@airbyte.io>",]
@@ -19,6 +19,7 @@ include = "source_github"
 python = "^3.10,<3.14"
 airbyte-cdk = "^7.4.1"
 sgqlc = "==16.3"
+pyjwt = {version = ">=2.8.0", extras = ["crypto"]}
 
 [tool.poetry.scripts]
 source-github = "source_github.run:run"

--- a/airbyte-integrations/connectors/source-github/source_github/source.py
+++ b/airbyte-integrations/connectors/source-github/source_github/source.py
@@ -128,9 +128,6 @@ class SourceGithub(AbstractSource):
         if "personal_access_token" in credentials:
             return constants.PERSONAL_ACCESS_TOKEN_TITLE, credentials["personal_access_token"]
         if "private_key" in credentials:
-            # GitHub App auth — generate an installation token on the fly.
-            # NOTE: installation tokens expire after 1 hour. For syncs longer
-            # than that, the token will need to be refreshed (not yet implemented).
             for field in ("app_id", "installation_id"):
                 if field not in credentials:
                     raise AirbyteTracedException(
@@ -151,7 +148,19 @@ class SourceGithub(AbstractSource):
         _, token = self.get_access_token(config)
         tokens = [t.strip() for t in token.split(constants.TOKEN_SEPARATOR)]
         api_url = config.get("api_url", "https://api.github.com")
-        return MultipleTokenAuthenticatorWithRateLimiter(tokens=tokens, api_url=api_url)
+
+        # Pass GitHub App credentials so the authenticator can refresh tokens
+        github_app_config = None
+        credentials = config.get("credentials", {})
+        if "private_key" in credentials:
+            github_app_config = {
+                "app_id": credentials["app_id"],
+                "private_key": credentials["private_key"],
+                "installation_id": credentials["installation_id"],
+                "api_url": api_url,
+            }
+
+        return MultipleTokenAuthenticatorWithRateLimiter(tokens=tokens, api_url=api_url, github_app_config=github_app_config)
 
     def _validate_and_transform_config(self, config: MutableMapping[str, Any]) -> MutableMapping[str, Any]:
         config = self._ensure_default_values(config)

--- a/airbyte-integrations/connectors/source-github/source_github/source.py
+++ b/airbyte-integrations/connectors/source-github/source_github/source.py
@@ -12,7 +12,7 @@ from airbyte_cdk.sources.streams import Stream
 from airbyte_cdk.sources.streams.http.http_client import MessageRepresentationAirbyteTracedErrors
 from airbyte_cdk.sources.streams.http.requests_native_auth import MultipleTokenAuthenticator
 from airbyte_cdk.utils.traced_exception import AirbyteTracedException
-from source_github.utils import MultipleTokenAuthenticatorWithRateLimiter
+from source_github.utils import MultipleTokenAuthenticatorWithRateLimiter, generate_github_app_token
 
 from . import constants
 from .streams import (
@@ -127,12 +127,31 @@ class SourceGithub(AbstractSource):
             return constants.ACCESS_TOKEN_TITLE, credentials["access_token"]
         if "personal_access_token" in credentials:
             return constants.PERSONAL_ACCESS_TOKEN_TITLE, credentials["personal_access_token"]
+        if "private_key" in credentials:
+            # GitHub App auth — generate an installation token on the fly.
+            # NOTE: installation tokens expire after 1 hour. For syncs longer
+            # than that, the token will need to be refreshed (not yet implemented).
+            for field in ("app_id", "installation_id"):
+                if field not in credentials:
+                    raise AirbyteTracedException(
+                        message=f"GitHub App auth requires '{field}'. Please check your credentials configuration.",
+                        failure_type=FailureType.config_error,
+                    )
+            api_url = config.get("api_url", "https://api.github.com")
+            token = generate_github_app_token(
+                app_id=credentials["app_id"],
+                private_key=credentials["private_key"],
+                installation_id=credentials["installation_id"],
+                api_url=api_url,
+            )
+            return "GitHub App", token
         raise Exception("Invalid config format")
 
     def _get_authenticator(self, config: Mapping[str, Any]):
         _, token = self.get_access_token(config)
         tokens = [t.strip() for t in token.split(constants.TOKEN_SEPARATOR)]
-        return MultipleTokenAuthenticatorWithRateLimiter(tokens=tokens)
+        api_url = config.get("api_url", "https://api.github.com")
+        return MultipleTokenAuthenticatorWithRateLimiter(tokens=tokens, api_url=api_url)
 
     def _validate_and_transform_config(self, config: MutableMapping[str, Any]) -> MutableMapping[str, Any]:
         config = self._ensure_default_values(config)

--- a/airbyte-integrations/connectors/source-github/source_github/source.py
+++ b/airbyte-integrations/connectors/source-github/source_github/source.py
@@ -135,7 +135,7 @@ class SourceGithub(AbstractSource):
                         failure_type=FailureType.config_error,
                     )
             api_url = config.get("api_url", "https://api.github.com")
-            token = generate_github_app_token(
+            token, _ = generate_github_app_token(
                 app_id=credentials["app_id"],
                 private_key=credentials["private_key"],
                 installation_id=credentials["installation_id"],

--- a/airbyte-integrations/connectors/source-github/source_github/spec.json
+++ b/airbyte-integrations/connectors/source-github/source_github/spec.json
@@ -75,17 +75,19 @@
               "app_id": {
                 "type": "string",
                 "title": "App ID",
-                "description": "The App ID of your GitHub App."
+                "description": "The numeric App ID of your GitHub App (found in the app's General settings).",
+                "pattern": "^[0-9]+$"
               },
               "installation_id": {
                 "type": "string",
                 "title": "Installation ID",
-                "description": "The Installation ID of the GitHub App installed in your organization/account."
+                "description": "The numeric Installation ID of the GitHub App installed in your organization/account (found in the URL after installing the app).",
+                "pattern": "^[0-9]+$"
               },
               "private_key": {
                 "type": "string",
                 "title": "Private Key",
-                "description": "The private key (PEM format) of your GitHub App.",
+                "description": "The private key (PEM format) of your GitHub App. Note: GitHub App installation tokens expire after 1 hour. Syncs longer than 1 hour may fail with authentication errors.",
                 "airbyte_secret": true,
                 "multiline": true
               }

--- a/airbyte-integrations/connectors/source-github/source_github/spec.json
+++ b/airbyte-integrations/connectors/source-github/source_github/spec.json
@@ -61,6 +61,35 @@
                 "airbyte_secret": true
               }
             }
+          },
+          {
+            "type": "object",
+            "title": "GitHub App",
+            "required": ["app_id", "installation_id", "private_key"],
+            "properties": {
+              "option_title": {
+                "type": "string",
+                "const": "GitHub App Credentials",
+                "order": 0
+              },
+              "app_id": {
+                "type": "string",
+                "title": "App ID",
+                "description": "The App ID of your GitHub App."
+              },
+              "installation_id": {
+                "type": "string",
+                "title": "Installation ID",
+                "description": "The Installation ID of the GitHub App installed in your organization/account."
+              },
+              "private_key": {
+                "type": "string",
+                "title": "Private Key",
+                "description": "The private key (PEM format) of your GitHub App.",
+                "airbyte_secret": true,
+                "multiline": true
+              }
+            }
           }
         ]
       },

--- a/airbyte-integrations/connectors/source-github/source_github/spec.json
+++ b/airbyte-integrations/connectors/source-github/source_github/spec.json
@@ -87,7 +87,7 @@
               "private_key": {
                 "type": "string",
                 "title": "Private Key",
-                "description": "The private key (PEM format) of your GitHub App. Note: GitHub App installation tokens expire after 1 hour. Syncs longer than 1 hour may fail with authentication errors.",
+                "description": "The private key (PEM format) of your GitHub App. Installation tokens are automatically refreshed during long-running syncs.",
                 "airbyte_secret": true,
                 "multiline": true
               }

--- a/airbyte-integrations/connectors/source-github/source_github/utils.py
+++ b/airbyte-integrations/connectors/source-github/source_github/utils.py
@@ -6,7 +6,7 @@ import time
 from dataclasses import dataclass
 from datetime import timedelta
 from itertools import cycle
-from typing import Any, Dict, List, Mapping, Optional
+from typing import Any, Dict, List, Mapping, Optional, Tuple
 
 import backoff
 import jwt
@@ -103,15 +103,21 @@ class MultipleTokenAuthenticatorWithRateLimiter(AbstractHeaderAuthenticator):
         return {}
 
     def _refresh_token_if_needed(self):
-        """Refresh the GitHub App installation token if it's close to expiry."""
+        """Refresh the GitHub App installation token if it's close to expiry.
+
+        Note: this method is called per-request from __call__(). Airbyte's source
+        framework is single-threaded for HTTP calls, so no locking is needed.
+        """
         if self._github_app_config is None:
             return
         if time.time() < self._token_expires_at - self.REFRESH_BUFFER_SECONDS:
             return
 
         self._logger.info("GitHub App installation token is expiring soon, refreshing...")
+        # GitHub App auth always uses a single token
+        assert len(self._tokens) == 1, "GitHub App auth only supports a single token"
         old_token = list(self._tokens.keys())[0]
-        new_token = generate_github_app_token(**self._github_app_config)
+        new_token, expires_at = generate_github_app_token(**self._github_app_config)
 
         # Replace the token in all internal data structures
         token_state = self._tokens.pop(old_token)
@@ -120,9 +126,20 @@ class MultipleTokenAuthenticatorWithRateLimiter(AbstractHeaderAuthenticator):
         self._token_to_http_client.update(self._initialize_http_clients([new_token]))
         self._tokens_iter = cycle(self._tokens)
         self._active_token = next(self._tokens_iter)
-        self._token_expires_at = time.time() + 3600
+        self._token_expires_at = self._parse_expiry(expires_at)
 
         self._logger.info("GitHub App installation token refreshed successfully")
+
+    @staticmethod
+    def _parse_expiry(expires_at: Optional[str]) -> float:
+        """Parse the expires_at ISO 8601 timestamp from GitHub, falling back to 1 hour from now."""
+        if expires_at:
+            try:
+                from datetime import datetime, timezone
+                return datetime.fromisoformat(expires_at.replace("Z", "+00:00")).timestamp()
+            except (ValueError, TypeError):
+                pass
+        return time.time() + 3600
 
     def __call__(self, request):
         """Attach the HTTP headers required to authenticate on the HTTP request"""
@@ -216,11 +233,14 @@ class MultipleTokenAuthenticatorWithRateLimiter(AbstractHeaderAuthenticator):
         return False
 
 
-def generate_github_app_token(app_id: str, private_key: str, installation_id: str, api_url: str = "https://api.github.com") -> str:
+def generate_github_app_token(app_id: str, private_key: str, installation_id: str, api_url: str = "https://api.github.com") -> Tuple[str, Optional[str]]:
     """Generate a GitHub App installation access token.
 
     Creates a JWT signed with the app's private key, then exchanges it for
     a short-lived installation access token (expires in 1 hour).
+
+    Returns a tuple of (token, expires_at) where expires_at is an ISO 8601
+    timestamp string from the GitHub API response, or None if not present.
     """
     logger = logging.getLogger("airbyte")
 
@@ -259,9 +279,11 @@ def generate_github_app_token(app_id: str, private_key: str, installation_id: st
             failure_type=FailureType.config_error,
         )
 
-    token = response.json()["token"]
-    logger.info("Successfully generated GitHub App installation token")
-    return token
+    data = response.json()
+    token = data["token"]
+    expires_at = data.get("expires_at")
+    logger.info(f"Successfully generated GitHub App installation token (expires_at={expires_at})")
+    return token, expires_at
 
 
 def _should_retry(e):

--- a/airbyte-integrations/connectors/source-github/source_github/utils.py
+++ b/airbyte-integrations/connectors/source-github/source_github/utils.py
@@ -214,7 +214,15 @@ def generate_github_app_token(app_id: str, private_key: str, installation_id: st
     url = f"{api_url}/app/installations/{installation_id}/access_tokens"
     logger.info(f"Requesting GitHub App installation token from {url}")
 
-    response = _post_with_retry(url, encoded_jwt)
+    try:
+        response = _post_with_retry(url, encoded_jwt)
+    except requests.exceptions.RequestException as e:
+        raise AirbyteTracedException(
+            message="Failed to generate GitHub App installation token after retries. "
+                    "Check network connectivity and GitHub API status.",
+            internal_message=str(e),
+            failure_type=FailureType.transient_error,
+        )
 
     if response.status_code != 201:
         raise AirbyteTracedException(

--- a/airbyte-integrations/connectors/source-github/source_github/utils.py
+++ b/airbyte-integrations/connectors/source-github/source_github/utils.py
@@ -6,7 +6,7 @@ import time
 from dataclasses import dataclass
 from datetime import timedelta
 from itertools import cycle
-from typing import Any, List, Mapping
+from typing import Any, Dict, List, Mapping, Optional
 
 import backoff
 import jwt
@@ -62,11 +62,15 @@ class MultipleTokenAuthenticatorWithRateLimiter(AbstractHeaderAuthenticator):
 
     DURATION = timedelta(seconds=3600)  # Duration at which the current rate limit window resets
 
-    def __init__(self, tokens: List[str], auth_method: str = "token", auth_header: str = "Authorization", api_url: str = "https://api.github.com"):
+    REFRESH_BUFFER_SECONDS = 300  # Refresh token 5 minutes before expiry
+
+    def __init__(self, tokens: List[str], auth_method: str = "token", auth_header: str = "Authorization", api_url: str = "https://api.github.com", github_app_config: Optional[Dict[str, str]] = None):
         self._logger = logging.getLogger("airbyte")
         self._auth_method = auth_method
         self._auth_header = auth_header
         self._api_url = api_url.rstrip("/")
+        self._github_app_config = github_app_config
+        self._token_expires_at: Optional[float] = time.time() + 3600 if github_app_config else None
         self._tokens = {t: Token() for t in tokens}
         # It would've been nice to instantiate a single client on this authenticator. However, we are checking
         # the limits of each token which is associated with a TokenAuthenticator. And each HttpClient can only
@@ -98,8 +102,31 @@ class MultipleTokenAuthenticatorWithRateLimiter(AbstractHeaderAuthenticator):
             return {self.auth_header: self.token}
         return {}
 
+    def _refresh_token_if_needed(self):
+        """Refresh the GitHub App installation token if it's close to expiry."""
+        if self._github_app_config is None:
+            return
+        if time.time() < self._token_expires_at - self.REFRESH_BUFFER_SECONDS:
+            return
+
+        self._logger.info("GitHub App installation token is expiring soon, refreshing...")
+        old_token = list(self._tokens.keys())[0]
+        new_token = generate_github_app_token(**self._github_app_config)
+
+        # Replace the token in all internal data structures
+        token_state = self._tokens.pop(old_token)
+        self._tokens[new_token] = token_state
+        self._token_to_http_client.pop(old_token)
+        self._token_to_http_client.update(self._initialize_http_clients([new_token]))
+        self._tokens_iter = cycle(self._tokens)
+        self._active_token = next(self._tokens_iter)
+        self._token_expires_at = time.time() + 3600
+
+        self._logger.info("GitHub App installation token refreshed successfully")
+
     def __call__(self, request):
         """Attach the HTTP headers required to authenticate on the HTTP request"""
+        self._refresh_token_if_needed()
         while True:
             current_token = self._tokens[self.current_active_token]
             if "graphql" in request.path_url:

--- a/airbyte-integrations/connectors/source-github/source_github/utils.py
+++ b/airbyte-integrations/connectors/source-github/source_github/utils.py
@@ -8,6 +8,8 @@ from datetime import timedelta
 from itertools import cycle
 from typing import Any, List, Mapping
 
+import backoff
+import jwt
 import requests
 
 from airbyte_cdk.models import FailureType, SyncMode
@@ -60,10 +62,11 @@ class MultipleTokenAuthenticatorWithRateLimiter(AbstractHeaderAuthenticator):
 
     DURATION = timedelta(seconds=3600)  # Duration at which the current rate limit window resets
 
-    def __init__(self, tokens: List[str], auth_method: str = "token", auth_header: str = "Authorization"):
+    def __init__(self, tokens: List[str], auth_method: str = "token", auth_header: str = "Authorization", api_url: str = "https://api.github.com"):
         self._logger = logging.getLogger("airbyte")
         self._auth_method = auth_method
         self._auth_header = auth_header
+        self._api_url = api_url.rstrip("/")
         self._tokens = {t: Token() for t in tokens}
         # It would've been nice to instantiate a single client on this authenticator. However, we are checking
         # the limits of each token which is associated with a TokenAuthenticator. And each HttpClient can only
@@ -139,7 +142,7 @@ class MultipleTokenAuthenticatorWithRateLimiter(AbstractHeaderAuthenticator):
 
         _, response = http_client.send_request(
             http_method="GET",
-            url="https://api.github.com/rate_limit",
+            url=f"{self._api_url}/rate_limit",
             headers={"Accept": "application/vnd.github+json", "X-GitHub-Api-Version": "2022-11-28"},
             request_kwargs={},
         )
@@ -184,3 +187,68 @@ class MultipleTokenAuthenticatorWithRateLimiter(AbstractHeaderAuthenticator):
         else:
             self.update_token()
         return False
+
+
+def generate_github_app_token(app_id: str, private_key: str, installation_id: str, api_url: str = "https://api.github.com") -> str:
+    """Generate a GitHub App installation access token.
+
+    Creates a JWT signed with the app's private key, then exchanges it for
+    a short-lived installation access token (expires in 1 hour).
+    """
+    logger = logging.getLogger("airbyte")
+
+    # PEM keys pasted through UI forms often have literal "\n" instead of
+    # real newlines, which causes PyJWT to fail with a confusing
+    # "Could not parse the provided public key" error.
+    private_key = private_key.replace("\\n", "\n").strip()
+
+    now = int(time.time())
+    payload = {
+        "iat": now - 60,  # issued at (60s in the past for clock skew)
+        "exp": now + (10 * 60),  # expires in 10 minutes (max allowed)
+        "iss": app_id,
+    }
+    encoded_jwt = jwt.encode(payload, private_key, algorithm="RS256")
+
+    api_url = api_url.rstrip("/")
+    url = f"{api_url}/app/installations/{installation_id}/access_tokens"
+    logger.info(f"Requesting GitHub App installation token from {url}")
+
+    response = _post_with_retry(url, encoded_jwt)
+
+    if response.status_code != 201:
+        raise AirbyteTracedException(
+            message=f"Failed to generate GitHub App installation token (HTTP {response.status_code}). "
+                    "Verify your App ID, Installation ID, and private key are correct.",
+            internal_message=f"GitHub App token exchange failed: {response.text}",
+            failure_type=FailureType.config_error,
+        )
+
+    token = response.json()["token"]
+    logger.info("Successfully generated GitHub App installation token")
+    return token
+
+
+def _should_retry(e):
+    """Retry on network errors and 5xx/429 responses."""
+    if isinstance(e, requests.exceptions.RequestException) and not isinstance(e, requests.exceptions.HTTPError):
+        return True
+    if hasattr(e, "response") and e.response is not None:
+        return e.response.status_code == 429 or e.response.status_code >= 500
+    return False
+
+
+@backoff.on_exception(backoff.expo, requests.exceptions.RequestException, max_tries=4, giveup=lambda e: not _should_retry(e))
+def _post_with_retry(url: str, bearer_token: str) -> requests.Response:
+    response = requests.post(
+        url,
+        headers={
+            "Authorization": f"Bearer {bearer_token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+        timeout=30,
+    )
+    if response.status_code == 429 or response.status_code >= 500:
+        raise requests.exceptions.HTTPError(response=response)
+    return response

--- a/airbyte-integrations/connectors/source-github/source_github/utils.py
+++ b/airbyte-integrations/connectors/source-github/source_github/utils.py
@@ -4,7 +4,7 @@
 import logging
 import time
 from dataclasses import dataclass
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 from itertools import cycle
 from typing import Any, Dict, List, Mapping, Optional, Tuple
 
@@ -135,7 +135,6 @@ class MultipleTokenAuthenticatorWithRateLimiter(AbstractHeaderAuthenticator):
         """Parse the expires_at ISO 8601 timestamp from GitHub, falling back to 1 hour from now."""
         if expires_at:
             try:
-                from datetime import datetime, timezone
                 return datetime.fromisoformat(expires_at.replace("Z", "+00:00")).timestamp()
             except (ValueError, TypeError):
                 pass

--- a/airbyte-integrations/connectors/source-github/unit_tests/test_github_app_auth.py
+++ b/airbyte-integrations/connectors/source-github/unit_tests/test_github_app_auth.py
@@ -1,0 +1,174 @@
+#
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+#
+
+import time
+from unittest.mock import MagicMock, patch
+
+import jwt
+import pytest
+import responses
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from source_github.source import SourceGithub
+from source_github.utils import generate_github_app_token
+
+from airbyte_cdk.utils.traced_exception import AirbyteTracedException
+
+
+def _generate_test_rsa_key():
+    """Generate a test RSA private key in PEM format."""
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    return private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode("utf-8")
+
+
+TEST_PEM_KEY = _generate_test_rsa_key()
+
+
+@responses.activate
+def test_generate_github_app_token_success():
+    responses.add(
+        responses.POST,
+        "https://api.github.com/app/installations/12345/access_tokens",
+        json={"token": "ghs_test_token_123", "expires_at": "2026-01-01T00:00:00Z"},
+        status=201,
+    )
+
+    token = generate_github_app_token(
+        app_id="99999",
+        private_key=TEST_PEM_KEY,
+        installation_id="12345",
+    )
+
+    assert token == "ghs_test_token_123"
+    # Verify the JWT was sent correctly
+    auth_header = responses.calls[0].request.headers["Authorization"]
+    assert auth_header.startswith("Bearer ")
+    decoded = jwt.decode(auth_header.split(" ")[1], options={"verify_signature": False})
+    assert decoded["iss"] == "99999"
+    assert "iat" in decoded
+    assert "exp" in decoded
+
+
+@responses.activate
+def test_generate_github_app_token_custom_api_url():
+    responses.add(
+        responses.POST,
+        "https://github.example.com/api/v3/app/installations/555/access_tokens",
+        json={"token": "ghs_enterprise_token"},
+        status=201,
+    )
+
+    token = generate_github_app_token(
+        app_id="111",
+        private_key=TEST_PEM_KEY,
+        installation_id="555",
+        api_url="https://github.example.com/api/v3",
+    )
+
+    assert token == "ghs_enterprise_token"
+
+
+@responses.activate
+def test_generate_github_app_token_bad_credentials():
+    responses.add(
+        responses.POST,
+        "https://api.github.com/app/installations/12345/access_tokens",
+        json={"message": "Bad credentials"},
+        status=401,
+    )
+
+    with pytest.raises(AirbyteTracedException, match="Failed to generate GitHub App installation token"):
+        generate_github_app_token(
+            app_id="99999",
+            private_key=TEST_PEM_KEY,
+            installation_id="12345",
+        )
+
+
+@responses.activate
+def test_generate_github_app_token_retries_on_5xx():
+    responses.add(
+        responses.POST,
+        "https://api.github.com/app/installations/12345/access_tokens",
+        json={"message": "Internal Server Error"},
+        status=500,
+    )
+    responses.add(
+        responses.POST,
+        "https://api.github.com/app/installations/12345/access_tokens",
+        json={"token": "ghs_after_retry"},
+        status=201,
+    )
+
+    token = generate_github_app_token(
+        app_id="99999",
+        private_key=TEST_PEM_KEY,
+        installation_id="12345",
+    )
+
+    assert token == "ghs_after_retry"
+    assert len(responses.calls) == 2
+
+
+def test_pem_newline_normalization():
+    """Verify that literal \\n sequences are converted to real newlines."""
+    # Take a real PEM key and replace newlines with literal \n
+    mangled_key = TEST_PEM_KEY.replace("\n", "\\n")
+    assert "\\n" in mangled_key
+
+    # The function should normalize this internally — verify by checking JWT generation doesn't fail
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            responses.POST,
+            "https://api.github.com/app/installations/12345/access_tokens",
+            json={"token": "ghs_normalized"},
+            status=201,
+        )
+        token = generate_github_app_token(
+            app_id="99999",
+            private_key=mangled_key,
+            installation_id="12345",
+        )
+        assert token == "ghs_normalized"
+
+
+def test_get_access_token_github_app():
+    """Verify that SourceGithub.get_access_token dispatches to GitHub App auth."""
+    source = SourceGithub()
+    config = {
+        "credentials": {
+            "private_key": TEST_PEM_KEY,
+            "app_id": "99999",
+            "installation_id": "12345",
+        }
+    }
+
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            responses.POST,
+            "https://api.github.com/app/installations/12345/access_tokens",
+            json={"token": "ghs_from_source"},
+            status=201,
+        )
+        title, token = source.get_access_token(config)
+        assert title == "GitHub App"
+        assert token == "ghs_from_source"
+
+
+def test_get_access_token_missing_field():
+    """Verify error when GitHub App config is missing required fields."""
+    source = SourceGithub()
+    config = {
+        "credentials": {
+            "private_key": TEST_PEM_KEY,
+            # missing app_id and installation_id
+        }
+    }
+
+    with pytest.raises(AirbyteTracedException, match="app_id"):
+        source.get_access_token(config)

--- a/airbyte-integrations/connectors/source-github/unit_tests/test_github_app_auth.py
+++ b/airbyte-integrations/connectors/source-github/unit_tests/test_github_app_auth.py
@@ -39,13 +39,14 @@ def test_generate_github_app_token_success():
         status=201,
     )
 
-    token = generate_github_app_token(
+    token, expires_at = generate_github_app_token(
         app_id="99999",
         private_key=TEST_PEM_KEY,
         installation_id="12345",
     )
 
     assert token == "ghs_test_token_123"
+    assert expires_at == "2026-01-01T00:00:00Z"
     # Verify the JWT was sent correctly
     auth_header = responses.calls[0].request.headers["Authorization"]
     assert auth_header.startswith("Bearer ")
@@ -64,7 +65,7 @@ def test_generate_github_app_token_custom_api_url():
         status=201,
     )
 
-    token = generate_github_app_token(
+    token, _ = generate_github_app_token(
         app_id="111",
         private_key=TEST_PEM_KEY,
         installation_id="555",
@@ -106,7 +107,7 @@ def test_generate_github_app_token_retries_on_5xx():
         status=201,
     )
 
-    token = generate_github_app_token(
+    token, _ = generate_github_app_token(
         app_id="99999",
         private_key=TEST_PEM_KEY,
         installation_id="12345",
@@ -130,7 +131,7 @@ def test_pem_newline_normalization():
             json={"token": "ghs_normalized"},
             status=201,
         )
-        token = generate_github_app_token(
+        token, _ = generate_github_app_token(
             app_id="99999",
             private_key=mangled_key,
             installation_id="12345",

--- a/airbyte-integrations/connectors/source-github/unit_tests/test_github_app_auth.py
+++ b/airbyte-integrations/connectors/source-github/unit_tests/test_github_app_auth.py
@@ -10,8 +10,9 @@ import pytest
 import responses
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
+from freezegun import freeze_time
 from source_github.source import SourceGithub
-from source_github.utils import generate_github_app_token
+from source_github.utils import MultipleTokenAuthenticatorWithRateLimiter, generate_github_app_token
 
 from airbyte_cdk.utils.traced_exception import AirbyteTracedException
 
@@ -172,3 +173,95 @@ def test_get_access_token_missing_field():
 
     with pytest.raises(AirbyteTracedException, match="app_id"):
         source.get_access_token(config)
+
+
+RATE_LIMIT_RESPONSE = {
+    "resources": {
+        "core": {"remaining": 5000, "reset": int(time.time()) + 3600},
+        "graphql": {"remaining": 5000, "reset": int(time.time()) + 3600},
+    }
+}
+
+
+@responses.activate
+def test_token_refresh_when_expired():
+    """Verify token is refreshed when close to expiry."""
+    # Mock rate limit check (called during __init__)
+    responses.add(responses.GET, "https://api.github.com/rate_limit", json=RATE_LIMIT_RESPONSE, status=200)
+
+    github_app_config = {
+        "app_id": "99999",
+        "private_key": TEST_PEM_KEY,
+        "installation_id": "12345",
+        "api_url": "https://api.github.com",
+    }
+
+    auth = MultipleTokenAuthenticatorWithRateLimiter(
+        tokens=["ghs_initial_token"],
+        api_url="https://api.github.com",
+        github_app_config=github_app_config,
+    )
+
+    assert "ghs_initial_token" in auth._tokens
+
+    # Simulate token about to expire (set expiry to 2 minutes from now, within 5-min buffer)
+    auth._token_expires_at = time.time() + 120
+
+    # Mock the token refresh call
+    responses.add(
+        responses.POST,
+        "https://api.github.com/app/installations/12345/access_tokens",
+        json={"token": "ghs_refreshed_token"},
+        status=201,
+    )
+    # Mock rate limit check for new token
+    responses.add(responses.GET, "https://api.github.com/rate_limit", json=RATE_LIMIT_RESPONSE, status=200)
+
+    # Trigger refresh
+    auth._refresh_token_if_needed()
+
+    assert "ghs_refreshed_token" in auth._tokens
+    assert "ghs_initial_token" not in auth._tokens
+
+
+@responses.activate
+def test_token_not_refreshed_when_still_valid():
+    """Verify token is NOT refreshed when still valid."""
+    responses.add(responses.GET, "https://api.github.com/rate_limit", json=RATE_LIMIT_RESPONSE, status=200)
+
+    github_app_config = {
+        "app_id": "99999",
+        "private_key": TEST_PEM_KEY,
+        "installation_id": "12345",
+        "api_url": "https://api.github.com",
+    }
+
+    auth = MultipleTokenAuthenticatorWithRateLimiter(
+        tokens=["ghs_valid_token"],
+        api_url="https://api.github.com",
+        github_app_config=github_app_config,
+    )
+
+    # Token expires in 50 minutes — well within valid range
+    auth._token_expires_at = time.time() + 3000
+
+    auth._refresh_token_if_needed()
+
+    # Token should NOT have been refreshed
+    assert "ghs_valid_token" in auth._tokens
+
+
+@responses.activate
+def test_no_refresh_for_pat_auth():
+    """Verify that PAT auth (no github_app_config) never triggers refresh."""
+    responses.add(responses.GET, "https://api.github.com/rate_limit", json=RATE_LIMIT_RESPONSE, status=200)
+
+    auth = MultipleTokenAuthenticatorWithRateLimiter(
+        tokens=["ghp_pat_token"],
+        api_url="https://api.github.com",
+        github_app_config=None,
+    )
+
+    # Should be a no-op
+    auth._refresh_token_if_needed()
+    assert "ghp_pat_token" in auth._tokens

--- a/docs/integrations/sources/github.md
+++ b/docs/integrations/sources/github.md
@@ -229,6 +229,7 @@ Your token should have at least the `repo` scope. Depending on which streams you
 
 | Version    | Date       | Pull Request                                                                                                      | Subject                                                                                                                                                                |
 |:-----------|:-----------|:------------------------------------------------------------------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 2.2.0 | 2026-03-18 | [75188](https://github.com/airbytehq/airbyte/issues/75188) | Add GitHub App authentication support (app_id, installation_id, private_key) |
 | 2.1.14 | 2026-03-09 | [74284](https://github.com/airbytehq/airbyte/pull/74284) | Fix heartbeat timeout for pull_request_stats by using descending sort on incremental syncs |
 | 2.1.13 | 2026-03-03 | [73698](https://github.com/airbytehq/airbyte/pull/73698) | feat(source-github): use GraphQL API for Releases stream to bypass 10k REST limit |
 | 2.1.12 | 2026-03-03 | [74204](https://github.com/airbytehq/airbyte/pull/74204) | Update dependencies |

--- a/docs/integrations/sources/github.md
+++ b/docs/integrations/sources/github.md
@@ -23,7 +23,7 @@ This page contains the setup guide and reference information for the [GitHub](ht
 **For Airbyte Open Source:**
 
 - Personal Access Token (see [Permissions and scopes](https://docs.airbyte.com/integrations/sources/github#permissions-and-scopes))
-- GitHub App (App ID, Installation ID, and private key)
+- GitHub App (see [GitHub App permissions](https://docs.airbyte.com/integrations/sources/github#permissions-and-scopes))
 <!-- /env:oss -->
 
 ## Setup guide

--- a/docs/integrations/sources/github.md
+++ b/docs/integrations/sources/github.md
@@ -23,6 +23,7 @@ This page contains the setup guide and reference information for the [GitHub](ht
 **For Airbyte Open Source:**
 
 - Personal Access Token (see [Permissions and scopes](https://docs.airbyte.com/integrations/sources/github#permissions-and-scopes))
+- GitHub App (App ID, Installation ID, and private key)
 <!-- /env:oss -->
 
 ## Setup guide
@@ -56,7 +57,9 @@ Log into [GitHub](https://github.com) and then generate a [personal access token
   <!-- /env:cloud -->
   <!-- env:oss -->
 
-- **For Airbyte Open Source:** Authenticate with **Personal Access Token**. To generate a personal access token, log into [GitHub](https://github.com) and then generate a [personal access token](https://github.com/settings/tokens). Enter your GitHub personal access token. To load balance your API quota consumption across multiple API tokens, input multiple tokens separated with `,`.
+- **For Airbyte Open Source:** Authenticate with **Personal Access Token** or **GitHub App**.
+  - **Personal Access Token:** Log into [GitHub](https://github.com) and then generate a [personal access token](https://github.com/settings/tokens). Enter your GitHub personal access token. To load balance your API quota consumption across multiple API tokens, input multiple tokens separated with `,`.
+  - **GitHub App:** Enter your App ID, Installation ID, and private key (PEM format). The connector will generate a short-lived installation access token at sync time. Note: installation tokens expire after 1 hour; syncs longer than 1 hour are not currently supported with this auth method.
 <!-- /env:oss -->
 
 6. **GitHub Repositories** - Enter a list of GitHub organizations/repositories, e.g. `airbytehq/airbyte` for single repository, `airbytehq/airbyte airbytehq/another-repo` for multiple repositories. If you want to specify the organization to receive data from all its repositories, then you should specify it according to the following example: `airbytehq/*`.

--- a/docs/integrations/sources/github.md
+++ b/docs/integrations/sources/github.md
@@ -59,7 +59,7 @@ Log into [GitHub](https://github.com) and then generate a [personal access token
 
 - **For Airbyte Open Source:** Authenticate with **Personal Access Token** or **GitHub App**.
   - **Personal Access Token:** Log into [GitHub](https://github.com) and then generate a [personal access token](https://github.com/settings/tokens). Enter your GitHub personal access token. To load balance your API quota consumption across multiple API tokens, input multiple tokens separated with `,`.
-  - **GitHub App:** Enter your App ID, Installation ID, and private key (PEM format). The connector will generate a short-lived installation access token at sync time. Note: installation tokens expire after 1 hour; syncs longer than 1 hour are not currently supported with this auth method.
+  - **GitHub App:** Enter your App ID, Installation ID, and private key (PEM format). The connector generates a short-lived installation access token at sync time and automatically refreshes it during long-running syncs.
 <!-- /env:oss -->
 
 6. **GitHub Repositories** - Enter a list of GitHub organizations/repositories, e.g. `airbytehq/airbyte` for single repository, `airbytehq/airbyte airbytehq/another-repo` for multiple repositories. If you want to specify the organization to receive data from all its repositories, then you should specify it according to the following example: `airbytehq/*`.

--- a/docs/integrations/sources/github.md
+++ b/docs/integrations/sources/github.md
@@ -219,6 +219,21 @@ Your token should have at least the `repo` scope. Depending on which streams you
 - Syncing [Teams](https://docs.github.com/en/organizations/organizing-members-into-teams/about-teams) is only available to authenticated members of a team's [organization](https://docs.github.com/en/rest/orgs). [Personal user accounts](https://docs.github.com/en/get-started/learning-about-github/types-of-github-accounts) and repositories belonging to them don't have access to Teams features. In this case no records will be synced.
 - To sync the Projects stream, the repository must have the Projects feature enabled.
 
+**GitHub App permissions:** If you use GitHub App authentication, the app must be installed on the target organization or account and granted the following [repository permissions](https://docs.github.com/en/rest/authentication/permissions-required-for-github-apps):
+
+| Permission | Access | Required for |
+|---|---|---|
+| Contents | Read | Repositories, branches, commits, tags |
+| Issues | Read | Issues, issue events, issue milestones, issue comments, issue reactions |
+| Pull requests | Read | Pull requests, pull request comments, reviews, review comments |
+| Metadata | Read | Required by default for all GitHub Apps |
+| Members | Read | Collaborators, teams, team members |
+| Organization administration | Read | Organizations |
+| Projects | Read | Projects (v2) |
+| Webhooks | Read | Repository webhook events |
+
+Not all permissions are required — only grant what is needed for the streams you plan to sync.
+
 ### Troubleshooting
 
 - Check out common troubleshooting issues for the GitHub source connector on our [Airbyte Forum](https://github.com/airbytehq/airbyte/discussions)


### PR DESCRIPTION
## What

Fixes #75188

Adds GitHub App authentication as a third credential option for source-github, alongside Personal Access Token and OAuth. Installation tokens are automatically refreshed during long-running syncs.

## How

- **`spec.json`**: New `oneOf` auth option with `app_id`, `installation_id` (validated as numeric via `pattern`), and `private_key` fields
- **`source.py`**: Dispatches GitHub App credentials through `get_access_token()` and passes them to the authenticator for token refresh
- **`utils.py`**:
  - `generate_github_app_token()` — creates a JWT signed with the app's private key, exchanges it for an installation token via GitHub's API. Returns `(token, expires_at)` tuple. Includes retry logic and PEM newline normalization
  - `MultipleTokenAuthenticatorWithRateLimiter` — new `github_app_config` parameter enables automatic token refresh. `_refresh_token_if_needed()` is called per-request in `__call__()`, refreshing 5 minutes before expiry using the actual `expires_at` from GitHub's API response
  - Hardcoded `api.github.com` in rate-limit checker replaced with configurable `api_url` (GitHub Enterprise support)
- **`pyproject.toml`** / **`poetry.lock`**: Added `pyjwt[crypto]` dependency for RS256 JWT signing

## Review guide

1. `spec.json` — new auth option schema with input validation
2. `utils.py` — core token generation, refresh logic, and API URL fix
3. `source.py` — integration of new auth type and credential passthrough
4. `unit_tests/test_github_app_auth.py` — 10 tests covering token generation, refresh, retry, PEM normalization, error handling
5. `docs/integrations/sources/github.md` — updated prerequisites and setup guide

## User Impact

Users can authenticate with GitHub App credentials instead of a PAT or OAuth token. This is backwards-compatible — existing configurations are unaffected. Installation tokens are automatically refreshed during long-running syncs, so there is no 1-hour time limit.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚