### PR TITLE
ci(slash-commands): add /ai-dev command for testing dev playbooks

### DIFF
--- a/.github/workflows/ai-dev-command.yml
+++ b/.github/workflows/ai-dev-command.yml
@@ -1,0 +1,129 @@
+name: AI Dev Playbook Command
+
+# Runs a dev version of an ai-skills playbook against an issue in this repo.
+# Triggered via slash command: /ai-dev pr=<PR_NUMBER> playbook=<PLAYBOOK_NAME>
+#
+# Examples:
+#   /ai-dev pr=42 playbook=issue_triage
+#   /ai-dev pr=42 playbook=issue_fix
+#
+# The dev playbook must already exist in the Devin API (created by the
+# dev-playbooks.yml workflow in airbytehq/ai-skills when a PR is opened).
+
+on:
+  workflow_dispatch:
+    inputs:
+      issue:
+        description: "Issue number to test against"
+        type: number
+        required: false
+      pr:
+        description: "ai-skills PR number with the dev playbook"
+        type: number
+        required: true
+      playbook:
+        description: "Playbook name (e.g. issue_triage, issue_fix)"
+        type: string
+        required: true
+      comment-id:
+        description: "The comment-id of the slash command. Used to update the comment with the status."
+        required: false
+      repo:
+        description: "Repo (passed by slash command dispatcher)"
+        required: false
+        default: "airbytehq/airbyte"
+      gitref:
+        description: "Git ref (passed by slash command dispatcher)"
+        required: false
+
+run-name: "AI Dev Playbook: !${{ github.event.inputs.playbook }}__dev-${{ github.event.inputs.pr }}"
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  ai-dev:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get job variables
+        id: job-vars
+        run: |
+          echo "run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> $GITHUB_OUTPUT
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Authenticate as GitHub App
+        uses: actions/create-github-app-token@v2
+        id: get-app-token
+        with:
+          owner: "airbytehq"
+          repositories: "airbyte"
+          app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
+          private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
+
+      - name: Resolve inputs
+        id: resolve
+        run: |
+          set -euo pipefail
+
+          pr_number="${{ inputs.pr }}"
+          playbook_name="${{ inputs.playbook }}"
+          issue_number="${{ inputs.issue }}"
+          comment_id="${{ inputs.comment-id }}"
+
+          if [[ -z "$pr_number" ]]; then
+            echo "::error::Missing required argument: pr (ai-skills PR number)"
+            exit 1
+          fi
+
+          if [[ -z "$playbook_name" ]]; then
+            echo "::error::Missing required argument: playbook (e.g. issue_triage)"
+            exit 1
+          fi
+
+          dev_macro="!${playbook_name}__dev-${pr_number}"
+
+          echo "pr_number=${pr_number}" >> $GITHUB_OUTPUT
+          echo "playbook_name=${playbook_name}" >> $GITHUB_OUTPUT
+          echo "issue_number=${issue_number}" >> $GITHUB_OUTPUT
+          echo "comment_id=${comment_id}" >> $GITHUB_OUTPUT
+          echo "dev_macro=${dev_macro}" >> $GITHUB_OUTPUT
+
+          echo "Resolved inputs:"
+          echo "  PR number: ${pr_number}"
+          echo "  Playbook: ${playbook_name}"
+          echo "  Issue: ${issue_number}"
+          echo "  Dev macro: ${dev_macro}"
+
+      - name: Post start comment
+        if: inputs.comment-id != ''
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          token: ${{ steps.get-app-token.outputs.token }}
+          comment-id: ${{ inputs.comment-id }}
+          issue-number: ${{ steps.resolve.outputs.issue_number }}
+          body: |
+            > **AI Dev Playbook Starting**
+            >
+            > Using dev macro `${{ steps.resolve.outputs.dev_macro }}` from [ai-skills PR #${{ steps.resolve.outputs.pr_number }}](https://github.com/airbytehq/ai-skills/pull/${{ steps.resolve.outputs.pr_number }})
+            > [View workflow run](${{ steps.job-vars.outputs.run-url }})
+
+      - name: Run dev playbook
+        uses: aaronsteers/devin-action@main
+        with:
+          comment-id: ${{ steps.resolve.outputs.comment_id }}
+          issue-number: ${{ steps.resolve.outputs.issue_number }}
+          playbook-macro: ${{ steps.resolve.outputs.dev_macro }}
+          devin-token: ${{ secrets.DEVIN_AI_API_KEY }}
+          github-token: ${{ steps.get-app-token.outputs.token }}
+          api-version: v3
+          org-id: ${{ vars.DEVIN_AI_ORG_ID }}
+          start-message: '🔬 **Dev playbook session starting...** Using dev macro `${{ steps.resolve.outputs.dev_macro }}` from [ai-skills PR #${{ steps.resolve.outputs.pr_number }}](https://github.com/airbytehq/ai-skills/pull/${{ steps.resolve.outputs.pr_number }})'
+          bypass-approval: 'true'
+          tags: |
+            ai-oncall
+            playbook-dev
+            dev-pr-${{ steps.resolve.outputs.pr_number }}

--- a/.github/workflows/ai-dev-command.yml
+++ b/.github/workflows/ai-dev-command.yml
@@ -28,6 +28,10 @@ on:
       comment-id:
         description: "The comment-id of the slash command. Used to update the comment with the status."
         required: false
+      pr:
+        description: "PR number (passed by slash command dispatcher, unused)"
+        type: number
+        required: false
       repo:
         description: "Repo (passed by slash command dispatcher)"
         required: false

--- a/.github/workflows/ai-dev-command.yml
+++ b/.github/workflows/ai-dev-command.yml
@@ -121,8 +121,8 @@ jobs:
           github-token: ${{ steps.get-app-token.outputs.token }}
           api-version: v3
           org-id: ${{ vars.DEVIN_AI_ORG_ID }}
-          start-message: '🔬 **Dev playbook session starting...** Using dev macro `${{ steps.resolve.outputs.dev_macro }}` from [ai-skills PR #${{ steps.resolve.outputs.pr_number }}](https://github.com/airbytehq/ai-skills/pull/${{ steps.resolve.outputs.pr_number }})'
-          bypass-approval: 'true'
+          start-message: "🔬 **Dev playbook session starting...** Using dev macro `${{ steps.resolve.outputs.dev_macro }}` from [ai-skills PR #${{ steps.resolve.outputs.pr_number }}](https://github.com/airbytehq/ai-skills/pull/${{ steps.resolve.outputs.pr_number }})"
+          bypass-approval: "true"
           tags: |
             ai-oncall
             playbook-dev

--- a/.github/workflows/ai-dev-command.yml
+++ b/.github/workflows/ai-dev-command.yml
@@ -78,9 +78,17 @@ jobs:
             echo "::error::Missing required argument: pr (ai-skills PR number)"
             exit 1
           fi
+          if ! [[ "$pr_number" =~ ^[0-9]+$ ]]; then
+            echo "::error::Invalid pr number: must be digits only"
+            exit 1
+          fi
 
           if [[ -z "$playbook_name" ]]; then
             echo "::error::Missing required argument: playbook (e.g. issue_triage)"
+            exit 1
+          fi
+          if ! [[ "$playbook_name" =~ ^[a-z0-9_]+$ ]]; then
+            echo "::error::Invalid playbook name: must match [a-z0-9_]+"
             exit 1
           fi
 

--- a/.github/workflows/ai-dev-command.yml
+++ b/.github/workflows/ai-dev-command.yml
@@ -15,7 +15,7 @@ on:
     inputs:
       issue:
         description: "Issue number to test against"
-        type: number
+        type: string
         required: false
       skills-pr:
         description: "ai-skills PR number with the dev playbook (named skills-pr to avoid collision with the pr static-arg)"
@@ -88,7 +88,7 @@ jobs:
           # When invoked via slash command, inputs.issue is empty because
           # the slash-commands.yml static-args don't include issue=.
           # Resolve the issue number from the comment-id via the GitHub API.
-          if [[ -z "$issue_number" && -n "$comment_id" ]]; then
+          if [[ -z "$issue_number" || "$issue_number" == "0" ]] && [[ -n "$comment_id" ]]; then
             echo "Resolving issue number from comment-id..."
             issue_number=$(curl -s \
               -H "Authorization: Bearer $GH_TOKEN" \

--- a/.github/workflows/ai-dev-command.yml
+++ b/.github/workflows/ai-dev-command.yml
@@ -66,13 +66,19 @@ jobs:
 
       - name: Resolve inputs
         id: resolve
+        env:
+          INPUT_PR_NUMBER: ${{ inputs.pr }}
+          INPUT_PLAYBOOK_NAME: ${{ inputs.playbook }}
+          INPUT_ISSUE_NUMBER: ${{ inputs.issue }}
+          INPUT_COMMENT_ID: ${{ inputs.comment-id }}
         run: |
           set -euo pipefail
 
-          pr_number="${{ inputs.pr }}"
-          playbook_name="${{ inputs.playbook }}"
-          issue_number="${{ inputs.issue }}"
-          comment_id="${{ inputs.comment-id }}"
+          # Resolve from env vars (safely passed via env: to avoid script injection)
+          pr_number="$INPUT_PR_NUMBER"
+          playbook_name="$INPUT_PLAYBOOK_NAME"
+          issue_number="$INPUT_ISSUE_NUMBER"
+          comment_id="$INPUT_COMMENT_ID"
 
           if [[ -z "$pr_number" ]]; then
             echo "::error::Missing required argument: pr (ai-skills PR number)"

--- a/.github/workflows/ai-dev-command.yml
+++ b/.github/workflows/ai-dev-command.yml
@@ -75,6 +75,7 @@ jobs:
           INPUT_PLAYBOOK_NAME: ${{ inputs.playbook }}
           INPUT_ISSUE_NUMBER: ${{ inputs.issue }}
           INPUT_COMMENT_ID: ${{ inputs.comment-id }}
+          GH_TOKEN: ${{ steps.get-app-token.outputs.token }}
         run: |
           set -euo pipefail
 
@@ -83,6 +84,24 @@ jobs:
           playbook_name="$INPUT_PLAYBOOK_NAME"
           issue_number="$INPUT_ISSUE_NUMBER"
           comment_id="$INPUT_COMMENT_ID"
+
+          # When invoked via slash command, inputs.issue is empty because
+          # the slash-commands.yml static-args don't include issue=.
+          # Resolve the issue number from the comment-id via the GitHub API.
+          if [[ -z "$issue_number" && -n "$comment_id" ]]; then
+            echo "Resolving issue number from comment-id..."
+            issue_number=$(curl -s \
+              -H "Authorization: Bearer $GH_TOKEN" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/$GITHUB_REPOSITORY/issues/comments/$comment_id" \
+              | jq -r '.issue_url | split("/") | last')
+            if [[ -z "$issue_number" || "$issue_number" == "null" ]]; then
+              echo "::warning::Could not resolve issue number from comment-id $comment_id"
+              issue_number=""
+            else
+              echo "Resolved issue number: $issue_number"
+            fi
+          fi
 
           if [[ -z "$pr_number" ]]; then
             echo "::error::Missing required argument: pr (ai-skills PR number)"

--- a/.github/workflows/ai-dev-command.yml
+++ b/.github/workflows/ai-dev-command.yml
@@ -1,11 +1,11 @@
 name: AI Dev Playbook Command
 
 # Runs a dev version of an ai-skills playbook against an issue in this repo.
-# Triggered via slash command: /ai-dev pr=<PR_NUMBER> playbook=<PLAYBOOK_NAME>
+# Triggered via slash command: /ai-dev skills-pr=<PR_NUMBER> playbook=<PLAYBOOK_NAME>
 #
 # Examples:
-#   /ai-dev pr=42 playbook=issue_triage
-#   /ai-dev pr=42 playbook=issue_fix
+#   /ai-dev skills-pr=42 playbook=issue_triage
+#   /ai-dev skills-pr=42 playbook=issue_fix
 #
 # The dev playbook must already exist in the Devin API (created by the
 # dev-playbooks.yml workflow in airbytehq/ai-skills when a PR is opened).
@@ -17,8 +17,8 @@ on:
         description: "Issue number to test against"
         type: number
         required: false
-      pr:
-        description: "ai-skills PR number with the dev playbook"
+      skills-pr:
+        description: "ai-skills PR number with the dev playbook (named skills-pr to avoid collision with the pr static-arg)"
         type: number
         required: true
       playbook:
@@ -36,7 +36,7 @@ on:
         description: "Git ref (passed by slash command dispatcher)"
         required: false
 
-run-name: "AI Dev Playbook: !${{ github.event.inputs.playbook }}__dev-${{ github.event.inputs.pr }}"
+run-name: "AI Dev Playbook: !${{ github.event.inputs.playbook }}__dev-${{ github.event.inputs.skills-pr }}"
 
 permissions:
   contents: read
@@ -67,7 +67,7 @@ jobs:
       - name: Resolve inputs
         id: resolve
         env:
-          INPUT_PR_NUMBER: ${{ inputs.pr }}
+          INPUT_PR_NUMBER: ${{ inputs.skills-pr }}
           INPUT_PLAYBOOK_NAME: ${{ inputs.playbook }}
           INPUT_ISSUE_NUMBER: ${{ inputs.issue }}
           INPUT_COMMENT_ID: ${{ inputs.comment-id }}

--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -76,6 +76,7 @@ jobs:
             run-connector-tests
             run-regression-tests
             test-performance
+            ai-dev
             update-connector-cdk-version
 
           # Notes regarding static-args:

--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -58,15 +58,16 @@ jobs:
 
           commands: |
             ai-canary-prerelease
-            ai-docs-review
             ai-create-docs-pr
+            ai-dev
+            ai-docs-review
             ai-prove-fix
             ai-release-watch
             ai-review
             approve-regression-tests
+            build-connector-images
             bump-progressive-rollout-version
             bump-version
-            build-connector-images
             force-merge
             format-fix
             poe
@@ -76,7 +77,6 @@ jobs:
             run-connector-tests
             run-regression-tests
             test-performance
-            ai-dev
             update-connector-cdk-version
 
           # Notes regarding static-args:


### PR DESCRIPTION
## What

Adds `/ai-dev` slash command support to the airbyte repo, enabling engineers to test dev versions of ai-skills playbooks against issues before the playbook PR is merged.

Companion PRs:
- https://github.com/airbytehq/ai-skills/pull/158 — creates dev playbooks automatically when a PR modifies playbook `.md` files
- https://github.com/airbytehq/oncall/pull/11784 — same `/ai-dev` command for the oncall repo

Usage on any issue:
```
/ai-dev skills-pr=42 playbook=issue_triage
```

## How

1. **`ai-dev-command.yml`** — New workflow triggered via `workflow_dispatch` (from slash command dispatcher). Resolves inputs safely via `env:` mapping, validates them with regex checks, constructs the dev macro `!{playbook}__dev-{skills-pr}`, posts a start comment, and invokes `devin-action` with that macro.
2. **`slash-commands.yml`** — Registers `ai-dev` in the existing command dispatcher and alpha-sorts the full commands list.

### Issue number resolution

Since airbyte's `slash-commands.yml` static-args don't include `issue=` (and adding it would require updating every other command workflow), the `ai-dev-command.yml` resolves the issue number from the `comment-id` via the GitHub API at runtime. This handles the slash command case where `inputs.issue` is empty.

## Review guide

1. `.github/workflows/slash-commands.yml` — `ai-dev` added to commands list; list alpha-sorted
2. `.github/workflows/ai-dev-command.yml` — new workflow; modeled after `ai-prove-fix-command.yml`

**Key things to verify:**
- Input `skills-pr` (not `pr`) avoids collision with the `pr` static-arg that the dispatcher always sends (line 90 of `slash-commands.yml`). If a user omits `skills-pr=`, the workflow correctly errors instead of silently using the wrong value.
- Dev macro construction `!{playbook}__dev-{skills-pr}` matches the convention in the ai-skills companion PR
- Required secrets (`DEVIN_AI_API_KEY`, `OCTAVIA_BOT_APP_ID`, `OCTAVIA_BOT_PRIVATE_KEY`) and vars (`DEVIN_AI_ORG_ID`) exist in this repo (they are already used by other `ai-*` workflows)
- `bypass-approval: "true"` is intentional — dev playbook sessions skip Devin's approval gate, consistent with other ai-* commands
- User-controlled inputs are passed via `env:` mapping (not interpolated directly into `run:` blocks) to prevent script injection
- Input validation enforces `skills-pr` is digits-only and `playbook` matches `[a-z0-9_]+`
- The `issue` input uses `type: string` (not `number`) because `number` defaults to `0` when omitted, which would bypass the fallback resolution from `comment-id`
- The issue resolution fallback (lines 91–104) calls the GitHub API to extract the issue number from the comment — **this path is untested** since it requires a real slash command invocation; worth verifying after merge

> **Note for reviewers:** The `run-name` on line 43 uses `${{ github.event.inputs.* }}` directly, but this is in a YAML metadata context (not a shell `run:` block) so it is not vulnerable to script injection — GitHub evaluates it as a display string only.

## User Impact

Engineers can now test in-progress playbook changes from `airbytehq/ai-skills` PRs directly against airbyte issues using `/ai-dev skills-pr=<N> playbook=<name>`, without waiting for the playbook PR to merge.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/5367214fbe504430ac7c56798b704e5d
Requested by: @pedroslopez