### PR TITLE
chore(source-faker): update global version override to 7.0.2 (post-launch test plan step 2)

### DIFF
--- a/.github/workflows/connector-ci-checks.yml
+++ b/.github/workflows/connector-ci-checks.yml
@@ -473,7 +473,7 @@ jobs:
       matrix: ${{ fromJson(needs.generate-matrix.outputs.connectors-matrix) }}
       max-parallel: 10
       fail-fast: false
-    name: "Build and Verify Artifacts (${{ matrix.connector || 'No-Op' }})"
+    name: "Verify ${{ matrix.connector || 'No-Op' }} Artifacts"
     runs-on: ubuntu-24.04
     continue-on-error: true
     steps:

--- a/airbyte-integrations/connectors/source-faker/metadata.yaml
+++ b/airbyte-integrations/connectors/source-faker/metadata.yaml
@@ -25,10 +25,10 @@ data:
   name: Sample Data
   registryOverrides:
     cloud:
-      dockerImageTag: 6.2.24
+      dockerImageTag: 7.0.2
       enabled: true
     oss:
-      dockerImageTag: 6.2.24
+      dockerImageTag: 7.0.2
       enabled: true
   releaseStage: beta
   releases:


### PR DESCRIPTION
## What

Two changes:
1. **source-faker global version override**: Update `registryOverrides.cloud.dockerImageTag` and `registryOverrides.oss.dockerImageTag` from `6.2.24` → `7.0.2` to align with the current top-level `dockerImageTag`.
2. **CI job rename**: Rename the pre-release checks job from `"Build and Verify Artifacts ({connector})"` to `"Verify {connector} Artifacts"` for brevity.

The metadata change is **step 2** of the [post-launch test plan](https://github.com/airbytehq/airbyte-ops-mcp/issues/560): exercise the ops CLI registry compile pipeline with a global version override change and verify end-to-end propagation.

## How

- `metadata.yaml`: Changed two `dockerImageTag` values under `registryOverrides` (cloud + oss) from `6.2.24` to `7.0.2`.
- `connector-ci-checks.yml`: Changed the job `name` field (line 476). No logic changes.

## Review guide

1. `airbyte-integrations/connectors/source-faker/metadata.yaml` — The override was previously pinning cloud/oss to 6.2.24 while the top-level version was 7.0.2. This change removes that divergence.
2. `.github/workflows/connector-ci-checks.yml` — Cosmetic rename only.

**⚠️ Items for reviewer attention:**
- [ ] The override jump crosses the 7.0.0 breaking change boundary. Confirm this is acceptable for `source-faker` (a test/sample connector used for infrastructure validation).
- [ ] Verify the CI job rename doesn't break any branch protection rules or required status checks that match on the old job name string `"Build and Verify Artifacts"`.

## User Impact

source-faker will now serve version 7.0.2 to both cloud and oss users (previously pinned to 6.2.24). This is a test connector, so real-user impact is minimal, but the 7.0.0 breaking change boundary is crossed.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

**Link to Devin run:** https://app.devin.ai/sessions/f900274cb0884bf99e399b1c40c48067
**Requested by:** AJ Steers (@aaronsteers)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75236" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
