### PR TITLE
ci: auto-convert connector version tags to PEP 440 for PyPI publishing

### DIFF
--- a/poe-tasks/publish-python-registry.sh
+++ b/poe-tasks/publish-python-registry.sh
@@ -45,6 +45,30 @@ function get_pypi_package_name() {
     yq eval '.data.remoteRegistries.pypi.packageName' "$1"
 }
 
+function to_pep440() {
+    # Convert a semver-style version string to PEP 440 format for PyPI compatibility.
+    #
+    # Docker tags use semver pre-release syntax (e.g. "1.2.3-preview.abc1234" or "1.2.3-rc1"),
+    # but PyPI requires PEP 440 (https://peps.python.org/pep-0440/), which does not allow hyphens.
+    #
+    # Conversions applied:
+    #   X.Y.Z-preview.SHA  ->  X.Y.Z.devYYYYMMDDHHMM  (timestamp-based; SHA dropped, PyPI forbids local identifiers)
+    #   X.Y.Z-rc1          ->  X.Y.Zrc1
+    #   X.Y.Z              ->  X.Y.Z       (no change)
+    #
+    local version="$1"
+    if [[ "$version" =~ ^([0-9]+\.[0-9]+\.[0-9]+)-preview\..+$ ]]; then
+        # Use a timestamp to keep each preview build unique on PyPI.
+        local ts
+        ts=$(date +"%Y%m%d%H%M")
+        echo "${BASH_REMATCH[1]}.dev${ts}"
+    elif [[ "$version" =~ ^([0-9]+\.[0-9]+\.[0-9]+)-(rc[0-9]+)$ ]]; then
+        echo "${BASH_REMATCH[1]}${BASH_REMATCH[2]}"
+    else
+        echo "$version"
+    fi
+}
+
 # Default values
 REGISTRY_UPLOAD_URL="https://upload.pypi.org/legacy/"
 REGISTRY_CHECK_URL="https://pypi.org/pypi"
@@ -157,14 +181,15 @@ BASE_VERSION=$(poe -qq get-version)
 if [[ -n "$VERSION_OVERRIDE" ]]; then
     VERSION="$VERSION_OVERRIDE"
 elif [[ -n "${CONNECTOR_VERSION_TAG:-}" ]]; then
-    # When set by the publish workflow, use the pre-resolved tag directly.
-    VERSION="$CONNECTOR_VERSION_TAG"
+    # When set by the publish workflow, convert Docker-style semver tag to PEP 440 for PyPI.
+    # e.g. "5.2.3-preview.d3e969f" -> "5.2.3.dev202603241200"
+    VERSION="$(to_pep440 "$CONNECTOR_VERSION_TAG")"
 elif [[ "$SEMVER_SUFFIX" == "preview" ]]; then
     # Add current timestamp for preview builds.
     # we can't use the git revision because not all python registries allow local version identifiers. 
     # Public version identifiers must conform to PEP 440 and only allow digits.
     TIMESTAMP=$(date +"%Y%m%d%H%M")
-    VERSION="${BASE_VERSION}.dev.${TIMESTAMP}"
+    VERSION="${BASE_VERSION}.dev${TIMESTAMP}"
 elif [[ "$SEMVER_SUFFIX" == "rc" ]]; then
     # Add rc1 suffix for release candidates
     VERSION="${BASE_VERSION}rc1"


### PR DESCRIPTION
## What

Fixes pre-release connector publish failures caused by non-PEP-440 version strings being passed to PyPI.

The publish workflow sets `CONNECTOR_VERSION_TAG` to Docker-style semver strings like `5.2.3-preview.d3e969f`, but PyPI/Poetry rejects these because hyphens are not [PEP 440](https://peps.python.org/pep-0440/) compliant. This caused the "Publish to Python Registry" step to fail in three recent runs:
- [23478186081](https://github.com/airbytehq/airbyte/actions/runs/23478186081) (`source-facebook-marketing`)
- [23500179183](https://github.com/airbytehq/airbyte/actions/runs/23500179183) (`source-github`)

Error: `Invalid version '5.2.3-preview.d3e969f' on package airbyte-source-facebook-marketing`

Also fixes a secondary PEP 440 issue: the existing fallback path produced `.dev.TIMESTAMP` (extra dot between `dev` and the number), which is not valid PEP 440 either.

## How

Adds a `to_pep440()` bash function that converts semver-style version tags to PEP 440 before use as the PyPI version:

| Input (Docker tag) | Output (PyPI version) |
|---|---|
| `5.2.3-preview.d3e969f` | `5.2.3.dev202603241200` |
| `5.2.3-rc1` | `5.2.3rc1` |
| `5.2.3` | `5.2.3` (no change) |

Preview builds use a timestamp suffix (not the git SHA) because PyPI forbids local version identifiers.

## Review guide

Single file change: `poe-tasks/publish-python-registry.sh`

1. **`to_pep440()` function (lines 48–70)**: The regex patterns and PEP 440 output formats. Verify:
   - Preview: SHA is intentionally dropped (PyPI forbids `+local` identifiers); timestamp provides uniqueness instead. Two builds within the same minute would collide — the existing "already exists" check skips silently, which seems acceptable.
   - RC: `X.Y.Z-rc1` → `X.Y.Zrc1` is correct PEP 440.
   - Passthrough: unrecognized formats are returned as-is (no silent mangling).
2. **Line 186**: `CONNECTOR_VERSION_TAG` now passes through `to_pep440()` instead of being used verbatim.
3. **Line 192**: `.dev.${TIMESTAMP}` → `.dev${TIMESTAMP}` — fixes the existing fallback path to also be PEP 440 compliant.

## User Impact

Pre-release connector publishes (`/publish-connectors-prerelease`) will no longer fail at the PyPI step. Docker image publishing was unaffected by this bug and remains unchanged.

Note: the PyPI version for preview builds will no longer contain the git SHA (e.g., `5.2.3.dev202603241200` instead of `5.2.3-preview.d3e969f`). The Docker tag still contains the SHA.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/3188d2c4f5e64cbe85c2487e7b15397e
Requested by: @aaronsteers