### PR TITLE
chore(source-harvest): test dev SDM image in prod

### DIFF
--- a/airbyte-integrations/connectors/source-harvest/metadata.yaml
+++ b/airbyte-integrations/connectors/source-harvest/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: fe2b4084-3386-4d3b-9ad6-308f61a6f1e6
-  dockerImageTag: 1.2.32-dev
+  dockerImageTag: 1.2.32
   dockerRepository: airbyte/source-harvest
   documentationUrl: https://docs.airbyte.com/integrations/sources/harvest
   externalDocumentationUrls:

--- a/airbyte-integrations/connectors/source-harvest/metadata.yaml
+++ b/airbyte-integrations/connectors/source-harvest/metadata.yaml
@@ -6,7 +6,7 @@ data:
     hosts:
       - api.harvestapp.com
   connectorBuildOptions:
-    baseImage: docker.io/airbyte/source-declarative-manifest:7.13.0.post6.dev23497311155@sha256:56b7a51d385bd56096f664f2b0c891c1d267a9c0526c06c712eebe84c76661e8
+    baseImage: docker.io/airbyte/source-declarative-manifest:7.13.0.post6.dev23497311155@sha256:d907ff9b81bcc8ce8a11c09e18faa6bd707d9cf42f4bc95d8d156800d05b7717
   connectorSubtype: api
   connectorType: source
   definitionId: fe2b4084-3386-4d3b-9ad6-308f61a6f1e6

--- a/airbyte-integrations/connectors/source-harvest/metadata.yaml
+++ b/airbyte-integrations/connectors/source-harvest/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: fe2b4084-3386-4d3b-9ad6-308f61a6f1e6
-  dockerImageTag: 1.2.32
+  dockerImageTag: 1.2.32-rc.1
   dockerRepository: airbyte/source-harvest
   documentationUrl: https://docs.airbyte.com/integrations/sources/harvest
   externalDocumentationUrls:
@@ -33,6 +33,8 @@ data:
     oss:
       enabled: true
   releases:
+    rolloutConfiguration:
+      enableProgressiveRollout: true
     breakingChanges:
       1.0.0:
         message:

--- a/airbyte-integrations/connectors/source-harvest/metadata.yaml
+++ b/airbyte-integrations/connectors/source-harvest/metadata.yaml
@@ -6,11 +6,11 @@ data:
     hosts:
       - api.harvestapp.com
   connectorBuildOptions:
-    baseImage: docker.io/airbyte/source-declarative-manifest:7.10.4@sha256:2f551a3fb5d580b34f4253aa1904d26c309364b09538f0b0fef3d8a98546f795
+    baseImage: docker.io/airbyte/source-declarative-manifest:7.13.0.post6.dev23497311155@sha256:56b7a51d385bd56096f664f2b0c891c1d267a9c0526c06c712eebe84c76661e8
   connectorSubtype: api
   connectorType: source
   definitionId: fe2b4084-3386-4d3b-9ad6-308f61a6f1e6
-  dockerImageTag: 1.2.31
+  dockerImageTag: 1.2.32-dev
   dockerRepository: airbyte/source-harvest
   documentationUrl: https://docs.airbyte.com/integrations/sources/harvest
   externalDocumentationUrls:

--- a/docs/integrations/sources/harvest.md
+++ b/docs/integrations/sources/harvest.md
@@ -91,7 +91,7 @@ The connector is restricted by the [Harvest rate limits](https://help.getharvest
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:--------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 1.2.32 | 2026-03-24 | | Test dev image of source-declarative-manifest (7.13.0.post6.dev23497311155) |
+| 1.2.32-rc.1 | 2026-03-24 | | Test dev image of source-declarative-manifest (7.13.0.post6.dev23497311155) |
 | 1.2.31 | 2026-03-10 | [74687](https://github.com/airbytehq/airbyte/pull/74687) | Update dependencies |
 | 1.2.30 | 2026-02-24 | [73930](https://github.com/airbytehq/airbyte/pull/73930) | Update dependencies |
 | 1.2.29 | 2026-02-10 | [73113](https://github.com/airbytehq/airbyte/pull/73113) | Update dependencies |

--- a/docs/integrations/sources/harvest.md
+++ b/docs/integrations/sources/harvest.md
@@ -91,7 +91,7 @@ The connector is restricted by the [Harvest rate limits](https://help.getharvest
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:--------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 1.2.32-dev | 2026-03-24 | | Test dev image of source-declarative-manifest (7.13.0.post6.dev23497311155) |
+| 1.2.32 | 2026-03-24 | | Test dev image of source-declarative-manifest (7.13.0.post6.dev23497311155) |
 | 1.2.31 | 2026-03-10 | [74687](https://github.com/airbytehq/airbyte/pull/74687) | Update dependencies |
 | 1.2.30 | 2026-02-24 | [73930](https://github.com/airbytehq/airbyte/pull/73930) | Update dependencies |
 | 1.2.29 | 2026-02-10 | [73113](https://github.com/airbytehq/airbyte/pull/73113) | Update dependencies |

--- a/docs/integrations/sources/harvest.md
+++ b/docs/integrations/sources/harvest.md
@@ -91,6 +91,7 @@ The connector is restricted by the [Harvest rate limits](https://help.getharvest
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:--------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1.2.32-dev | 2026-03-24 | | Test dev image of source-declarative-manifest (7.13.0.post6.dev23497311155) |
 | 1.2.31 | 2026-03-10 | [74687](https://github.com/airbytehq/airbyte/pull/74687) | Update dependencies |
 | 1.2.30 | 2026-02-24 | [73930](https://github.com/airbytehq/airbyte/pull/73930) | Update dependencies |
 | 1.2.29 | 2026-02-10 | [73113](https://github.com/airbytehq/airbyte/pull/73113) | Update dependencies |


### PR DESCRIPTION
## Summary
- Updates source-harvest base image to `source-declarative-manifest:7.13.0.post6.dev23497311155` (dev build)
- Bumps connector version to `1.2.32-rc.1` for progressive rollout testing
- Purpose: validate the dev SDM image on a certified manifest-only connector in production for a few days


🤖 Generated with [Claude Code](https://claude.com/claude-code)