### PR TITLE
docs(source-mongodb-v2): add schema discovery performance impact warning

### DIFF
--- a/docs/integrations/sources/mongodb-v2.md
+++ b/docs/integrations/sources/mongodb-v2.md
@@ -203,6 +203,10 @@ To see connector limitations, or troubleshoot your MongoDB connector, see more [
 
 ### Schema discovery performance impact
 
+:::warning
+Schema discovery runs heavy aggregation queries against your MongoDB cluster **in parallel across all collections**. On production clusters with many collections or large documents, this can cause significant resource pressure, including degraded query performance, replication lag, or in extreme cases, cluster instability.
+:::
+
 Because MongoDB collections are schemaless, no sample size can guarantee a complete or stable schema — new fields can appear in documents at any time. When schema enforcement is enabled, the connector's Discover phase runs `$sample` aggregation pipelines against every collection in the configured databases **in parallel**. On clusters with many collections or large documents, these concurrent queries can cause significant resource pressure on your MongoDB deployment, including degraded performance or cluster instability.
 
 For recommended approaches and other alternatives to protect your production cluster, see [Schema discovery performance impact](/integrations/sources/mongodb-v2/mongodb-v2-troubleshooting#schema-discovery-performance-impact) in the troubleshooting guide.

--- a/docs/integrations/sources/mongodb-v2.md
+++ b/docs/integrations/sources/mongodb-v2.md
@@ -203,9 +203,9 @@ To see connector limitations, or troubleshoot your MongoDB connector, see more [
 
 ### Schema discovery performance impact
 
-When schema enforcement is enabled, the connector's Discover phase runs `$sample` aggregation pipelines against every collection in the configured databases **in parallel**. Each pipeline samples up to 10,000 documents by default. On clusters with many collections or large documents, these concurrent aggregation queries can cause significant CPU, memory, and I/O pressure on your MongoDB deployment — in extreme cases, enough to degrade or disrupt production workloads.
+Because MongoDB collections are schemaless, no sample size can guarantee a complete or stable schema — new fields can appear in documents at any time. When schema enforcement is enabled, the connector's Discover phase runs `$sample` aggregation pipelines against every collection in the configured databases **in parallel**. On clusters with many collections or large documents, these concurrent queries can cause significant resource pressure on your MongoDB deployment, including degraded performance or cluster instability.
 
-For precautions you can take to protect your production cluster, see [Schema discovery performance impact](/integrations/sources/mongodb-v2/mongodb-v2-troubleshooting#schema-discovery-performance-impact) in the troubleshooting guide.
+For recommended approaches and other alternatives to protect your production cluster, see [Schema discovery performance impact](/integrations/sources/mongodb-v2/mongodb-v2-troubleshooting#schema-discovery-performance-impact) in the troubleshooting guide.
 
 ### MongoDB CDC Limitations
 

--- a/docs/integrations/sources/mongodb-v2.md
+++ b/docs/integrations/sources/mongodb-v2.md
@@ -201,6 +201,12 @@ This normalization is intended for occasional type inconsistencies. If your coll
 
 To see connector limitations, or troubleshoot your MongoDB connector, see more [in our MongoDB troubleshooting guide](/integrations/sources/mongodb-v2/mongodb-v2-troubleshooting).
 
+### Schema discovery performance impact
+
+When schema enforcement is enabled, the connector's Discover phase runs `$sample` aggregation pipelines against every collection in the configured databases **in parallel**. Each pipeline samples up to 10,000 documents by default. On clusters with many collections or large documents, these concurrent aggregation queries can cause significant CPU, memory, and I/O pressure on your MongoDB deployment — in extreme cases, enough to degrade or disrupt production workloads.
+
+For precautions you can take to protect your production cluster, see [Schema discovery performance impact](/integrations/sources/mongodb-v2/mongodb-v2-troubleshooting#schema-discovery-performance-impact) in the troubleshooting guide.
+
 ### MongoDB CDC Limitations
 
 MongoDB has a 16MB maximum document size limit for BSON documents. During CDC syncs, change stream events can exceed this limit when documents are large, causing a `BSONObjectTooLarge` error. For details on resolving this error, see the [MongoDB CDC Limitations](/integrations/sources/mongodb-v2/mongodb-v2-troubleshooting#mongodb-cdc-limitations) section in the troubleshooting guide.

--- a/docs/integrations/sources/mongodb-v2/mongodb-v2-troubleshooting.md
+++ b/docs/integrations/sources/mongodb-v2/mongodb-v2-troubleshooting.md
@@ -55,10 +55,6 @@ For more information about MongoDB's document size limits, see the [MongoDB docu
 
 ### Schema discovery performance impact
 
-:::warning
-Schema discovery runs heavy aggregation queries against your MongoDB cluster **in parallel across all collections**. On production clusters with many collections or large documents, this can cause significant resource pressure, including degraded query performance, replication lag, or in extreme cases, cluster instability.
-:::
-
 Because MongoDB collections are [schemaless](https://www.mongodb.com/docs/manual/data-modeling/), documents in the same collection can have different fields and data types. The connector attempts to infer a schema by sampling documents, but no sample size can guarantee a complete or stable schema. New fields can be added to documents at any time, and a schema derived from today's sample may not represent tomorrow's data. Keep this inherent limitation in mind when choosing between schema-enforced and schemaless modes.
 
 When schema enforcement is enabled, the Discover phase executes a [`$sample`](https://www.mongodb.com/docs/manual/reference/operator/aggregation/sample/) aggregation pipeline against every collection in each configured database. These pipelines run **concurrently** using parallel threads, one per collection. Each pipeline samples up to 10,000 documents by default, then processes them through `$project`, `$unwind`, and `$group` stages to extract field names and types.

--- a/docs/integrations/sources/mongodb-v2/mongodb-v2-troubleshooting.md
+++ b/docs/integrations/sources/mongodb-v2/mongodb-v2-troubleshooting.md
@@ -59,19 +59,31 @@ For more information about MongoDB's document size limits, see the [MongoDB docu
 Schema discovery runs heavy aggregation queries against your MongoDB cluster **in parallel across all collections**. On production clusters with many collections or large documents, this can cause significant resource pressure, including degraded query performance, replication lag, or in extreme cases, cluster instability.
 :::
 
+Because MongoDB collections are [schemaless](https://www.mongodb.com/docs/manual/data-modeling/), documents in the same collection can have different fields and data types. The connector attempts to infer a schema by sampling documents, but no sample size can guarantee a complete or stable schema. New fields can be added to documents at any time, and a schema derived from today's sample may not represent tomorrow's data. Keep this inherent limitation in mind when choosing between schema-enforced and schemaless modes.
+
 When schema enforcement is enabled, the Discover phase executes a [`$sample`](https://www.mongodb.com/docs/manual/reference/operator/aggregation/sample/) aggregation pipeline against every collection in each configured database. These pipelines run **concurrently** using parallel threads, one per collection. Each pipeline samples up to 10,000 documents by default, then processes them through `$project`, `$unwind`, and `$group` stages to extract field names and types.
 
-On clusters with hundreds of collections, this means hundreds of simultaneous aggregation queries hitting the database at once. The `$sample` stage performs a random collection scan, which can be I/O-intensive on large collections. Combined with the downstream aggregation stages, this can exhaust available CPU and memory on your MongoDB nodes.
+On clusters with hundreds of collections, this means hundreds of simultaneous aggregation queries hitting the database at once. The `$sample` stage performs a [random collection scan](https://www.mongodb.com/docs/manual/reference/operator/aggregation/sample/#behavior), which can be I/O-intensive on large collections. Combined with the downstream aggregation stages, this can exhaust available CPU and memory on your MongoDB nodes.
 
-**Precautions to protect your production cluster:**
+#### Recommended approaches
 
-1. **Direct reads to a secondary node.** Add `readPreference=secondary` or `readPreference=secondaryPreferred` to your MongoDB connection string. This routes the discovery queries to a secondary replica set member instead of the primary, protecting your primary node from the additional load.
+These approaches address the root cause of the performance risk by reducing or eliminating the discovery workload.
+
+1. **Disable schema enforcement.** Set **Schema Enforced** to `false` to skip the sampling-based discovery entirely. In schemaless mode, the connector samples only one document per collection to confirm the `_id` field exists. This dramatically reduces the load on your cluster, but all data is returned as a single JSON object per document rather than individual typed fields. See [Schema Enforcement](/integrations/sources/mongodb-v2#schema-enforcement) for configuration details.
+
+2. **Reduce the discovery sample size.** If you need schema enforcement, lower the **Discovery Sample Size** setting to reduce the number of documents sampled per collection. The default is 10,000. A smaller value such as 1,000 reduces the load on your cluster but may miss fields in collections with highly variable document structures. See the [Discovery Sample Size](https://docs.airbyte.com/integrations/sources/mongodb-v2#configuration-parameters) configuration parameter.
+
+#### Other alternatives
+
+These approaches do not reduce the discovery workload itself, but can help isolate it from your production traffic.
+
+1. **Direct reads to a secondary node.** Add [`readPreference=secondary`](https://www.mongodb.com/docs/manual/core/read-preference/#mongodb-readmode-secondary) or [`readPreference=secondaryPreferred`](https://www.mongodb.com/docs/manual/core/read-preference/#mongodb-readmode-secondaryPreferred) to your MongoDB [connection string](https://www.mongodb.com/docs/manual/reference/connection-string/). This routes the discovery queries to a secondary replica set member instead of the primary, protecting your primary node from the additional load.
 
    ```text
    mongodb+srv://cluster0.abcd1.mongodb.net/?readPreference=secondaryPreferred
    ```
 
-2. **Use MongoDB Atlas analytics nodes.** If you use MongoDB Atlas (M10 tier or above), you can provision [analytics nodes](https://www.mongodb.com/docs/atlas/reference/replica-set-tags/) that are isolated from your operational workload. Direct Airbyte's reads to an analytics node by adding read preference tags to your connection string:
+2. **Use MongoDB Atlas analytics nodes.** If you use MongoDB Atlas (M10 tier or above), you can provision [analytics nodes](https://www.mongodb.com/docs/atlas/reference/replica-set-tags/) that are isolated from your operational workload. Direct Airbyte's reads to an analytics node by adding [read preference tags](https://www.mongodb.com/docs/manual/core/read-preference-tags/) to your connection string:
 
    ```text
    mongodb+srv://cluster0.abcd1.mongodb.net/?readPreference=secondary&readPreferenceTags=nodeType:ANALYTICS
@@ -79,13 +91,9 @@ On clusters with hundreds of collections, this means hundreds of simultaneous ag
 
    This fully isolates the discovery workload from your production traffic.
 
-3. **Reduce the discovery sample size.** Lower the **Discovery Sample Size** setting to reduce the number of documents sampled per collection. The default is 10,000. A smaller value such as 1,000 reduces the load on your cluster at the cost of potentially missing some fields in collections with highly variable schemas.
+3. **Schedule syncs during off-peak hours.** If you cannot isolate the read workload, [schedule your Airbyte syncs](https://docs.airbyte.com/cloud/managing-airbyte-cloud/configuring-connections#connection-schedule) to run during periods of low production traffic. Schema discovery runs at the start of every sync, so timing matters.
 
-4. **Disable schema enforcement.** Set **Schema Enforced** to `false` to skip the sampling-based discovery entirely. In schemaless mode, the connector samples only one document per collection to confirm the `_id` field exists. This dramatically reduces the load on your cluster, but all data is returned as a single JSON object per document rather than individual typed fields.
-
-5. **Schedule syncs during off-peak hours.** If you cannot isolate the read workload, schedule your Airbyte syncs to run during periods of low production traffic. Schema discovery runs at the start of every sync, so timing matters.
-
-6. **Reduce the number of configured databases.** The connector discovers collections across all configured databases. If you only need data from specific databases, remove unnecessary databases from your source configuration to reduce the total number of collections discovered.
+4. **Reduce the number of configured databases.** The connector discovers collections across all configured databases. If you only need data from specific databases, remove unnecessary databases from your source configuration to reduce the total number of collections discovered.
 
 ### Vendor-Specific Connector Limitations
 

--- a/docs/integrations/sources/mongodb-v2/mongodb-v2-troubleshooting.md
+++ b/docs/integrations/sources/mongodb-v2/mongodb-v2-troubleshooting.md
@@ -51,7 +51,41 @@ For more information about MongoDB's document size limits, see the [MongoDB docu
 ### Schema Discovery & Enforcement
 
 - Schema discovery uses [sampling](https://www.mongodb.com/docs/manual/reference/operator/aggregation/sample/) of the documents to collect all distinct top-level fields. This value is universally applied to all collections discovered in the target database. The approach is modelled after [MongoDB Compass sampling](https://www.mongodb.com/docs/compass/current/sampling/) and is used for efficiency. By default, 10,000 documents are sampled. This value can be increased up to 100,000 documents to increase the likelihood that all fields will be discovered. However, the trade-off is time, as a higher value will take the process longer to sample the collection.
-- When Running with Schema Enforced set to `false` there is no attempt to discover any schema. See more in [Schema Enforcement](#Schema-Enforcement).
+- When running with Schema Enforced set to `false`, there is no attempt to discover any schema. See more in [Schema Enforcement](/integrations/sources/mongodb-v2#schema-enforcement).
+
+### Schema discovery performance impact
+
+:::warning
+Schema discovery runs heavy aggregation queries against your MongoDB cluster **in parallel across all collections**. On production clusters with many collections or large documents, this can cause significant resource pressure, including degraded query performance, replication lag, or in extreme cases, cluster instability.
+:::
+
+When schema enforcement is enabled, the Discover phase executes a [`$sample`](https://www.mongodb.com/docs/manual/reference/operator/aggregation/sample/) aggregation pipeline against every collection in each configured database. These pipelines run **concurrently** using parallel threads, one per collection. Each pipeline samples up to 10,000 documents by default, then processes them through `$project`, `$unwind`, and `$group` stages to extract field names and types.
+
+On clusters with hundreds of collections, this means hundreds of simultaneous aggregation queries hitting the database at once. The `$sample` stage performs a random collection scan, which can be I/O-intensive on large collections. Combined with the downstream aggregation stages, this can exhaust available CPU and memory on your MongoDB nodes.
+
+**Precautions to protect your production cluster:**
+
+1. **Direct reads to a secondary node.** Add `readPreference=secondary` or `readPreference=secondaryPreferred` to your MongoDB connection string. This routes the discovery queries to a secondary replica set member instead of the primary, protecting your primary node from the additional load.
+
+   ```text
+   mongodb+srv://cluster0.abcd1.mongodb.net/?readPreference=secondaryPreferred
+   ```
+
+2. **Use MongoDB Atlas analytics nodes.** If you use MongoDB Atlas (M10 tier or above), you can provision [analytics nodes](https://www.mongodb.com/docs/atlas/reference/replica-set-tags/) that are isolated from your operational workload. Direct Airbyte's reads to an analytics node by adding read preference tags to your connection string:
+
+   ```text
+   mongodb+srv://cluster0.abcd1.mongodb.net/?readPreference=secondary&readPreferenceTags=nodeType:ANALYTICS
+   ```
+
+   This fully isolates the discovery workload from your production traffic.
+
+3. **Reduce the discovery sample size.** Lower the **Discovery Sample Size** setting to reduce the number of documents sampled per collection. The default is 10,000. A smaller value such as 1,000 reduces the load on your cluster at the cost of potentially missing some fields in collections with highly variable schemas.
+
+4. **Disable schema enforcement.** Set **Schema Enforced** to `false` to skip the sampling-based discovery entirely. In schemaless mode, the connector samples only one document per collection to confirm the `_id` field exists. This dramatically reduces the load on your cluster, but all data is returned as a single JSON object per document rather than individual typed fields.
+
+5. **Schedule syncs during off-peak hours.** If you cannot isolate the read workload, schedule your Airbyte syncs to run during periods of low production traffic. Schema discovery runs at the start of every sync, so timing matters.
+
+6. **Reduce the number of configured databases.** The connector discovers collections across all configured databases. If you only need data from specific databases, remove unnecessary databases from your source configuration to reduce the total number of collections discovered.
 
 ### Vendor-Specific Connector Limitations
 


### PR DESCRIPTION
## Documentation Confidence Assessment

**Overall Confidence: 2/5** *capped: too much code inference*

| Dimension | Score | Rationale |
|-----------|-------|-----------|
| Code Comprehension | 1/5 | Java connector; parallel discovery behavior inferred from `MongoUtil.java` line 126 but full execution path not traced end-to-end. |
| API Documentation Quality | 4/5 | MongoDB has comprehensive docs for `$sample`, read preferences, and Atlas analytics nodes; minor gap on parallel query load characteristics. |
| Change Scope & Risk | 4/5 | ~50 lines added across 2 files; targeted addition of a warning section and two-tier precautions list. |
| Existing Doc Maturity | 4/5 | Well-established doc (~341 lines) with good structure; identifiable gap around discovery performance risks. |
| Connector Sensitivity | 2/5 | Certified connector (`ql: 200`, `sl: 200`); errors here affect production MongoDB users. |
| Triggering Context | 2/5 | Triggered from oncall issue describing a real customer production outage (3 hours of downtime). |

### What I verified vs. what I inferred

- **Verified from code**: `MongoUtil.java:126` uses `authorizedCollections.parallelStream()` for discovery; `MongoConstants.java:26` sets `DEFAULT_DISCOVER_SAMPLE_SIZE = 10000`; `spec.json` defines `discover_sample_size` range as 10–100,000; `getFieldsInCollection()` uses `$sample`, `$project`, `$unwind`, `$group` pipeline stages.
- **Verified from API docs**: MongoDB `$sample` performs a random collection scan; `readPreference=secondary` and `readPreference=secondaryPreferred` route reads to secondary nodes; Atlas analytics nodes use `readPreferenceTags=nodeType:ANALYTICS`.
- **Inferred**: That `parallelStream()` processes all collections concurrently without any throttling or batching (no thread pool cap was found, but one could exist elsewhere). That schemaless mode samples only one document per collection — this is based on code reading but not traced through all code paths.

### Areas of concern

- The claim that schemaless mode "samples only one document per collection to confirm the `_id` field exists" should be verified against the actual code path when `Schema Enforced = false`.
- The `parallelStream()` call may be bounded by the JVM's common ForkJoinPool; the documentation implies unbounded parallelism which may overstate the risk for small collection counts.
- Connection string example 1 uses `readPreference=secondaryPreferred` while example 2 uses `readPreference=secondary` — intentional (analytics nodes shouldn't fall back to primary) but could confuse readers.

### Human review checklist

- [ ] Verify `parallelStream()` at `MongoUtil.java:126` still reflects current discovery behavior
- [ ] Confirm the schemaless-mode claim (only one document sampled per collection)
- [ ] Check that the inline MongoDB doc links resolve correctly
- [ ] Review the two-tier framing ("Recommended" vs "Other alternatives") for accuracy — is disabling schema enforcement truly the top recommendation for all users?

---

## What

Adds documentation warning users that the MongoDB V2 connector's Discover phase can overwhelm production MongoDB clusters, and provides actionable precautions to mitigate this risk.

Addresses [airbytehq/airbyte-internal-issues#16101](https://github.com/airbytehq/airbyte-internal-issues/issues/16101) — a customer's production DB was taken down for 3 hours by parallel schema discovery queries.

## How

- **`mongodb-v2.md`**: Adds a "Schema discovery performance impact" subsection under Limitations & Troubleshooting with:
  - A `:::warning` admonition for high visibility on the main connector page
  - A caveat that MongoDB is schemaless and no sample size can guarantee a complete or stable schema
  - A link to the detailed troubleshooting guide
- **`mongodb-v2-troubleshooting.md`**: Adds a new "Schema discovery performance impact" section with:
  - An explanation of the inherent schema instability of schemaless databases
  - Technical explanation of *why* discovery is expensive (parallel `$sample` aggregation pipelines across all collections)
  - **Recommended approaches** (address root cause): (1) disable schema enforcement, (2) reduce discovery sample size
  - **Other alternatives** (isolate the workload): (1) `readPreference` to secondary nodes, (2) Atlas analytics nodes, (3) off-peak scheduling, (4) reducing configured databases
  - Inline references to MongoDB documentation for each alternative
- Fixes a broken anchor link (`#Schema-Enforcement` → full cross-doc path `/integrations/sources/mongodb-v2#schema-enforcement`)

## Review guide

1. `docs/integrations/sources/mongodb-v2.md` — warning admonition and summary paragraph (lines 204–212) linking to the troubleshooting guide.
2. `docs/integrations/sources/mongodb-v2/mongodb-v2-troubleshooting.md` — the main content addition (new section starting at `### Schema discovery performance impact`). Pay attention to the two-tier structure under `#### Recommended approaches` and `#### Other alternatives`.

## User Impact

Users configuring the MongoDB V2 source connector will see a clear warning about the inherent schema instability of schemaless databases and the performance risk of schema discovery on production clusters, along with tiered recommendations to protect their databases. No functional changes.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

> **Note**: I am an AI assistant (Devin) and have proposed these documentation updates based on a review of the connector source code and third-party API documentation. Reviewers may merge, modify, or close this PR as they see fit.

Link to Devin session: https://app.devin.ai/sessions/f452f3cb90ba46939cb1c2688e4da17d
Requested by: @ian-at-airbyte
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75439" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
