### PR TITLE
fix(source-intercom): Remove Client Side Incremental for conversations and contacts streams. Fix end_time boundary from < (exclusive) to <= (inclusive)

### DIFF
--- a/airbyte-integrations/connectors/source-intercom/manifest.yaml
+++ b/airbyte-integrations/connectors/source-intercom/manifest.yaml
@@ -439,8 +439,10 @@ definitions:
               {"field" : "updated_at", "operator" : ">", "value" : {{
               stream_interval['start_time'] }} }, {"field" : "updated_at",
               "operator" : "=", "value" : {{ stream_interval['start_time'] }}
-              }]},  {"field" : "updated_at", "operator" : "<", "value" :  {{
-              stream_interval['end_time'] }} } ]}
+              }]},  {"operator" : "OR", "value" : [ {"field" : "updated_at",
+              "operator" : "<", "value" : {{ stream_interval['end_time'] }}
+              }, {"field" : "updated_at", "operator" : "=", "value" : {{
+              stream_interval['end_time'] }} }]} ]}
             sort: "{\"field\": \"updated_at\", \"order\": \"ascending\"}"
           error_handler:
             type: CustomErrorHandler
@@ -492,7 +494,6 @@ definitions:
         step: P30D
         cursor_granularity: PT1S
         lookback_window: P{{ config.get('lookback_window', 0) }}D
-        is_client_side_incremental: true
       schema_loader:
         type: InlineSchemaLoader
         schema:
@@ -518,8 +519,10 @@ definitions:
               {"field" : "updated_at", "operator" : ">", "value" : {{
               stream_interval['start_time'] }} }, {"field" : "updated_at",
               "operator" : "=", "value" : {{ stream_interval['start_time'] }}
-              }]},  {"field" : "updated_at", "operator" : "<", "value" :  {{
-              stream_interval['end_time'] }} } ]}
+              }]},  {"operator" : "OR", "value" : [ {"field" : "updated_at",
+              "operator" : "<", "value" : {{ stream_interval['end_time'] }}
+              }, {"field" : "updated_at", "operator" : "=", "value" : {{
+              stream_interval['end_time'] }} }]} ]}
           error_handler:
             type: CustomErrorHandler
             class_name: source_declarative_manifest.components.ErrorHandlerWithRateLimiter
@@ -570,7 +573,6 @@ definitions:
         step: P30D
         cursor_granularity: PT1S
         lookback_window: P{{ config.get('lookback_window', 0) }}D
-        is_client_side_incremental: true
       schema_loader:
         type: InlineSchemaLoader
         schema:
@@ -735,8 +737,10 @@ definitions:
               {"field" : "updated_at", "operator" : ">", "value" : {{
               stream_interval['start_time'] }} }, {"field" : "updated_at",
               "operator" : "=", "value" : {{ stream_interval['start_time'] }}
-              }]},  {"field" : "updated_at", "operator" : "<", "value" :  {{
-              stream_interval['end_time'] }} } ]}
+              }]},  {"operator" : "OR", "value" : [ {"field" : "updated_at",
+              "operator" : "<", "value" : {{ stream_interval['end_time'] }}
+              }, {"field" : "updated_at", "operator" : "=", "value" : {{
+              stream_interval['end_time'] }} }]} ]}
             sort: "{\"field\": \"updated_at\", \"order\": \"ascending\"}"
           error_handler:
             type: CustomErrorHandler

--- a/airbyte-integrations/connectors/source-intercom/metadata.yaml
+++ b/airbyte-integrations/connectors/source-intercom/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: d8313939-3782-41b0-be29-b3ca20d8dd3a
-  dockerImageTag: 0.13.16
+  dockerImageTag: 0.13.17
   dockerRepository: airbyte/source-intercom
   documentationUrl: https://docs.airbyte.com/integrations/sources/intercom
   externalDocumentationUrls:

--- a/docs/integrations/sources/intercom.md
+++ b/docs/integrations/sources/intercom.md
@@ -123,6 +123,7 @@ Because these streams must read all records on every sync, syncing Companies and
 
 | Version      | Date       | Pull Request                                             | Subject                                                                                                                              |
 |:-------------|:-----------|:---------------------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------|
+| 0.13.17 | 2026-03-26 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) | fix(source-intercom): Remove Client Side Incremental for conversations and contacts streams and fix end_time boundary from < (exclusive) to <= (inclusive)|
 | 0.13.16 | 2026-03-24 | [75419](https://github.com/airbytehq/airbyte/pull/75419) | Promote 0.13.16-rc.6 to GA — includes CDK 7.13.0 upgrade, block_simultaneous_read for companies, rate limiter fix, step size/end_datetime for incremental streams, and heartbeat timeout bump |
 | 0.13.16-rc.6 | 2026-03-19 | [75216](https://github.com/airbytehq/airbyte/pull/75216) | Bump CDK base image to 7.13.0 (includes block_simultaneous_read support and cursor field fix) |
 | 0.13.16-rc.5 | 2026-03-11 | [71141](https://github.com/airbytehq/airbyte/pull/71141) | Block simultaneous reading from companies endpoint |


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->

  Changes to contacts and conversations streams:

  1. Removed is_client_side_incremental: true — API testing confirmed Intercom's Search API correctly
  filters updated_at server-side. The search API supports datetime filtering, so removing this will make these streams substantially faster.

  2. Fixed end_time boundary from < (exclusive) to <= (inclusive) — The CDK's DatetimeBasedCursor computes
  end_time = start + step - cursor_granularity and treats it as inclusive. The old < end_time query created
  a 1-second gap at every 30-day slice boundary where records were silently dropped. Changed to OR(<, =) to
  simulate <= (Intercom has no native <= operator).  

## How
<!--
* Describe how code changes achieve the solution.
-->
Before, we would have to query all records and filter locally for the newer ones; with this change, we will only query for the newer ones and allow the server to do the filtering. (True incremental)

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ X] YES 💚
- [ ] NO ❌
