### PR TITLE
ci(registry): consolidate reference links in publish success Slack notifications

### DIFF
--- a/.github/workflows/generate-connector-registries.yml
+++ b/.github/workflows/generate-connector-registries.yml
@@ -108,7 +108,7 @@ jobs:
             {
               "channel": "#connector-publish-updates",
               "username": "Connectors CI/CD Bot",
-              "text": "☑️ *Registry Compile SUCCESS*${{ steps.notification-context.outputs.details-text }}\n<${{ steps.notification-context.outputs.run-url }}|View workflow run>${{ steps.notification-context.outputs.pr-text }}"
+              "text": "☑️ *Registry Compile SUCCESS*${{ steps.notification-context.outputs.details-text }}\n<${{ steps.notification-context.outputs.run-url }}|View workflow run>${{ steps.notification-context.outputs.pr-text }}\nRegistry: <https://connectors.airbyte.com/files/registries/v0/oss_registry.json|OSS Registry> · <https://connectors.airbyte.com/files/registries/v0/cloud_registry.json|Cloud Registry> · <https://console.cloud.google.com/storage/browser/prod-airbyte-cloud-connector-metadata-service/registries/v0|GCS Bucket>"
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.PUBLISH_ON_MERGE_SLACK_WEBHOOK }}

--- a/.github/workflows/generate-connector-registries.yml
+++ b/.github/workflows/generate-connector-registries.yml
@@ -108,7 +108,7 @@ jobs:
             {
               "channel": "#connector-publish-updates",
               "username": "Connectors CI/CD Bot",
-              "text": "☑️ *Registry Compile SUCCESS*${{ steps.notification-context.outputs.details-text }}${{ steps.notification-context.outputs.pr-text }}\nLinks: <https://connectors.airbyte.com/files/registries/v0/oss_registry.json|OSS Registry> · <https://connectors.airbyte.com/files/registries/v0/cloud_registry.json|Cloud Registry> · <https://console.cloud.google.com/storage/browser/prod-airbyte-cloud-connector-metadata-service/registries/v0|GCS Bucket> · <${{ steps.notification-context.outputs.run-url }}|CI Logs>"
+              "text": "☑️ *Registry Compile SUCCESS*${{ steps.notification-context.outputs.details-text }}${{ steps.notification-context.outputs.pr-text }}\nReference: <https://connectors.airbyte.com/files/registries/v0/oss_registry.json|OSS Registry> · <https://connectors.airbyte.com/files/registries/v0/cloud_registry.json|Cloud Registry> · <https://console.cloud.google.com/storage/browser/prod-airbyte-cloud-connector-metadata-service/registries/v0|GCS Bucket> · <${{ steps.notification-context.outputs.run-url }}|CI Logs>"
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.PUBLISH_ON_MERGE_SLACK_WEBHOOK }}

--- a/.github/workflows/generate-connector-registries.yml
+++ b/.github/workflows/generate-connector-registries.yml
@@ -108,7 +108,7 @@ jobs:
             {
               "channel": "#connector-publish-updates",
               "username": "Connectors CI/CD Bot",
-              "text": "☑️ *Registry Compile SUCCESS*${{ steps.notification-context.outputs.details-text }}\n<${{ steps.notification-context.outputs.run-url }}|View workflow run>${{ steps.notification-context.outputs.pr-text }}\nRegistry: <https://connectors.airbyte.com/files/registries/v0/oss_registry.json|OSS Registry> · <https://connectors.airbyte.com/files/registries/v0/cloud_registry.json|Cloud Registry> · <https://console.cloud.google.com/storage/browser/prod-airbyte-cloud-connector-metadata-service/registries/v0|GCS Bucket>"
+              "text": "☑️ *Registry Compile SUCCESS*${{ steps.notification-context.outputs.details-text }}${{ steps.notification-context.outputs.pr-text }}\nLinks: <https://connectors.airbyte.com/files/registries/v0/oss_registry.json|OSS Registry> · <https://connectors.airbyte.com/files/registries/v0/cloud_registry.json|Cloud Registry> · <https://console.cloud.google.com/storage/browser/prod-airbyte-cloud-connector-metadata-service/registries/v0|GCS Bucket> · <${{ steps.notification-context.outputs.run-url }}|CI Logs>"
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.PUBLISH_ON_MERGE_SLACK_WEBHOOK }}

--- a/.github/workflows/generate-connector-registries.yml
+++ b/.github/workflows/generate-connector-registries.yml
@@ -108,7 +108,7 @@ jobs:
             {
               "channel": "#connector-publish-updates",
               "username": "Connectors CI/CD Bot",
-              "text": "☑️ *Registry Compile SUCCESS*${{ steps.notification-context.outputs.details-text }}${{ steps.notification-context.outputs.pr-text }}\nReference: <https://connectors.airbyte.com/files/registries/v0/oss_registry.json|OSS Registry> · <https://connectors.airbyte.com/files/registries/v0/cloud_registry.json|Cloud Registry> · <https://console.cloud.google.com/storage/browser/prod-airbyte-cloud-connector-metadata-service/registries/v0|GCS Bucket> · <${{ steps.notification-context.outputs.run-url }}|CI Logs>"
+              "text": "☑️ *Registry Compile SUCCESS*${{ steps.notification-context.outputs.details-text }}${{ steps.notification-context.outputs.pr-text }}\nReference: <https://connectors.airbyte.com/files/registries/v0/cloud_registry.json|Cloud Registry> · <https://connectors.airbyte.com/files/registries/v0/oss_registry.json|OSS Registry> · <https://console.cloud.google.com/storage/browser/prod-airbyte-cloud-connector-metadata-service/registries/v0|GCS Bucket> · <${{ steps.notification-context.outputs.run-url }}|CI Logs>"
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.PUBLISH_ON_MERGE_SLACK_WEBHOOK }}

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -531,7 +531,7 @@ jobs:
             {
               "channel": "#connector-publish-updates",
               "username": "Connectors CI/CD Bot",
-              "text": "${{ steps.success-context.outputs.emoji }} *${{ steps.success-context.outputs.release-type }} Publish SUCCESS:*\nConnector: <${{ steps.success-context.outputs.dockerhub-url }}|airbyte/${{ matrix.connector }}:${{ steps.resolve-docker-image-tag.outputs.docker-image-tag }}>\nRegistry: <${{ steps.success-context.outputs.cloud-registry-url }}|cloud.json> · <${{ steps.success-context.outputs.oss-registry-url }}|oss.json>\n<${{ steps.success-context.outputs.run-url }}|View workflow run>${{ steps.success-context.outputs.pr-text }}"
+              "text": "${{ steps.success-context.outputs.emoji }} *${{ steps.success-context.outputs.release-type }} Publish SUCCESS:*\nConnector: <${{ steps.success-context.outputs.dockerhub-url }}|airbyte/${{ matrix.connector }}:${{ steps.resolve-docker-image-tag.outputs.docker-image-tag }}>\nReference: <${{ steps.success-context.outputs.cloud-registry-url }}|cloud.json> · <${{ steps.success-context.outputs.oss-registry-url }}|oss.json> · <${{ steps.success-context.outputs.run-url }}|CI Logs>${{ steps.success-context.outputs.pr-text }}"
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.PUBLISH_ON_MERGE_SLACK_WEBHOOK }}


### PR DESCRIPTION
## What

Improves the Slack notifications posted to `#connector-publish-updates` after successful connector publishes and registry compiles by consolidating all reference links onto a single `Reference:` line. This makes it easier to verify that publishes and registry updates completed correctly without manually navigating to each resource.

Motivated by a recent `source-oracle` publish where the compiled registry in GCS was correctly updated to 0.5.8 but the CDN-cached version still showed 0.5.7 — having these links in the notification would have made verification faster.

## How

In both `generate-connector-registries.yml` and `publish_connectors.yml`, replaces the standalone "View workflow run" link and `Registry:` label with a consolidated `Reference:` line using Slack-formatted links separated by `·`.

**Registry compile success** (`generate-connector-registries.yml`):
- Adds new static links: Cloud Registry, OSS Registry, GCS Bucket (Console deep link)
- Moves the workflow run URL inline as "CI Logs"

**Connector publish success** (`publish_connectors.yml`):
- Renames `Registry:` → `Reference:`
- Moves the workflow run URL from its own line into the `Reference:` line as "CI Logs"

## Review guide

1. `.github/workflows/generate-connector-registries.yml` — success notification `text` field
2. `.github/workflows/publish_connectors.yml` — success notification `text` field

Things to verify:
- The three static URLs in the registry compile notification are correct
- The GCS Console link requires GCP authentication — confirm this is acceptable for the `#connector-publish-updates` audience
- `pr-text` still renders correctly after repositioning (it includes its own `\n` prefix)
- Cloud Registry is listed before OSS Registry in both notifications

## User Impact

Engineers monitoring `#connector-publish-updates` will see clickable reference links (registry endpoints, GCS bucket, CI logs) directly in both publish and compile success notifications, enabling faster verification of registry state.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/fcf74b6927ab44358c245c8103a18f38
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75472" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
