### PR TITLE
ci: [DO NOT MERGE] soft launch test - release candidate edge case (source-gitlab)

### DIFF
--- a/airbyte-integrations/connectors/source-gitlab/metadata.yaml
+++ b/airbyte-integrations/connectors/source-gitlab/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 5e6175e5-68e1-4c17-bff9-56103bbb0d80
-  dockerImageTag: 4.4.23-rc.1
+  dockerImageTag: 4.4.24
   dockerRepository: airbyte/source-gitlab
   documentationUrl: https://docs.airbyte.com/integrations/sources/gitlab
   externalDocumentationUrls:

--- a/docs/integrations/sources/gitlab.md
+++ b/docs/integrations/sources/gitlab.md
@@ -112,6 +112,7 @@ Gitlab has the [rate limits](https://docs.gitlab.com/ee/user/gitlab_com/index.ht
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                                                            |
 | :------ | :--------- | :------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 4.4.24 | 2026-03-18 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Ops CLI soft launch test - release candidate edge case - no functional changes |
 | 4.4.23-rc.1 | 2026-03-07 | [70858](https://github.com/airbytehq/airbyte/pull/70858) | Add HTTPAPIBudget and concurrency_level for improved sync performance |
 | 4.4.22 | 2026-02-24 | [73774](https://github.com/airbytehq/airbyte/pull/73774) | Update dependencies |
 | 4.4.21 | 2026-02-17 | [73401](https://github.com/airbytehq/airbyte/pull/73401) | Update dependencies |


### PR DESCRIPTION
## What

Test PR to validate the ops CLI `bump_version_in_repo` tool behavior when a connector's current version is a **release candidate** (`-rc.N` suffix). This is one of 3 test PRs for the ops CLI soft launch validation (see also #75203, #75204).

**This PR should NOT be merged. Close it once validation is complete.**

## How

Ran `bump_version_in_repo` with `bump_type=patch` on `source-gitlab`, which had version `4.4.23-rc.1` with `enableProgressiveRollout: true`.

The tool produced:
- `4.4.23-rc.1` → **`4.4.24`** (RC suffix stripped, patch version incremented from the base `4.4.23`)

## Review guide

1. **`metadata.yaml`** — The key change: `dockerImageTag` went from `4.4.23-rc.1` to `4.4.24`. **Is this the correct behavior for a patch bump on an RC version?** Alternatives the tool could have produced:
   - `4.4.23` (promote RC to release, no patch bump)
   - `4.4.23-rc.2` (bump the RC number)
   - `4.4.24` (what it actually did — treat the base as `4.4.23` and bump patch)
2. **`gitlab.md`** — Changelog entry added with `*PR_NUMBER_PLACEHOLDER*` (expected — tool doesn't know PR number at bump time)

### Human review checklist
- [ ] Confirm `4.4.23-rc.1` → `4.4.24` is the desired behavior for a patch bump on an RC version, or note the expected behavior for a tool fix
- [ ] Note that `enableProgressiveRollout: true` is set — does this change what the expected bump behavior should be?
- [ ] Verify this PR remains marked DO NOT MERGE and is not accidentally merged

## User Impact

None. This is a CI-only test PR that will not be merged.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

[Devin session](https://app.devin.ai/sessions/f900274cb0884bf99e399b1c40c48067) | Requested by @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75205" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
