### PR TITLE
feat: add block-no-verify PreToolUse hook to protect git hooks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,10 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [{ "type": "command", "command": "npx block-no-verify@1.1.2" }]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Creates `.claude/settings.json` with `block-no-verify@1.1.2` as a `PreToolUse` Bash hook to prevent Claude Code agents from bypassing git hooks via the hook-skip flag.

## Details

When an agent runs `git commit` or `git push` with the hook-bypass flag, it silently disables pre-commit, commit-msg, and pre-push hooks. `block-no-verify` reads `tool_input.command` from the Claude Code hook stdin payload, detects the hook-bypass flag across all git subcommands, and exits 2 to block. The existing `.claude/skills` are unchanged.

Closes #75219

---

_Disclosure: I am the author and maintainer of `block-no-verify`._
