### PR TITLE
ci: use distinct emojis for connector publish Slack notifications

### DIFF
--- a/.github/workflows/generate-connector-registries.yml
+++ b/.github/workflows/generate-connector-registries.yml
@@ -108,7 +108,7 @@ jobs:
             {
               "channel": "#connector-publish-updates",
               "username": "Connectors CI/CD Bot",
-              "text": "✅ *Registry Compile SUCCESS*${{ steps.notification-context.outputs.details-text }}\n<${{ steps.notification-context.outputs.run-url }}|View workflow run>${{ steps.notification-context.outputs.pr-text }}"
+              "text": ":ballot_box_with_check: *Registry Compile SUCCESS*${{ steps.notification-context.outputs.details-text }}\n<${{ steps.notification-context.outputs.run-url }}|View workflow run>${{ steps.notification-context.outputs.pr-text }}"
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.PUBLISH_ON_MERGE_SLACK_WEBHOOK }}

--- a/.github/workflows/generate-connector-registries.yml
+++ b/.github/workflows/generate-connector-registries.yml
@@ -108,7 +108,7 @@ jobs:
             {
               "channel": "#connector-publish-updates",
               "username": "Connectors CI/CD Bot",
-              "text": ":ballot_box_with_check: *Registry Compile SUCCESS*${{ steps.notification-context.outputs.details-text }}\n<${{ steps.notification-context.outputs.run-url }}|View workflow run>${{ steps.notification-context.outputs.pr-text }}"
+              "text": "☑️ *Registry Compile SUCCESS*${{ steps.notification-context.outputs.details-text }}\n<${{ steps.notification-context.outputs.run-url }}|View workflow run>${{ steps.notification-context.outputs.pr-text }}"
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.PUBLISH_ON_MERGE_SLACK_WEBHOOK }}

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -500,7 +500,7 @@ jobs:
             RELEASE_TYPE="GA"
             EMOJI="🟢"
           else
-            RELEASE_TYPE="Pre-release (${SEMVER_SUFFIX})"
+            RELEASE_TYPE="Pre-release"
             EMOJI="🔵"
           fi
 

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -498,10 +498,10 @@ jobs:
           # Determine release type label and emoji
           if [[ "$SEMVER_SUFFIX" == "none" || -z "$SEMVER_SUFFIX" ]]; then
             RELEASE_TYPE="GA"
-            EMOJI=":large_green_circle:"
+            EMOJI="🟢"
           else
             RELEASE_TYPE="Pre-release (${SEMVER_SUFFIX})"
-            EMOJI=":large_blue_circle:"
+            EMOJI="🔵"
           fi
 
           # Build URLs for hyperlinks

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -495,11 +495,13 @@ jobs:
             RUN_URL="${RUN_URL}?pr=${PR_NUMBER}"
           fi
 
-          # Determine release type label
+          # Determine release type label and emoji
           if [[ "$SEMVER_SUFFIX" == "none" || -z "$SEMVER_SUFFIX" ]]; then
             RELEASE_TYPE="GA"
+            EMOJI=":large_green_circle:"
           else
             RELEASE_TYPE="Pre-release (${SEMVER_SUFFIX})"
+            EMOJI=":large_blue_circle:"
           fi
 
           # Build URLs for hyperlinks
@@ -514,6 +516,7 @@ jobs:
           fi
 
           echo "release-type=$RELEASE_TYPE" >> $GITHUB_OUTPUT
+          echo "emoji=$EMOJI" >> $GITHUB_OUTPUT
           echo "run-url=$RUN_URL" >> $GITHUB_OUTPUT
           echo "dockerhub-url=$DOCKERHUB_URL" >> $GITHUB_OUTPUT
           echo "cloud-registry-url=$CLOUD_REGISTRY_URL" >> $GITHUB_OUTPUT
@@ -528,7 +531,7 @@ jobs:
             {
               "channel": "#connector-publish-updates",
               "username": "Connectors CI/CD Bot",
-              "text": "✅ *${{ steps.success-context.outputs.release-type }} Publish SUCCESS:*\nConnector: <${{ steps.success-context.outputs.dockerhub-url }}|airbyte/${{ matrix.connector }}:${{ steps.resolve-docker-image-tag.outputs.docker-image-tag }}>\nRegistry: <${{ steps.success-context.outputs.cloud-registry-url }}|cloud.json> · <${{ steps.success-context.outputs.oss-registry-url }}|oss.json>\n<${{ steps.success-context.outputs.run-url }}|View workflow run>${{ steps.success-context.outputs.pr-text }}"
+              "text": "${{ steps.success-context.outputs.emoji }} *${{ steps.success-context.outputs.release-type }} Publish SUCCESS:*\nConnector: <${{ steps.success-context.outputs.dockerhub-url }}|airbyte/${{ matrix.connector }}:${{ steps.resolve-docker-image-tag.outputs.docker-image-tag }}>\nRegistry: <${{ steps.success-context.outputs.cloud-registry-url }}|cloud.json> · <${{ steps.success-context.outputs.oss-registry-url }}|oss.json>\n<${{ steps.success-context.outputs.run-url }}|View workflow run>${{ steps.success-context.outputs.pr-text }}"
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.PUBLISH_ON_MERGE_SLACK_WEBHOOK }}


### PR DESCRIPTION
## What

Updates the Slack notifications in `#connector-publish-updates` to use distinct emojis for each event type, replacing the generic ✅ checkmark used for all success events. Also simplifies the pre-release label by removing the parenthetical suffix.

## How

- **Registry Compile SUCCESS**: ✅ → ☑️ in `generate-connector-registries.yml`
- **GA Publish SUCCESS**: ✅ → 🟢 in `publish_connectors.yml`
- **Pre-release Publish SUCCESS**: ✅ → 🔵 in `publish_connectors.yml`

For the publish workflow, the emoji is determined dynamically based on `SEMVER_SUFFIX` (same logic that already determines the release type label) and passed as a new `emoji` step output.

Additionally, the success notification label is simplified from `"Pre-release (preview)"` / `"Pre-release (rc)"` to just `"Pre-release"` — the specific suffix is already visible in the version string on the next line.

**Note:** The failure notification context (`notify-failure-slack-channel`) still uses the parenthetical format. Only the success notification was changed per request.

## Review guide

1. `.github/workflows/generate-connector-registries.yml` — single-line emoji swap on line 111
2. `.github/workflows/publish_connectors.yml` — new `EMOJI` variable in the `success-context` step, new `emoji` output, reference in the Slack payload, and simplified `RELEASE_TYPE` for pre-release

### Human review checklist

- [ ] Verify the dynamic `${{ steps.success-context.outputs.emoji }}` substitution renders correctly in the Slack JSON payload (same pattern as the existing `release-type` output)
- [ ] Confirm the simplified "Pre-release" label (without suffix) is acceptable for the success notification, given the version string is shown directly below

## User Impact

Slack messages in `#connector-publish-updates` will show visually distinct emojis per event type, making it easier to scan the channel at a glance. Pre-release success notifications will show a cleaner title without redundant suffix info.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/9bbea72ada054ffdb964537b95a0ffa3
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75463" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
