### PR TITLE
ci(publish): suppress PyAirbyte telemetry banner in ops CLI stdout capture

### DIFF
--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -408,7 +408,8 @@ jobs:
               # Use the ops CLI as the single source of truth for preview version format.
               # This correctly strips any existing pre-release suffix (e.g., -rc.1) before
               # appending the -preview.<sha> tag.
-              PREVIEW_TAG=$(airbyte-ops registry connector-version next \
+              # DO_NOT_TRACK suppresses PyAirbyte's telemetry banner from contaminating stdout.
+              PREVIEW_TAG=$(DO_NOT_TRACK=1 airbyte-ops registry connector-version next \
                 --name "${{ matrix.connector }}" \
                 --sha "$(git rev-parse HEAD)" \
                 --base-version "${CONNECTOR_VERSION}")


### PR DESCRIPTION
## What

Fixes the prerelease publish workflow producing a docker image tag of `airbyte/source-bing-ads:Thank you for using PyAirbyte!` instead of the expected `2.23.16-preview.0161fe2`.

Root cause: the `airbyte-ops` CLI transitively imports PyAirbyte, whose telemetry module prints a welcome banner to **stdout** on first run (when `~/.airbyte/analytics.yml` doesn't exist — always true on fresh CI runners). The `$()` shell substitution captures this banner instead of (or in addition to) the version tag.

A companion fix in `airbytehq/PyAirbyte` redirects all telemetry banners to stderr, but that requires a PyAirbyte release + ops CLI dependency bump to take effect. This PR is the immediate workaround.

## How

Sets `DO_NOT_TRACK=1` as an inline env var on the `airbyte-ops registry connector-version next` invocation. This is a [well-known convention](https://consoledonottrack.com/) that PyAirbyte's telemetry module checks on import — when set, it skips analytics setup entirely and prints nothing.

## Review guide

1. `.github/workflows/publish_connectors.yml` — single-line change adding `DO_NOT_TRACK=1` prefix

**Things to consider:**
- Should `DO_NOT_TRACK=1` be set at the job or step level instead of inline? Other `airbyte-ops` calls later in the job (generate/publish artifacts) don't use `$()` capture, so they aren't affected by stdout contamination — but setting it broadly would be more defensive.
- This also suppresses the telemetry event for this one CLI call. Acceptable trade-off given it's a CI context.

## User Impact

Prerelease publishes via `/publish-connectors-prerelease` will produce correct docker image tags instead of the PyAirbyte banner string.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/edf592e70e4e4cdf885d2428192500ac
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75296" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
