### PR TITLE
chore: promote source-intercom 0.13.16-rc.6 to 0.13.16 GA

### DIFF
--- a/airbyte-integrations/connectors/source-intercom/metadata.yaml
+++ b/airbyte-integrations/connectors/source-intercom/metadata.yaml
@@ -43,7 +43,7 @@ data:
   releaseStage: generally_available
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: true
+      enableProgressiveRollout: false
   suggestedStreams:
     streams:
       - conversations

--- a/airbyte-integrations/connectors/source-intercom/metadata.yaml
+++ b/airbyte-integrations/connectors/source-intercom/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: d8313939-3782-41b0-be29-b3ca20d8dd3a
-  dockerImageTag: 0.13.16-rc.6
+  dockerImageTag: 0.13.16
   dockerRepository: airbyte/source-intercom
   documentationUrl: https://docs.airbyte.com/integrations/sources/intercom
   externalDocumentationUrls:

--- a/docs/integrations/sources/intercom.md
+++ b/docs/integrations/sources/intercom.md
@@ -123,7 +123,7 @@ Because these streams must read all records on every sync, syncing Companies and
 
 | Version      | Date       | Pull Request                                             | Subject                                                                                                                              |
 |:-------------|:-----------|:---------------------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------|
-| 0.13.16 | 2026-03-24 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Promote 0.13.16-rc.6 to GA — includes CDK 7.13.0 upgrade, block_simultaneous_read for companies, rate limiter fix, step size/end_datetime for incremental streams, and heartbeat timeout bump |
+| 0.13.16 | 2026-03-24 | [75419](https://github.com/airbytehq/airbyte/pull/75419) | Promote 0.13.16-rc.6 to GA — includes CDK 7.13.0 upgrade, block_simultaneous_read for companies, rate limiter fix, step size/end_datetime for incremental streams, and heartbeat timeout bump |
 | 0.13.16-rc.6 | 2026-03-19 | [75216](https://github.com/airbytehq/airbyte/pull/75216) | Bump CDK base image to 7.13.0 (includes block_simultaneous_read support and cursor field fix) |
 | 0.13.16-rc.5 | 2026-03-11 | [71141](https://github.com/airbytehq/airbyte/pull/71141) | Block simultaneous reading from companies endpoint |
 | 0.13.16-rc.4 | 2026-03-03 | [74143](https://github.com/airbytehq/airbyte/pull/74143) | fix(source-intercom): fix UnboundLocalError in rate limiter when response is not available |

--- a/docs/integrations/sources/intercom.md
+++ b/docs/integrations/sources/intercom.md
@@ -123,6 +123,7 @@ Because these streams must read all records on every sync, syncing Companies and
 
 | Version      | Date       | Pull Request                                             | Subject                                                                                                                              |
 |:-------------|:-----------|:---------------------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------|
+| 0.13.16 | 2026-03-24 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Promote 0.13.16-rc.6 to GA — includes CDK 7.13.0 upgrade, block_simultaneous_read for companies, rate limiter fix, step size/end_datetime for incremental streams, and heartbeat timeout bump |
 | 0.13.16-rc.6 | 2026-03-19 | [75216](https://github.com/airbytehq/airbyte/pull/75216) | Bump CDK base image to 7.13.0 (includes block_simultaneous_read support and cursor field fix) |
 | 0.13.16-rc.5 | 2026-03-11 | [71141](https://github.com/airbytehq/airbyte/pull/71141) | Block simultaneous reading from companies endpoint |
 | 0.13.16-rc.4 | 2026-03-03 | [74143](https://github.com/airbytehq/airbyte/pull/74143) | fix(source-intercom): fix UnboundLocalError in rate limiter when response is not available |


### PR DESCRIPTION
## What

Manually promotes `source-intercom` from `0.13.16-rc.6` to GA `0.13.16`.

The automated progressive rollout (rollout ID `84ceb503-8ceb-4537-8d29-cb105d531d8b`) is stuck in `finalizing` state — the Temporal workflow (`019d1b19-ce3d-7bf6-b444-b542fffe2500`) did not complete the finalization sequence, so the normal GA bump PR was never auto-generated. This PR creates it manually to unblock the release.

A bug report has been filed: https://github.com/airbytehq/airbyte-ops-mcp/issues/600

## How

1. `metadata.yaml`: Update `dockerImageTag` from `0.13.16-rc.6` → `0.13.16`
2. `metadata.yaml`: Set `enableProgressiveRollout: false` (required for GA versions; CI validation rejects non-RC tags when this is `true`)
3. `docs/integrations/sources/intercom.md`: Add GA changelog entry summarizing all fixes included across rc.1–rc.6

## Review guide

1. `airbyte-integrations/connectors/source-intercom/metadata.yaml` — version bump + rollout flag flip (matches [0.13.0 GA promotion precedent](https://github.com/airbytehq/airbyte/commit/f31bccd99e5))
2. `docs/integrations/sources/intercom.md` — new changelog row for 0.13.16 GA

**Things to verify:**
- Confirm this manual promotion is acceptable given the stuck Temporal workflow, vs. retrying the automated finalization.
- The GCS `release_candidate/` metadata marker may still need separate cleanup (normally handled by `finalize_rollout.yml` GHA).

## User Impact

Connector users on Cloud will receive `source-intercom 0.13.16` as the stable default version once this merges and the registry picks it up. The GA version includes all fixes from rc.1–rc.6 (companies pagination, rate limiter, step size/end_datetime for incremental streams, heartbeat timeout bump, CDK 7.13.0 upgrade with block_simultaneous_read).

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/75c25827e5304cf7a0b4ae9bcebbfd24
Requested by: @agarctfi