### PR TITLE
chore(source-google-ads): Add deprecation schedule URL to external docs

### DIFF
--- a/airbyte-integrations/connectors/source-google-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-ads/metadata.yaml
@@ -18,6 +18,9 @@ data:
     - title: Release notes
       url: https://developers.google.com/google-ads/api/docs/release-notes
       type: api_release_history
+    - title: Deprecation and sunset schedule
+      url: https://developers.google.com/google-ads/api/docs/sunset-dates
+      type: api_deprecations
     - title: Developer blog
       url: https://ads-developers.googleblog.com/
   githubIssueLabel: source-google-ads


### PR DESCRIPTION
## What

Adds Google's official [Deprecation and sunset schedule](https://developers.google.com/google-ads/api/docs/sunset-dates) page to the connector's `externalDocumentationUrls` in `metadata.yaml`.

This was identified as a missing URL during routine API deprecation monitoring (tracked in https://github.com/airbytehq/oncall/issues/10436). The connector already had the release notes and developer blog URLs, but lacked a direct link to the sunset dates page — the most authoritative source for version deprecation timelines.

Resolves https://github.com/airbytehq/oncall/issues/10436

- https://github.com/airbytehq/oncall/issues/10436

## How

Added a single entry to `externalDocumentationUrls` with `type: api_deprecations`.

## Review guide

1. `airbyte-integrations/connectors/source-google-ads/metadata.yaml` — only file changed; 3 lines added.

## User Impact

None. This is a metadata-only change that improves future deprecation monitoring by making the sunset schedule URL discoverable via tooling.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/99bb9afa5c6a456982fb6f2228de609b
Requested by: @DanyloGL
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75456" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
