### PR TITLE
ci(publish): ephemeral version bump for pre-release artifact generation

### DIFF
--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -459,6 +459,21 @@ jobs:
               ;;
           esac
 
+      # --- Ephemeral version bump for pre-release builds ---
+      # For preview builds, the metadata.yaml still contains the base version (e.g. 3.2.3)
+      # but the actual published tag is the preview version (e.g. 3.2.3-preview.820ce48).
+      # The artifact generator reads dockerImageTag from metadata.yaml, so we need to
+      # bump it in-place before generating artifacts. This is ephemeral — not committed.
+      # See: https://github.com/airbytehq/airbyte-ops-mcp/issues/604
+      - name: Ephemeral version bump for pre-release
+        if: needs.publish_options.outputs.with-semver-suffix == 'preview'
+        run: |
+          echo "Bumping metadata.yaml version to ${{ steps.connector-metadata.outputs.docker-image-tag }}"
+          airbyte-ops local connector bump-version \
+            --name "${{ matrix.connector }}" \
+            --repo-path "$GITHUB_WORKSPACE" \
+            --new-version "${{ steps.connector-metadata.outputs.docker-image-tag }}"
+
       # --- Registry artifact generation and publishing (ops CLI) ---
       - name: Generate Registry Artifacts
         id: generate-registry-artifacts


### PR DESCRIPTION
## What

Fixes the root cause of [airbytehq/airbyte-ops-mcp#604 (Bug 1)](https://github.com/airbytehq/airbyte-ops-mcp/issues/604): pre-release connector publishes generate registry artifacts with the **base** version tag (e.g. `3.2.3`) instead of the actual preview tag (e.g. `3.2.3-preview.820ce48`). This causes the platform to create `actor_definition_version` records that reference Docker images that don't exist on DockerHub, resulting in image pull backoff errors for pinned connections.

Recent example: `source-shopify:3.2.3` — [PR #75255](https://github.com/airbytehq/airbyte/pull/75255) published preview builds, but the registry artifacts contained `dockerImageTag: 3.2.3` instead of `3.2.3-preview.820ce48`.

## How

Adds a single new step to the `publish_connector_registry_entries` job that runs **before** artifact generation, only for `preview` builds. It calls the existing `airbyte-ops local connector bump-version --new-version <preview-tag>` to update `metadata.yaml`'s `dockerImageTag` in-place. This is ephemeral — not committed back to the repo.

The artifact generator then reads the correct preview version from `metadata.yaml` naturally, producing artifacts with the right `dockerImageTag`.

## Review guide

1. `.github/workflows/publish_connectors.yml` — the only file changed. The new step is inserted between "Get connector metadata" (which computes the preview tag) and "Generate Registry Artifacts" (which reads `dockerImageTag` from metadata.yaml).

Key things to verify:
- The `if` condition correctly gates this to preview builds only
- `bump-version --new-version` without `--changelog-message` only touches `metadata.yaml` (and `pyproject.toml` if present) — no changelog side effects
- The ephemeral file modification cannot leak into a git commit (there is no commit/push step in this job)

## User Impact

Connections pinned to pre-release connector versions will no longer encounter image pull backoff errors. The registry artifacts will contain the correct preview Docker image tag.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/b053cc67d52e4ef695eae678da28798e
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75431" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
