### PR TITLE
ci: bump devin-action to api-version v3 with org-id across all workflows

### DIFF
--- a/.github/workflows/ai-canary-prerelease-command.yml
+++ b/.github/workflows/ai-canary-prerelease-command.yml
@@ -67,6 +67,8 @@ jobs:
           playbook-macro: "!canary_prerelease"
           devin-token: ${{ secrets.DEVIN_AI_API_KEY }}
           github-token: ${{ steps.get-app-token.outputs.token }}
+          api-version: v3
+          org-id: ${{ vars.DEVIN_AI_ORG_ID }}
           start-message: "🐤 **AI Canary Prerelease session starting...** Rolling out to 5-10 connections, watching results, and reporting findings. [View playbook](https://github.com/airbytehq/oncall/blob/main/prompts/playbooks/canary_prerelease.md)"
           tags: |
             ai-oncall

--- a/.github/workflows/ai-canary-prerelease-command.yml
+++ b/.github/workflows/ai-canary-prerelease-command.yml
@@ -60,7 +60,7 @@ jobs:
             > [View workflow run](${{ steps.job-vars.outputs.run-url }})
 
       - name: Run AI Canary Prerelease
-        uses: aaronsteers/devin-action@main
+        uses: aaronsteers/devin-action@v0.5.0
         with:
           comment-id: ${{ inputs.comment-id }}
           issue-number: ${{ inputs.pr }}

--- a/.github/workflows/ai-create-docs-pr-command.yml
+++ b/.github/workflows/ai-create-docs-pr-command.yml
@@ -136,7 +136,7 @@ jobs:
             > [View workflow run](${{ steps.job-vars.outputs.run-url }})
 
       - name: Run AI Create Docs PR
-        uses: aaronsteers/devin-action@main
+        uses: aaronsteers/devin-action@v0.5.0
         with:
           comment-id: ${{ inputs.comment-id }}
           issue-number: ${{ inputs.pr }}

--- a/.github/workflows/ai-create-docs-pr-command.yml
+++ b/.github/workflows/ai-create-docs-pr-command.yml
@@ -143,6 +143,8 @@ jobs:
           playbook-macro: "!connectordocs"
           devin-token: ${{ secrets.DEVIN_AI_API_KEY }}
           github-token: ${{ steps.get-app-token.outputs.token }}
+          api-version: v3
+          org-id: ${{ vars.DEVIN_AI_ORG_ID }}
           start-message: ${{ steps.context.outputs.start-message }}
           extra-context: ${{ steps.context.outputs.extra-context }}
           tags: |

--- a/.github/workflows/ai-docs-review-command.yml
+++ b/.github/workflows/ai-docs-review-command.yml
@@ -176,7 +176,7 @@ jobs:
 
       - name: Start AI documentation recommendation session
         if: steps.validate.outputs.valid == 'true' && steps.pr-files.outputs.has_connector_changes == 'true'
-        uses: aaronsteers/devin-action@0d74d6d9ff1b16ada5966dc31af53a9d155759f4 # Pinned to specific commit for security
+        uses: aaronsteers/devin-action@main
         with:
           comment-id: ${{ inputs.comment-id }}
           issue-number: ${{ inputs.pr }}
@@ -184,6 +184,8 @@ jobs:
           github-token: ${{ steps.get-app-token.outputs.token }}
           playbook-macro: "!connectordocs_pr_review"
           prompt-text: "The pull request to review is ${{ inputs.pr }}."
+          api-version: v3
+          org-id: ${{ vars.DEVIN_AI_ORG_ID }}
           start-message: "AI Docs Review session starting... Analyzing connector changes and preparing documentation recommendations."
           tags: |
             area/documentation

--- a/.github/workflows/ai-docs-review-command.yml
+++ b/.github/workflows/ai-docs-review-command.yml
@@ -176,7 +176,7 @@ jobs:
 
       - name: Start AI documentation recommendation session
         if: steps.validate.outputs.valid == 'true' && steps.pr-files.outputs.has_connector_changes == 'true'
-        uses: aaronsteers/devin-action@main
+        uses: aaronsteers/devin-action@v0.5.0
         with:
           comment-id: ${{ inputs.comment-id }}
           issue-number: ${{ inputs.pr }}

--- a/.github/workflows/ai-prove-fix-command.yml
+++ b/.github/workflows/ai-prove-fix-command.yml
@@ -60,7 +60,7 @@ jobs:
             > [View workflow run](${{ steps.job-vars.outputs.run-url }})
 
       - name: Run AI Prove Fix
-        uses: aaronsteers/devin-action@main
+        uses: aaronsteers/devin-action@v0.5.0
         with:
           comment-id: ${{ inputs.comment-id }}
           issue-number: ${{ inputs.pr }}

--- a/.github/workflows/ai-prove-fix-command.yml
+++ b/.github/workflows/ai-prove-fix-command.yml
@@ -67,6 +67,8 @@ jobs:
           playbook-macro: "!prove_fix"
           devin-token: ${{ secrets.DEVIN_AI_API_KEY }}
           github-token: ${{ steps.get-app-token.outputs.token }}
+          api-version: v3
+          org-id: ${{ vars.DEVIN_AI_ORG_ID }}
           start-message: "🔍 **AI Prove Fix session starting...** Running readiness checks and testing against customer connections. [View playbook](https://github.com/airbytehq/oncall/blob/main/prompts/playbooks/prove_fix.md)"
           tags: |
             ai-oncall

--- a/.github/workflows/ai-release-watch-command.yml
+++ b/.github/workflows/ai-release-watch-command.yml
@@ -67,6 +67,8 @@ jobs:
           playbook-macro: "!release_watch"
           devin-token: ${{ secrets.DEVIN_AI_API_KEY }}
           github-token: ${{ steps.get-app-token.outputs.token }}
+          api-version: v3
+          org-id: ${{ vars.DEVIN_AI_ORG_ID }}
           start-message: "👁️ **AI Release Watch session starting...** Monitoring rollout and tracking sync success rates. [View playbook](https://github.com/airbytehq/oncall/blob/main/prompts/playbooks/release_watch.md)"
           tags: |
             ai-oncall

--- a/.github/workflows/ai-release-watch-command.yml
+++ b/.github/workflows/ai-release-watch-command.yml
@@ -60,7 +60,7 @@ jobs:
             > [View workflow run](${{ steps.job-vars.outputs.run-url }})
 
       - name: Run AI Release Watch
-        uses: aaronsteers/devin-action@main
+        uses: aaronsteers/devin-action@v0.5.0
         with:
           comment-id: ${{ inputs.comment-id }}
           issue-number: ${{ inputs.pr }}

--- a/.github/workflows/ai-review-command.yml
+++ b/.github/workflows/ai-review-command.yml
@@ -97,6 +97,8 @@ jobs:
           playbook-macro: "!pr_ai_review"
           devin-token: ${{ secrets.DEVIN_AI_API_KEY }}
           github-token: ${{ steps.get-app-token.outputs.token }}
+          api-version: v3
+          org-id: ${{ vars.DEVIN_AI_ORG_ID }}
           start-message: |
             **AI PR Review** starting...
 

--- a/.github/workflows/ai-review-command.yml
+++ b/.github/workflows/ai-review-command.yml
@@ -90,7 +90,7 @@ jobs:
             > [View workflow run](${{ steps.job-vars.outputs.run-url }})
 
       - name: Run PR AI Review
-        uses: aaronsteers/devin-action@main
+        uses: aaronsteers/devin-action@v0.5.0
         with:
           comment-id: ${{ inputs.comment-id }}
           issue-number: ${{ inputs.pr }}

--- a/.github/workflows/autodoc.yml
+++ b/.github/workflows/autodoc.yml
@@ -102,7 +102,7 @@ jobs:
         if: steps.check-connector.outputs.connector_changed == 'true'
         env:
           PROMPT_TEXT: "The commit to review is ${{ github.sha }}. This commit was pushed to master and may contain connector changes that need documentation updates."
-        uses: aaronsteers/devin-action@main
+        uses: aaronsteers/devin-action@v0.5.0
         with:
           devin-token: ${{ secrets.DEVIN_AI_API_KEY }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/autodoc.yml
+++ b/.github/workflows/autodoc.yml
@@ -102,12 +102,14 @@ jobs:
         if: steps.check-connector.outputs.connector_changed == 'true'
         env:
           PROMPT_TEXT: "The commit to review is ${{ github.sha }}. This commit was pushed to master and may contain connector changes that need documentation updates."
-        uses: aaronsteers/devin-action@98d15ae93d1848914f5ab8e9ce45341182958d27 # v0.1.7 - Pinned to specific commit for security
+        uses: aaronsteers/devin-action@main
         with:
           devin-token: ${{ secrets.DEVIN_AI_API_KEY }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           playbook-macro: "!connectordocs" # Use the connector documentation playbook
           prompt-text: ${{ env.PROMPT_TEXT }}
+          api-version: v3
+          org-id: ${{ vars.DEVIN_AI_ORG_ID }}
           tags: |
             area/documentation
             team/documentation

--- a/.github/workflows/oss-issue-triage.yml
+++ b/.github/workflows/oss-issue-triage.yml
@@ -85,7 +85,7 @@ jobs:
           private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
 
       - name: Run AI Triage
-        uses: aaronsteers/devin-action@main
+        uses: aaronsteers/devin-action@v0.5.0
         with:
           issue-number: ${{ github.event.issue.number }}
           playbook-macro: "!oss_issue_triage"
@@ -162,7 +162,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Run AI Triage
-        uses: aaronsteers/devin-action@main
+        uses: aaronsteers/devin-action@v0.5.0
         with:
           playbook-macro: "!oss_issue_triage"
           devin-token: ${{ secrets.DEVIN_AI_API_KEY }}

--- a/.github/workflows/oss-issue-triage.yml
+++ b/.github/workflows/oss-issue-triage.yml
@@ -85,12 +85,14 @@ jobs:
           private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
 
       - name: Run AI Triage
-        uses: aaronsteers/devin-action@v0.2.0
+        uses: aaronsteers/devin-action@main
         with:
           issue-number: ${{ github.event.issue.number }}
           playbook-macro: "!oss_issue_triage"
           devin-token: ${{ secrets.DEVIN_AI_API_KEY }}
           github-token: ${{ steps.get-app-token.outputs.token }}
+          api-version: v3
+          org-id: ${{ vars.DEVIN_AI_ORG_ID }}
           start-message: |
             **AI Triage Starting...**
 
@@ -160,12 +162,14 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Run AI Triage
-        uses: aaronsteers/devin-action@v0.2.0
+        uses: aaronsteers/devin-action@main
         with:
           playbook-macro: "!oss_issue_triage"
           devin-token: ${{ secrets.DEVIN_AI_API_KEY }}
           github-token: ${{ steps.get-app-token.outputs.token }}
           prompt-text: ${{ steps.prepare-prompt.outputs.prompt }}
+          api-version: v3
+          org-id: ${{ vars.DEVIN_AI_ORG_ID }}
           tags: |
             oss-issue-triage
             community-discussion


### PR DESCRIPTION
## What

Migrate all `aaronsteers/devin-action` usages to the Devin v3 API by adding `api-version: v3` and `org-id: ${{ vars.DEVIN_AI_ORG_ID }}` to every workflow that invokes the action, and pin all references to the `v0.5.0` release tag.

## How

Across all 8 workflow files (9 invocations) that use `devin-action`:
- Added `api-version: v3` input
- Added `org-id: ${{ vars.DEVIN_AI_ORG_ID }}` input (reads from GitHub Actions variables)
- Pinned all references to `@v0.5.0` (the latest release):
  - 5 files moved from `@main` → `@v0.5.0`
  - `oss-issue-triage.yml` bumped from `@v0.2.0` → `@v0.5.0`
  - `autodoc.yml` bumped from pinned commit SHA (`v0.1.7`) → `@v0.5.0`
  - `ai-docs-review-command.yml` bumped from pinned commit SHA → `@v0.5.0`

## Review guide

All 8 files follow the same mechanical pattern (add `api-version: v3` + `org-id`, pin to `@v0.5.0`). The ones worth a closer look:

1. `oss-issue-triage.yml` — two separate `devin-action` invocations (issue + discussion), both updated; version bumped from `@v0.2.0` → `@v0.5.0`
2. `autodoc.yml` — version bumped from pinned commit (`v0.1.7`) → `@v0.5.0`
3. `ai-docs-review-command.yml` — version bumped from pinned commit → `@v0.5.0`

**Pre-merge checklist:**
- [ ] `vars.DEVIN_AI_ORG_ID` is configured as a GitHub Actions variable (repo or org level) — workflows will fail at the action's input validation step if this is missing
- [ ] `secrets.DEVIN_AI_API_KEY` is a v3-compatible Service User credential (PATs are not supported for v3)

## User Impact

No user-facing impact. These are internal CI workflows that trigger Devin AI sessions for triage, docs, reviews, and release management. After merge, sessions will be created via the v3 API endpoint instead of v1.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/151617914e3c4c83825f4db701f8feff
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75413" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
