### PR TITLE
ci: test publish success notification for source-pokeapi

### DIFF
--- a/airbyte-integrations/connectors/source-pokeapi/metadata.yaml
+++ b/airbyte-integrations/connectors/source-pokeapi/metadata.yaml
@@ -22,7 +22,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 6371b14b-bc68-4236-bfbd-468e8df8e968
-  dockerImageTag: 0.3.51
+  dockerImageTag: 0.3.52
   dockerRepository: airbyte/source-pokeapi
   githubIssueLabel: source-pokeapi
   icon: pokeapi.svg


### PR DESCRIPTION
## What

Dummy PR to test the per-connector publish success notification added in #75442. Bumps `source-pokeapi` version to trigger a valid pre-release publish via `/publish-connectors-prerelease`.

**This PR should be reverted after testing is complete.**

## How

Bumps `dockerImageTag` from `0.3.51` → `0.3.52` in `source-pokeapi/metadata.yaml`. No code changes — this is solely to produce a valid version bump that the publish workflow will accept.

## Review guide

1. `airbyte-integrations/connectors/source-pokeapi/metadata.yaml` — single-line version bump

## User Impact

None if reverted after testing. If left merged, a no-op `0.3.52` release of source-pokeapi would be published on the next merge-to-master publish cycle.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

Link to Devin session: https://app.devin.ai/sessions/3188d2c4f5e64cbe85c2487e7b15397e
Requested by: @aaronsteers