### PR TITLE
ci: temporarily pin devin-action to @main for v3 iteration

### DIFF
--- a/.github/workflows/ai-canary-prerelease-command.yml
+++ b/.github/workflows/ai-canary-prerelease-command.yml
@@ -60,7 +60,7 @@ jobs:
             > [View workflow run](${{ steps.job-vars.outputs.run-url }})
 
       - name: Run AI Canary Prerelease
-        uses: aaronsteers/devin-action@v0.5.0
+        uses: aaronsteers/devin-action@main
         with:
           comment-id: ${{ inputs.comment-id }}
           issue-number: ${{ inputs.pr }}

--- a/.github/workflows/ai-create-docs-pr-command.yml
+++ b/.github/workflows/ai-create-docs-pr-command.yml
@@ -136,7 +136,7 @@ jobs:
             > [View workflow run](${{ steps.job-vars.outputs.run-url }})
 
       - name: Run AI Create Docs PR
-        uses: aaronsteers/devin-action@v0.5.0
+        uses: aaronsteers/devin-action@main
         with:
           comment-id: ${{ inputs.comment-id }}
           issue-number: ${{ inputs.pr }}

--- a/.github/workflows/ai-docs-review-command.yml
+++ b/.github/workflows/ai-docs-review-command.yml
@@ -176,7 +176,7 @@ jobs:
 
       - name: Start AI documentation recommendation session
         if: steps.validate.outputs.valid == 'true' && steps.pr-files.outputs.has_connector_changes == 'true'
-        uses: aaronsteers/devin-action@v0.5.0
+        uses: aaronsteers/devin-action@main
         with:
           comment-id: ${{ inputs.comment-id }}
           issue-number: ${{ inputs.pr }}

--- a/.github/workflows/ai-prove-fix-command.yml
+++ b/.github/workflows/ai-prove-fix-command.yml
@@ -60,7 +60,7 @@ jobs:
             > [View workflow run](${{ steps.job-vars.outputs.run-url }})
 
       - name: Run AI Prove Fix
-        uses: aaronsteers/devin-action@v0.5.0
+        uses: aaronsteers/devin-action@main
         with:
           comment-id: ${{ inputs.comment-id }}
           issue-number: ${{ inputs.pr }}

--- a/.github/workflows/ai-release-watch-command.yml
+++ b/.github/workflows/ai-release-watch-command.yml
@@ -60,7 +60,7 @@ jobs:
             > [View workflow run](${{ steps.job-vars.outputs.run-url }})
 
       - name: Run AI Release Watch
-        uses: aaronsteers/devin-action@v0.5.0
+        uses: aaronsteers/devin-action@main
         with:
           comment-id: ${{ inputs.comment-id }}
           issue-number: ${{ inputs.pr }}

--- a/.github/workflows/ai-review-command.yml
+++ b/.github/workflows/ai-review-command.yml
@@ -90,7 +90,7 @@ jobs:
             > [View workflow run](${{ steps.job-vars.outputs.run-url }})
 
       - name: Run PR AI Review
-        uses: aaronsteers/devin-action@v0.5.0
+        uses: aaronsteers/devin-action@main
         with:
           comment-id: ${{ inputs.comment-id }}
           issue-number: ${{ inputs.pr }}

--- a/.github/workflows/autodoc.yml
+++ b/.github/workflows/autodoc.yml
@@ -102,7 +102,7 @@ jobs:
         if: steps.check-connector.outputs.connector_changed == 'true'
         env:
           PROMPT_TEXT: "The commit to review is ${{ github.sha }}. This commit was pushed to master and may contain connector changes that need documentation updates."
-        uses: aaronsteers/devin-action@v0.5.0
+        uses: aaronsteers/devin-action@main
         with:
           devin-token: ${{ secrets.DEVIN_AI_API_KEY }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/oss-issue-triage.yml
+++ b/.github/workflows/oss-issue-triage.yml
@@ -85,7 +85,7 @@ jobs:
           private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
 
       - name: Run AI Triage
-        uses: aaronsteers/devin-action@v0.5.0
+        uses: aaronsteers/devin-action@main
         with:
           issue-number: ${{ github.event.issue.number }}
           playbook-macro: "!oss_issue_triage"
@@ -162,7 +162,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Run AI Triage
-        uses: aaronsteers/devin-action@v0.5.0
+        uses: aaronsteers/devin-action@main
         with:
           playbook-macro: "!oss_issue_triage"
           devin-token: ${{ secrets.DEVIN_AI_API_KEY }}


### PR DESCRIPTION
## What

Switch all `aaronsteers/devin-action` references from `@v0.5.0` to `@main` to pick up the `advanced_mode` fix ([aaronsteers/devin-action#43](https://github.com/aaronsteers/devin-action/pull/43)).

The previous PR (#75413) migrated these workflows to `api-version: v3` and pinned to `@v0.5.0`. Testing revealed that v0.5.0 sends `"advanced_mode": ""` in the v3 payload when `advanced-mode` is not set, which the v3 API rejects. The fix is merged to `main` but not yet released as a tag.

## How

Mechanical find-replace of `@v0.5.0` → `@main` across all 8 workflow files (9 invocations). No other changes.

## Review guide

All files follow the same one-line change. Spot-check any one file to confirm the pattern.

**Important:** This is intentionally temporary. Once v3 is confirmed working end-to-end, we'll re-pin to a known-good release tag.

## User Impact

No user-facing impact. Internal CI workflows that trigger Devin AI sessions will now use the latest action code from `main`, which includes the `advanced_mode` fix needed for v3 API compatibility.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/151617914e3c4c83825f4db701f8feff
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75414" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
