### PR TITLE
ci: change pr input type from number to string for workflow_call compatibility

### DIFF
--- a/.github/workflows/publish-connectors-prerelease-command.yml
+++ b/.github/workflows/publish-connectors-prerelease-command.yml
@@ -148,7 +148,7 @@ jobs:
       connectors: ${{ format('--name={0}', needs.init.outputs.connector-name) }}
       with-semver-suffix: preview
       gitref: refs/pull/${{ inputs.pr }}/head
-      pr: ${{ inputs.pr }}
+      pr: ${{ format('{0}', inputs.pr) }}
     secrets: inherit
 
   post-completion:

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -38,7 +38,7 @@ on:
       pr:
         description: "Pull request number that triggered this workflow (used for Slack notifications and run URL linking)."
         required: false
-        type: number
+        type: string
     outputs:
       docker-image-tag:
         description: "Docker image tag used when publishing. For single-connector callers only; multi-connector callers should not rely on this output."


### PR DESCRIPTION
## What

Fixes the `publish-connectors-prerelease` workflow, which is currently broken after #75418. GitHub Actions rejects the `pr` input with `Unexpected value '75107'` when a `workflow_dispatch` number input is passed to a `workflow_call` number input.

Failing run: https://github.com/airbytehq/airbyte/actions/runs/23511447577

## How

- Change `pr` input type from `number` to `string` in `publish_connectors.yml` (the callee)
- Use `format('{0}', inputs.pr)` in the caller to explicitly coerce the number to a string before passing it across the `workflow_call` boundary

## Review guide

1. `publish_connectors.yml` — single-line type change (`number` → `string`)
2. `publish-connectors-prerelease-command.yml` — coerce `inputs.pr` to string via `format()`

### Human review checklist

- [ ] When `pr` is not provided (e.g., push-to-master or enterprise repo), a `string` input defaults to `""` (empty string) instead of `0`. The downstream bash check `[[ -n "$PR_NUMBER" && "$PR_NUMBER" != "0" ]]` handles both correctly — the `-n` test catches empty strings. Verify this is sufficient.

## User Impact

`/publish-connectors-prerelease` slash command works again. No user-facing behavior changes beyond unblocking the workflow.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/3188d2c4f5e64cbe85c2487e7b15397e
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75421" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
