### PR TITLE
ci: add rc create step to publish workflow and fix finalize_rollout CLI commands

### DIFF
--- a/.github/workflows/finalize_rollout.yml
+++ b/.github/workflows/finalize_rollout.yml
@@ -47,15 +47,17 @@ jobs:
       - name: Install Ops CLI
         run: uv tool install airbyte-internal-ops
 
-      - name: "Promote or Rollback RC: ${{ env.ACTION }} ${{ env.CONNECTOR_NAME }}"
-        id: finalize-release-candidate
+      # Delete the release_candidate/ metadata marker from GCS.
+      # This is the same operation for both promote and rollback:
+      # it removes the RC pointer so the platform knows the rollout
+      # is finalized.  The versioned blob (e.g. 1.2.3-rc.1/) is
+      # intentionally preserved as an audit trail.
+      - name: "GCS cleanup: delete RC metadata marker"
         shell: bash
         env:
           GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
           REGISTRY_STORE: "coral:prod"
         run: >
-          airbyte-ops registry rc "${ACTION}"
+          airbyte-ops registry rc cleanup
           --name "${CONNECTOR_NAME}"
           --store "${REGISTRY_STORE}"
-          --with-pr
-          --with-store-cleanup

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -461,6 +461,31 @@ jobs:
             --store "${REGISTRY_STORE}" \
             --with-validate
 
+      # Create the release_candidate/ metadata marker in GCS so the
+      # platform knows an RC is active for this connector.  The marker
+      # is read by the compile step and injected into the compiled
+      # registry JSON as `releases.releaseCandidates`.
+      #
+      # Condition: the on-disk metadata.yaml version must contain
+      # "-rc." (path 1: RC version committed to master).  The
+      # `--with-semver-suffix rc` path (path 2) uses a different
+      # suffix format and is handled separately (used for -preview).
+      - name: Create RC metadata marker
+        if: >-
+          needs.publish_options.outputs.dry-run != 'true'
+          && steps.publish-registry-artifacts.outcome == 'success'
+          && contains(steps.connector-metadata.outputs.docker-image-tag, '-rc.')
+        shell: bash
+        env:
+          GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
+          REGISTRY_STORE: "coral:prod"
+        run: |
+          echo "Creating RC metadata marker for ${{ matrix.connector }}"
+          airbyte-ops \
+            registry rc create \
+            --name "${{ matrix.connector }}" \
+            --store "${REGISTRY_STORE}"
+
   generate_connector_registry:
     name: Generate connector registry
     needs: [publish_options, publish_connector_registry_entries]


### PR DESCRIPTION
## What

Two changes to align the connector CI workflows with the ops CLI after [airbyte-ops-mcp#565](https://github.com/airbytehq/airbyte-ops-mcp/pull/565) landed:

1. **Gap**: When an RC version (e.g. `2.23.15-rc.1`) is published via `publish_connectors.yml`, nothing creates the `release_candidate/metadata.yaml` marker in GCS. The platform's compiled registry JSON needs this marker to advertise active RCs.
2. **Bug**: `finalize_rollout.yml` calls `airbyte-ops registry rc "${ACTION}" --with-pr --with-store-cleanup`, but PR #565 deleted the `rc promote`/`rc rollback` sub-commands and the `--with-pr`/`--with-store-cleanup` flags. Any rollout finalization would fail right now.

## How

**`publish_connectors.yml`** — New step _"Create RC metadata marker"_ after _"Publish Registry Artifacts"_:
- Condition: `contains(docker-image-tag, '-rc.')` — matches path-1 RCs (version committed to master as `X.Y.Z-rc.N`) but **not** path-2 (`--with-semver-suffix rc` produces `X.Y.Z-rc1`, no dot).
- Calls `airbyte-ops registry rc create --name <connector> --store coral:prod`.

**`finalize_rollout.yml`** — Replace broken CLI invocation:
- Old: `airbyte-ops registry rc "${ACTION}" --with-pr --with-store-cleanup`
- New: `airbyte-ops registry rc cleanup --name ... --store ...`
- Cleanup is the same for both promote and rollback (deletes the `release_candidate/` blob; versioned blob preserved as audit trail).

## Review guide

1. `publish_connectors.yml` — Focus on the `if:` condition (line 474–477). Verify `-rc.` correctly distinguishes path-1 RCs from path-2 suffix format.
2. `finalize_rollout.yml` — Verify the new CLI invocation matches the current ops CLI signature (`rc cleanup --name --store`). Note: the `ACTION` env var and validation step are still present but unused by any step in this PR; they'll be needed when the workflow is expanded with PR creation / version bumping in a follow-up.

## User Impact

- RC versions published to the registry will now have their `release_candidate/metadata.yaml` marker created automatically, enabling the platform to detect active RCs via the compiled registry JSON.
- Connector rollout finalization (promote/rollback) will work again instead of failing on a missing CLI command.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/fa9a671420024a6d9de68563cd5a1951
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75243" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
