### PR TITLE
fix(source-salesforce): refresh OAuth token for Bulk API streams during long-running syncs

### DIFF
--- a/airbyte-integrations/connectors/source-salesforce/metadata.yaml
+++ b/airbyte-integrations/connectors/source-salesforce/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: b117307c-14b6-41aa-9422-947e34922962
-  dockerImageTag: 2.7.18
+  dockerImageTag: 2.7.19
   releases:
     rolloutConfiguration:
       enableProgressiveRollout: false

--- a/airbyte-integrations/connectors/source-salesforce/pyproject.toml
+++ b/airbyte-integrations/connectors/source-salesforce/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "2.7.18"
+version = "2.7.19"
 name = "source-salesforce"
 description = "Source implementation for Salesforce."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-salesforce/source_salesforce/streams.py
+++ b/airbyte-integrations/connectors/source-salesforce/source_salesforce/streams.py
@@ -4,6 +4,8 @@
 
 import csv
 import ctypes
+import logging
+import time
 import urllib.parse
 from abc import ABC
 from datetime import timedelta
@@ -34,7 +36,7 @@ from airbyte_cdk.models import ConfiguredAirbyteCatalog, SyncMode
 from airbyte_cdk.sources.declarative.async_job.job_orchestrator import AsyncJobOrchestrator
 from airbyte_cdk.sources.declarative.async_job.job_tracker import JobTracker
 from airbyte_cdk.sources.declarative.async_job.status import AsyncJobStatus
-from airbyte_cdk.sources.declarative.auth.token_provider import InterpolatedStringTokenProvider
+from airbyte_cdk.sources.declarative.auth.token_provider import TokenProvider
 from airbyte_cdk.sources.declarative.decoders import NoopDecoder
 from airbyte_cdk.sources.declarative.extractors import ResponseToFileExtractor
 from airbyte_cdk.sources.declarative.partition_routers import AsyncJobPartitionRouter
@@ -53,6 +55,36 @@ from airbyte_cdk.sources.utils.transform import TransformConfig, TypeTransformer
 from .api import PARENT_SALESFORCE_OBJECTS, UNSUPPORTED_FILTERING_STREAMS, Salesforce
 from .availability_strategy import SalesforceAvailabilityStrategy
 from .rate_limiting import BulkNotSupportedException, SalesforceErrorHandler, default_backoff_handler
+
+logger = logging.getLogger("airbyte")
+
+_DEFAULT_TOKEN_REFRESH_INTERVAL_SECONDS = 30 * 60  # 30 minutes
+
+
+class SalesforceOAuthTokenProvider(TokenProvider):
+    """Token provider that refreshes the Salesforce OAuth access token before it expires.
+
+    The Salesforce Bulk API uses declarative components that hold a reference to a token provider.
+    Previously, an InterpolatedStringTokenProvider was used which captured the access token as a
+    static string at initialization. This meant the token was never refreshed, causing
+    INVALID_SESSION_ID errors for long-running syncs that outlast the token TTL (typically 2 hours).
+
+    This provider proactively refreshes the token by calling Salesforce.login() at a configurable
+    interval, ensuring the token stays valid for the lifetime of the sync.
+    """
+
+    def __init__(self, sf_api: Salesforce, refresh_interval_seconds: int = _DEFAULT_TOKEN_REFRESH_INTERVAL_SECONDS) -> None:
+        self._sf_api = sf_api
+        self._refresh_interval_seconds = refresh_interval_seconds
+        self._last_refresh_time = time.monotonic()
+
+    def get_token(self) -> str:
+        elapsed = time.monotonic() - self._last_refresh_time
+        if elapsed >= self._refresh_interval_seconds:
+            logger.info("Refreshing Salesforce OAuth token (%.0fs since last refresh)", elapsed)
+            self._sf_api.login()
+            self._last_refresh_time = time.monotonic()
+        return self._sf_api.access_token
 
 
 # https://stackoverflow.com/a/54517228
@@ -530,7 +562,7 @@ class BulkSalesforceStream(SalesforceStream):
         job_query_path = f"/services/data/{self.sf_api.version}/jobs/query"
         decoder = JsonDecoder(parameters=parameters)
         authenticator = BearerAuthenticator(
-            token_provider=InterpolatedStringTokenProvider(api_token=self.sf_api.access_token, config=config, parameters=parameters),
+            token_provider=SalesforceOAuthTokenProvider(sf_api=self.sf_api),
             config=config,
             parameters=parameters,
         )

--- a/airbyte-integrations/connectors/source-salesforce/source_salesforce/streams.py
+++ b/airbyte-integrations/connectors/source-salesforce/source_salesforce/streams.py
@@ -56,6 +56,7 @@ from .api import PARENT_SALESFORCE_OBJECTS, UNSUPPORTED_FILTERING_STREAMS, Sales
 from .availability_strategy import SalesforceAvailabilityStrategy
 from .rate_limiting import BulkNotSupportedException, SalesforceErrorHandler, default_backoff_handler
 
+
 logger = logging.getLogger("airbyte")
 
 _DEFAULT_TOKEN_REFRESH_INTERVAL_SECONDS = 30 * 60  # 30 minutes

--- a/docs/integrations/sources/salesforce.md
+++ b/docs/integrations/sources/salesforce.md
@@ -274,6 +274,7 @@ The lookback window uses the ISO 8601 duration format. The format is `PT<number>
 
 | Version     | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:------------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 2.7.19 | 2026-03-23 | [TBD](https://github.com/airbytehq/airbyte/pull/TBD) | Fix Bulk API OAuth token expiry during long-running syncs by replacing static token provider with auto-refreshing provider |
 | 2.7.18 | 2026-02-25 | [73501](https://github.com/airbytehq/airbyte/pull/73501) | fix(source-salesforce): skip time-based slicing for full_refresh syncs (AI-Triage PR) |
 | 2.7.17 | 2026-02-10 | [73235](https://github.com/airbytehq/airbyte/pull/73235) | Make lookback window configurable to address Salesforce API eventual consistency |
 | 2.7.16 | 2025-10-29 | [69078](https://github.com/airbytehq/airbyte/pull/69078) | Promoting release candidate 2.7.16-rc.1 to a main version. |


### PR DESCRIPTION
## What

Fixes OAuth token expiry (`INVALID_SESSION_ID`) during long-running Salesforce Bulk API syncs.

Related: https://github.com/airbytehq/oncall/issues/11700

When a Bulk API sync runs longer than the Salesforce access token TTL (typically 2 hours), all subsequent Bulk API requests fail with HTTP 401 `INVALID_SESSION_ID` because the token is never refreshed. This was introduced in https://github.com/airbytehq/airbyte/pull/45678 (v2.5.32) when Bulk API streams were migrated to declarative components using `InterpolatedStringTokenProvider`, which captures the access token as a **static string** at initialization and has no refresh mechanism.

## Design

### Root cause

The Salesforce connector's Bulk API streams use declarative CDK components (`HttpRequester`, `BearerAuthenticator`) for job creation, polling, download, abort, and delete operations. Each of these requesters shares a single `BearerAuthenticator`, which delegates to a `TokenProvider.get_token()` call on every HTTP request.

Previously, the authenticator was initialized like this:

```python
authenticator = BearerAuthenticator(
    token_provider=InterpolatedStringTokenProvider(
        api_token=self.sf_api.access_token,  # ← static string snapshot
        ...
    ), ...
)
```

`InterpolatedStringTokenProvider` (CDK: `airbyte_cdk/sources/declarative/auth/token_provider.py`) wraps its input in an `InterpolatedString` at `__post_init__` and returns the same evaluated string on every `get_token()` call — it has **no refresh logic**. The value `self.sf_api.access_token` is a plain `str` obtained once during `Salesforce.login()` at connector startup. After startup, `login()` is never called again.

The token lifecycle before this fix:
1. Startup → `Salesforce.login()` obtains `access_token` via OAuth `refresh_token` grant
2. `access_token` string is copied into `InterpolatedStringTokenProvider` for all 6 Bulk API requesters
3. Token expires after Salesforce session TTL (default: 2 hours)
4. All Bulk API requests fail with `INVALID_SESSION_ID` — no recovery path

Meanwhile, the CDK provides `SessionTokenProvider` with `_refresh_if_necessary()` logic, but the Salesforce connector never used it for Bulk API streams.

### Why this wasn't caught earlier

- REST API streams use `TokenAuthenticator(sf_object.access_token)` — also a static token, but REST streams typically complete fast enough that the token hasn't expired yet.
- Only Bulk API streams with enough data to run >2 hours trigger the bug.
- The bug was latent since v2.5.32 (Oct 2024) and only manifests for large objects like Task (300k+ records).

### Fix approach

Introduce `SalesforceOAuthTokenProvider`, a `TokenProvider` subclass that:
- Holds a **reference** to the `Salesforce` API object (not a token string)
- Tracks time since last refresh via `time.monotonic()`
- Proactively calls `Salesforce.login()` every 30 minutes (well within the 2-hour TTL)
- Returns the live `sf_api.access_token` which stays current after each `login()` call

This approach was chosen over alternatives because:
- **vs. `SessionTokenProvider`**: Would require wiring up a login `Requester` and token path extraction, adding complexity. Our provider directly reuses the existing `Salesforce.login()` method.
- **vs. reactive refresh on 401**: The declarative CDK error handler doesn't have a "refresh token and retry" action. Proactive refresh is simpler and avoids any failed-request overhead.

## How

Replaces `InterpolatedStringTokenProvider` with a new `SalesforceOAuthTokenProvider` that:
1. Holds a reference to the `Salesforce` API object (instead of a static token string)
2. Tracks elapsed time since last token refresh using `time.monotonic()`
3. Proactively calls `Salesforce.login()` every 30 minutes (well within the typical 2-hour TTL) to obtain a fresh access token
4. Always returns the current `sf_api.access_token`, which stays up-to-date after each `login()` call

## Review guide

1. `source_salesforce/streams.py` — the only meaningful code change:
   - New `SalesforceOAuthTokenProvider` class (lines 65–88): **Check thread safety** — `get_token()` can be called from multiple concurrent threads via the concurrent CDK. Concurrent `login()` calls would result in redundant refreshes but not data corruption since `login()` just sets `self.access_token` and `self.instance_url`. However, there is no locking.
   - Line 566: The authenticator now uses `SalesforceOAuthTokenProvider(sf_api=self.sf_api)` instead of `InterpolatedStringTokenProvider(api_token=self.sf_api.access_token, ...)`.
   - **No error handling** around the `login()` call in `get_token()` — if refresh fails, the exception propagates. This seems acceptable since a stale token would fail with 401 anyway, but worth confirming.

2. Version bump: `metadata.yaml`, `pyproject.toml` (2.7.18 → 2.7.19)
3. `docs/integrations/sources/salesforce.md` — changelog entry (PR link is TBD, needs update after merge)

### Human review checklist

- [ ] **Thread safety**: Is it acceptable that concurrent threads may call `login()` simultaneously? (We believe yes — redundant but harmless, since `login()` just sets two string attributes.)
- [ ] **Error propagation**: Should `get_token()` catch and log `login()` failures and return the stale token, or is letting it propagate correct? A transient network error during proactive refresh could kill the sync even if the current token is still valid.
- [ ] **30-minute interval**: Is this a reasonable default? Salesforce default session timeout is 2 hours, but it can be configured lower by admins.
- [ ] **No unit tests added** — the existing test suite (107 tests passing) should be checked for coverage of the authenticator setup in `_instantiate_declarative_stream`.

## User Impact

Salesforce Bulk API syncs that run longer than the session token TTL (typically 2 hours) will no longer fail with `INVALID_SESSION_ID`. The token is transparently refreshed every 30 minutes. Users with large streams (e.g., Task with 300k+ records) who were unable to complete initial syncs should now succeed without configuration changes.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/b21731fb5d494a438f82c029e2269da6
Requested by: @agarctfi