### PR TITLE
feat(source-clickhouse): upgrade ClickHouse JDBC driver to 0.9.8

### DIFF
--- a/airbyte-integrations/connectors/source-clickhouse-strict-encrypt/build.gradle
+++ b/airbyte-integrations/connectors/source-clickhouse-strict-encrypt/build.gradle
@@ -18,7 +18,7 @@ application {
 dependencies {
     implementation project(':airbyte-integrations:connectors:source-clickhouse')
 
-    implementation('com.clickhouse:clickhouse-jdbc:0.9.7:all') {
+    implementation('com.clickhouse:clickhouse-jdbc:0.9.8:all') {
         // The :all fat jar bundles lz4 internally. Exclude the transitive
         // at.yawk.lz4:lz4-java to avoid a Gradle capability conflict with
         // org.lz4:lz4-java pulled in by Debezium/Kafka via the CDK.

--- a/airbyte-integrations/connectors/source-clickhouse-strict-encrypt/build.gradle
+++ b/airbyte-integrations/connectors/source-clickhouse-strict-encrypt/build.gradle
@@ -18,7 +18,7 @@ application {
 dependencies {
     implementation project(':airbyte-integrations:connectors:source-clickhouse')
 
-    implementation 'com.clickhouse:clickhouse-jdbc:0.3.2-patch10:all'
+    implementation 'com.clickhouse:clickhouse-jdbc:0.9.7:all'
 
     testImplementation 'org.testcontainers:clickhouse:1.19.4'
 }

--- a/airbyte-integrations/connectors/source-clickhouse-strict-encrypt/build.gradle
+++ b/airbyte-integrations/connectors/source-clickhouse-strict-encrypt/build.gradle
@@ -18,7 +18,7 @@ application {
 dependencies {
     implementation project(':airbyte-integrations:connectors:source-clickhouse')
 
-    implementation 'com.clickhouse:clickhouse-jdbc:0.9.8:all'
+    implementation 'com.clickhouse:clickhouse-jdbc:0.9.7:all'
 
     testImplementation 'org.testcontainers:clickhouse:1.19.4'
 }

--- a/airbyte-integrations/connectors/source-clickhouse-strict-encrypt/build.gradle
+++ b/airbyte-integrations/connectors/source-clickhouse-strict-encrypt/build.gradle
@@ -18,7 +18,12 @@ application {
 dependencies {
     implementation project(':airbyte-integrations:connectors:source-clickhouse')
 
-    implementation 'com.clickhouse:clickhouse-jdbc:0.9.7:all'
+    implementation('com.clickhouse:clickhouse-jdbc:0.9.7:all') {
+        // The :all fat jar bundles lz4 internally. Exclude the transitive
+        // at.yawk.lz4:lz4-java to avoid a Gradle capability conflict with
+        // org.lz4:lz4-java pulled in by Debezium/Kafka via the CDK.
+        exclude group: 'at.yawk.lz4', module: 'lz4-java'
+    }
 
     testImplementation 'org.testcontainers:clickhouse:1.19.4'
 }

--- a/airbyte-integrations/connectors/source-clickhouse-strict-encrypt/build.gradle
+++ b/airbyte-integrations/connectors/source-clickhouse-strict-encrypt/build.gradle
@@ -18,7 +18,7 @@ application {
 dependencies {
     implementation project(':airbyte-integrations:connectors:source-clickhouse')
 
-    implementation 'com.clickhouse:clickhouse-jdbc:0.9.7:all'
+    implementation 'com.clickhouse:clickhouse-jdbc:0.9.8:all'
 
     testImplementation 'org.testcontainers:clickhouse:1.19.4'
 }

--- a/airbyte-integrations/connectors/source-clickhouse-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/source-clickhouse-strict-encrypt/metadata.yaml
@@ -11,7 +11,7 @@ data:
     - suite: acceptanceTests
   connectorType: source
   definitionId: bad83517-5e54-4a3d-9b53-63e85fbd4d7c
-  dockerImageTag: 0.3.0-rc.1
+  dockerImageTag: 0.3.0-rc.2
   dockerRepository: airbyte/source-clickhouse-strict-encrypt
   documentationUrl: https://docs.airbyte.com/integrations/sources/clickhouse
   githubIssueLabel: source-clickhouse

--- a/airbyte-integrations/connectors/source-clickhouse/build.gradle
+++ b/airbyte-integrations/connectors/source-clickhouse/build.gradle
@@ -16,7 +16,7 @@ application {
 }
 
 dependencies {
-    implementation 'com.clickhouse:clickhouse-jdbc:0.9.5:all'
+    implementation 'com.clickhouse:clickhouse-jdbc:0.9.7:all'
 
     testImplementation 'org.testcontainers:clickhouse:1.19.4'
     testImplementation 'org.hamcrest:hamcrest-all:1.3'

--- a/airbyte-integrations/connectors/source-clickhouse/build.gradle
+++ b/airbyte-integrations/connectors/source-clickhouse/build.gradle
@@ -16,7 +16,12 @@ application {
 }
 
 dependencies {
-    implementation 'com.clickhouse:clickhouse-jdbc:0.9.7:all'
+    implementation('com.clickhouse:clickhouse-jdbc:0.9.7:all') {
+        // The :all fat jar bundles lz4 internally. Exclude the transitive
+        // at.yawk.lz4:lz4-java to avoid a Gradle capability conflict with
+        // org.lz4:lz4-java pulled in by Debezium/Kafka via the CDK.
+        exclude group: 'at.yawk.lz4', module: 'lz4-java'
+    }
 
     testImplementation 'org.testcontainers:clickhouse:1.19.4'
     testImplementation 'org.hamcrest:hamcrest-all:1.3'

--- a/airbyte-integrations/connectors/source-clickhouse/build.gradle
+++ b/airbyte-integrations/connectors/source-clickhouse/build.gradle
@@ -16,7 +16,7 @@ application {
 }
 
 dependencies {
-    implementation 'com.clickhouse:clickhouse-jdbc:0.9.7:all'
+    implementation 'com.clickhouse:clickhouse-jdbc:0.9.8:all'
 
     testImplementation 'org.testcontainers:clickhouse:1.19.4'
     testImplementation 'org.hamcrest:hamcrest-all:1.3'

--- a/airbyte-integrations/connectors/source-clickhouse/build.gradle
+++ b/airbyte-integrations/connectors/source-clickhouse/build.gradle
@@ -16,7 +16,7 @@ application {
 }
 
 dependencies {
-    implementation('com.clickhouse:clickhouse-jdbc:0.9.7:all') {
+    implementation('com.clickhouse:clickhouse-jdbc:0.9.8:all') {
         // The :all fat jar bundles lz4 internally. Exclude the transitive
         // at.yawk.lz4:lz4-java to avoid a Gradle capability conflict with
         // org.lz4:lz4-java pulled in by Debezium/Kafka via the CDK.

--- a/airbyte-integrations/connectors/source-clickhouse/build.gradle
+++ b/airbyte-integrations/connectors/source-clickhouse/build.gradle
@@ -16,7 +16,7 @@ application {
 }
 
 dependencies {
-    implementation 'com.clickhouse:clickhouse-jdbc:0.9.8:all'
+    implementation 'com.clickhouse:clickhouse-jdbc:0.9.7:all'
 
     testImplementation 'org.testcontainers:clickhouse:1.19.4'
     testImplementation 'org.hamcrest:hamcrest-all:1.3'

--- a/airbyte-integrations/connectors/source-clickhouse/metadata.yaml
+++ b/airbyte-integrations/connectors/source-clickhouse/metadata.yaml
@@ -14,7 +14,7 @@ data:
     - suite: acceptanceTests
   connectorType: source
   definitionId: bad83517-5e54-4a3d-9b53-63e85fbd4d7c
-  dockerImageTag: 0.3.0-rc.1
+  dockerImageTag: 0.3.0-rc.2
   dockerRepository: airbyte/source-clickhouse
   documentationUrl: https://docs.airbyte.com/integrations/sources/clickhouse
   githubIssueLabel: source-clickhouse

--- a/docs/integrations/sources/clickhouse.md
+++ b/docs/integrations/sources/clickhouse.md
@@ -80,6 +80,7 @@ Using this feature requires additional configuration, when creating the source. 
 
 | Version | Date       | Pull Request                                                | Subject                                                                                                   |
 |:--------|:-----------|:------------------------------------------------------------|:----------------------------------------------------------------------------------------------------------|
+| 0.3.0-rc.2 | 2026-03-19 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Upgrade ClickHouse JDBC driver from 0.9.5 to 0.9.7 |
 | 0.3.0-rc.1 | 2026-02-03 | [72395](https://github.com/airbytehq/airbyte/pull/72395) | Upgrade ClickHouse JDBC driver to 0.9.5 with custom type mapping |
 | 0.2.6 | 2025-11-03 | [66714](https://github.com/airbytehq/airbyte/pull/66714) | Revert JDBC driver upgrade |
 | 0.2.5 | 2025-09-25 | [66482](https://github.com/airbytehq/airbyte/pull/66482) | Upgrade ClickHouse JDBC driver from 0.3.2-patch10 to 0.9.0 |

--- a/docs/integrations/sources/clickhouse.md
+++ b/docs/integrations/sources/clickhouse.md
@@ -80,7 +80,7 @@ Using this feature requires additional configuration, when creating the source. 
 
 | Version | Date       | Pull Request                                                | Subject                                                                                                   |
 |:--------|:-----------|:------------------------------------------------------------|:----------------------------------------------------------------------------------------------------------|
-| 0.3.0-rc.2 | 2026-03-19 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Upgrade ClickHouse JDBC driver from 0.9.5 to 0.9.7 |
+| 0.3.0-rc.2 | 2026-03-19 | [75226](https://github.com/airbytehq/airbyte/pull/75226) | Upgrade ClickHouse JDBC driver from 0.9.5 to 0.9.7 |
 | 0.3.0-rc.1 | 2026-02-03 | [72395](https://github.com/airbytehq/airbyte/pull/72395) | Upgrade ClickHouse JDBC driver to 0.9.5 with custom type mapping |
 | 0.2.6 | 2025-11-03 | [66714](https://github.com/airbytehq/airbyte/pull/66714) | Revert JDBC driver upgrade |
 | 0.2.5 | 2025-09-25 | [66482](https://github.com/airbytehq/airbyte/pull/66482) | Upgrade ClickHouse JDBC driver from 0.3.2-patch10 to 0.9.0 |

--- a/docs/integrations/sources/clickhouse.md
+++ b/docs/integrations/sources/clickhouse.md
@@ -80,7 +80,7 @@ Using this feature requires additional configuration, when creating the source. 
 
 | Version | Date       | Pull Request                                                | Subject                                                                                                   |
 |:--------|:-----------|:------------------------------------------------------------|:----------------------------------------------------------------------------------------------------------|
-| 0.3.0-rc.2 | 2026-03-19 | [75226](https://github.com/airbytehq/airbyte/pull/75226) | Upgrade ClickHouse JDBC driver from 0.9.5 to 0.9.7 |
+| 0.3.0-rc.2 | 2026-03-19 | [75226](https://github.com/airbytehq/airbyte/pull/75226) | Upgrade ClickHouse JDBC driver from 0.9.5 to 0.9.8 |
 | 0.3.0-rc.1 | 2026-02-03 | [72395](https://github.com/airbytehq/airbyte/pull/72395) | Upgrade ClickHouse JDBC driver to 0.9.5 with custom type mapping |
 | 0.2.6 | 2025-11-03 | [66714](https://github.com/airbytehq/airbyte/pull/66714) | Revert JDBC driver upgrade |
 | 0.2.5 | 2025-09-25 | [66482](https://github.com/airbytehq/airbyte/pull/66482) | Upgrade ClickHouse JDBC driver from 0.3.2-patch10 to 0.9.0 |


### PR DESCRIPTION
## What
Upgrades the ClickHouse JDBC driver dependency to version 0.9.8 for both `source-clickhouse` and `source-clickhouse-strict-encrypt`.

- `source-clickhouse`: 0.9.5 → 0.9.8
- `source-clickhouse-strict-encrypt`: 0.3.2-patch10 → 0.9.8

Bumps both connectors from `0.3.0-rc.1` → `0.3.0-rc.2`.

## How
Updated the `clickhouse-jdbc` dependency version in both connectors' `build.gradle` files.

Additionally, excluded the transitive `at.yawk.lz4:lz4-java` dependency from the clickhouse-jdbc fat jar (`:all` classifier). The 0.9.x driver transitively pulls `at.yawk.lz4:lz4-java`, which declares the same Gradle capability as `org.lz4:lz4-java:1.8.0` (pulled in by Debezium/Kafka via the CDK), causing a build failure. Since the `:all` fat jar already bundles lz4 internally, excluding the transitive declaration is safe and has no runtime impact.

## Review guide
1. `airbyte-integrations/connectors/source-clickhouse/build.gradle` — bump from 0.9.5 → 0.9.8 + lz4 exclusion
2. `airbyte-integrations/connectors/source-clickhouse-strict-encrypt/build.gradle` — **large jump** from 0.3.2-patch10 → 0.9.8 + lz4 exclusion
3. `airbyte-integrations/connectors/source-clickhouse/metadata.yaml` — version bump 0.3.0-rc.1 → 0.3.0-rc.2
4. `airbyte-integrations/connectors/source-clickhouse-strict-encrypt/metadata.yaml` — version bump 0.3.0-rc.1 → 0.3.0-rc.2
5. `docs/integrations/sources/clickhouse.md` — changelog entry for 0.3.0-rc.2

### ⚠️ Key items for reviewer attention
- **strict-encrypt large version jump**: The strict-encrypt connector jumps from 0.3.2-patch10 to 0.9.8. The 0.9.x line is effectively a rewrite of the JDBC driver (jdbc-v2). Note that a previous attempt to upgrade strict-encrypt to 0.9.0 was reverted in [v0.2.6](https://github.com/airbytehq/airbyte/pull/66714). Please verify this upgrade is now safe.
- **strict-encrypt test coverage gap**: CI shows tests for strict-encrypt are all skipped. There is no executed test coverage validating this upgrade for the strict-encrypt variant.
- **0.9.7 breaking changes still apply** ([v0.9.7 release notes](https://github.com/ClickHouse/clickhouse-java/releases/tag/v0.9.7)):
  - `Date`/`Date32` columns now decoded as `LocalDate` without timezone adjustment (previously could return `ZonedDateTime`).
  - `Client.Builder#build()` now throws on unknown configuration properties (previously silently ignored).
- **0.9.8 is a bugfix-only release** ([v0.9.8 release notes](https://github.com/ClickHouse/clickhouse-java/releases/tag/v0.9.8)): fixes for large unsigned integer type mapping/conversion, `ArrayResultSet#next()` off-by-one, and malformed `SELECT` query handling. No new breaking changes.
- The existing `ClickHouseSourceOperations` class handles type mapping for 0.9.x `JDBCType.OTHER` behavior, which should cover the source-clickhouse connector. Confirm strict-encrypt inherits this correctly via its `implementation project(':airbyte-integrations:connectors:source-clickhouse')` dependency.

## User Impact
Users of source-clickhouse get the latest JDBC driver bug fixes and improvements. No expected user-facing behavior change if the driver's breaking changes are handled by the existing type mapping code.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/ba48fc74b84f40a7a4dabe0154184784
Requested by: @sophiecuiy
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75226" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
