### PR TITLE
chore: downgrade vector destinations from `certified` to `community` support

### DIFF
--- a/airbyte-integrations/connectors/destination-milvus/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-milvus/metadata.yaml
@@ -36,7 +36,7 @@ data:
   ab_internal:
     sl: 300
     ql: 300
-  supportLevel: certified
+  supportLevel: community
   connectorTestSuitesOptions:
     - suite: unitTests
     - suite: integrationTests

--- a/airbyte-integrations/connectors/destination-pgvector/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-pgvector/metadata.yaml
@@ -36,7 +36,7 @@ data:
         resourceRequirements:
           memory_limit: 2Gi
           memory_request: 2Gi
-  supportLevel: certified
+  supportLevel: community
   tags:
     - language:python
     - cdk:python

--- a/airbyte-integrations/connectors/destination-snowflake-cortex/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-snowflake-cortex/metadata.yaml
@@ -37,7 +37,7 @@ data:
         resourceRequirements:
           memory_limit: 2Gi
           memory_request: 2Gi
-  supportLevel: certified
+  supportLevel: community
   tags:
     - language:python
     - cdk:python

--- a/airbyte-integrations/connectors/destination-weaviate/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-weaviate/metadata.yaml
@@ -37,7 +37,7 @@ data:
         resourceRequirements:
           memory_limit: 2Gi
           memory_request: 2Gi
-  supportLevel: certified
+  supportLevel: community
   tags:
     - language:python
     - cdk:python


### PR DESCRIPTION
## What

Downgrades four low-usage vector store destination connectors from `certified` to `community` support level:
- `destination-weaviate`
- `destination-milvus`
- `destination-snowflake-cortex`
- `destination-pgvector`

This is based on Airbyte Cloud production connection data showing relatively low adoption:

| Connector | Total Connections | Enabled | Active (30d) |
|---|---|---|---|
| PGVector | 176 | 18 | 11 |
| Weaviate | 76 | 16 | 0 |
| Milvus | 42 | 8 | 2 |
| Snowflake Cortex | 28 | 6 | 1 |

After this change, **Pinecone** (621 total, 102 enabled) remains the only certified Python vector destination.

## How

Changed `supportLevel: certified` → `supportLevel: community` in each connector's `metadata.yaml`. No other fields modified.

## Review guide

1. `airbyte-integrations/connectors/destination-milvus/metadata.yaml`
2. `airbyte-integrations/connectors/destination-snowflake-cortex/metadata.yaml`
3. `airbyte-integrations/connectors/destination-weaviate/metadata.yaml`
4. `airbyte-integrations/connectors/destination-pgvector/metadata.yaml`

**Reviewer check**: Confirm whether the `ab_internal.sl` and `ab_internal.ql` fields should also be updated to reflect the new community support level, or if those are independent. Current values: Weaviate/Milvus/Snowflake Cortex have `sl: 300, ql: 300`; PGVector has `sl: 200, ql: 300`.

## User Impact

These four connectors will appear as "community" instead of "certified" in the Airbyte UI and connector registry. No functional changes to the connectors themselves.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/0d4c25fa273147bba0ed9ed9d4f76a0b
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75299" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
