### PR TITLE
fix(source-clickhouse): remove invalid sslmode=none parameter for 0.9.7+ driver

### DIFF
--- a/airbyte-integrations/connectors/source-clickhouse-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/source-clickhouse-strict-encrypt/metadata.yaml
@@ -11,7 +11,7 @@ data:
     - suite: acceptanceTests
   connectorType: source
   definitionId: bad83517-5e54-4a3d-9b53-63e85fbd4d7c
-  dockerImageTag: 0.3.0-rc.2
+  dockerImageTag: 0.3.0-rc.3
   dockerRepository: airbyte/source-clickhouse-strict-encrypt
   documentationUrl: https://docs.airbyte.com/integrations/sources/clickhouse
   githubIssueLabel: source-clickhouse

--- a/airbyte-integrations/connectors/source-clickhouse/metadata.yaml
+++ b/airbyte-integrations/connectors/source-clickhouse/metadata.yaml
@@ -14,7 +14,7 @@ data:
     - suite: acceptanceTests
   connectorType: source
   definitionId: bad83517-5e54-4a3d-9b53-63e85fbd4d7c
-  dockerImageTag: 0.3.0-rc.2
+  dockerImageTag: 0.3.0-rc.3
   dockerRepository: airbyte/source-clickhouse
   documentationUrl: https://docs.airbyte.com/integrations/sources/clickhouse
   githubIssueLabel: source-clickhouse

--- a/airbyte-integrations/connectors/source-clickhouse/src/main/java/io/airbyte/integrations/source/clickhouse/ClickHouseSource.java
+++ b/airbyte-integrations/connectors/source-clickhouse/src/main/java/io/airbyte/integrations/source/clickhouse/ClickHouseSource.java
@@ -20,7 +20,6 @@ import io.airbyte.protocol.models.CommonField;
 import java.sql.JDBCType;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -38,7 +37,6 @@ public class ClickHouseSource extends AbstractJdbcSource<JDBCType> implements So
    * https://clickhouse.tech/docs/en/operations/system-tables/columns/ to fetch the primary keys.
    */
 
-  public static final String SSL_MODE = "ssl=true";
   public static final String HTTPS_PROTOCOL = "https";
   public static final String HTTP_PROTOCOL = "http";
 
@@ -93,18 +91,9 @@ public class ClickHouseSource extends AbstractJdbcSource<JDBCType> implements So
 
     final boolean isAdditionalParamsExists =
         config.get(JdbcUtils.JDBC_URL_PARAMS_KEY) != null && !config.get(JdbcUtils.JDBC_URL_PARAMS_KEY).asText().isEmpty();
-    final List<String> params = new ArrayList<>();
-    // assume ssl if not explicitly mentioned.
-    if (isSsl) {
-      params.add(SSL_MODE);
-    }
     if (isAdditionalParamsExists) {
-      params.add(config.get(JdbcUtils.JDBC_URL_PARAMS_KEY).asText());
-    }
-
-    if (isSsl || isAdditionalParamsExists) {
       jdbcUrl.append("?");
-      jdbcUrl.append(String.join("&", params));
+      jdbcUrl.append(config.get(JdbcUtils.JDBC_URL_PARAMS_KEY).asText());
     }
 
     final ImmutableMap.Builder<Object, Object> configBuilder = ImmutableMap.builder()

--- a/airbyte-integrations/connectors/source-clickhouse/src/main/java/io/airbyte/integrations/source/clickhouse/ClickHouseSource.java
+++ b/airbyte-integrations/connectors/source-clickhouse/src/main/java/io/airbyte/integrations/source/clickhouse/ClickHouseSource.java
@@ -20,6 +20,7 @@ import io.airbyte.protocol.models.CommonField;
 import java.sql.JDBCType;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -37,6 +38,7 @@ public class ClickHouseSource extends AbstractJdbcSource<JDBCType> implements So
    * https://clickhouse.tech/docs/en/operations/system-tables/columns/ to fetch the primary keys.
    */
 
+  public static final String SSL_MODE = "ssl=true";
   public static final String HTTPS_PROTOCOL = "https";
   public static final String HTTP_PROTOCOL = "http";
 
@@ -91,9 +93,18 @@ public class ClickHouseSource extends AbstractJdbcSource<JDBCType> implements So
 
     final boolean isAdditionalParamsExists =
         config.get(JdbcUtils.JDBC_URL_PARAMS_KEY) != null && !config.get(JdbcUtils.JDBC_URL_PARAMS_KEY).asText().isEmpty();
+    final List<String> params = new ArrayList<>();
+    // assume ssl if not explicitly mentioned.
+    if (isSsl) {
+      params.add(SSL_MODE);
+    }
     if (isAdditionalParamsExists) {
+      params.add(config.get(JdbcUtils.JDBC_URL_PARAMS_KEY).asText());
+    }
+
+    if (isSsl || isAdditionalParamsExists) {
       jdbcUrl.append("?");
-      jdbcUrl.append(config.get(JdbcUtils.JDBC_URL_PARAMS_KEY).asText());
+      jdbcUrl.append(String.join("&", params));
     }
 
     final ImmutableMap.Builder<Object, Object> configBuilder = ImmutableMap.builder()

--- a/airbyte-integrations/connectors/source-clickhouse/src/main/java/io/airbyte/integrations/source/clickhouse/ClickHouseSource.java
+++ b/airbyte-integrations/connectors/source-clickhouse/src/main/java/io/airbyte/integrations/source/clickhouse/ClickHouseSource.java
@@ -20,7 +20,6 @@ import io.airbyte.protocol.models.CommonField;
 import java.sql.JDBCType;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -38,7 +37,6 @@ public class ClickHouseSource extends AbstractJdbcSource<JDBCType> implements So
    * https://clickhouse.tech/docs/en/operations/system-tables/columns/ to fetch the primary keys.
    */
 
-  public static final String SSL_MODE = "sslmode=none";
   public static final String HTTPS_PROTOCOL = "https";
   public static final String HTTP_PROTOCOL = "http";
 
@@ -93,18 +91,9 @@ public class ClickHouseSource extends AbstractJdbcSource<JDBCType> implements So
 
     final boolean isAdditionalParamsExists =
         config.get(JdbcUtils.JDBC_URL_PARAMS_KEY) != null && !config.get(JdbcUtils.JDBC_URL_PARAMS_KEY).asText().isEmpty();
-    final List<String> params = new ArrayList<>();
-    // assume ssl if not explicitly mentioned.
-    if (isSsl) {
-      params.add(SSL_MODE);
-    }
     if (isAdditionalParamsExists) {
-      params.add(config.get(JdbcUtils.JDBC_URL_PARAMS_KEY).asText());
-    }
-
-    if (isSsl || isAdditionalParamsExists) {
       jdbcUrl.append("?");
-      jdbcUrl.append(String.join("&", params));
+      jdbcUrl.append(config.get(JdbcUtils.JDBC_URL_PARAMS_KEY).asText());
     }
 
     final ImmutableMap.Builder<Object, Object> configBuilder = ImmutableMap.builder()

--- a/airbyte-integrations/connectors/source-clickhouse/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/ClickHouseJdbcSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-clickhouse/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/ClickHouseJdbcSourceAcceptanceTest.java
@@ -5,6 +5,7 @@
 package io.airbyte.integrations.io.airbyte.integration_tests.sources;
 
 import static io.airbyte.cdk.db.jdbc.JdbcUtils.JDBC_URL_KEY;
+import static io.airbyte.integrations.source.clickhouse.ClickHouseSource.SSL_MODE;
 import static java.time.temporal.ChronoUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -107,9 +108,7 @@ public class ClickHouseJdbcSourceAcceptanceTest extends JdbcSourceAcceptanceTest
     JsonNode jdbcUrlNode = jdbcConfig.get(JDBC_URL_KEY);
     assertNotNull(jdbcUrlNode);
     String actualJdbcUrl = jdbcUrlNode.asText();
-    // SSL is handled via the https:// protocol prefix, no extra params needed
-    assertTrue(actualJdbcUrl.startsWith("jdbc:clickhouse:https://"));
-    assertTrue(actualJdbcUrl.endsWith(config.get("database").asText()));
+    assertTrue(actualJdbcUrl.endsWith("?" + SSL_MODE));
   }
 
   @Test
@@ -131,9 +130,7 @@ public class ClickHouseJdbcSourceAcceptanceTest extends JdbcSourceAcceptanceTest
     JsonNode jdbcUrlNode = jdbcConfig.get(JDBC_URL_KEY);
     assertNotNull(jdbcUrlNode);
     String actualJdbcUrl = jdbcUrlNode.asText();
-    // SSL is handled via https:// protocol, extra params appended directly
-    assertTrue(actualJdbcUrl.startsWith("jdbc:clickhouse:https://"));
-    assertTrue(actualJdbcUrl.endsWith("?" + extraParam));
+    assertTrue(actualJdbcUrl.endsWith(getFullExpectedValue(extraParam, SSL_MODE)));
   }
 
   @Test
@@ -145,6 +142,11 @@ public class ClickHouseJdbcSourceAcceptanceTest extends JdbcSourceAcceptanceTest
     assertNotNull(jdbcUrlNode);
     String actualJdbcUrl = jdbcUrlNode.asText();
     assertTrue(actualJdbcUrl.endsWith("?" + extraParam));
+  }
+
+  private String getFullExpectedValue(String extraParam, String sslMode) {
+    StringBuilder expected = new StringBuilder();
+    return expected.append("?").append(sslMode).append("&").append(extraParam).toString();
   }
 
   private JsonNode buildConfigWithExtraJdbcParameters(String extraParam, boolean isSsl) {

--- a/airbyte-integrations/connectors/source-clickhouse/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/ClickHouseJdbcSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-clickhouse/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/ClickHouseJdbcSourceAcceptanceTest.java
@@ -5,7 +5,6 @@
 package io.airbyte.integrations.io.airbyte.integration_tests.sources;
 
 import static io.airbyte.cdk.db.jdbc.JdbcUtils.JDBC_URL_KEY;
-import static io.airbyte.integrations.source.clickhouse.ClickHouseSource.SSL_MODE;
 import static java.time.temporal.ChronoUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -108,7 +107,9 @@ public class ClickHouseJdbcSourceAcceptanceTest extends JdbcSourceAcceptanceTest
     JsonNode jdbcUrlNode = jdbcConfig.get(JDBC_URL_KEY);
     assertNotNull(jdbcUrlNode);
     String actualJdbcUrl = jdbcUrlNode.asText();
-    assertTrue(actualJdbcUrl.endsWith("?" + SSL_MODE));
+    // SSL is handled via the https:// protocol prefix, no extra params needed
+    assertTrue(actualJdbcUrl.startsWith("jdbc:clickhouse:https://"));
+    assertTrue(actualJdbcUrl.endsWith(config.get("database").asText()));
   }
 
   @Test
@@ -130,7 +131,9 @@ public class ClickHouseJdbcSourceAcceptanceTest extends JdbcSourceAcceptanceTest
     JsonNode jdbcUrlNode = jdbcConfig.get(JDBC_URL_KEY);
     assertNotNull(jdbcUrlNode);
     String actualJdbcUrl = jdbcUrlNode.asText();
-    assertTrue(actualJdbcUrl.endsWith(getFullExpectedValue(extraParam, SSL_MODE)));
+    // SSL is handled via https:// protocol, extra params appended directly
+    assertTrue(actualJdbcUrl.startsWith("jdbc:clickhouse:https://"));
+    assertTrue(actualJdbcUrl.endsWith("?" + extraParam));
   }
 
   @Test
@@ -142,11 +145,6 @@ public class ClickHouseJdbcSourceAcceptanceTest extends JdbcSourceAcceptanceTest
     assertNotNull(jdbcUrlNode);
     String actualJdbcUrl = jdbcUrlNode.asText();
     assertTrue(actualJdbcUrl.endsWith("?" + extraParam));
-  }
-
-  private String getFullExpectedValue(String extraParam, String sslMode) {
-    StringBuilder expected = new StringBuilder();
-    return expected.append("?").append(sslMode).append("&").append(extraParam).toString();
   }
 
   private JsonNode buildConfigWithExtraJdbcParameters(String extraParam, boolean isSsl) {

--- a/docs/integrations/sources/clickhouse.md
+++ b/docs/integrations/sources/clickhouse.md
@@ -80,6 +80,7 @@ Using this feature requires additional configuration, when creating the source. 
 
 | Version | Date       | Pull Request                                                | Subject                                                                                                   |
 |:--------|:-----------|:------------------------------------------------------------|:----------------------------------------------------------------------------------------------------------|
+| 0.3.0-rc.3 | 2026-03-20 | [PR_NUMBER_PLACEHOLDER](https://github.com/airbytehq/airbyte/pull/PR_NUMBER_PLACEHOLDER) | Remove legacy `sslmode=none` JDBC parameter incompatible with 0.9.7+ driver |
 | 0.3.0-rc.2 | 2026-03-19 | [75226](https://github.com/airbytehq/airbyte/pull/75226) | Upgrade ClickHouse JDBC driver from 0.9.5 to 0.9.8 |
 | 0.3.0-rc.1 | 2026-02-03 | [72395](https://github.com/airbytehq/airbyte/pull/72395) | Upgrade ClickHouse JDBC driver to 0.9.5 with custom type mapping |
 | 0.2.6 | 2025-11-03 | [66714](https://github.com/airbytehq/airbyte/pull/66714) | Revert JDBC driver upgrade |

--- a/docs/integrations/sources/clickhouse.md
+++ b/docs/integrations/sources/clickhouse.md
@@ -80,7 +80,7 @@ Using this feature requires additional configuration, when creating the source. 
 
 | Version | Date       | Pull Request                                                | Subject                                                                                                   |
 |:--------|:-----------|:------------------------------------------------------------|:----------------------------------------------------------------------------------------------------------|
-| 0.3.0-rc.3 | 2026-03-20 | [PR_NUMBER_PLACEHOLDER](https://github.com/airbytehq/airbyte/pull/PR_NUMBER_PLACEHOLDER) | Remove legacy `sslmode=none` JDBC parameter incompatible with 0.9.7+ driver |
+| 0.3.0-rc.3 | 2026-03-20 | [75260](https://github.com/airbytehq/airbyte/pull/75260) | Remove legacy `sslmode=none` JDBC parameter incompatible with 0.9.7+ driver |
 | 0.3.0-rc.2 | 2026-03-19 | [75226](https://github.com/airbytehq/airbyte/pull/75226) | Upgrade ClickHouse JDBC driver from 0.9.5 to 0.9.8 |
 | 0.3.0-rc.1 | 2026-02-03 | [72395](https://github.com/airbytehq/airbyte/pull/72395) | Upgrade ClickHouse JDBC driver to 0.9.5 with custom type mapping |
 | 0.2.6 | 2025-11-03 | [66714](https://github.com/airbytehq/airbyte/pull/66714) | Revert JDBC driver upgrade |


### PR DESCRIPTION
## What

Fixes 100% connection failure rate (`SQLSTATE 08000: Failed to create connection`) introduced by the ClickHouse JDBC driver upgrade to 0.9.8 in `0.3.0-rc.2`.

The 0.9.7 driver introduced a breaking change: `Client.Builder#build()` now throws `ClientMisconfigurationException` on unknown configuration properties (previously silently ignored). The connector was hardcoding `sslmode=none` as a JDBC URL parameter, which the new driver rejects.

This was discovered during a progressive rollout of rc.2 where both pinned actors failed at the `check` phase.

## How

Remove the `SSL_MODE = "sslmode=none"` constant and all associated URL-building logic entirely. SSL is already determined by the `https://` vs `http://` protocol prefix in the JDBC URL — the `sslmode=none` parameter was always redundant (and contradictory, since it was only appended when `isSsl=true`).

Changes in `ClickHouseSource.java`:
- Remove `SSL_MODE` constant and unused `ArrayList` import
- Simplify `toDatabaseConfig()`: only append user-provided `jdbc_url_params` to the URL
- The `isSsl` flag still controls protocol selection (`https://` vs `http://`) — unchanged

Changes in `ClickHouseJdbcSourceAcceptanceTest.java`:
- Update assertions to verify `https://` protocol prefix instead of removed `sslmode` param
- Remove unused `getFullExpectedValue` helper and `SSL_MODE` import

Also bumps both `source-clickhouse` and `source-clickhouse-strict-encrypt` to `0.3.0-rc.3`.

## Review guide

1. `ClickHouseSource.java` — core fix: removal of `SSL_MODE` and simplification of URL building in `toDatabaseConfig()`
2. `ClickHouseJdbcSourceAcceptanceTest.java` — updated test assertions
3. `metadata.yaml` (both connectors) — version bumps to rc.3
4. `clickhouse.md` — changelog entry

### ⚠️ Reviewer checklist
- [ ] Verify that `https://` protocol prefix is sufficient for the ClickHouse JDBC 0.9.8 driver to enable TLS — no explicit `ssl=true` URL parameter needed
- [ ] Confirm the simplified URL building still correctly handles: SSL with no extra params, SSL with extra params, no-SSL with extra params, no-SSL with no extra params (all 4 cases covered by tests)
- [ ] Note that the strict-encrypt variant (`source-clickhouse-strict-encrypt`) also benefits from this fix because it wraps `ClickHouseSource` and delegates to the same `toDatabaseConfig()` method — no separate fix needed
- [ ] `sslmode` was never a valid ClickHouse JDBC property (it's a PostgreSQL concept) — the old driver silently ignored it

## User Impact

No user-facing behavior change. The `sslmode=none` parameter was an internal implementation detail that:
- Was contradictory (disabling SSL mode while using `https://` protocol)
- Was already a no-op silently ignored by pre-0.9.7 drivers
- Is not exposed in the connector's config spec

Connections that previously worked on pre-rc.2 versions will continue working. Connections that broke on rc.2 will be unblocked.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/5f4bde9194db41839fac8261c9c8051f
Requested by: @sophiecuiy
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75260" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
