### PR TITLE
chore(source-microsoft-sharepoint): Add api_release_history and api_deprecations URLs to external documentation

### DIFF
--- a/airbyte-integrations/connectors/source-microsoft-sharepoint/metadata.yaml
+++ b/airbyte-integrations/connectors/source-microsoft-sharepoint/metadata.yaml
@@ -48,6 +48,12 @@ data:
             type: GSM
             alias: airbyte-connector-testing-secret-store
   externalDocumentationUrls:
+    - title: Microsoft Graph API Changelog
+      url: https://developer.microsoft.com/en-us/graph/changelog
+      type: api_release_history
+    - title: Microsoft Graph API Deprecations (drive sharedWithMe)
+      url: https://learn.microsoft.com/en-us/graph/api/drive-sharedwithme?view=graph-rest-1.0
+      type: api_deprecations
     - title: SharePoint REST API
       url: https://learn.microsoft.com/en-us/sharepoint/dev/sp-add-ins/get-to-know-the-sharepoint-rest-service
       type: api_reference


### PR DESCRIPTION
## What

Adds missing `api_release_history` and `api_deprecations` external documentation URLs to the `source-microsoft-sharepoint` connector metadata.

These URLs were identified as missing during an API deprecation monitoring review. The `sharedWithMe` Graph API method used by this connector is deprecated with a November 2026 sunset date (see [oncall#10533](https://github.com/airbytehq/oncall/issues/10533)), and having these URLs in the metadata enables future automated deprecation checks to surface relevant changes earlier.

Resolves https://github.com/airbytehq/oncall/issues/10533

- https://github.com/airbytehq/oncall/issues/10533

## How

Added two new entries to `externalDocumentationUrls` in `metadata.yaml`:
1. **Microsoft Graph API Changelog** (`api_release_history`) — the canonical changelog for all Graph API changes
2. **Microsoft Graph API Deprecations — drive sharedWithMe** (`api_deprecations`) — the specific deprecated endpoint documentation

Existing URLs (`api_reference`, `authentication_guide`, `status_page`) are unchanged.

## Review guide

1. `airbyte-integrations/connectors/source-microsoft-sharepoint/metadata.yaml` — only file changed; verify the two new URLs are valid and the `type` values are correct

## User Impact

None. This is a metadata-only change with no impact on connector behavior or syncs.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/8615bbf2ff404b43bb1de73b8bcd39d4
Requested by: @DanyloGL
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75460" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
