### PR TITLE
ci(publish): strip pre-release suffix from version tags in all semver code paths

### DIFF
--- a/.github/actions/connector-image-build-push/action.yml
+++ b/.github/actions/connector-image-build-push/action.yml
@@ -140,7 +140,9 @@ runs:
           echo "🏷 Using provided tag override: $CONNECTOR_VERSION_TAG"
         elif [[ "${{ inputs.with-semver-suffix }}" == "preview" ]]; then
           hash=$(git rev-parse --short=7 HEAD)
-          CONNECTOR_VERSION_TAG="${CONNECTOR_VERSION}-preview.${hash}"
+          # Strip any existing pre-release suffix (e.g., -rc.1) before appending -preview.<hash>.
+          CLEAN_VERSION="${CONNECTOR_VERSION%%-*}"
+          CONNECTOR_VERSION_TAG="${CLEAN_VERSION}-preview.${hash}"
           echo "🏷 Using preview tag: $CONNECTOR_VERSION_TAG"
         elif [[ "${{ inputs.with-semver-suffix }}" == "rc" ]]; then
           CONNECTOR_VERSION_TAG="${CONNECTOR_VERSION}-rc1"

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -201,10 +201,11 @@ jobs:
           # We pass a token with dedicated GH rate limit
           github-token: ${{ steps.get-app-token.outputs.token }}
 
-      - name: Install Poe
+      - name: Install Poe and Ops CLI
         run: |
           # Install Poe so we can run the connector tasks:
           uv tool install poethepoet
+          uv tool install airbyte-internal-ops
 
       - name: Get connector metadata
         id: connector-metadata
@@ -213,6 +214,36 @@ jobs:
           set -euo pipefail
           echo "connector-language=$(poe -qq get-language)" | tee -a $GITHUB_OUTPUT
           echo "connector-version=$(poe -qq get-version)" | tee -a $GITHUB_OUTPUT
+
+      - name: Resolve docker image tag
+        id: resolve-docker-tag
+        working-directory: airbyte-integrations/connectors/${{ matrix.connector }}
+        run: |
+          set -euo pipefail
+          CONNECTOR_VERSION=$(poe -qq get-version)
+          SEMVER_SUFFIX="${{ needs.publish_options.outputs.with-semver-suffix }}"
+
+          # Use the ops CLI as the single source of truth for version tag resolution.
+          # This correctly strips any existing pre-release suffix (e.g., -rc.1) before
+          # appending the target suffix.
+          case "$SEMVER_SUFFIX" in
+            preview)
+              # DO_NOT_TRACK suppresses PyAirbyte's telemetry banner from contaminating stdout.
+              DOCKER_IMAGE_TAG=$(DO_NOT_TRACK=1 airbyte-ops registry connector-version next \
+                --name "${{ matrix.connector }}" \
+                --sha "$(git rev-parse HEAD)" \
+                --base-version "${CONNECTOR_VERSION}")
+              ;;
+            rc)
+              DOCKER_IMAGE_TAG="${CONNECTOR_VERSION}-rc1"
+              ;;
+            none|*)
+              DOCKER_IMAGE_TAG="${CONNECTOR_VERSION}"
+              ;;
+          esac
+
+          echo "docker-image-tag=${DOCKER_IMAGE_TAG}" | tee -a $GITHUB_OUTPUT
+          echo "Resolved docker image tag: ${DOCKER_IMAGE_TAG}"
 
       # We're intentionally not using the `google-github-actions/auth` action.
       # The upload-connector-metadata step runs a script which handles auth manually.
@@ -298,7 +329,7 @@ jobs:
         uses: ./.github/actions/connector-image-build-push
         with:
           connector-name: ${{ matrix.connector }}
-          with-semver-suffix: ${{ needs.publish_options.outputs.with-semver-suffix }}
+          tag-override: ${{ steps.resolve-docker-tag.outputs.docker-image-tag }}
           dry-run: ${{ needs.publish_options.outputs.dry-run }}
           docker-hub-username: ${{ secrets.DOCKER_HUB_USERNAME }}
           docker-hub-password: ${{ secrets.DOCKER_HUB_PASSWORD }}

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -330,6 +330,7 @@ jobs:
         with:
           connector-name: ${{ matrix.connector }}
           tag-override: ${{ steps.resolve-docker-tag.outputs.docker-image-tag }}
+          with-semver-suffix: ${{ needs.publish_options.outputs.with-semver-suffix }}
           dry-run: ${{ needs.publish_options.outputs.dry-run }}
           docker-hub-username: ${{ secrets.DOCKER_HUB_USERNAME }}
           docker-hub-password: ${{ secrets.DOCKER_HUB_PASSWORD }}

--- a/poe-tasks/lib/util.sh
+++ b/poe-tasks/lib/util.sh
@@ -55,12 +55,18 @@ get_only_connector() {
 }
 
 # Generate the preview image tag (e.g. `1.2.3-preview.abcde12`).
+# Strips any existing pre-release suffix (e.g. `-rc.1`) before appending `-preview.<hash>`.
+# Note: In the publish workflow, the ops CLI is used as the single source of truth for
+# preview tag computation (via a dedicated "Resolve docker image tag" step). This function
+# serves as a consistent fallback for standalone script usage.
 generate_dev_tag() {
   local base="$1"
+  # Strip any pre-release suffix (everything from the first hyphen onward).
+  local clean_version="${base%%-*}"
   # Use 7-char short hash to match the new prerelease format.
   local hash
   hash=$(git rev-parse --short=7 HEAD)
-  echo "${base}-preview.${hash}"
+  echo "${clean_version}-preview.${hash}"
 }
 
 # Generate the release candidate image tag (e.g. `1.2.3-rc1`).

--- a/poe-tasks/publish-python-registry.sh
+++ b/poe-tasks/publish-python-registry.sh
@@ -160,8 +160,10 @@ elif [[ "$SEMVER_SUFFIX" == "preview" ]]; then
     # Add current timestamp for preview builds.
     # we can't use the git revision because not all python registries allow local version identifiers. 
     # Public version identifiers must conform to PEP 440 and only allow digits.
+    # Strip any existing pre-release suffix (e.g. -rc.1) before appending the dev tag.
+    CLEAN_VERSION="${BASE_VERSION%%-*}"
     TIMESTAMP=$(date +"%Y%m%d%H%M")
-    VERSION="${BASE_VERSION}.dev.${TIMESTAMP}"
+    VERSION="${CLEAN_VERSION}.dev.${TIMESTAMP}"
 elif [[ "$SEMVER_SUFFIX" == "rc" ]]; then
     # Add rc1 suffix for release candidates
     VERSION="${BASE_VERSION}rc1"


### PR DESCRIPTION
## What

When a connector version in `metadata.yaml` already carries a pre-release suffix (e.g. `2.23.15-rc.1`), the prerelease publish pipeline produced malformed Docker image tags like `2.23.15-rc.2-preview.998ce3c` instead of the correct `2.23.15-preview.998ce3c`. This caused a tag mismatch between the Docker image build step and the registry entries step, failing the publish.

Root cause: multiple independent code paths computed the preview tag by naively concatenating `-preview.<hash>` onto the base version without first stripping any existing pre-release suffix.

Related prior fixes:
- airbytehq/airbyte-ops-mcp#585 (ops CLI fix, v0.33.2)
- #75294 (ops CLI in `publish_connector_registry_entries` job)
- #75296 (`DO_NOT_TRACK` workaround)

## How

1. **`publish_connectors.yml`** — Adds a dedicated "Resolve docker image tag" step that uses the ops CLI (`airbyte-ops registry connector-version next`) as the single source of truth for version tag computation. The resolved tag is passed to the composite action via `tag-override`. Both `tag-override` and `with-semver-suffix` are passed so the action's `PUSH_LATEST_TAG` auto-determination still works correctly for production releases.

2. **`connector-image-build-push/action.yml`** — Fixes the inline preview tag logic to strip the pre-release suffix (`${CONNECTOR_VERSION%%-*}`) as a safety net for standalone action usage.

3. **`poe-tasks/lib/util.sh`** — Fixes `generate_dev_tag()` to strip the pre-release suffix before appending `-preview.<hash>`. This transitively fixes all callers: `upload-connector-metadata.sh`, `upload-python-dependencies.sh`, `build-and-publish-java-connectors-with-tag.sh`, `upload-java-connector-tar-file.sh`.

4. **`poe-tasks/publish-python-registry.sh`** — Fixes the PEP 440 dev version computation to strip the pre-release suffix before appending `.dev.<timestamp>`.

## Review guide

1. `.github/workflows/publish_connectors.yml` — **Most important.** The new "Resolve docker image tag" step and the `tag-override` + `with-semver-suffix` pass-through to the composite action.
2. `.github/actions/connector-image-build-push/action.yml` — Small inline fix, safety net only. When `tag-override` is set, the action uses it directly and the inline preview logic is skipped.
3. `poe-tasks/lib/util.sh` — `generate_dev_tag()` fix. Verify that `${base%%-*}` is correct for all expected version formats (strips everything from first hyphen onward; passes through cleanly when no hyphen is present).
4. `poe-tasks/publish-python-registry.sh` — Same pattern for PEP 440 versions.

### Human review checklist
- [ ] Verify that the `tag-override` + `with-semver-suffix` interaction in the composite action is correct: `tag-override` takes priority for the tag itself (first branch in the if/elif), while `with-semver-suffix` is still used for `PUSH_LATEST_TAG` auto-determination.
- [ ] Confirm adding `uv tool install airbyte-internal-ops` to the `publish_connectors` job is acceptable (adds a dependency + minor install time).
- [ ] These changes are CI/CD-only and cannot be validated locally — requires a real prerelease run to verify end-to-end.

## User Impact

Connector prerelease publishes (`/publish-connectors-prerelease`) will produce correct Docker image tags when the connector version in `metadata.yaml` has an `-rc.N` suffix. Previously these publishes would fail with a tag mismatch error.

No impact on production (non-prerelease) connector publishes.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/edf592e70e4e4cdf885d2428192500ac
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75300" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
