### PR TITLE
ci(finalize_rollout): add GitHub App auth and Temporal orchestration docs

### DIFF
--- a/.github/workflows/finalize_rollout.yml
+++ b/.github/workflows/finalize_rollout.yml
@@ -1,12 +1,28 @@
-name: Finalize connector rollout
-# This workflow is called by the backend Temporal workflow "finalizeRollout"
-# as a part of its response to calls to `/connector_rollout/manual_finalize`,
-# or in response to automatic fallback/finalization.
+# Finalize Connector Rollout
 #
-# The workflow performs these tasks:
-# 1. Generate an `auto-merge/bypass`-labeled PR to version-bump forward
-#    the named connector, including changelog entry.
-# 2. Delete the `.../release_candidate` subdirectory in the GCS Registry Store.
+# This workflow is triggered by the Airbyte platform's Temporal workflow
+# (ConnectorRolloutWorkflowImpl) via the PromoteOrRollbackActivityImpl activity,
+# which dispatches it through the GitHub API:
+#   POST https://api.github.com/repos/airbytehq/airbyte/actions/workflows/finalize_rollout.yml/dispatches
+#
+# By the time this workflow runs, the platform has already:
+#   1. Completed the progressive rollout decision (automated or manual_finalize API).
+#   2. Set the rollout state to FINALIZING.
+#
+# After this workflow completes, the Temporal workflow continues to:
+#   3. Poll verifyDefaultVersionActivity (up to 3 hours) waiting for the new
+#      GA version to become the default version in the platform.
+#   4. Call finalizeRolloutActivity to unpin all actors from the RC version.
+#
+# The --with-pr flag creates an auto-merge cleanup PR that strips the -rc.N
+# suffix, disables progressive rollout, and removes registry override pins.
+# This PR merge -> publish pipeline -> new GA version is what the
+# verifyDefaultVersionActivity is waiting for.
+#
+# See: airbyte-platform-internal/.../ConnectorRolloutWorkflowImpl.kt
+# See: airbyte-platform-internal/.../PromoteOrRollbackActivityImpl.kt
+
+name: Finalize connector rollout
 
 on:
   repository_dispatch:
@@ -41,21 +57,43 @@ jobs:
         with:
           fetch-depth: 1
 
+      # Authenticate as the GitHub App (OCTAVIA_BOT) so that:
+      #   1. The cleanup PR can be created with a token that triggers downstream CI.
+      #      (PRs created with the default GITHUB_TOKEN do not trigger workflows.)
+      #   2. The PR can be pushed to a branch in the airbytehq/airbyte repo.
+      - name: Authenticate as GitHub App
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
+        id: get-app-token
+        with:
+          owner: "airbytehq"
+          repositories: "airbyte"
+          app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
+          private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
+
       - name: Install uv
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
 
       - name: Install Ops CLI
         run: uv tool install airbyte-internal-ops
 
+      # The ops CLI rc promote/rollback command:
+      #   --with-store-cleanup: deletes the release_candidate/ blob (and versioned
+      #     blob for rollback) from GCS.
+      #   --with-pr: creates a cleanup PR that strips the -rc.N suffix (promote),
+      #     disables progressive rollout, and removes registry override pins.
+      #     This PR's merge triggers the normal publish pipeline, which publishes
+      #     the GA version that the platform's verifyDefaultVersionActivity is
+      #     waiting for.
       - name: "Promote or Rollback RC: ${{ env.ACTION }} ${{ env.CONNECTOR_NAME }}"
         id: finalize-release-candidate
         shell: bash
         env:
           GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
+          GITHUB_TOKEN: ${{ steps.get-app-token.outputs.token }}
           REGISTRY_STORE: "coral:prod"
         run: >
           airbyte-ops registry rc "${ACTION}"
           --name "${CONNECTOR_NAME}"
           --store "${REGISTRY_STORE}"
-          --with-pr
           --with-store-cleanup
+          --with-pr


### PR DESCRIPTION
## What

Adds GitHub App authentication (OCTAVIA_BOT) to the `finalize_rollout.yml` workflow so that cleanup PRs created by the ops CLI can trigger downstream CI workflows. Also replaces the brief header comments with comprehensive documentation of the Temporal orchestration context.

Addresses [airbytehq/airbyte-ops-mcp#562](https://github.com/airbytehq/airbyte-ops-mcp/issues/562).

Companion PR (ops CLI side): [airbytehq/airbyte-ops-mcp#563](https://github.com/airbytehq/airbyte-ops-mcp/pull/563).

## How

1. **GitHub App token step**: Uses `actions/create-github-app-token` (pinned to SHA, v1.12.0) to authenticate as OCTAVIA_BOT. The resulting token is passed as `GITHUB_TOKEN` to the ops CLI step. This is necessary because PRs created with the default `GITHUB_TOKEN` [do not trigger workflows](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow).

2. **Inline documentation**: Replaced the old 5-line header with a detailed comment block explaining:
   - What triggers this workflow (Temporal `PromoteOrRollbackActivityImpl`)
   - What the platform has already done before this runs (rollout decision, FINALIZING state)
   - What happens after this workflow completes (verify default version, unpin actors)
   - How the `--with-pr` flag fits into the overall lifecycle

## Review guide

1. `.github/workflows/finalize_rollout.yml` — single file change

Key things to verify:
- **Secrets exist**: `OCTAVIA_BOT_APP_ID` and `OCTAVIA_BOT_PRIVATE_KEY` must be configured as repo secrets. These are used in other workflows in this repo (e.g., `publish_connectors.yml`), so they should already exist.
- **Token consumption**: The ops CLI's `--with-pr` flag will use the `GITHUB_TOKEN` env var to create PRs via the GitHub REST API. This env var is now populated from the app token instead of being absent.
- **No functional change to existing flags**: `--with-store-cleanup` and `--with-pr` were already present in the base — this PR only adds the auth step and reorders the flags.

## User Impact

No direct user impact. This is a CI-only change. When an RC promote/rollback runs, the cleanup PR will now be created with a token that properly triggers downstream CI (publish pipeline), which is required for the Temporal `verifyDefaultVersionActivity` to succeed.

Without this change, cleanup PRs created by the ops CLI would use `GITHUB_TOKEN` (if available) which does not trigger workflows, causing the Temporal verify step to time out after 3 hours.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Reverting removes the GitHub App auth step. The workflow would still run but cleanup PRs would fail to trigger downstream CI — the same state as before this PR.

Link to Devin session: https://app.devin.ai/sessions/fa9a671420024a6d9de68563cd5a1951
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75234" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
