### PR TITLE
feat(source-clickhouse): upgrade ClickHouse JDBC driver to 0.9.8 and remove invalid sslmode=none

### DIFF
--- a/airbyte-integrations/connectors/source-clickhouse/build.gradle
+++ b/airbyte-integrations/connectors/source-clickhouse/build.gradle
@@ -16,7 +16,9 @@ application {
 }
 
 dependencies {
-    implementation 'com.clickhouse:clickhouse-jdbc:0.3.2-patch10:all'
+    implementation('com.clickhouse:clickhouse-jdbc:0.9.8:all') {
+        exclude group: 'at.yawk.lz4', module: 'lz4-java'
+    }
 
     testImplementation 'org.testcontainers:clickhouse:1.19.4'
 }

--- a/airbyte-integrations/connectors/source-clickhouse/metadata.yaml
+++ b/airbyte-integrations/connectors/source-clickhouse/metadata.yaml
@@ -14,7 +14,7 @@ data:
     - suite: acceptanceTests
   connectorType: source
   definitionId: bad83517-5e54-4a3d-9b53-63e85fbd4d7c
-  dockerImageTag: 0.4.0-rc.1
+  dockerImageTag: 1.0.0
   dockerRepository: airbyte/source-clickhouse
   documentationUrl: https://docs.airbyte.com/integrations/sources/clickhouse
   githubIssueLabel: source-clickhouse
@@ -27,10 +27,8 @@ data:
     oss:
       enabled: true
   releases:
-    rolloutConfiguration:
-      enableProgressiveRollout: true
     breakingChanges:
-      0.4.0:
+      1.0.0:
         message: >-
           This release upgrades the ClickHouse JDBC driver from 0.3.2-patch10 to 0.9.8.
           The 0.9.7+ driver decodes Date/Date32 columns as LocalDate without timezone adjustment.

--- a/airbyte-integrations/connectors/source-clickhouse/metadata.yaml
+++ b/airbyte-integrations/connectors/source-clickhouse/metadata.yaml
@@ -37,9 +37,6 @@ data:
           Users syncing Date/Date32 columns may see changed values if their data relied on the
           previous timezone-adjusted behavior. A full refresh of affected streams is recommended.
         upgradeDeadline: "2026-04-07"
-        scopedImpact:
-          - scopeType: stream
-            impactedScopes: []
   releaseStage: alpha
   supportLevel: community
   tags:

--- a/airbyte-integrations/connectors/source-clickhouse/metadata.yaml
+++ b/airbyte-integrations/connectors/source-clickhouse/metadata.yaml
@@ -14,7 +14,7 @@ data:
     - suite: acceptanceTests
   connectorType: source
   definitionId: bad83517-5e54-4a3d-9b53-63e85fbd4d7c
-  dockerImageTag: 0.3.0
+  dockerImageTag: 0.4.0-rc.1
   dockerRepository: airbyte/source-clickhouse
   documentationUrl: https://docs.airbyte.com/integrations/sources/clickhouse
   githubIssueLabel: source-clickhouse
@@ -26,6 +26,20 @@ data:
       enabled: true
     oss:
       enabled: true
+  releases:
+    rolloutConfiguration:
+      enableProgressiveRollout: true
+    breakingChanges:
+      0.4.0:
+        message: >-
+          This release upgrades the ClickHouse JDBC driver from 0.3.2-patch10 to 0.9.8.
+          The 0.9.7+ driver decodes Date/Date32 columns as LocalDate without timezone adjustment.
+          Users syncing Date/Date32 columns may see changed values if their data relied on the
+          previous timezone-adjusted behavior. A full refresh of affected streams is recommended.
+        upgradeDeadline: "2026-04-07"
+        scopedImpact:
+          - scopeType: stream
+            impactedScopes: []
   releaseStage: alpha
   supportLevel: community
   tags:

--- a/airbyte-integrations/connectors/source-clickhouse/src/main/java/io/airbyte/integrations/source/clickhouse/ClickHouseSource.java
+++ b/airbyte-integrations/connectors/source-clickhouse/src/main/java/io/airbyte/integrations/source/clickhouse/ClickHouseSource.java
@@ -25,7 +25,6 @@ import io.airbyte.protocol.models.v0.ConnectorSpecification;
 import java.sql.JDBCType;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -43,7 +42,6 @@ public class ClickHouseSource extends AbstractJdbcSource<JDBCType> implements So
    * https://clickhouse.tech/docs/en/operations/system-tables/columns/ to fetch the primary keys.
    */
 
-  public static final String SSL_MODE = "sslmode=none";
   public static final String HTTPS_PROTOCOL = "https";
   public static final String HTTP_PROTOCOL = "http";
 
@@ -124,18 +122,9 @@ public class ClickHouseSource extends AbstractJdbcSource<JDBCType> implements So
 
     final boolean isAdditionalParamsExists =
         config.get(JdbcUtils.JDBC_URL_PARAMS_KEY) != null && !config.get(JdbcUtils.JDBC_URL_PARAMS_KEY).asText().isEmpty();
-    final List<String> params = new ArrayList<>();
-    // assume ssl if not explicitly mentioned.
-    if (isSsl) {
-      params.add(SSL_MODE);
-    }
     if (isAdditionalParamsExists) {
-      params.add(config.get(JdbcUtils.JDBC_URL_PARAMS_KEY).asText());
-    }
-
-    if (isSsl || isAdditionalParamsExists) {
       jdbcUrl.append("?");
-      jdbcUrl.append(String.join("&", params));
+      jdbcUrl.append(config.get(JdbcUtils.JDBC_URL_PARAMS_KEY).asText());
     }
 
     final ImmutableMap.Builder<Object, Object> configBuilder = ImmutableMap.builder()

--- a/airbyte-integrations/connectors/source-clickhouse/src/main/java/io/airbyte/integrations/source/clickhouse/ClickHouseSource.java
+++ b/airbyte-integrations/connectors/source-clickhouse/src/main/java/io/airbyte/integrations/source/clickhouse/ClickHouseSource.java
@@ -88,7 +88,7 @@ public class ClickHouseSource extends AbstractJdbcSource<JDBCType> implements So
   }
 
   public ClickHouseSource(final FeatureFlags featureFlags) {
-    super(DRIVER_CLASS, NoOpStreamingQueryConfig::new, JdbcUtils.getDefaultSourceOperations());
+    super(DRIVER_CLASS, NoOpStreamingQueryConfig::new, new ClickHouseSourceOperations());
     this.featureFlags = featureFlags;
   }
 

--- a/airbyte-integrations/connectors/source-clickhouse/src/main/java/io/airbyte/integrations/source/clickhouse/ClickHouseSourceOperations.java
+++ b/airbyte-integrations/connectors/source-clickhouse/src/main/java/io/airbyte/integrations/source/clickhouse/ClickHouseSourceOperations.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.source.clickhouse;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.airbyte.cdk.db.jdbc.JdbcConstants;
+import io.airbyte.cdk.db.jdbc.JdbcSourceOperations;
+import java.sql.JDBCType;
+import java.sql.Types;
+
+/**
+ * Custom source operations for ClickHouse that handles type mapping differences.
+ *
+ * <p>
+ * The ClickHouse JDBC driver 0.9.x returns JDBCType.OTHER for large integer types that don't have
+ * exact JDBC equivalents (UInt64, Int128, Int256, UInt128, UInt256). This class maps those types to
+ * NUMERIC so they can be used as cursor columns for incremental sync.
+ */
+public class ClickHouseSourceOperations extends JdbcSourceOperations {
+
+  @Override
+  public JDBCType getDatabaseFieldType(final JsonNode field) {
+    final int columnType = field.get(JdbcConstants.INTERNAL_COLUMN_TYPE).asInt();
+
+    // If the driver returns OTHER, look at the type name and map it appropriately
+    if (columnType == Types.OTHER) {
+      final String typeName = field.get(JdbcConstants.INTERNAL_COLUMN_TYPE_NAME).asText();
+      return mapOtherTypeToJdbcType(typeName);
+    }
+
+    // For standard JDBC types, use the parent implementation
+    return super.getDatabaseFieldType(field);
+  }
+
+  /**
+   * Maps ClickHouse type names to standard JDBC types when the driver returns JDBCType.OTHER. Only
+   * handles types that actually return as OTHER (large integers without JDBC equivalents).
+   */
+  private JDBCType mapOtherTypeToJdbcType(final String rawTypeName) {
+    final String typeName = rawTypeName.toLowerCase();
+
+    // Large integers that don't have standard JDBC equivalents return as OTHER
+    // UInt64 can't fit in signed BIGINT, and Int128/Int256/UInt128/UInt256 have no JDBC equivalent
+    if (typeName.startsWith("uint64") || typeName.startsWith("int128") ||
+        typeName.startsWith("int256") || typeName.startsWith("uint128") ||
+        typeName.startsWith("uint256")) {
+      return JDBCType.NUMERIC;
+    }
+
+    // Default to VARCHAR for any other types that unexpectedly return as OTHER
+    return JDBCType.VARCHAR;
+  }
+
+}

--- a/airbyte-integrations/connectors/source-clickhouse/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/ClickHouseJdbcSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-clickhouse/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/ClickHouseJdbcSourceAcceptanceTest.java
@@ -5,7 +5,6 @@
 package io.airbyte.integrations.io.airbyte.integration_tests.sources;
 
 import static io.airbyte.cdk.db.jdbc.JdbcUtils.JDBC_URL_KEY;
-import static io.airbyte.integrations.source.clickhouse.ClickHouseSource.SSL_MODE;
 import static java.time.temporal.ChronoUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -93,7 +92,8 @@ public class ClickHouseJdbcSourceAcceptanceTest extends JdbcSourceAcceptanceTest
     JsonNode jdbcUrlNode = jdbcConfig.get(JDBC_URL_KEY);
     assertNotNull(jdbcUrlNode);
     String actualJdbcUrl = jdbcUrlNode.asText();
-    assertTrue(actualJdbcUrl.endsWith("?" + SSL_MODE));
+    assertTrue(actualJdbcUrl.startsWith("jdbc:clickhouse:https://"));
+    assertTrue(actualJdbcUrl.endsWith(config.get("database").asText()));
   }
 
   @Test
@@ -115,7 +115,8 @@ public class ClickHouseJdbcSourceAcceptanceTest extends JdbcSourceAcceptanceTest
     JsonNode jdbcUrlNode = jdbcConfig.get(JDBC_URL_KEY);
     assertNotNull(jdbcUrlNode);
     String actualJdbcUrl = jdbcUrlNode.asText();
-    assertTrue(actualJdbcUrl.endsWith(getFullExpectedValue(extraParam, SSL_MODE)));
+    assertTrue(actualJdbcUrl.startsWith("jdbc:clickhouse:https://"));
+    assertTrue(actualJdbcUrl.endsWith("?" + extraParam));
   }
 
   @Test
@@ -127,11 +128,6 @@ public class ClickHouseJdbcSourceAcceptanceTest extends JdbcSourceAcceptanceTest
     assertNotNull(jdbcUrlNode);
     String actualJdbcUrl = jdbcUrlNode.asText();
     assertTrue(actualJdbcUrl.endsWith("?" + extraParam));
-  }
-
-  private String getFullExpectedValue(String extraParam, String sslMode) {
-    StringBuilder expected = new StringBuilder();
-    return expected.append("?").append(sslMode).append("&").append(extraParam).toString();
   }
 
   private JsonNode buildConfigWithExtraJdbcParameters(String extraParam, boolean isSsl) {

--- a/docs/integrations/sources/clickhouse-migrations.md
+++ b/docs/integrations/sources/clickhouse-migrations.md
@@ -1,0 +1,11 @@
+import MigrationGuide from '@site/static/_migration_guides_upgrade_guide.md';
+
+# ClickHouse Migration Guide
+
+## Upgrading to 0.4.0
+
+This release upgrades the ClickHouse JDBC driver from 0.3.2-patch10 to 0.9.8. The 0.9.7+ driver decodes Date and Date32 columns as `LocalDate` without timezone adjustment. Users syncing Date or Date32 columns may see changed values if their data relied on the previous timezone-adjusted behavior. A full refresh of affected streams is recommended after upgrading.
+
+## Connector upgrade guide
+
+<MigrationGuide />

--- a/docs/integrations/sources/clickhouse-migrations.md
+++ b/docs/integrations/sources/clickhouse-migrations.md
@@ -2,7 +2,7 @@ import MigrationGuide from '@site/static/_migration_guides_upgrade_guide.md';
 
 # ClickHouse Migration Guide
 
-## Upgrading to 0.4.0
+## Upgrading to 1.0.0
 
 This release upgrades the ClickHouse JDBC driver from 0.3.2-patch10 to 0.9.8. The 0.9.7+ driver decodes Date and Date32 columns as `LocalDate` without timezone adjustment. Users syncing Date or Date32 columns may see changed values if their data relied on the previous timezone-adjusted behavior. A full refresh of affected streams is recommended after upgrading.
 

--- a/docs/integrations/sources/clickhouse.md
+++ b/docs/integrations/sources/clickhouse.md
@@ -80,7 +80,7 @@ Using this feature requires additional configuration, when creating the source. 
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                   |
 |:--------|:-----------|:-----------------------------------------------------------|:----------------------------------------------------------------------------------------------------------|
-| 0.4.0   | 2026-03-24 | [75432](https://github.com/airbytehq/airbyte/pull/75432) | Upgrade ClickHouse JDBC driver to 0.9.8; remove invalid sslmode=none parameter |
+| 0.4.0-rc.1 | 2026-03-24 | [75432](https://github.com/airbytehq/airbyte/pull/75432) | Upgrade ClickHouse JDBC driver to 0.9.8; remove invalid sslmode=none parameter; restore large integer type mapping |
 | 0.3.0   | 2026-01-27 | [75298](https://github.com/airbytehq/airbyte/pull/75298)   | Fold source-clickhouse-strict-encrypt into source-clickhouse                                              |
 | 0.2.6   | 2025-11-03 | [66714](https://github.com/airbytehq/airbyte/pull/66714)   | Revert JDBC driver upgrade                                                                                |
 | 0.2.5   | 2025-09-25 | [66482](https://github.com/airbytehq/airbyte/pull/66482)   | Upgrade ClickHouse JDBC driver from 0.3.2-patch10 to 0.9.0                                                |

--- a/docs/integrations/sources/clickhouse.md
+++ b/docs/integrations/sources/clickhouse.md
@@ -80,7 +80,7 @@ Using this feature requires additional configuration, when creating the source. 
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                   |
 |:--------|:-----------|:-----------------------------------------------------------|:----------------------------------------------------------------------------------------------------------|
-| 0.4.0   | 2026-03-24 | [PR_NUMBER_PLACEHOLDER](https://github.com/airbytehq/airbyte/pull/PR_NUMBER_PLACEHOLDER) | Upgrade ClickHouse JDBC driver to 0.9.8; remove invalid sslmode=none parameter |
+| 0.4.0   | 2026-03-24 | [75432](https://github.com/airbytehq/airbyte/pull/75432) | Upgrade ClickHouse JDBC driver to 0.9.8; remove invalid sslmode=none parameter |
 | 0.3.0   | 2026-01-27 | [75298](https://github.com/airbytehq/airbyte/pull/75298)   | Fold source-clickhouse-strict-encrypt into source-clickhouse                                              |
 | 0.2.6   | 2025-11-03 | [66714](https://github.com/airbytehq/airbyte/pull/66714)   | Revert JDBC driver upgrade                                                                                |
 | 0.2.5   | 2025-09-25 | [66482](https://github.com/airbytehq/airbyte/pull/66482)   | Upgrade ClickHouse JDBC driver from 0.3.2-patch10 to 0.9.0                                                |

--- a/docs/integrations/sources/clickhouse.md
+++ b/docs/integrations/sources/clickhouse.md
@@ -80,6 +80,7 @@ Using this feature requires additional configuration, when creating the source. 
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                   |
 |:--------|:-----------|:-----------------------------------------------------------|:----------------------------------------------------------------------------------------------------------|
+| 0.4.0   | 2026-03-24 | [PR_NUMBER_PLACEHOLDER](https://github.com/airbytehq/airbyte/pull/PR_NUMBER_PLACEHOLDER) | Upgrade ClickHouse JDBC driver to 0.9.8; remove invalid sslmode=none parameter |
 | 0.3.0   | 2026-01-27 | [75298](https://github.com/airbytehq/airbyte/pull/75298)   | Fold source-clickhouse-strict-encrypt into source-clickhouse                                              |
 | 0.2.6   | 2025-11-03 | [66714](https://github.com/airbytehq/airbyte/pull/66714)   | Revert JDBC driver upgrade                                                                                |
 | 0.2.5   | 2025-09-25 | [66482](https://github.com/airbytehq/airbyte/pull/66482)   | Upgrade ClickHouse JDBC driver from 0.3.2-patch10 to 0.9.0                                                |

--- a/docs/integrations/sources/clickhouse.md
+++ b/docs/integrations/sources/clickhouse.md
@@ -80,7 +80,7 @@ Using this feature requires additional configuration, when creating the source. 
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                   |
 |:--------|:-----------|:-----------------------------------------------------------|:----------------------------------------------------------------------------------------------------------|
-| 0.4.0-rc.1 | 2026-03-24 | [75432](https://github.com/airbytehq/airbyte/pull/75432) | Upgrade ClickHouse JDBC driver to 0.9.8; remove invalid sslmode=none parameter; restore large integer type mapping |
+| 1.0.0   | 2026-03-24 | [75432](https://github.com/airbytehq/airbyte/pull/75432) | Upgrade ClickHouse JDBC driver to 0.9.8; remove invalid sslmode=none parameter; restore large integer type mapping |
 | 0.3.0   | 2026-01-27 | [75298](https://github.com/airbytehq/airbyte/pull/75298)   | Fold source-clickhouse-strict-encrypt into source-clickhouse                                              |
 | 0.2.6   | 2025-11-03 | [66714](https://github.com/airbytehq/airbyte/pull/66714)   | Revert JDBC driver upgrade                                                                                |
 | 0.2.5   | 2025-09-25 | [66482](https://github.com/airbytehq/airbyte/pull/66482)   | Upgrade ClickHouse JDBC driver from 0.3.2-patch10 to 0.9.0                                                |


### PR DESCRIPTION
## What

Combines the changes from [#75226](https://github.com/airbytehq/airbyte/pull/75226) and [#75260](https://github.com/airbytehq/airbyte/pull/75260) on top of the latest `master` (v0.3.0, which already folded `source-clickhouse-strict-encrypt` into `source-clickhouse` via [#75298](https://github.com/airbytehq/airbyte/pull/75298)).

1. Upgrades the ClickHouse JDBC driver from `0.3.2-patch10` to `0.9.8`
2. Removes the invalid `sslmode=none` JDBC URL parameter that the 0.9.7+ driver now rejects
3. Restores `ClickHouseSourceOperations` for large integer type mapping (accidentally removed by the v0.3.0 strict-encrypt fold)
4. Bumps version to `1.0.0` as a breaking change (Date/Date32 timezone behavior change in 0.9.7+)

## How

- **`build.gradle`**: Upgrade `clickhouse-jdbc` to `0.9.8:all` and exclude transitive `at.yawk.lz4:lz4-java` to resolve a Gradle capability conflict with `org.lz4:lz4-java` (pulled in by Debezium/Kafka via the CDK). The `:all` fat jar already bundles lz4 internally, so this exclusion is safe.
- **`ClickHouseSourceOperations.java`** *(new file)*: Restores the custom `JdbcSourceOperations` subclass from [#72395](https://github.com/airbytehq/airbyte/pull/72395), which was accidentally deleted by the v0.3.0 merge. Overrides `getDatabaseFieldType()` to map ClickHouse large integer types (UInt64, Int128, Int256, UInt128, UInt256) from `JDBCType.OTHER` → `JDBCType.NUMERIC` so they work as cursor columns for incremental sync. The `copyToJsonField()` Array workaround from the 0.9.5 era is intentionally omitted since the `ArrayResultSet` off-by-one bug was fixed in driver 0.9.8.
- **`ClickHouseSource.java`**: Replace `JdbcUtils.getDefaultSourceOperations()` with `new ClickHouseSourceOperations()` in the constructor. Remove the `SSL_MODE` constant, the unused `ArrayList` import, and simplify `toDatabaseConfig()` to only append user-provided `jdbc_url_params`. SSL is determined entirely by the `https://` vs `http://` protocol prefix — `sslmode=none` was always redundant (and contradictory, since it was only appended when `isSsl=true`).
- **`ClickHouseJdbcSourceAcceptanceTest.java`**: Update assertions to verify `https://` protocol prefix instead of the removed `sslmode` param. Remove the now-unused `getFullExpectedValue` helper and `SSL_MODE` import.
- **`metadata.yaml`**: Version `1.0.0` with breaking change entry for the Date/Date32 timezone behavior change in 0.9.7+. No progressive rollout — this is a major version bump.
- **`clickhouse-migrations.md`** *(new file)*: Migration guide for the 1.0.0 breaking change (Date/Date32 timezone behavior).
- **`clickhouse.md`**: Changelog entry for 1.0.0.

## Review guide

1. `ClickHouseSourceOperations.java` — new file: type mapping for large integers that the 0.9.x driver returns as `JDBCType.OTHER`
2. `ClickHouseSource.java` — constructor wired to `ClickHouseSourceOperations`; removal of `SSL_MODE` and simplified URL building in `toDatabaseConfig()`
3. `metadata.yaml` — version bump to 1.0.0, breaking change metadata (no progressive rollout)
4. `build.gradle` — driver upgrade + lz4 exclusion
5. `ClickHouseJdbcSourceAcceptanceTest.java` — updated test assertions
6. `clickhouse-migrations.md` — migration guide for 1.0.0 breaking change
7. `clickhouse.md` — changelog

### Reviewer checklist
- [ ] Verify that `https://` protocol prefix is sufficient for the 0.9.8 driver to enable TLS — no explicit `ssl=true` URL parameter needed
- [ ] Confirm the `getDatabaseFieldType` type mapping in `ClickHouseSourceOperations` covers all large integer types that 0.9.8 returns as `JDBCType.OTHER`
- [ ] Verify that omitting the `copyToJsonField` Array workaround is safe — i.e. the 0.9.8 driver actually fixes the `ArrayResultSet.next()` off-by-one bug
- [ ] Confirm the lz4 exclusion has no runtime impact since the `:all` fat jar bundles it internally
- [ ] The test assertions in `ClickHouseJdbcSourceAcceptanceTest` are now weaker (check prefix/suffix instead of exact `sslmode` param) — verify this is acceptable coverage
- [ ] `ClickHouseSourceOperations` was reconstructed (not cherry-picked) from [#72395](https://github.com/airbytehq/airbyte/pull/72395) — verify the type mapping logic matches the original intent
- [ ] No end-to-end testing against a live ClickHouse instance was performed — this was unit/integration tested only

## User Impact

Users of source-clickhouse get the latest JDBC driver (0.9.8) with bug fixes for large unsigned integer type mapping, `ArrayResultSet#next()` off-by-one, and malformed `SELECT` query handling. Large integer types (UInt64, Int128, Int256, UInt128, UInt256) are now correctly mapped to `NUMERIC` so they can be used as cursor columns for incremental sync — this was accidentally broken in v0.3.0. The `sslmode=none` removal is purely internal — it was never exposed in the connector spec and was already a no-op in pre-0.9.7 drivers.

**Breaking**: The 0.9.7+ driver changed Date/Date32 decoding to `LocalDate` without timezone adjustment, which may affect synced values for users relying on the previous behavior. A full refresh of affected streams is recommended. Upgrade deadline: 2026-04-07.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/b1e276c8a25d4cffb8df576b47771f77
Requested by: @sophiecuiy