### PR TITLE
chore(source-faker): bump version 7.0.1 → 7.0.2 (post-launch test plan step 1)

### DIFF
--- a/airbyte-integrations/connectors/source-faker/metadata.yaml
+++ b/airbyte-integrations/connectors/source-faker/metadata.yaml
@@ -9,7 +9,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: dfd88b22-b603-4c3d-aad7-3701784586b1
-  dockerImageTag: 7.0.1
+  dockerImageTag: 7.0.2
   dockerRepository: airbyte/source-faker
   documentationUrl: https://docs.airbyte.com/integrations/sources/faker
   externalDocumentationUrls:

--- a/airbyte-integrations/connectors/source-faker/pyproject.toml
+++ b/airbyte-integrations/connectors/source-faker/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "7.0.1"
+version = "7.0.2"
 name = "source-faker"
 description = "Source implementation for fake but realistic looking data."
 authors = [ "Airbyte <evan@airbyte.io>",]

--- a/docs/integrations/sources/faker.md
+++ b/docs/integrations/sources/faker.md
@@ -47,6 +47,7 @@ Purchase records link users to products through `user_id` and `product_id` field
 
 | Version     | Date       | Pull Request                                                                                                          | Subject                                                                                                         |
 |:------------|:-----------| :-------------------------------------------------------------------------------------------------------------------- |:----------------------------------------------------------------------------------------------------------------|
+| 7.0.2 | 2026-03-19 | [75232](https://github.com/airbytehq/airbyte/pull/75232) | Patch version bump (ops CLI registry post-launch test) |
 | 7.0.1 | 2026-03-13 | [74818](https://github.com/airbytehq/airbyte/pull/74818) | Patch version bump (publish test) |
 | 7.0.0 | 2026-03-05 | [74318](https://github.com/airbytehq/airbyte/pull/74318) | Test breaking change to validate breaking change infrastructure |
 | 6.2.38 | 2025-11-12 | [69289](https://github.com/airbytehq/airbyte/pull/69289) | Add externalDocumentationUrls field to metadata |


### PR DESCRIPTION
## What

Patch version bump for `source-faker` (7.0.1 → 7.0.2) to exercise the newly merged ops CLI registry pipeline ([#75224](https://github.com/airbytehq/airbyte/pull/75224)).

This is **step 1** of the [post-launch test plan](https://github.com/airbytehq/airbyte-ops-mcp/issues/560): publish a new connector version through the production ops CLI pipeline and verify end-to-end propagation.

## How

Version bumped in:
1. `metadata.yaml` — `dockerImageTag: 7.0.1` → `7.0.2`
2. `pyproject.toml` — `version = "7.0.1"` → `"7.0.2"`

No code changes.

## Review guide

1. Verify version strings are consistent across both files.
2. Note: a changelog entry may still be needed — this was generated via `bump_version_in_repo` which does not auto-add changelog entries.

## User Impact

No functional change to the connector. This bump exists solely to validate the new registry publish pipeline.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

**Link to Devin run:** https://app.devin.ai/sessions/f900274cb0884bf99e399b1c40c48067
**Requested by:** @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75232" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
