### PR TITLE
ci: clarify inline comment about path-2 RC suffix format

### DIFF
--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -467,9 +467,13 @@ jobs:
       # registry JSON as `releases.releaseCandidates`.
       #
       # Condition: the on-disk metadata.yaml version must contain
-      # "-rc." (path 1: RC version committed to master).  The
-      # `--with-semver-suffix rc` path (path 2) uses a different
-      # suffix format and is handled separately (used for -preview).
+      # "-rc." (path 1: RC version committed to master with an
+      # explicit RC tag like 2.0.0-rc.1).
+      #
+      # Note: the `--with-semver-suffix rc` path (path 2) produces
+      # tags like "1.2.3-rc1" (no dot) and is NOT matched here.
+      # Path 2 is primarily used for preview-style releases and
+      # will be handled separately in a follow-up.
       - name: Create RC metadata marker
         if: >-
           needs.publish_options.outputs.dry-run != 'true'


### PR DESCRIPTION
## What

Clarifies the inline comment on the "Create RC metadata marker" step in `publish_connectors.yml` to explicitly document why the `--with-semver-suffix rc` path (path 2) is not matched by the `-rc.` condition.

This was flagged by Devin Review on #75243 as potentially confusing — the original comment said path 2 "is handled separately (used for -preview)" which was misleading.

## How

Comment-only change. No functional diff.

- Spells out that path 1 uses tags like `2.0.0-rc.1` (with dot) while path 2 produces `1.2.3-rc1` (no dot)
- Clarifies that path 2 will be handled in a follow-up, removing the confusing "(used for -preview)" parenthetical

## Review guide

1. `.github/workflows/publish_connectors.yml` — only the comment block above the "Create RC metadata marker" step changed

## User Impact

None. Comment-only change.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/fa9a671420024a6d9de68563cd5a1951
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75244" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
