### PR TITLE
ci: add ?pr=N suffix to run URL and remove duplicate link in slash command comment

### DIFF
--- a/.github/workflows/publish-connectors-prerelease-command.yml
+++ b/.github/workflows/publish-connectors-prerelease-command.yml
@@ -72,7 +72,12 @@ jobs:
       - name: Get job variables
         id: job-vars
         run: |
-          echo "run-url=https://github.com/${{ github.repository }}/actions/runs/$GITHUB_RUN_ID" >> $GITHUB_OUTPUT
+          RUN_URL="https://github.com/${{ github.repository }}/actions/runs/$GITHUB_RUN_ID"
+          # Append ?pr=N for "Back to pull request" link in GitHub Actions UI
+          if [[ -n "${{ inputs.pr }}" ]]; then
+            RUN_URL="${RUN_URL}?pr=${{ inputs.pr }}"
+          fi
+          echo "run-url=$RUN_URL" >> $GITHUB_OUTPUT
           echo "pr-number=${{ inputs.pr }}" >> $GITHUB_OUTPUT
 
       - name: Resolve connector name
@@ -219,4 +224,4 @@ jobs:
           comment-id: ${{ needs.init.outputs.comment-id }}
           issue-number: ${{ needs.init.outputs.pr-number }}
           body: |
-            ${{ steps.status.outputs.status_emoji }} **Pre-release Publish ${{ steps.status.outputs.status_text }}** for `${{ needs.init.outputs.connector-name }}`. [View workflow run](${{ needs.init.outputs.run-url }})
+            ${{ steps.status.outputs.status_emoji }} **Pre-release Publish ${{ steps.status.outputs.status_text }}** for `${{ needs.init.outputs.connector-name }}`.


### PR DESCRIPTION
## What

The workflow run URL posted in the `/publish-connectors-prerelease` slash command comment was missing the `?pr=N` query parameter (which enables the "Back to pull request #..." button in the GitHub Actions UI). Additionally, the run URL was shown twice in the same comment — once in the "Started" block and again in the failure completion line.

## How

1. In the `job-vars` step, append `?pr=N` to the run URL when a PR number is available.
2. Remove the redundant `[View workflow run](...)` link from the failure completion comment body — it's already present in the "Started" block above (both are appended to the same GitHub comment via `peter-evans/create-or-update-comment`).

## Review guide

1. `.github/workflows/publish-connectors-prerelease-command.yml`

### Human review checklist

- [ ] The `?pr=N` URL format matches what GitHub Actions expects for the "Back to pull request" button (same pattern already used in `publish_connectors.yml`'s Slack notification context step).
- [ ] Removing the link from the failure line is acceptable — the "Started" block above it (same comment) already contains the run URL with the `?pr=N` suffix, so users still have one-click access.
- [ ] `inputs.pr` is `required: true` for this workflow, so the `-n` guard is always true. Confirm this defensive check is preferred over omitting it.

## User Impact

Clicking the workflow run link from the PR comment now shows GitHub's "Back to pull request #..." button. The comment body is cleaner with only one run URL link instead of two.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/3188d2c4f5e64cbe85c2487e7b15397e
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75423" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
