### PR TITLE
chore(source-faker): remove stale registryOverrides version pin

### DIFF
--- a/airbyte-integrations/connectors/source-faker/metadata.yaml
+++ b/airbyte-integrations/connectors/source-faker/metadata.yaml
@@ -25,10 +25,8 @@ data:
   name: Sample Data
   registryOverrides:
     cloud:
-      dockerImageTag: 6.2.24
       enabled: true
     oss:
-      dockerImageTag: 6.2.24
       enabled: true
   releaseStage: beta
   releases:


### PR DESCRIPTION
## What

Removes the stale `dockerImageTag: 6.2.24` pins from `registryOverrides.cloud` and `registryOverrides.oss` in the source-faker metadata. These pins were introduced as test debris in [#61645](https://github.com/airbytehq/airbyte/pull/61645) ("test docker image overrides with release candidate") and were never cleaned up.

With the pins removed, the compiled registries will serve the top-level `dockerImageTag` value (`7.0.2`) instead of the stale `6.2.24`.

Related issue: [airbytehq/airbyte-ops-mcp#566](https://github.com/airbytehq/airbyte-ops-mcp/issues/566) — platform DB never discovers new GA versions when a standing registryOverrides pin shadows them.

## How

Removed the two `dockerImageTag: 6.2.24` lines from `registryOverrides.cloud` and `registryOverrides.oss`, keeping `enabled: true` on both.

## Review guide

1. `airbyte-integrations/connectors/source-faker/metadata.yaml` — only file changed. Verify the `registryOverrides` section still has `enabled: true` for both cloud and oss, with no version pin.

**Key reviewer consideration:** This will cause the compiled registries to serve source-faker `7.0.2` (up from `6.2.24`). Version 7.0.0 declares a breaking change with deadline 2026-03-19 and `deadlineAction: "disable"`. Since source-faker is a sample data connector used primarily for testing, this is intentional.

## User Impact

- Source-faker will appear as version `7.0.2` in both cloud and OSS registries (previously pinned at `6.2.24`).
- The 7.0.0 breaking change (stream schema changes to `users`, `products`, `purchases`) will take effect for users on the upgrade deadline.
- The platform should discover version 7.0.2 for the first time after the next registry compile cycle.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Link to Devin run: https://app.devin.ai/sessions/f900274cb0884bf99e399b1c40c48067
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75239" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
