### PR TITLE
chore: bump source-faker 7.0.1 → 7.0.2 (Registry 2.0 post-launch test Step 1)

### DIFF
--- a/airbyte-integrations/connectors/source-faker/metadata.yaml
+++ b/airbyte-integrations/connectors/source-faker/metadata.yaml
@@ -9,7 +9,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: dfd88b22-b603-4c3d-aad7-3701784586b1
-  dockerImageTag: 7.0.1
+  dockerImageTag: 7.0.2
   dockerRepository: airbyte/source-faker
   documentationUrl: https://docs.airbyte.com/integrations/sources/faker
   externalDocumentationUrls:

--- a/airbyte-integrations/connectors/source-faker/pyproject.toml
+++ b/airbyte-integrations/connectors/source-faker/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "7.0.1"
+version = "7.0.2"
 name = "source-faker"
 description = "Source implementation for fake but realistic looking data."
 authors = [ "Airbyte <evan@airbyte.io>",]

--- a/docs/integrations/sources/faker.md
+++ b/docs/integrations/sources/faker.md
@@ -47,7 +47,7 @@ Purchase records link users to products through `user_id` and `product_id` field
 
 | Version     | Date       | Pull Request                                                                                                          | Subject                                                                                                         |
 |:------------|:-----------| :-------------------------------------------------------------------------------------------------------------------- |:----------------------------------------------------------------------------------------------------------------|
-| 7.0.2 | 2026-03-19 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Registry 2.0 post-launch validation test (patch bump) |
+| 7.0.2 | 2026-03-19 | [75233](https://github.com/airbytehq/airbyte/pull/75233) | Registry 2.0 post-launch validation test (patch bump) |
 | 7.0.1 | 2026-03-13 | [74818](https://github.com/airbytehq/airbyte/pull/74818) | Patch version bump (publish test) |
 | 7.0.0 | 2026-03-05 | [74318](https://github.com/airbytehq/airbyte/pull/74318) | Test breaking change to validate breaking change infrastructure |
 | 6.2.38 | 2025-11-12 | [69289](https://github.com/airbytehq/airbyte/pull/69289) | Add externalDocumentationUrls field to metadata |

--- a/docs/integrations/sources/faker.md
+++ b/docs/integrations/sources/faker.md
@@ -47,6 +47,7 @@ Purchase records link users to products through `user_id` and `product_id` field
 
 | Version     | Date       | Pull Request                                                                                                          | Subject                                                                                                         |
 |:------------|:-----------| :-------------------------------------------------------------------------------------------------------------------- |:----------------------------------------------------------------------------------------------------------------|
+| 7.0.2 | 2026-03-19 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Registry 2.0 post-launch validation test (patch bump) |
 | 7.0.1 | 2026-03-13 | [74818](https://github.com/airbytehq/airbyte/pull/74818) | Patch version bump (publish test) |
 | 7.0.0 | 2026-03-05 | [74318](https://github.com/airbytehq/airbyte/pull/74318) | Test breaking change to validate breaking change infrastructure |
 | 6.2.38 | 2025-11-12 | [69289](https://github.com/airbytehq/airbyte/pull/69289) | Add externalDocumentationUrls field to metadata |
@@ -62,57 +63,57 @@ Purchase records link users to products through `user_id` and `product_id` field
 | 6.2.28 | 2025-07-19 | [63534](https://github.com/airbytehq/airbyte/pull/63534) | Update dependencies |
 | 6.2.27 | 2025-07-17 | [63354](https://github.com/airbytehq/airbyte/pull/63354) | Updated icon |
 | 6.2.26 | 2025-07-16 | [63342](https://github.com/airbytehq/airbyte/pull/63342) | Rendered name changed to `Sample Data` |
-| 6.2.26-rc.1 | 2025-06-16 | [61645](https://github.com/airbytehq/airbyte/pull/61645) | Update for testing                                                                                              |
-| 6.2.25-rc.1 | 2025-04-07 | [57500](https://github.com/airbytehq/airbyte/pull/57500) | Update for testing                                                                                              |
-| 6.2.24      | 2025-04-05 | [57263](https://github.com/airbytehq/airbyte/pull/57263) | Update dependencies                                                                                             |
-| 6.2.23      | 2025-03-29 | [56502](https://github.com/airbytehq/airbyte/pull/56502) | Update dependencies                                                                                             |
-| 6.2.22      | 2025-03-22 | [46821](https://github.com/airbytehq/airbyte/pull/46821) | Update dependencies                                                                                             |
-| 6.2.21      | 2025-03-11 | [55705](https://github.com/airbytehq/airbyte/pull/55705) | Promoting release candidate 6.2.21-rc.1 to a main version.                                                      |
-| 6.2.21-rc.1 | 2024-11-13 | [48013](https://github.com/airbytehq/airbyte/pull/48013) | Update for testing.                                                                                             |
-| 6.2.20      | 2024-10-30 | [48013](https://github.com/airbytehq/airbyte/pull/48013) | Promoting release candidate 6.2.20-rc.1 to a main version.                                                      |
-| 6.2.20-rc.1 | 2024-10-21 | [46678](https://github.com/airbytehq/airbyte/pull/46678)                                                              | Testing release candidate with RC suffix versioning.                                                            |
-| 6.2.19-rc.1 | 2024-10-21 | [47221](https://github.com/airbytehq/airbyte/pull/47221)                                                              | Testing release candidate with RC suffix versioning.                                                            |
-| 6.2.18-rc.1 | 2024-10-09 | [46678](https://github.com/airbytehq/airbyte/pull/46678)                                                              | Testing release candidate with RC suffix versioning.                                                            |
-| 6.2.17      | 2024-10-05 | [46398](https://github.com/airbytehq/airbyte/pull/46398)                                                              | Update dependencies                                                                                             |
-| 6.2.16      | 2024-09-28 | [46207](https://github.com/airbytehq/airbyte/pull/46207)                                                              | Update dependencies                                                                                             |
-| 6.2.15      | 2024-09-21 | [45740](https://github.com/airbytehq/airbyte/pull/45740)                                                              | Update dependencies                                                                                             |
-| 6.2.14      | 2024-09-14 | [45567](https://github.com/airbytehq/airbyte/pull/45567)                                                              | Update dependencies                                                                                             |
-| 6.2.13      | 2024-09-07 | [45327](https://github.com/airbytehq/airbyte/pull/45327)                                                              | Update dependencies                                                                                             |
-| 6.2.12      | 2024-09-04 | [45126](https://github.com/airbytehq/airbyte/pull/45126)                                                              | Test a release candidate release                                                                                |
-| 6.2.11      | 2024-08-31 | [45025](https://github.com/airbytehq/airbyte/pull/45025)                                                              | Update dependencies                                                                                             |
-| 6.2.10      | 2024-08-24 | [44659](https://github.com/airbytehq/airbyte/pull/44659)                                                              | Update dependencies                                                                                             |
-| 6.2.9       | 2024-08-17 | [44221](https://github.com/airbytehq/airbyte/pull/44221)                                                              | Update dependencies                                                                                             |
-| 6.2.8       | 2024-08-12 | [43753](https://github.com/airbytehq/airbyte/pull/43753)                                                              | Update dependencies                                                                                             |
-| 6.2.7       | 2024-08-10 | [43570](https://github.com/airbytehq/airbyte/pull/43570)                                                              | Update dependencies                                                                                             |
-| 6.2.6       | 2024-08-03 | [43102](https://github.com/airbytehq/airbyte/pull/43102)                                                              | Update dependencies                                                                                             |
-| 6.2.5       | 2024-07-27 | [42682](https://github.com/airbytehq/airbyte/pull/42682)                                                              | Update dependencies                                                                                             |
-| 6.2.4       | 2024-07-20 | [42367](https://github.com/airbytehq/airbyte/pull/42367)                                                              | Update dependencies                                                                                             |
-| 6.2.3       | 2024-07-13 | [41848](https://github.com/airbytehq/airbyte/pull/41848)                                                              | Update dependencies                                                                                             |
-| 6.2.2       | 2024-07-10 | [41467](https://github.com/airbytehq/airbyte/pull/41467)                                                              | Update dependencies                                                                                             |
-| 6.2.1       | 2024-07-09 | [41180](https://github.com/airbytehq/airbyte/pull/41180)                                                              | Update dependencies                                                                                             |
-| 6.2.0       | 2024-07-07 | [39935](https://github.com/airbytehq/airbyte/pull/39935)                                                              | Update CDK to 2.0.                                                                                              |
-| 6.1.6       | 2024-07-06 | [40956](https://github.com/airbytehq/airbyte/pull/40956)                                                              | Update dependencies                                                                                             |
-| 6.1.5       | 2024-06-25 | [40426](https://github.com/airbytehq/airbyte/pull/40426)                                                              | Update dependencies                                                                                             |
-| 6.1.4       | 2024-06-21 | [39935](https://github.com/airbytehq/airbyte/pull/39935)                                                              | Update dependencies                                                                                             |
-| 6.1.3       | 2024-06-04 | [39029](https://github.com/airbytehq/airbyte/pull/39029)                                                              | [autopull] Upgrade base image to v1.2.1                                                                         |
-| 6.1.2       | 2024-06-03 | [38831](https://github.com/airbytehq/airbyte/pull/38831)                                                              | Bump CDK to allow and prefer versions `1.x`                                                                     |
-| 6.1.1       | 2024-05-20 | [38256](https://github.com/airbytehq/airbyte/pull/38256)                                                              | Replace AirbyteLogger with logging.Logger                                                                       |
-| 6.1.0       | 2024-04-08 | [36898](https://github.com/airbytehq/airbyte/pull/36898)                                                              | Update car prices and years                                                                                     |
-| 6.0.3       | 2024-03-15 | [36167](https://github.com/airbytehq/airbyte/pull/36167)                                                              | Make 'count' an optional config parameter.                                                                      |
-| 6.0.2       | 2024-02-12 | [35174](https://github.com/airbytehq/airbyte/pull/35174)                                                              | Manage dependencies with Poetry.                                                                                |
-| 6.0.1       | 2024-02-12 | [35172](https://github.com/airbytehq/airbyte/pull/35172)                                                              | Base image migration: remove Dockerfile and use the python-connector-base image                                 |
-| 6.0.0       | 2024-01-30 | [34644](https://github.com/airbytehq/airbyte/pull/34644)                                                              | Declare 'id' columns as primary keys.                                                                           |
-| 5.0.2       | 2024-01-17 | [34344](https://github.com/airbytehq/airbyte/pull/34344)                                                              | Ensure unique state messages                                                                                    |
-| 5.0.1       | 2023-01-08 | [34033](https://github.com/airbytehq/airbyte/pull/34033)                                                              | Add standard entrypoints for usage with AirbyteLib                                                              |
-| 5.0.0       | 2023-08-08 | [29213](https://github.com/airbytehq/airbyte/pull/29213)                                                              | Change all `*id` fields and `products.year` to be integer                                                       |
-| 4.0.0       | 2023-07-19 | [28485](https://github.com/airbytehq/airbyte/pull/28485)                                                              | Bump to test publication                                                                                        |
-| 3.0.2       | 2023-07-07 | [28060](https://github.com/airbytehq/airbyte/pull/28060)                                                              | Bump to test publication                                                                                        |
-| 3.0.1       | 2023-06-28 | [27807](https://github.com/airbytehq/airbyte/pull/27807)                                                              | Fix bug with purchase stream updated_at                                                                         |
-| 3.0.0       | 2023-06-23 | [27684](https://github.com/airbytehq/airbyte/pull/27684)                                                              | Stream cursor is now `updated_at` & remove `records_per_sync` option                                            |
-| 2.1.0       | 2023-05-08 | [25903](https://github.com/airbytehq/airbyte/pull/25903)                                                              | Add user.address (object)                                                                                       |
-| 2.0.3       | 2023-02-20 | [23259](https://github.com/airbytehq/airbyte/pull/23259)                                                              | bump to test publication                                                                                        |
-| 2.0.2       | 2023-02-20 | [23259](https://github.com/airbytehq/airbyte/pull/23259)                                                              | bump to test publication                                                                                        |
-| 2.0.1       | 2023-01-30 | [22117](https://github.com/airbytehq/airbyte/pull/22117)                                                              | `source-faker` goes beta                                                                                        |
+| 6.2.26-rc.1 | 2025-06-16 | [61645](https://github.com/airbytehq/airbyte/pull/61645) | Update for testing |
+| 6.2.25-rc.1 | 2025-04-07 | [57500](https://github.com/airbytehq/airbyte/pull/57500) | Update for testing |
+| 6.2.24 | 2025-04-05 | [57263](https://github.com/airbytehq/airbyte/pull/57263) | Update dependencies |
+| 6.2.23 | 2025-03-29 | [56502](https://github.com/airbytehq/airbyte/pull/56502) | Update dependencies |
+| 6.2.22 | 2025-03-22 | [46821](https://github.com/airbytehq/airbyte/pull/46821) | Update dependencies |
+| 6.2.21 | 2025-03-11 | [55705](https://github.com/airbytehq/airbyte/pull/55705) | Promoting release candidate 6.2.21-rc.1 to a main version. |
+| 6.2.21-rc.1 | 2024-11-13 | [48013](https://github.com/airbytehq/airbyte/pull/48013) | Update for testing. |
+| 6.2.20 | 2024-10-30 | [48013](https://github.com/airbytehq/airbyte/pull/48013) | Promoting release candidate 6.2.20-rc.1 to a main version. |
+| 6.2.20-rc.1 | 2024-10-21 | [46678](https://github.com/airbytehq/airbyte/pull/46678) | Testing release candidate with RC suffix versioning. |
+| 6.2.19-rc.1 | 2024-10-21 | [47221](https://github.com/airbytehq/airbyte/pull/47221) | Testing release candidate with RC suffix versioning. |
+| 6.2.18-rc.1 | 2024-10-09 | [46678](https://github.com/airbytehq/airbyte/pull/46678) | Testing release candidate with RC suffix versioning. |
+| 6.2.17 | 2024-10-05 | [46398](https://github.com/airbytehq/airbyte/pull/46398) | Update dependencies |
+| 6.2.16 | 2024-09-28 | [46207](https://github.com/airbytehq/airbyte/pull/46207) | Update dependencies |
+| 6.2.15 | 2024-09-21 | [45740](https://github.com/airbytehq/airbyte/pull/45740) | Update dependencies |
+| 6.2.14 | 2024-09-14 | [45567](https://github.com/airbytehq/airbyte/pull/45567) | Update dependencies |
+| 6.2.13 | 2024-09-07 | [45327](https://github.com/airbytehq/airbyte/pull/45327) | Update dependencies |
+| 6.2.12 | 2024-09-04 | [45126](https://github.com/airbytehq/airbyte/pull/45126) | Test a release candidate release |
+| 6.2.11 | 2024-08-31 | [45025](https://github.com/airbytehq/airbyte/pull/45025) | Update dependencies |
+| 6.2.10 | 2024-08-24 | [44659](https://github.com/airbytehq/airbyte/pull/44659) | Update dependencies |
+| 6.2.9 | 2024-08-17 | [44221](https://github.com/airbytehq/airbyte/pull/44221) | Update dependencies |
+| 6.2.8 | 2024-08-12 | [43753](https://github.com/airbytehq/airbyte/pull/43753) | Update dependencies |
+| 6.2.7 | 2024-08-10 | [43570](https://github.com/airbytehq/airbyte/pull/43570) | Update dependencies |
+| 6.2.6 | 2024-08-03 | [43102](https://github.com/airbytehq/airbyte/pull/43102) | Update dependencies |
+| 6.2.5 | 2024-07-27 | [42682](https://github.com/airbytehq/airbyte/pull/42682) | Update dependencies |
+| 6.2.4 | 2024-07-20 | [42367](https://github.com/airbytehq/airbyte/pull/42367) | Update dependencies |
+| 6.2.3 | 2024-07-13 | [41848](https://github.com/airbytehq/airbyte/pull/41848) | Update dependencies |
+| 6.2.2 | 2024-07-10 | [41467](https://github.com/airbytehq/airbyte/pull/41467) | Update dependencies |
+| 6.2.1 | 2024-07-09 | [41180](https://github.com/airbytehq/airbyte/pull/41180) | Update dependencies |
+| 6.2.0 | 2024-07-07 | [39935](https://github.com/airbytehq/airbyte/pull/39935) | Update CDK to 2.0. |
+| 6.1.6 | 2024-07-06 | [40956](https://github.com/airbytehq/airbyte/pull/40956) | Update dependencies |
+| 6.1.5 | 2024-06-25 | [40426](https://github.com/airbytehq/airbyte/pull/40426) | Update dependencies |
+| 6.1.4 | 2024-06-21 | [39935](https://github.com/airbytehq/airbyte/pull/39935) | Update dependencies |
+| 6.1.3 | 2024-06-04 | [39029](https://github.com/airbytehq/airbyte/pull/39029) | [autopull] Upgrade base image to v1.2.1 |
+| 6.1.2 | 2024-06-03 | [38831](https://github.com/airbytehq/airbyte/pull/38831) | Bump CDK to allow and prefer versions `1.x` |
+| 6.1.1 | 2024-05-20 | [38256](https://github.com/airbytehq/airbyte/pull/38256) | Replace AirbyteLogger with logging.Logger |
+| 6.1.0 | 2024-04-08 | [36898](https://github.com/airbytehq/airbyte/pull/36898) | Update car prices and years |
+| 6.0.3 | 2024-03-15 | [36167](https://github.com/airbytehq/airbyte/pull/36167) | Make 'count' an optional config parameter. |
+| 6.0.2 | 2024-02-12 | [35174](https://github.com/airbytehq/airbyte/pull/35174) | Manage dependencies with Poetry. |
+| 6.0.1 | 2024-02-12 | [35172](https://github.com/airbytehq/airbyte/pull/35172) | Base image migration: remove Dockerfile and use the python-connector-base image |
+| 6.0.0 | 2024-01-30 | [34644](https://github.com/airbytehq/airbyte/pull/34644) | Declare 'id' columns as primary keys. |
+| 5.0.2 | 2024-01-17 | [34344](https://github.com/airbytehq/airbyte/pull/34344) | Ensure unique state messages |
+| 5.0.1 | 2023-01-08 | [34033](https://github.com/airbytehq/airbyte/pull/34033) | Add standard entrypoints for usage with AirbyteLib |
+| 5.0.0 | 2023-08-08 | [29213](https://github.com/airbytehq/airbyte/pull/29213) | Change all `*id` fields and `products.year` to be integer |
+| 4.0.0 | 2023-07-19 | [28485](https://github.com/airbytehq/airbyte/pull/28485) | Bump to test publication |
+| 3.0.2 | 2023-07-07 | [28060](https://github.com/airbytehq/airbyte/pull/28060) | Bump to test publication |
+| 3.0.1 | 2023-06-28 | [27807](https://github.com/airbytehq/airbyte/pull/27807) | Fix bug with purchase stream updated_at |
+| 3.0.0 | 2023-06-23 | [27684](https://github.com/airbytehq/airbyte/pull/27684) | Stream cursor is now `updated_at` & remove `records_per_sync` option |
+| 2.1.0 | 2023-05-08 | [25903](https://github.com/airbytehq/airbyte/pull/25903) | Add user.address (object) |
+| 2.0.3 | 2023-02-20 | [23259](https://github.com/airbytehq/airbyte/pull/23259) | bump to test publication |
+| 2.0.2 | 2023-02-20 | [23259](https://github.com/airbytehq/airbyte/pull/23259) | bump to test publication |
+| 2.0.1 | 2023-01-30 | [22117](https://github.com/airbytehq/airbyte/pull/22117) | `source-faker` goes beta |
 | 2.0.0       | 2022-12-14 | [20492](https://github.com/airbytehq/airbyte/pull/20492) and [20741](https://github.com/airbytehq/airbyte/pull/20741) | Decouple stream states for better parallelism                                                                   |
 | 1.0.0       | 2022-11-28 | [19490](https://github.com/airbytehq/airbyte/pull/19490)                                                              | Faker uses the CDK; rename streams to be lower-case (breaking), add determinism to random purchases, and rename |
 | 0.2.1       | 2022-10-14 | [19197](https://github.com/airbytehq/airbyte/pull/19197)                                                              | Emit `AirbyteEstimateTraceMessage`                                                                              |


### PR DESCRIPTION
## What

Patch bump of `source-faker` from 7.0.1 to 7.0.2 with no functional changes. This is **Step 1** of the [Registry 2.0 post-launch test plan](https://github.com/airbytehq/airbyte-ops-mcp/issues/560) — validating the new ops CLI publish pipeline end-to-end after the production cutover in #75224.

## How

Standard version bump across the three required files:
1. `metadata.yaml` — `dockerImageTag: 7.0.2`
2. `pyproject.toml` — `version = "7.0.2"`
3. `docs/integrations/sources/faker.md` — new changelog entry

The changelog diff also includes whitespace normalization of existing rows (trailing spaces stripped). These are cosmetic only.

## Review guide

1. `metadata.yaml` / `pyproject.toml` — one-line version bump each
2. `faker.md` — new changelog row at top; remaining diff is whitespace cleanup

**⚠️ Note:** The changelog entry contains `*PR_NUMBER_PLACEHOLDER*` — this will need to be backfilled with the actual PR number after creation.

## User Impact

No user-facing impact. No code changes to the connector itself. The purpose is to trigger the `publish_connectors.yml` and `generate-connector-registries.yml` workflows post-merge to validate the Registry 2.0 pipeline.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/c761ba6292f14386952840bea135a786
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75233" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
