### PR TITLE
ci: [DO NOT MERGE] soft launch test - global version override edge case (source-faker)

### DIFF
--- a/airbyte-integrations/connectors/source-faker/metadata.yaml
+++ b/airbyte-integrations/connectors/source-faker/metadata.yaml
@@ -9,7 +9,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: dfd88b22-b603-4c3d-aad7-3701784586b1
-  dockerImageTag: 7.0.1
+  dockerImageTag: 7.0.2
   dockerRepository: airbyte/source-faker
   documentationUrl: https://docs.airbyte.com/integrations/sources/faker
   externalDocumentationUrls:

--- a/airbyte-integrations/connectors/source-faker/pyproject.toml
+++ b/airbyte-integrations/connectors/source-faker/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "7.0.1"
+version = "7.0.2"
 name = "source-faker"
 description = "Source implementation for fake but realistic looking data."
 authors = [ "Airbyte <evan@airbyte.io>",]

--- a/docs/integrations/sources/faker.md
+++ b/docs/integrations/sources/faker.md
@@ -47,6 +47,7 @@ Purchase records link users to products through `user_id` and `product_id` field
 
 | Version     | Date       | Pull Request                                                                                                          | Subject                                                                                                         |
 |:------------|:-----------| :-------------------------------------------------------------------------------------------------------------------- |:----------------------------------------------------------------------------------------------------------------|
+| 7.0.2 | 2026-03-18 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Ops CLI soft launch test - global version override edge case - no functional changes |
 | 7.0.1 | 2026-03-13 | [74818](https://github.com/airbytehq/airbyte/pull/74818) | Patch version bump (publish test) |
 | 7.0.0 | 2026-03-05 | [74318](https://github.com/airbytehq/airbyte/pull/74318) | Test breaking change to validate breaking change infrastructure |
 | 6.2.38 | 2025-11-12 | [69289](https://github.com/airbytehq/airbyte/pull/69289) | Add externalDocumentationUrls field to metadata |


### PR DESCRIPTION
## What

Test PR to validate the ops CLI `bump_version_in_repo` tool behavior when a connector has **global version overrides** — i.e., `registryOverrides.cloud.dockerImageTag` and `registryOverrides.oss.dockerImageTag` differ from the base `dockerImageTag`.

**This PR should NOT be merged. Close it once validation is complete.**

Related: replaces closed PR #74805 (stale). This is one of 3 test PRs for the ops CLI soft launch validation (see also #75203).

## How

Ran `bump_version_in_repo` with `bump_type=patch` on `source-faker`, which has:
- Base `dockerImageTag: 7.0.1` → bumped to **7.0.2**
- `registryOverrides.cloud.dockerImageTag: 6.2.24` → **unchanged**
- `registryOverrides.oss.dockerImageTag: 6.2.24` → **unchanged**

The tool also bumped `pyproject.toml` version and added a changelog entry.

## Review guide

1. **`metadata.yaml`** — Verify only the base `dockerImageTag` was bumped (7.0.1 → 7.0.2) and the `registryOverrides` cloud/oss tags remain at `6.2.24`. **This is the key thing to validate**: is it correct that the tool leaves override versions untouched, or should it bump those too?
2. **`pyproject.toml`** — Version bumped 7.0.1 → 7.0.2 (consistent with metadata)
3. **`faker.md`** — Changelog entry added with `*PR_NUMBER_PLACEHOLDER*` (expected — tool doesn't know PR number at bump time)

## User Impact

None. This is a CI-only test PR that will not be merged.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

[Devin session](https://app.devin.ai/sessions/f900274cb0884bf99e399b1c40c48067) | Requested by @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75204" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
