### PR TITLE
ci: improve publish failure notifications for pre-release builds

### DIFF
--- a/.github/workflows/publish-connectors-prerelease-command.yml
+++ b/.github/workflows/publish-connectors-prerelease-command.yml
@@ -148,6 +148,7 @@ jobs:
       connectors: ${{ format('--name={0}', needs.init.outputs.connector-name) }}
       with-semver-suffix: preview
       gitref: refs/pull/${{ inputs.pr }}/head
+      pr: ${{ inputs.pr }}
     secrets: inherit
 
   post-completion:
@@ -175,6 +176,7 @@ jobs:
 
       - name: Prepare message variables
         id: message-vars
+        if: needs.publish.result == 'success'
         run: |
           CONNECTOR_NAME="${{ needs.init.outputs.connector-name }}"
           # Use the actual docker-image-tag from the publish workflow output
@@ -192,7 +194,8 @@ jobs:
           echo "oss_registry_url=https://connectors.airbyte.com/files/metadata/airbyte/$CONNECTOR_NAME/$DOCKER_TAG/oss.json" >> $GITHUB_OUTPUT
           echo "cloud_registry_url=https://connectors.airbyte.com/files/metadata/airbyte/$CONNECTOR_NAME/$DOCKER_TAG/cloud.json" >> $GITHUB_OUTPUT
 
-      - name: Append completion comment
+      - name: Append completion comment (success)
+        if: needs.publish.result == 'success'
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
           comment-id: ${{ needs.init.outputs.comment-id }}
@@ -208,3 +211,12 @@ jobs:
             > **Registry JSON:**
             > - [OSS Registry](${{ steps.message-vars.outputs.oss_registry_url }})
             > - [Cloud Registry](${{ steps.message-vars.outputs.cloud_registry_url }})
+
+      - name: Append completion comment (failure)
+        if: needs.publish.result != 'success'
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        with:
+          comment-id: ${{ needs.init.outputs.comment-id }}
+          issue-number: ${{ needs.init.outputs.pr-number }}
+          body: |
+            ${{ steps.status.outputs.status_emoji }} **Pre-release Publish ${{ steps.status.outputs.status_text }}** for `${{ needs.init.outputs.connector-name }}`. [View workflow run](${{ needs.init.outputs.run-url }})

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -35,6 +35,10 @@ on:
         required: false
         default: false
         type: boolean
+      pr:
+        description: "Pull request number that triggered this workflow (used for Slack notifications and run URL linking)."
+        required: false
+        type: number
     outputs:
       docker-image-tag:
         description: "Docker image tag used when publishing. For single-connector callers only; multi-connector callers should not rely on this output."
@@ -549,7 +553,8 @@ jobs:
     runs-on: ubuntu-24.04
     needs:
       - publish_connector_registry_entries
-    if: ${{ always() && contains(needs.*.result, 'failure') && github.ref == 'refs/heads/master' }}
+      - publish_options
+    if: ${{ always() && contains(needs.publish_connector_registry_entries.result, 'failure') }}
     steps:
       - name: Authenticate as GitHub App
         uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
@@ -573,6 +578,37 @@ jobs:
         env:
           AIRBYTE_TEAM_BOT_SLACK_TOKEN: ${{ secrets.SLACK_AIRBYTE_TEAM_READ_USERS }}
           GITHUB_API_TOKEN: ${{ steps.get-app-token.outputs.token }}
+      - name: Build notification context
+        id: context
+        run: |
+          PR_NUMBER="${{ inputs.pr }}"
+          SEMVER_SUFFIX="${{ needs.publish_options.outputs.with-semver-suffix }}"
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+          # Append ?pr=N for "Back to pull request" link in GitHub Actions UI
+          if [[ -n "$PR_NUMBER" && "$PR_NUMBER" != "0" ]]; then
+            RUN_URL="${RUN_URL}?pr=${PR_NUMBER}"
+          fi
+
+          # Determine release type label
+          if [[ "$SEMVER_SUFFIX" == "none" || -z "$SEMVER_SUFFIX" ]]; then
+            RELEASE_TYPE="GA"
+          else
+            RELEASE_TYPE="Pre-release (${SEMVER_SUFFIX})"
+          fi
+
+          # Build trigger description
+          if [[ -n "$PR_NUMBER" && "$PR_NUMBER" != "0" ]]; then
+            TRIGGER_TEXT="triggered from PR <${{ github.server_url }}/${{ github.repository }}/pull/${PR_NUMBER}|#${PR_NUMBER}>"
+          elif [[ "${{ github.ref }}" == "refs/heads/master" ]]; then
+            TRIGGER_TEXT="merged to main"
+          else
+            TRIGGER_TEXT="triggered via workflow_dispatch"
+          fi
+
+          echo "run-url=$RUN_URL" >> $GITHUB_OUTPUT
+          echo "release-type=$RELEASE_TYPE" >> $GITHUB_OUTPUT
+          echo "trigger-text=$TRIGGER_TEXT" >> $GITHUB_OUTPUT
       - name: Send publish failures to connector-publish-failures channel
         id: slack
         uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
@@ -582,7 +618,7 @@ jobs:
             {
               "channel": "#connector-publish-failures",
               "username": "Connectors CI/CD Bot",
-              "text": "🚨 Publish workflow failed:\n ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} \n merged by ${{ github.actor }} (<@${{ steps.match-github-to-slack-user.outputs.slack_user_ids }}>). "
+              "text": "🚨 ${{ steps.context.outputs.release-type }} publish workflow failed:\n <${{ steps.context.outputs.run-url }}|View workflow run>\n ${{ steps.context.outputs.trigger-text }} by ${{ github.actor }} (<@${{ steps.match-github-to-slack-user.outputs.slack_user_ids }}>)."
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.PUBLISH_ON_MERGE_SLACK_WEBHOOK }}

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -553,8 +553,9 @@ jobs:
     runs-on: ubuntu-24.04
     needs:
       - publish_connector_registry_entries
+      - publish_connectors
       - publish_options
-    if: ${{ always() && contains(needs.publish_connector_registry_entries.result, 'failure') }}
+    if: ${{ always() && (needs.publish_connector_registry_entries.result == 'failure' || needs.publish_connectors.result == 'failure') }}
     steps:
       - name: Authenticate as GitHub App
         uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
@@ -601,9 +602,13 @@ jobs:
           if [[ -n "$PR_NUMBER" && "$PR_NUMBER" != "0" ]]; then
             TRIGGER_TEXT="triggered from PR <${{ github.server_url }}/${{ github.repository }}/pull/${PR_NUMBER}|#${PR_NUMBER}>"
           elif [[ "${{ github.ref }}" == "refs/heads/master" ]]; then
-            TRIGGER_TEXT="merged to main"
-          else
+            TRIGGER_TEXT="merged to master"
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             TRIGGER_TEXT="triggered via workflow_dispatch"
+          elif [[ "${{ github.event_name }}" == "workflow_call" ]]; then
+            TRIGGER_TEXT="triggered via workflow_call"
+          else
+            TRIGGER_TEXT="triggered via ${{ github.event_name }}"
           fi
 
           echo "run-url=$RUN_URL" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## What

Two issues with publish failure notifications when triggered from pre-release builds (`/publish-connectors-prerelease`):

1. **Slack notification never fires for pre-releases** — the `notify-failure-slack-channel` job was gated on `github.ref == 'refs/heads/master'`, so pre-release failures from PR branches were silently swallowed. When it does fire (GA), the message doesn't distinguish release type or link back to the triggering PR.
2. **PR comment never posted on failure** — in the pre-release workflow, the `post-completion` job's "Prepare message variables" step calls `exit 1` when `docker-image-tag` is empty (which it always is on failure), so the `:x:` completion comment is never appended to the slash command comment.

## How

### `publish_connectors.yml`
- Add optional `pr` input (`type: number`) to `workflow_call` inputs
- Remove `github.ref == 'refs/heads/master'` gate from `notify-failure-slack-channel` so it fires for all publish failures
- Add `publish_connectors` and `publish_options` to the job's `needs` so we can detect failures in either the publish or registry-entries jobs, and read `with-semver-suffix`
- New "Build notification context" step constructs:
  - Run URL with `?pr=N` suffix (enables GitHub's "Back to pull request" link in the Actions UI)
  - Release type label: `GA` vs `Pre-release (preview)`
  - Trigger description: "triggered from PR #N" / "merged to master" / "triggered via workflow_dispatch" / "triggered via workflow_call"
- Slack message now uses the enriched context

### `publish-connectors-prerelease-command.yml`
- Pass `pr` input through to `publish_connectors.yml`
- Gate `message-vars` step on `needs.publish.result == 'success'` so it doesn't `exit 1` on failures
- Split completion comment into success (existing rich template) and failure (`:x:` status + workflow run link) variants

## Review guide

1. `publish_connectors.yml` — Slack notification changes (new `pr` input, removed master gate, enriched message)
2. `publish-connectors-prerelease-command.yml` — failure comment fix and `pr` passthrough

### Human review checklist

- [ ] **`inputs.pr` default for number type**: When `pr` is not provided (e.g., on push to master), GitHub Actions sets optional number inputs to `0`. The "Build notification context" step checks `"$PR_NUMBER" != "0"` to handle this — verify this is correct behavior.
- [ ] **PagerDuty notification intentionally unchanged**: `notify-failure-pager-duty` still has the `github.ref == 'refs/heads/master'` gate, so it only pages for GA failures. Confirm this is desired (pre-release failures → Slack only, no PagerDuty).
- [ ] **Matrix job failure detection**: `publish_connectors` uses `strategy.matrix` with `fail-fast: false`. Verify that `needs.publish_connectors.result == 'failure'` correctly captures the case where any matrix job fails (GitHub Actions docs say the aggregate result is `failure` if any matrix job fails).
- [ ] **Slack webhook compatibility**: The `PUBLISH_ON_MERGE_SLACK_WEBHOOK` will now receive messages for pre-release failures too. Confirm the webhook has no channel or content restrictions that would break.
- [ ] **Enterprise repo compatibility**: `airbyte-enterprise` calls `publish_connectors.yml@master` without passing `pr` (confirmed compatible — it only runs from master push / workflow_dispatch, so `pr=0` correctly falls through to "merged to master" or event-name-based trigger text).

## User Impact

- Pre-release publish failures now post a `:x:` status comment back to the slash command comment on the PR (previously silent)
- Pre-release publish failures now post to `#connector-publish-failures` Slack channel with clear context: release type, PR link, and run URL with `?pr=N` for easy navigation
- GA publish failure Slack messages are enriched with "GA" label and "merged to master" context
- No change to PagerDuty alerting (still GA-only)

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/3188d2c4f5e64cbe85c2487e7b15397e
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75418" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
