### PR TITLE
chore(source-amplitude): Update external documentation URLs

### DIFF
--- a/airbyte-integrations/connectors/source-amplitude/metadata.yaml
+++ b/airbyte-integrations/connectors/source-amplitude/metadata.yaml
@@ -64,13 +64,16 @@ data:
             type: GSM
             alias: airbyte-connector-testing-secret-store
   externalDocumentationUrls:
+    - title: Product Updates
+      url: https://amplitude.com/releases
+      type: api_release_history
     - title: Analytics API
-      url: https://www.docs.developers.amplitude.com/analytics/apis/http-v2-api/
+      url: https://amplitude.com/docs/apis/analytics/http-v2
       type: api_reference
     - title: Authentication
-      url: https://www.docs.developers.amplitude.com/analytics/apis/authentication/
+      url: https://amplitude.com/docs/apis/authentication
       type: authentication_guide
     - title: Rate limits
-      url: https://www.docs.developers.amplitude.com/analytics/apis/http-v2-api/#rate-limits
+      url: https://amplitude.com/docs/apis/analytics/http-v2#rate-limits
       type: rate_limits
 metadataSpecVersion: "1.0"


### PR DESCRIPTION
## What

Updates the `externalDocumentationUrls` in `source-amplitude`'s `metadata.yaml` to use Amplitude's current canonical domain and adds a missing `api_release_history` entry.

Resolves https://github.com/airbytehq/oncall/issues/10524

- https://github.com/airbytehq/oncall/issues/10524

## How

1. **Updated three existing URLs** from the old domain (`www.docs.developers.amplitude.com`) to the current canonical domain (`amplitude.com/docs`). The old URLs return HTTP 308 permanent redirects to the new locations. Notably, the authentication URL at the old path (`/analytics/apis/authentication/`) now returns a 404.
2. **Added a new `api_release_history` entry** pointing to Amplitude's [Product Updates page](https://amplitude.com/releases), which is where Amplitude publishes feature releases and API changes.

## Review guide

1. `airbyte-integrations/connectors/source-amplitude/metadata.yaml` — the only file changed

**Key items to verify:**
- [ ] Spot-check that the new URLs resolve (e.g. `https://amplitude.com/docs/apis/analytics/http-v2` loads correctly)
- [ ] Confirm `https://amplitude.com/releases` is a reasonable `api_release_history` source — it's Amplitude's product changelog, not a dedicated API changelog (Amplitude doesn't publish one)

## User Impact

No user-facing impact. This only affects internal deprecation monitoring tooling that reads `externalDocumentationUrls` from connector metadata.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/07a6c151fa9a4cc9a40e4f95aca008f7
Requested by: @DanyloGL
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75454" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
