### PR TITLE
fix(ci): allow Slack publish failure notification when github-to-slack user match fails

### DIFF
--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -575,6 +575,7 @@ jobs:
           submodules: true # Required for the enterprise repo since it uses a submodule that needs to exist for this workflow to run successfully.
       - name: Match GitHub User to Slack User
         id: match-github-to-slack-user
+        continue-on-error: true
         uses: ./.github/actions/match-github-to-slack-user
         env:
           AIRBYTE_TEAM_BOT_SLACK_TOKEN: ${{ secrets.SLACK_AIRBYTE_TEAM_READ_USERS }}
@@ -623,7 +624,7 @@ jobs:
             {
               "channel": "#connector-publish-failures",
               "username": "Connectors CI/CD Bot",
-              "text": "🚨 ${{ steps.context.outputs.release-type }} publish workflow failed:\n <${{ steps.context.outputs.run-url }}|View workflow run>\n ${{ steps.context.outputs.trigger-text }} by ${{ github.actor }} (<@${{ steps.match-github-to-slack-user.outputs.slack_user_ids }}>)."
+              "text": "🚨 ${{ steps.context.outputs.release-type }} publish workflow failed:\n <${{ steps.context.outputs.run-url }}|View workflow run>\n ${{ steps.context.outputs.trigger-text }} by ${{ github.actor }}${{ steps.match-github-to-slack-user.outputs.slack_user_ids && format(' (<@{0}>)', steps.match-github-to-slack-user.outputs.slack_user_ids) || '' }}."
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.PUBLISH_ON_MERGE_SLACK_WEBHOOK }}


### PR DESCRIPTION
## What

Fixes the `notify-failure-slack-channel` job silently failing when triggered by bot actors (e.g., `/publish-connectors-prerelease` slash commands). The `match-github-to-slack-user` action exits with code 3 when `github.actor` is a bot that has no Slack profile, which blocks all subsequent steps — including the actual Slack notification.

Observed in workflow run [23511975000](https://github.com/airbytehq/airbyte/actions/runs/23511975000): the "Match GitHub User to Slack User" step failed, causing "Build notification context" and "Send publish failures" to be skipped entirely.

## How

1. Added `continue-on-error: true` to the `match-github-to-slack-user` step so the job continues even when the lookup fails.
2. Changed the Slack message to conditionally include the `<@slack_id>` mention only when a Slack user ID was successfully resolved. When it wasn't, the message still posts but just shows the GitHub actor name without a Slack ping.

## Review guide

1. `.github/workflows/publish_connectors.yml` — both changes are in the `notify-failure-slack-channel` job.

### Human review checklist

- [ ] Verify the GitHub Actions expression `steps.match-github-to-slack-user.outputs.slack_user_ids && format(' (<@{0}>)', ...) || ''` evaluates correctly for both cases: (a) output is a valid Slack ID → includes mention, (b) output is empty/unset → omits mention gracefully.
- [ ] Confirm `continue-on-error: true` is appropriate here — the user lookup is informational and should never block the failure notification itself.

## User Impact

Publish failure notifications will now reliably appear in `#connector-publish-failures` for *all* triggers, including bot-initiated pre-release publishes. Previously, these notifications were silently dropped.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/3188d2c4f5e64cbe85c2487e7b15397e
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75422" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
