### PR TITLE
ci: add `--force` and `--connector-name` inputs to registry `compile` workflow

### DIFF
--- a/.github/workflows/generate-connector-registries.yml
+++ b/.github/workflows/generate-connector-registries.yml
@@ -7,6 +7,15 @@ on:
         description: "The git ref to check out from the repository"
         required: false
         type: string
+      force:
+        description: "Force resync of all latest/ directories even if version markers are current. Useful when metadata changes without a version bump."
+        required: false
+        type: boolean
+        default: false
+      connector-name:
+        description: "Comma-separated list of connector names to limit the latest/ resync scope (e.g. 'source-faker,source-github'). Leave empty to compile all connectors."
+        required: false
+        type: string
   workflow_call:
 
 permissions:
@@ -44,8 +53,19 @@ jobs:
         env:
           GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
         shell: bash
-        run: >
-          airbyte-ops registry store compile
-          --store "${REGISTRY_STORE}"
-          --with-secrets-mask
-          --with-legacy-migration v1
+        run: |
+          COMPILE_ARGS="airbyte-ops registry store compile"
+          COMPILE_ARGS="${COMPILE_ARGS} --store ${REGISTRY_STORE}"
+          COMPILE_ARGS="${COMPILE_ARGS} --with-secrets-mask"
+          COMPILE_ARGS="${COMPILE_ARGS} --with-legacy-migration v1"
+          if [[ "${{ inputs.force }}" == "true" ]]; then
+            COMPILE_ARGS="${COMPILE_ARGS} --force"
+          fi
+          if [[ -n "${{ inputs.connector-name }}" ]]; then
+            IFS=',' read -ra CONNECTORS <<< "${{ inputs.connector-name }}"
+            for c in "${CONNECTORS[@]}"; do
+              COMPILE_ARGS="${COMPILE_ARGS} --connector-name $(echo "$c" | xargs)"
+            done
+          fi
+          echo "Running: ${COMPILE_ARGS}"
+          ${COMPILE_ARGS}

--- a/.github/workflows/generate-connector-registries.yml
+++ b/.github/workflows/generate-connector-registries.yml
@@ -13,7 +13,7 @@ on:
         type: boolean
         default: false
       connector-name:
-        description: "Comma-separated list of connector names to limit the latest/ resync scope (e.g. 'source-faker,source-github'). Leave empty to compile all connectors."
+        description: "A connector name to limit the latest/ resync scope (e.g. 'source-faker'). Leave empty to compile all connectors."
         required: false
         type: string
   workflow_call:
@@ -52,22 +52,13 @@ jobs:
       - name: Compile Registries
         env:
           GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
-          INPUT_FORCE: ${{ inputs.force }}
-          INPUT_CONNECTOR_NAME: ${{ inputs.connector-name }}
+          FORCE_FLAG: ${{ inputs.force == true && '--force' || '' }}
+          CONNECTOR_NAME_FLAG: ${{ inputs.connector-name && format('--connector-name {0}', inputs.connector-name) || '' }}
         shell: bash
-        run: |
-          COMPILE_ARGS="airbyte-ops registry store compile"
-          COMPILE_ARGS="${COMPILE_ARGS} --store ${REGISTRY_STORE}"
-          COMPILE_ARGS="${COMPILE_ARGS} --with-secrets-mask"
-          COMPILE_ARGS="${COMPILE_ARGS} --with-legacy-migration v1"
-          if [[ "${INPUT_FORCE}" == "true" ]]; then
-            COMPILE_ARGS="${COMPILE_ARGS} --force"
-          fi
-          if [[ -n "${INPUT_CONNECTOR_NAME}" ]]; then
-            IFS=',' read -ra CONNECTORS <<< "${INPUT_CONNECTOR_NAME}"
-            for c in "${CONNECTORS[@]}"; do
-              COMPILE_ARGS="${COMPILE_ARGS} --connector-name $(echo "$c" | xargs)"
-            done
-          fi
-          echo "Running: ${COMPILE_ARGS}"
-          ${COMPILE_ARGS}
+        run: >
+          airbyte-ops registry store compile
+          --store "${REGISTRY_STORE}"
+          --with-secrets-mask
+          --with-legacy-migration v1
+          ${FORCE_FLAG}
+          ${CONNECTOR_NAME_FLAG}

--- a/.github/workflows/generate-connector-registries.yml
+++ b/.github/workflows/generate-connector-registries.yml
@@ -52,17 +52,19 @@ jobs:
       - name: Compile Registries
         env:
           GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
+          INPUT_FORCE: ${{ inputs.force }}
+          INPUT_CONNECTOR_NAME: ${{ inputs.connector-name }}
         shell: bash
         run: |
           COMPILE_ARGS="airbyte-ops registry store compile"
           COMPILE_ARGS="${COMPILE_ARGS} --store ${REGISTRY_STORE}"
           COMPILE_ARGS="${COMPILE_ARGS} --with-secrets-mask"
           COMPILE_ARGS="${COMPILE_ARGS} --with-legacy-migration v1"
-          if [[ "${{ inputs.force }}" == "true" ]]; then
+          if [[ "${INPUT_FORCE}" == "true" ]]; then
             COMPILE_ARGS="${COMPILE_ARGS} --force"
           fi
-          if [[ -n "${{ inputs.connector-name }}" ]]; then
-            IFS=',' read -ra CONNECTORS <<< "${{ inputs.connector-name }}"
+          if [[ -n "${INPUT_CONNECTOR_NAME}" ]]; then
+            IFS=',' read -ra CONNECTORS <<< "${INPUT_CONNECTOR_NAME}"
             for c in "${CONNECTORS[@]}"; do
               COMPILE_ARGS="${COMPILE_ARGS} --connector-name $(echo "$c" | xargs)"
             done


### PR DESCRIPTION
## What

Adds two optional `workflow_dispatch` inputs to the **Generate Connector Registries** workflow so operators can trigger targeted or forced recompiles from the GitHub Actions UI:

- **`force`** (boolean): passes `--force` to skip the version-marker cache, resyncing all `latest/` directories even when markers match. Needed when metadata content changes without a version bump (e.g. removing a `registryOverrides` pin). Related: https://github.com/airbytehq/airbyte-ops-mcp/issues/567
- **`connector-name`** (string): passes `--connector-name <value>` to scope the `latest/` resync to a specific connector.

Both inputs are no-ops when left empty, preserving the existing default behavior for `workflow_call` and unparameterized `workflow_dispatch` triggers.

## How

The new inputs are pre-computed into CLI flag strings using GitHub Actions expressions in the step's `env` block:

```yaml
FORCE_FLAG: ${{ inputs.force == true && '--force' || '' }}
CONNECTOR_NAME_FLAG: ${{ inputs.connector-name && format('--connector-name {0}', inputs.connector-name) || '' }}
```

These env vars are then expanded inline in the existing folded-scalar `run:` command, keeping the CLI invocation a clean one-liner with no bash conditionals or dynamic string building.

## Review guide

1. `.github/workflows/generate-connector-registries.yml` — the only file changed.

Key things to verify:
- **Expression correctness**: `inputs.force == true` evaluates to `false` (and thus `''`) when the input is omitted or `false`. `inputs.connector-name` is falsy when empty. Both fall through to `''` for the default no-op case.
- **Unquoted `${FORCE_FLAG}` / `${CONNECTOR_NAME_FLAG}`**: Empty vars produce harmless extra whitespace that bash ignores. Non-empty vars word-split correctly since `--force` is a single token and connector names never contain spaces.
- **`workflow_call` compatibility**: The new inputs are only defined under `workflow_dispatch`, so `workflow_call` invocations get empty/falsy values and the command is unchanged.

### Human review checklist
- [ ] Confirm GHA ternary expressions (`A && B || C`) behave as expected for boolean and string input types
- [ ] Confirm that `format('--connector-name {0}', ...)` produces the expected single-token output for typical connector names

## User Impact

Operators can now trigger a forced registry recompile or a connector-scoped recompile directly from the GitHub Actions UI without modifying the workflow file. No impact on automated (publish-triggered) compiles.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Requested by: @aaronsteers
[Devin session](https://app.devin.ai/sessions/f900274cb0884bf99e399b1c40c48067)