### PR TITLE
ci(publish): add --no-changelog flag to ephemeral version bump step

### DIFF
--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -472,7 +472,8 @@ jobs:
           airbyte-ops local connector bump-version \
             --name "${{ matrix.connector }}" \
             --repo-path "$GITHUB_WORKSPACE" \
-            --new-version "${{ steps.connector-metadata.outputs.docker-image-tag }}"
+            --new-version "${{ steps.connector-metadata.outputs.docker-image-tag }}" \
+            --no-changelog
 
       # --- Registry artifact generation and publishing (ops CLI) ---
       - name: Generate Registry Artifacts


### PR DESCRIPTION
## What

Adds the `--no-changelog` flag to the ephemeral version bump step for pre-release builds, so the CLI skips writing a changelog entry during the in-place metadata version bump.

Related: https://github.com/airbytehq/airbyte-ops-mcp/issues/604

## How

Appends `--no-changelog` to the existing `airbyte-ops local connector bump-version` call in the `publish_connectors.yml` workflow. The flag was added to the ops CLI in [airbytehq/airbyte-ops-mcp#607](https://github.com/airbytehq/airbyte-ops-mcp/pull/607) (merged).

## Review guide

1. `.github/workflows/publish_connectors.yml` — single-line addition of `--no-changelog` to the ephemeral version bump step (line 476).

**Key thing to verify:** The installed version of `airbyte-ops` in the workflow includes the `--no-changelog` flag (i.e., picks up the merged airbytehq/airbyte-ops-mcp#607). If the CLI is pinned to an older version, this will cause the bump step to fail.

## User Impact

No user-facing impact. This is a CI-only change that makes the ephemeral version bump cleaner by not writing an unnecessary changelog entry to files that are never committed.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/b053cc67d52e4ef695eae678da28798e
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75435" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
