### PR TITLE
ci(publish): use ops CLI for preview version tag computation

### DIFF
--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -376,6 +376,9 @@ jobs:
           # Install Poe so we can run the connector tasks:
           uv tool install poethepoet
 
+      - name: Install Ops CLI
+        run: uv tool install airbyte-internal-ops
+
       - name: Enable progressive rollout for RC builds
         if: needs.publish_options.outputs.with-semver-suffix == 'rc'
         working-directory: airbyte-integrations/connectors/${{ matrix.connector }}
@@ -402,8 +405,14 @@ jobs:
           # Generate docker image tag based on semver suffix mode
           case "$SEMVER_SUFFIX" in
             preview)
-              hash=$(git rev-parse --short=7 HEAD)
-              echo "docker-image-tag=${CONNECTOR_VERSION}-preview.${hash}" | tee -a $GITHUB_OUTPUT
+              # Use the ops CLI as the single source of truth for preview version format.
+              # This correctly strips any existing pre-release suffix (e.g., -rc.1) before
+              # appending the -preview.<sha> tag.
+              PREVIEW_TAG=$(airbyte-ops registry connector-version next \
+                --name "${{ matrix.connector }}" \
+                --sha "$(git rev-parse HEAD)" \
+                --base-version "${CONNECTOR_VERSION}")
+              echo "docker-image-tag=${PREVIEW_TAG}" | tee -a $GITHUB_OUTPUT
               echo "release-type-flag=--pre-release" | tee -a $GITHUB_OUTPUT
               ;;
             rc)
@@ -417,9 +426,6 @@ jobs:
           esac
 
       # --- Registry artifact generation and publishing (ops CLI) ---
-      - name: Install Ops CLI
-        run: uv tool install airbyte-internal-ops
-
       - name: Generate Registry Artifacts
         id: generate-registry-artifacts
         shell: bash


### PR DESCRIPTION
## What

Fixes a bug where the prerelease slash command produces malformed docker image tags when a connector's `metadata.yaml` version already contains a pre-release suffix (e.g., `2.23.16-rc.1`).

The old inline bash naively concatenated `-preview.{hash}` onto the version, producing `2.23.16-rc.1-preview.{hash}` instead of `2.23.16-preview.{hash}`.

Related: https://github.com/airbytehq/airbyte/pull/74885 (source-bing-ads example where this bug manifests)
Related: https://github.com/airbytehq/airbyte-ops-mcp/pull/585 (ops-mcp fix released in v0.33.2)

## How

1. Moved the `Install Ops CLI` step earlier in the job — before `Get connector metadata` — so the CLI is available during version tag computation.
2. Replaced the inline bash `preview)` case with a call to `airbyte-ops registry connector-version next`, which strips any existing pre-release suffix before appending `-preview.<sha>`. This makes the workflow use the same logic as the MCP tool and CLI, establishing a single source of truth for preview version format.

## Review guide

1. `.github/workflows/publish_connectors.yml` — the only file changed. Three edits:
   - New `Install Ops CLI` step added after `Install Poe` (line 379)
   - `preview)` case rewritten to call the ops CLI (lines 408–415)
   - Old `Install Ops CLI` step removed from its previous location (was after the metadata step)

**Things to verify:**
- The ops CLI install is now on the critical path for tag computation. Previously, a failure here only affected registry artifact steps. Confirm this is acceptable.
- The CLI's `connector-version next` command makes a GitHub API call to compare against master (for a non-blocking warning on stderr). This is a new network dependency in this step — it should be benign but is worth noting.
- The `rc)` case still uses naive concatenation (`${CONNECTOR_VERSION}-rc1`). This is intentionally left unchanged in this PR.

## User Impact

Prerelease publishes (`/publish-connectors-prerelease`) will now produce correct version tags for connectors that are in an RC state (e.g., `2.23.16-rc.1` → `2.23.16-preview.abcdef1` instead of `2.23.16-rc.1-preview.abcdef1`).

No impact on non-RC connectors — the behavior is identical for versions without a pre-release suffix.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Reverting restores the old inline bash logic. The only consequence is re-introducing the malformed tag bug for RC-state connectors.

Link to Devin session: https://app.devin.ai/sessions/edf592e70e4e4cdf885d2428192500ac
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75294" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
