### PR TITLE
ci: add connector name to failure notifications and per-connector success notifications

### DIFF
--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -481,6 +481,58 @@ jobs:
             --name "${{ matrix.connector }}" \
             --store "${REGISTRY_STORE}"
 
+      - name: Build success notification context
+        id: success-context
+        if: success() && needs.publish_options.outputs.dry-run != 'true'
+        run: |
+          CONNECTOR="${{ matrix.connector }}"
+          DOCKER_TAG="${{ steps.resolve-docker-image-tag.outputs.docker-image-tag }}"
+          SEMVER_SUFFIX="${{ needs.publish_options.outputs.with-semver-suffix }}"
+          PR_NUMBER="${{ inputs.pr }}"
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+          if [[ -n "$PR_NUMBER" && "$PR_NUMBER" != "0" ]]; then
+            RUN_URL="${RUN_URL}?pr=${PR_NUMBER}"
+          fi
+
+          # Determine release type label
+          if [[ "$SEMVER_SUFFIX" == "none" || -z "$SEMVER_SUFFIX" ]]; then
+            RELEASE_TYPE="GA"
+          else
+            RELEASE_TYPE="Pre-release (${SEMVER_SUFFIX})"
+          fi
+
+          # Build URLs for hyperlinks
+          DOCKERHUB_URL="https://hub.docker.com/r/airbyte/${CONNECTOR}/tags?name=${DOCKER_TAG}"
+          CLOUD_REGISTRY_URL="https://connectors.airbyte.com/files/metadata/airbyte/${CONNECTOR}/${DOCKER_TAG}/cloud.json"
+          OSS_REGISTRY_URL="https://connectors.airbyte.com/files/metadata/airbyte/${CONNECTOR}/${DOCKER_TAG}/oss.json"
+
+          # Build PR text
+          PR_TEXT=""
+          if [[ -n "$PR_NUMBER" && "$PR_NUMBER" != "0" ]]; then
+            PR_TEXT="\nPR: <${{ github.server_url }}/${{ github.repository }}/pull/${PR_NUMBER}|#${PR_NUMBER}>"
+          fi
+
+          echo "release-type=$RELEASE_TYPE" >> $GITHUB_OUTPUT
+          echo "run-url=$RUN_URL" >> $GITHUB_OUTPUT
+          echo "dockerhub-url=$DOCKERHUB_URL" >> $GITHUB_OUTPUT
+          echo "cloud-registry-url=$CLOUD_REGISTRY_URL" >> $GITHUB_OUTPUT
+          echo "oss-registry-url=$OSS_REGISTRY_URL" >> $GITHUB_OUTPUT
+          echo "pr-text=$PR_TEXT" >> $GITHUB_OUTPUT
+
+      - name: Notify Slack on connector publish success
+        if: success() && needs.publish_options.outputs.dry-run != 'true' && steps.success-context.outcome == 'success'
+        uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
+        with:
+          payload: |
+            {
+              "channel": "#connector-publish-updates",
+              "username": "Connectors CI/CD Bot",
+              "text": "✅ *${{ steps.success-context.outputs.release-type }} Publish SUCCESS:*\nConnector: <${{ steps.success-context.outputs.dockerhub-url }}|airbyte/${{ matrix.connector }}:${{ steps.resolve-docker-image-tag.outputs.docker-image-tag }}>\nRegistry: <${{ steps.success-context.outputs.cloud-registry-url }}|cloud.json> · <${{ steps.success-context.outputs.oss-registry-url }}|oss.json>\n<${{ steps.success-context.outputs.run-url }}|View workflow run>${{ steps.success-context.outputs.pr-text }}"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.PUBLISH_ON_MERGE_SLACK_WEBHOOK }}
+
   generate_connector_registry:
     name: Generate connector registry
     needs: [publish_options, publish_connectors]
@@ -540,6 +592,15 @@ jobs:
             RELEASE_TYPE="Pre-release (${SEMVER_SUFFIX})"
           fi
 
+          # Extract connector names from the matrix JSON
+          CONNECTORS_JSON='${{ needs.publish_options.outputs.connectors-to-publish }}'
+          CONNECTOR_NAMES=$(echo "$CONNECTORS_JSON" | jq -r '.connector | join(", ")')
+          if [[ -n "$CONNECTOR_NAMES" ]]; then
+            CONNECTOR_TEXT="\nConnector(s): \`${CONNECTOR_NAMES}\`"
+          else
+            CONNECTOR_TEXT=""
+          fi
+
           # Build trigger description
           if [[ -n "$PR_NUMBER" && "$PR_NUMBER" != "0" ]]; then
             TRIGGER_TEXT="triggered from PR <${{ github.server_url }}/${{ github.repository }}/pull/${PR_NUMBER}|#${PR_NUMBER}>"
@@ -556,6 +617,7 @@ jobs:
           echo "run-url=$RUN_URL" >> $GITHUB_OUTPUT
           echo "release-type=$RELEASE_TYPE" >> $GITHUB_OUTPUT
           echo "trigger-text=$TRIGGER_TEXT" >> $GITHUB_OUTPUT
+          echo "connector-text=$CONNECTOR_TEXT" >> $GITHUB_OUTPUT
       - name: Send publish failures to connector-publish-failures channel
         id: slack
         uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
@@ -565,7 +627,7 @@ jobs:
             {
               "channel": "#connector-publish-failures",
               "username": "Connectors CI/CD Bot",
-              "text": "🚨 ${{ steps.context.outputs.release-type }} publish workflow failed:\n <${{ steps.context.outputs.run-url }}|View workflow run>\n ${{ steps.context.outputs.trigger-text }} by ${{ github.actor }}${{ steps.match-github-to-slack-user.outputs.slack_user_ids && format(' (<@{0}>)', steps.match-github-to-slack-user.outputs.slack_user_ids) || '' }}."
+              "text": "🚨 ${{ steps.context.outputs.release-type }} publish workflow failed:${{ steps.context.outputs.connector-text }}\n <${{ steps.context.outputs.run-url }}|View workflow run>\n ${{ steps.context.outputs.trigger-text }} by ${{ github.actor }}${{ steps.match-github-to-slack-user.outputs.slack_user_ids && format(' (<@{0}>)', steps.match-github-to-slack-user.outputs.slack_user_ids) || '' }}."
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.PUBLISH_ON_MERGE_SLACK_WEBHOOK }}


### PR DESCRIPTION
## What

Two improvements to the connector publish Slack notifications:
1. **Failure notifications** (#connector-publish-failures) were missing the connector name — just said "publish workflow failed" with no indication of which connector.
2. **Per-connector success notifications** (#connector-publish-updates) didn't exist — only the registry compile step posted there, with no per-connector publish confirmation.

## How

1. **Failure notification**: Extract connector names from the `connectors-to-publish` matrix JSON via `jq` and append a `Connector(s): \`name\`` line to the Slack message.
2. **Success notification**: Add two new steps at the end of the `publish_connectors` matrix job:
   - `Build success notification context` — assembles hyperlink URLs for Docker Hub, cloud.json, and oss.json registry entries.
   - `Notify Slack on connector publish success` — posts to #connector-publish-updates with clickable links (replacing the monospace format used by the legacy registry entry generation messages).

Both notifications include `?pr=N` on the run URL and conditionally include the PR link.

## Review guide

1. `.github/workflows/publish_connectors.yml` — single file, two logical changes:
   - Lines 484–534: New success notification steps in the `publish_connectors` matrix job
   - Lines 592–618: Connector name extraction added to the existing failure notification context step

### Human review checklist

- [ ] Verify the `success()` condition is correct for the success notification — it gates on all prior steps in the job succeeding, which means the Slack post only fires on full publish success (Docker + registry artifacts + metadata). Confirm this is the desired behavior vs. a more granular check.
- [ ] The literal `\n` strings stored in `$GITHUB_OUTPUT` (e.g. `connector-text`, `pr-text`) are interpolated into the JSON payload `text` field. This matches the existing pattern for `trigger-text`. Confirm this renders correctly in Slack.
- [ ] Docker Hub URL format: `https://hub.docker.com/r/airbyte/{connector}/tags?name={tag}` — verify this resolves correctly for a real connector+tag.
- [ ] Registry URL format: `https://connectors.airbyte.com/files/metadata/airbyte/{connector}/{tag}/cloud.json` — verify this matches the actual GCS public URL pattern.
- [ ] The success notification uses the same `SLACK_WEBHOOK_URL` secret (`PUBLISH_ON_MERGE_SLACK_WEBHOOK`) as the failure notification. Confirm this webhook is authorized to post to both `#connector-publish-failures` and `#connector-publish-updates`.

## User Impact

- Failure notifications in #connector-publish-failures now show which connector(s) failed.
- Each successful connector publish now posts a notification to #connector-publish-updates with clickable links to Docker Hub and registry JSON entries.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/3188d2c4f5e64cbe85c2487e7b15397e
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75442" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
