### PR TITLE
ci: skip PyPI publish for pre-release connector builds

### DIFF
--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -268,7 +268,7 @@ jobs:
 
       - name: Publish to Python Registry
         id: publish-python-registry
-        if: steps.connector-metadata.outputs.connector-language == 'python' && needs.publish_options.outputs.dry-run != 'true'
+        if: steps.connector-metadata.outputs.connector-language == 'python' && needs.publish_options.outputs.dry-run != 'true' && needs.publish_options.outputs.with-semver-suffix == 'none'
         shell: bash
         run: |
           ./poe-tasks/publish-python-registry.sh --name ${{ matrix.connector }} --with-semver-suffix ${{ needs.publish_options.outputs.with-semver-suffix }}
@@ -276,8 +276,13 @@ jobs:
           PYTHON_REGISTRY_TOKEN: ${{ secrets.PYPI_TOKEN }}
           CONNECTOR_VERSION_TAG: ${{ steps.resolve-version.outputs.connector-version-tag }}
 
+      - name: "[SKIP] Pre-release: Skip Publish to Python Registry"
+        if: steps.connector-metadata.outputs.connector-language == 'python' && needs.publish_options.outputs.with-semver-suffix != 'none'
+        run: |
+          echo "Skipping PyPI publish for pre-release build (semver-suffix=${{ needs.publish_options.outputs.with-semver-suffix }})"
+
       - name: "[DRY-RUN] Skip Publish to Python Registry"
-        if: steps.connector-metadata.outputs.connector-language == 'python' && needs.publish_options.outputs.dry-run == 'true'
+        if: steps.connector-metadata.outputs.connector-language == 'python' && needs.publish_options.outputs.dry-run == 'true' && needs.publish_options.outputs.with-semver-suffix == 'none'
         run: |
           echo "DRY-RUN: Skipping Python Registry publish for ${{ matrix.connector }}"
 

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -276,11 +276,6 @@ jobs:
           PYTHON_REGISTRY_TOKEN: ${{ secrets.PYPI_TOKEN }}
           CONNECTOR_VERSION_TAG: ${{ steps.resolve-version.outputs.connector-version-tag }}
 
-      - name: "[SKIP] Pre-release: Skip Publish to Python Registry"
-        if: steps.connector-metadata.outputs.connector-language == 'python' && needs.publish_options.outputs.with-semver-suffix != 'none'
-        run: |
-          echo "Skipping PyPI publish for pre-release build (semver-suffix=${{ needs.publish_options.outputs.with-semver-suffix }})"
-
       - name: "[DRY-RUN] Skip Publish to Python Registry"
         if: steps.connector-metadata.outputs.connector-language == 'python' && needs.publish_options.outputs.dry-run == 'true' && needs.publish_options.outputs.with-semver-suffix == 'none'
         run: |


### PR DESCRIPTION
## What

Fixes pre-release connector publish failures caused by non-PEP-440 version strings being passed to PyPI.

The publish workflow sets `CONNECTOR_VERSION_TAG` to Docker-style semver strings like `5.2.3-preview.d3e969f`, but PyPI/Poetry rejects these because hyphens are not [PEP 440](https://peps.python.org/pep-0440/) compliant. This caused the "Publish to Python Registry" step to fail in recent pre-release runs:
- [23478186081](https://github.com/airbytehq/airbyte/actions/runs/23478186081) (`source-facebook-marketing`): `Invalid version '5.2.3-preview.d3e969f'`
- [23500179183](https://github.com/airbytehq/airbyte/actions/runs/23500179183) (`source-github`): `Invalid version '2.1.15-preview.94eb249'`

Since the primary artifact for pre-releases is the Docker image (which publishes successfully), PyPI publishing is not needed for preview/RC builds.

## How

Gates the "Publish to Python Registry" and its dry-run counterpart with `needs.publish_options.outputs.with-semver-suffix == 'none'` so they only run for production releases. For pre-release builds, these steps are silently skipped.

## Review guide

1. `.github/workflows/publish_connectors.yml` — the only change. Two `if` conditions updated.

### Human review checklist

- [ ] Confirm `with-semver-suffix` is always `'none'` (never empty/unset) for production publish runs, so the new gate doesn't accidentally skip production PyPI publishes.
- [ ] Confirm the "Upload Python Dependencies to GCS" step (unchanged) doesn't need the same pre-release skip treatment — it also receives `CONNECTOR_VERSION_TAG` with the non-PEP-440 value.

## User Impact

Pre-release connector publishes (`/publish-connectors-prerelease`) will no longer fail at the PyPI step. Docker image publishing is unaffected. Production connector publishes (`with-semver-suffix == 'none'`) are unchanged.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/3188d2c4f5e64cbe85c2487e7b15397e
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75417" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
