### PR TITLE
fix(source-intercom): bump CDK base image to 7.13.0 and version to rc.6

### DIFF
--- a/airbyte-integrations/connectors/source-intercom/metadata.yaml
+++ b/airbyte-integrations/connectors/source-intercom/metadata.yaml
@@ -6,11 +6,11 @@ data:
     hosts:
       - api.intercom.io
   connectorBuildOptions:
-    baseImage: docker.io/airbyte/source-declarative-manifest:7.6.1.post28.dev22724700845@sha256:ac9cce26e99ba3f0848d5c10b566795d1400ccf943b993249ead41c30facbf2c
+    baseImage: docker.io/airbyte/source-declarative-manifest:7.13.0.post30.dev23303933335@sha256:266dda691d2928e00adc6401ac43823be107b5ae39364047ce03d4031c95e1cd
   connectorSubtype: api
   connectorType: source
   definitionId: d8313939-3782-41b0-be29-b3ca20d8dd3a
-  dockerImageTag: 0.13.16-rc.5
+  dockerImageTag: 0.13.16-rc.6
   dockerRepository: airbyte/source-intercom
   documentationUrl: https://docs.airbyte.com/integrations/sources/intercom
   externalDocumentationUrls:

--- a/docs/integrations/sources/intercom.md
+++ b/docs/integrations/sources/intercom.md
@@ -118,12 +118,12 @@ Because these streams must read all records on every sync, syncing Companies and
 
 ## Changelog
 
-<details>
+<details>75216
   <summary>Expand to review</summary>
 
 | Version      | Date       | Pull Request                                             | Subject                                                                                                                              |
 |:-------------|:-----------|:---------------------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------|
-| 0.13.16-rc.6 | 2026-03-19 | | Bump CDK base image to 7.13.0 (includes block_simultaneous_read support and cursor field fix) |
+| 0.13.16-rc.6 | 2026-03-19 | [75216](https://github.com/airbytehq/airbyte/pull/75216) | Bump CDK base image to 7.13.0 (includes block_simultaneous_read support and cursor field fix) |
 | 0.13.16-rc.5 | 2026-03-11 | [71141](https://github.com/airbytehq/airbyte/pull/71141) | Block simultaneous reading from companies endpoint |
 | 0.13.16-rc.4 | 2026-03-03 | [74143](https://github.com/airbytehq/airbyte/pull/74143) | fix(source-intercom): fix UnboundLocalError in rate limiter when response is not available |
 | 0.13.16-rc.3 | 2026-03-03 | [72955](https://github.com/airbytehq/airbyte/pull/72955) | fix(source-intercom): add step size and end_datetime to contacts, conversations, and activity_logs streams |

--- a/docs/integrations/sources/intercom.md
+++ b/docs/integrations/sources/intercom.md
@@ -118,7 +118,7 @@ Because these streams must read all records on every sync, syncing Companies and
 
 ## Changelog
 
-<details>75216
+<details>
   <summary>Expand to review</summary>
 
 | Version      | Date       | Pull Request                                             | Subject                                                                                                                              |

--- a/docs/integrations/sources/intercom.md
+++ b/docs/integrations/sources/intercom.md
@@ -123,6 +123,7 @@ Because these streams must read all records on every sync, syncing Companies and
 
 | Version      | Date       | Pull Request                                             | Subject                                                                                                                              |
 |:-------------|:-----------|:---------------------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------|
+| 0.13.16-rc.6 | 2026-03-19 | | Bump CDK base image to 7.13.0 (includes block_simultaneous_read support and cursor field fix) |
 | 0.13.16-rc.5 | 2026-03-11 | [71141](https://github.com/airbytehq/airbyte/pull/71141) | Block simultaneous reading from companies endpoint |
 | 0.13.16-rc.4 | 2026-03-03 | [74143](https://github.com/airbytehq/airbyte/pull/74143) | fix(source-intercom): fix UnboundLocalError in rate limiter when response is not available |
 | 0.13.16-rc.3 | 2026-03-03 | [72955](https://github.com/airbytehq/airbyte/pull/72955) | fix(source-intercom): add step size and end_datetime to contacts, conversations, and activity_logs streams |


### PR DESCRIPTION
## What

Bumps the source-intercom CDK base image from `7.6.1.post28` to `7.13.0.post30` and the connector version from `0.13.16-rc.5` to `0.13.16-rc.6`.

This CDK upgrade picks up two critical fixes needed for the ongoing progressive rollout:
1. **Cursor field fix** (CDK v7.6.2/v7.6.3): Empty `CursorField("")` objects were incorrectly truthy, causing full-refresh streams like `teams` to advertise `source_defined_cursor=True` and `SyncMode.incremental` during discover. This led to phantom schema change detections when bouncing between connector versions during rollout.
2. **`block_simultaneous_read` / `stream_groups` support** (CDK PR [#870](https://github.com/airbytehq/airbyte-python-cdk/pull/870)): The manifest already uses `stream_groups` with `BlockSimultaneousSyncsAction` for the companies endpoint (added in rc.5), but the pinned CDK version (7.6.1) predates the CDK-side implementation of this feature.

## How

- Updated `baseImage` in `metadata.yaml` to the new CDK digest
- Bumped `dockerImageTag` to `0.13.16-rc.6`
- Added changelog entry

## Review guide

1. `airbyte-integrations/connectors/source-intercom/metadata.yaml` — the two-line version bump
2. `docs/integrations/sources/intercom.md` — changelog entry (note: PR link column is empty and should be backfilled after merge)

**Key question for reviewer:** The CDK jump is from 7.6.1 → 7.13.0 (several minor versions). Verify there are no unintended behavioral changes for this manifest-only connector beyond the two targeted fixes.

## User Impact

- Resolves phantom cursor field change detections on the `teams` stream during progressive rollout, which were triggering schema update workflows and causing Snowflake destination issues.
- Enables the `stream_groups` / `block_simultaneous_read` feature for the companies endpoint (prevents concurrent scroll API calls that Intercom rejects).

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/64ba14cd350f4bd6910a68398eef0dec
Requested by: @agarctfi