### PR TITLE
docs(source-mongodb-v2): Add schema discovery performance warning and precautions

### DIFF
--- a/docs/integrations/sources/mongodb-v2.md
+++ b/docs/integrations/sources/mongodb-v2.md
@@ -201,6 +201,24 @@ This normalization is intended for occasional type inconsistencies. If your coll
 
 To see connector limitations, or troubleshoot your MongoDB connector, see more [in our MongoDB troubleshooting guide](/integrations/sources/mongodb-v2/mongodb-v2-troubleshooting).
 
+### Schema Discovery Performance Impact
+
+:::warning
+Schema discovery can place significant load on your MongoDB cluster. On large or resource-constrained clusters, this load can degrade performance or cause an outage. Read this section before running your first sync.
+:::
+
+During schema discovery, the connector runs an aggregation pipeline on each collection to sample documents and identify field types. These pipelines execute **in parallel across all collections** in the configured database. Each pipeline uses MongoDB's [`$sample`](https://www.mongodb.com/docs/manual/reference/operator/aggregation/sample/) stage, which can trigger a full collection scan (COLLSCAN) on collections where the sample size exceeds 5% of total documents or the collection contains fewer than 100 documents. The pipeline also enables `allowDiskUse`, which permits MongoDB to write temporary data to disk on your server.
+
+On clusters with many collections, large collections, or limited I/O capacity, the combined effect of these concurrent operations can saturate disk throughput and CPU, potentially causing replica set heartbeat failures and primary elections.
+
+To reduce the risk of performance impact during discovery:
+
+- **Reduce the Discovery Sample Size.** The default is 10,000 documents. Lower this to 1,000 in the connector's advanced settings, especially if your collections are small or numerous. This is the single most effective precaution.
+- **Schedule discovery during off-peak hours.** Schema discovery runs during connection setup and whenever you refresh the source schema. Avoid triggering these operations during peak database usage.
+- **Use a dedicated read-only replica.** Configure the connector's connection string to direct reads to a specific secondary replica using a [read preference tag set](https://www.mongodb.com/docs/manual/core/read-preference-mechanics/). This isolates discovery I/O from your primary and other secondaries. The connector already defaults to `secondaryPreferred`, but on a saturated cluster, even secondary I/O pressure can cascade to the primary through heartbeat delays.
+- **Monitor your cluster during the first discovery.** Watch disk I/O, CPU, and replication lag in your MongoDB monitoring tool while the initial discovery runs. If you see resource saturation, cancel the operation and reconfigure with a lower sample size.
+- **Consider disabling schema enforcement.** If you enable schemaless mode, the connector samples only one document per collection during discovery, which reduces load dramatically. See [Schema Enforcement](#schema-enforcement) for trade-offs.
+
 ### MongoDB CDC Limitations
 
 MongoDB has a 16MB maximum document size limit for BSON documents. During CDC syncs, change stream events can exceed this limit when documents are large, causing a `BSONObjectTooLarge` error. For details on resolving this error, see the [MongoDB CDC Limitations](/integrations/sources/mongodb-v2/mongodb-v2-troubleshooting#mongodb-cdc-limitations) section in the troubleshooting guide.

--- a/docs/integrations/sources/mongodb-v2.md
+++ b/docs/integrations/sources/mongodb-v2.md
@@ -204,20 +204,8 @@ To see connector limitations, or troubleshoot your MongoDB connector, see more [
 ### Schema Discovery Performance Impact
 
 :::warning
-Schema discovery can place significant load on your MongoDB cluster. On large or resource-constrained clusters, this load can degrade performance or cause an outage. Read this section before running your first sync.
+Schema discovery can place significant load on your MongoDB cluster. On large or resource-constrained clusters, this load can degrade performance or cause an outage. Before running your first sync, read the [schema discovery performance](/integrations/sources/mongodb-v2/mongodb-v2-troubleshooting#schema-discovery-performance) section of the troubleshooting guide for details and mitigations.
 :::
-
-During schema discovery, the connector runs an aggregation pipeline on each collection to sample documents and identify field types. These pipelines execute **in parallel across all collections** in the configured database. Each pipeline uses MongoDB's [`$sample`](https://www.mongodb.com/docs/manual/reference/operator/aggregation/sample/) stage, which can trigger a full collection scan (COLLSCAN) on collections where the sample size exceeds 5% of total documents or the collection contains fewer than 100 documents. The pipeline also enables `allowDiskUse`, which permits MongoDB to write temporary data to disk on your server.
-
-On clusters with many collections, large collections, or limited I/O capacity, the combined effect of these concurrent operations can saturate disk throughput and CPU, potentially causing replica set heartbeat failures and primary elections.
-
-To reduce the risk of performance impact during discovery:
-
-- **Reduce the Discovery Sample Size.** The default is 10,000 documents. Lower this to 1,000 in the connector's advanced settings, especially if your collections are small or numerous. This is the single most effective precaution.
-- **Schedule discovery during off-peak hours.** Schema discovery runs during connection setup and whenever you refresh the source schema. Avoid triggering these operations during peak database usage.
-- **Use a dedicated read-only replica.** Configure the connector's connection string to direct reads to a specific secondary replica using a [read preference tag set](https://www.mongodb.com/docs/manual/core/read-preference-mechanics/). This isolates discovery I/O from your primary and other secondaries. The connector already defaults to `secondaryPreferred`, but on a saturated cluster, even secondary I/O pressure can cascade to the primary through heartbeat delays.
-- **Monitor your cluster during the first discovery.** Watch disk I/O, CPU, and replication lag in your MongoDB monitoring tool while the initial discovery runs. If you see resource saturation, cancel the operation and reconfigure with a lower sample size.
-- **Consider disabling schema enforcement.** If you enable schemaless mode, the connector samples only one document per collection during discovery, which reduces load dramatically. See [Schema Enforcement](#schema-enforcement) for trade-offs.
 
 ### MongoDB CDC Limitations
 

--- a/docs/integrations/sources/mongodb-v2/mongodb-v2-troubleshooting.md
+++ b/docs/integrations/sources/mongodb-v2/mongodb-v2-troubleshooting.md
@@ -53,6 +53,25 @@ For more information about MongoDB's document size limits, see the [MongoDB docu
 - Schema discovery uses [sampling](https://www.mongodb.com/docs/manual/reference/operator/aggregation/sample/) of the documents to collect all distinct top-level fields. This value is universally applied to all collections discovered in the target database. The approach is modelled after [MongoDB Compass sampling](https://www.mongodb.com/docs/compass/current/sampling/) and is used for efficiency. By default, 10,000 documents are sampled. This value can be increased up to 100,000 documents to increase the likelihood that all fields will be discovered. However, the trade-off is time, as a higher value will take the process longer to sample the collection.
 - When Running with Schema Enforced set to `false` there is no attempt to discover any schema. See more in [Schema Enforcement](#Schema-Enforcement).
 
+#### Schema discovery performance
+
+Schema discovery runs an aggregation pipeline on every collection in the configured database **in parallel**. Each pipeline samples documents using MongoDB's `$sample` stage, then uses `$objectToArray`, `$unwind`, and `$group` to extract field names and types. The pipeline enables `allowDiskUse`, which permits MongoDB to write temporary data to disk on your database server.
+
+This design can place significant load on your MongoDB cluster for two reasons:
+
+1. **`$sample` can trigger full collection scans.** MongoDB uses an efficient pseudo-random cursor for `$sample` only when all of these conditions are met: `$sample` is the first pipeline stage, the sample size is less than 5% of the collection's total documents, and the collection contains more than 100 documents. When any condition is not met, MongoDB falls back to reading and randomly sorting the entire collection. With the default sample size of 10,000, any collection with fewer than 200,000 documents triggers this fallback.
+2. **All collections are sampled concurrently.** The connector discovers all collections in parallel with no concurrency limit. On a database with many collections, this means dozens of heavy aggregation pipelines can hit the cluster simultaneously.
+
+If your cluster experiences degraded performance or instability during schema discovery, try the following mitigations:
+
+| Mitigation | How to configure | Effect |
+| --- | --- | --- |
+| Lower the sample size | Set **Discovery Sample Size** to 1,000 in advanced connector settings | Fewer documents scanned per collection. Also increases the chance that `$sample` uses the efficient pseudo-random cursor. |
+| Disable schema enforcement | Set **Schema Enforced** to `false` in connector settings | Samples only 1 document per collection instead of 10,000. |
+| Direct reads to a secondary | Add `readPreference=secondary` and optionally a [tag set](https://www.mongodb.com/docs/manual/core/read-preference-mechanics/) to your connection string | Isolates discovery I/O from the primary node. |
+| Schedule discovery off-peak | Run initial connection setup or schema refreshes during low-traffic periods | Avoids compounding discovery load with production traffic. |
+| Set a discovery timeout | Set **Document discovery timeout** in advanced connector settings | Limits how long each collection's discovery pipeline can run before it is cancelled. Default is 600 seconds. |
+
 ### Vendor-Specific Connector Limitations
 
 :::warning


### PR DESCRIPTION
## Documentation Confidence Assessment

**Overall Confidence: 2/5** *capped: too much code inference*

| Dimension | Score | Rationale |
|-----------|-------|-----------|
| Code Comprehension | 1/5 | Java/Kotlin connector; reviewed `MongoUtil.java` for parallelStream, $sample pipeline, and allowDiskUse but inference required for broader behavior. |
| API Documentation Quality | 4/5 | MongoDB has comprehensive official docs for $sample, aggregation pipelines, and read preferences; minor gap on exact COLLSCAN fallback thresholds. |
| Change Scope & Risk | 4/5 | 25 lines added across 2 files; brief warning in main doc + detailed troubleshooting section. |
| Existing Doc Maturity | 5/5 | Main doc is 340 lines with comprehensive coverage; only a targeted addition was needed. |
| Connector Sensitivity | 2/5 | Certified connector (ql: 200, sl: 200), generally_available with meaningful usage. |
| Triggering Context | 2/5 | Triggered from oncall issue describing a documentation gap after a production incident. |

### What I Verified vs. What I Inferred

- **Verified from code**: `parallelStream()` usage at `MongoUtil.java:126` with no concurrency limit; `$sample(sampleSize)` at line 345; `allowDiskUse(true)` at line 356; default sample size of 10,000 from `MongoConstants.java:26`; schemaless mode samples 1 document (`Aggregates.sample(1)`) at line 374; default discovery timeout of 600 seconds from `MongoConstants.java:28`.
- **Verified from API docs**: MongoDB `$sample` uses efficient pseudo-random cursor only when it is the first stage, sample size < 5% of total docs, and collection > 100 docs. Otherwise falls back to COLLSCAN.
- **Inferred**: The exact user-visible labels for advanced settings fields ("Discovery Sample Size", "Schema Enforced", "Document discovery timeout") were inferred from config key names rather than verified in a running UI.

### Areas of Concern

- **UI field labels**: The mitigation table references setting names like "Discovery Sample Size" and "Document discovery timeout." These are inferred from config keys and may not match the exact labels in Airbyte's UI.
- **`$sample` threshold math**: The claim that collections under 200,000 documents trigger a COLLSCAN with default sample size should be verified against MongoDB docs.

---

## What

Adds documentation warning users that the MongoDB connector's schema discovery phase can place significant load on production clusters, potentially causing performance degradation or outages. This addresses [airbytehq/airbyte-internal-issues#16101](https://github.com/airbytehq/airbyte-internal-issues/issues/16101), where a customer's production MongoDB cluster went down for 3 hours during Airbyte schema discovery due to concurrent heavy aggregation pipelines saturating disk I/O.

No code changes — documentation only.

## How

### Updates since last revision

Per [reviewer feedback](https://github.com/airbytehq/airbyte/pull/75438#issuecomment-4122802803), consolidated all detailed content into the troubleshooting doc. The main connector doc now contains only a brief `:::warning` admonition linking to the troubleshooting guide. This eliminates the previous content overlap between the two files.

### Changes by file

1. **`docs/integrations/sources/mongodb-v2.md`** — A `:::warning` admonition under "Limitations & Troubleshooting" that links to the troubleshooting guide's schema discovery performance section. No detailed explanation here.

2. **`docs/integrations/sources/mongodb-v2/mongodb-v2-troubleshooting.md`** — A new "Schema discovery performance" sub-section under "Schema Discovery & Enforcement" explaining the two root causes (`$sample` COLLSCAN fallback and unbounded `parallelStream()` parallelism), plus a mitigation table with five configuration options.

## Review guide

1. `docs/integrations/sources/mongodb-v2.md` — Brief warning admonition + link (6 lines added)
2. `docs/integrations/sources/mongodb-v2/mongodb-v2-troubleshooting.md` — Technical explanation + mitigation table (19 lines added)

**Key claims to verify:**

- The `$sample` 5% threshold and 200,000-document math (10,000 default sample ÷ 0.05 = 200,000) — sourced from [MongoDB `$sample` docs](https://www.mongodb.com/docs/manual/reference/operator/aggregation/sample/).
- Schemaless mode samples only 1 document per collection — sourced from `MongoUtil.java` line 374 (`Aggregates.sample(1)`).

## User Impact

Users with large or resource-constrained MongoDB clusters will now see a prominent warning about schema discovery load before their first sync. The troubleshooting guide provides concrete, actionable steps to reduce risk — most importantly, lowering the default 10,000 sample size to 1,000.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

> **Note**: I am an AI assistant (Devin) and have proposed these documentation updates based on a review of the connector source code and third-party API documentation. Reviewers may merge, modify, or close this PR as they see fit.

Link to Devin session: https://app.devin.ai/sessions/899e778becc54d069d891f0dcee749f4
Requested by: @ian-at-airbyte
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75438" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
