### PR TITLE
docs(source-uptick): revert incorrect incremental sync status for 35 streams

### DIFF
--- a/docs/integrations/sources/uptick.md
+++ b/docs/integrations/sources/uptick.md
@@ -101,30 +101,30 @@ The Uptick connector syncs data from the following streams, organized by functio
 | Stream Name | Primary Key | Pagination | Supports Full Sync | Supports Incremental |
 |-------------|-------------|------------|---------------------|----------------------|
 | `tasks` | `id` | `DefaultPaginator` | ✅ | ✅ |
-| `taskcategories` | `id` | `DefaultPaginator` | ✅ | ✅ |
-| `clients` | `id` | `DefaultPaginator` | ✅ | ✅ |
-| `clientgroups` | `id` | `DefaultPaginator` | ✅ | ✅ |
-| `properties` | `id` | `DefaultPaginator` | ✅ | ✅ |
-| `invoices` | `id` | `DefaultPaginator` | ✅ | ✅ |
-| `projects` | `id` | `DefaultPaginator` | ✅ | ✅ |
-| `servicequotes` | `id` | `DefaultPaginator` | ✅ | ✅ |
-| `defectquotes` | `id` | `DefaultPaginator` | ✅ | ✅ |
-| `suppliers` | `id` | `DefaultPaginator` | ✅ | ✅ |
-| `purchaseorders` | `id` | `DefaultPaginator` | ✅ | ✅ |
-| `purchaseorderlineitems` | `id` | `DefaultPaginator` | ✅ | ✅ |
+| `taskcategories` | `id` | `DefaultPaginator` | ✅ | ❌ (no soft delete) |
+| `clients` | `id` | `DefaultPaginator` | ✅ | ❌ (no soft delete) |
+| `clientgroups` | `id` | `DefaultPaginator` | ✅ | ❌ (no soft delete) |
+| `properties` | `id` | `DefaultPaginator` | ✅ | ❌ (no soft delete) |
+| `invoices` | `id` | `DefaultPaginator` | ✅ | ❌ (no soft delete) |
+| `projects` | `id` | `DefaultPaginator` | ✅ | ❌ (no soft delete) |
+| `servicequotes` | `id` | `DefaultPaginator` | ✅ | ❌ (no soft delete) |
+| `defectquotes` | `id` | `DefaultPaginator` | ✅ | ❌ (no soft delete) |
+| `suppliers` | `id` | `DefaultPaginator` | ✅ | ❌ (no soft delete) |
+| `purchaseorders` | `id` | `DefaultPaginator` | ✅ | ❌ (no soft delete) |
+| `purchaseorderlineitems` | `id` | `DefaultPaginator` | ✅ | ❌ (no soft delete) |
 | `assets` | `id` | `DefaultPaginator` | ✅ | ✅ |
-| `routines` | `id` | `DefaultPaginator` | ✅ | ✅ |
-| `billingcards` | `id` | `DefaultPaginator` | ✅ | ✅ |
-| `purchaseorderbills` | `id` | `DefaultPaginator` | ✅ | ✅ |
-| `purchaseorderbilllineitems` | `id` | `DefaultPaginator` | ✅ | ✅ |
-| `purchaseorderdockets` | `id` | `DefaultPaginator` | ✅ | ✅ |
-| `invoicelineitems` | `id` | `DefaultPaginator` | ✅ | ✅ |
-| `users` | `id` | `DefaultPaginator` | ✅ | ✅ |
-| `servicegroups` | `id` | `DefaultPaginator` | ✅ | ✅ |
-| `costcentres` | `id` | `DefaultPaginator` | ✅ | ✅ |
-| `accreditationtypes` | `id` | `DefaultPaginator` | ✅ | ✅ |
-| `accreditations` | `id` | `DefaultPaginator` | ✅ | ✅ |
-| `branches` | `id` | `DefaultPaginator` | ✅ | ✅ |
+| `routines` | `id` | `DefaultPaginator` | ✅ | ❌ (no soft delete) |
+| `billingcards` | `id` | `DefaultPaginator` | ✅ | ❌ (no soft delete) |
+| `purchaseorderbills` | `id` | `DefaultPaginator` | ✅ | ❌ (no soft delete) |
+| `purchaseorderbilllineitems` | `id` | `DefaultPaginator` | ✅ | ❌ (no soft delete) |
+| `purchaseorderdockets` | `id` | `DefaultPaginator` | ✅ | ❌ (no soft delete) |
+| `invoicelineitems` | `id` | `DefaultPaginator` | ✅ | ❌ (no soft delete) |
+| `users` | `id` | `DefaultPaginator` | ✅ | ❌ (no soft delete) |
+| `servicegroups` | `id` | `DefaultPaginator` | ✅ | ❌ (no soft delete) |
+| `costcentres` | `id` | `DefaultPaginator` | ✅ | ❌ (no soft delete) |
+| `accreditationtypes` | `id` | `DefaultPaginator` | ✅ | ❌ (no soft delete) |
+| `accreditations` | `id` | `DefaultPaginator` | ✅ | ❌ (no soft delete) |
+| `branches` | `id` | `DefaultPaginator` | ✅ | ❌ (no soft delete) |
 | `creditnotes` | `id` | `DefaultPaginator` | ✅ | ✅ |
 | `creditnotelineitems` | `id` | `DefaultPaginator` | ✅ | ✅ |
 | `remarks` | `id` | `DefaultPaginator` | ✅ | ✅ |
@@ -132,20 +132,20 @@ The Uptick connector syncs data from the following streams, organized by functio
 | `assettypevariants` | `id` | `DefaultPaginator` | ✅ | ✅ |
 | `products` | `id` | `DefaultPaginator` | ✅ | ✅ |
 | `rounds` | `id` | `DefaultPaginator` | ✅ | ✅ |
-| `tasksessions` | `id` | `DefaultPaginator` | ✅ | ✅ |
-| `contractors` | `id` | `DefaultPaginator` | ✅ | ✅ |
-| `appointments` | `id` | `DefaultPaginator` | ✅ | ✅ |
-| `billingcontracts` | `id` | `DefaultPaginator` | ✅ | ✅ |
-| `billingcontractlineitems` | `id` | `DefaultPaginator` | ✅ | ✅ |
-| `defectquotelineitems` | `id` | `DefaultPaginator` | ✅ | ✅ |
-| `servicequotefixedlineitems` | `id` | `DefaultPaginator` | ✅ | ✅ |
-| `servicequotedoandchargelineitems` | `id` | `DefaultPaginator` | ✅ | ✅ |
-| `servicequoteproductlineitems` | `id` | `DefaultPaginator` | ✅ | ✅ |
-| `remarkevents` | `id` | `DefaultPaginator` | ✅ | ✅ |
-| `routineservices` | `id` | `DefaultPaginator` | ✅ | ✅ |
-| `routineservicelevels` | `id` | `DefaultPaginator` | ✅ | ✅ |
-| `routineservicetypes` | `id` | `DefaultPaginator` | ✅ | ✅ |
-| `routineserviceleveltypes` | `id` | `DefaultPaginator` | ✅ | ✅ |
+| `tasksessions` | `id` | `DefaultPaginator` | ✅ | ❌ (no soft delete) |
+| `contractors` | `id` | `DefaultPaginator` | ✅ | ❌ (no soft delete) |
+| `appointments` | `id` | `DefaultPaginator` | ✅ | ❌ (no soft delete) |
+| `billingcontracts` | `id` | `DefaultPaginator` | ✅ | ❌ (no soft delete) |
+| `billingcontractlineitems` | `id` | `DefaultPaginator` | ✅ | ❌ (no soft delete) |
+| `defectquotelineitems` | `id` | `DefaultPaginator` | ✅ | ❌ (no soft delete) |
+| `servicequotefixedlineitems` | `id` | `DefaultPaginator` | ✅ | ❌ (no soft delete) |
+| `servicequotedoandchargelineitems` | `id` | `DefaultPaginator` | ✅ | ❌ (no soft delete) |
+| `servicequoteproductlineitems` | `id` | `DefaultPaginator` | ✅ | ❌ (no soft delete) |
+| `remarkevents` | `id` | `DefaultPaginator` | ✅ | ❌ (no soft delete) |
+| `routineservices` | `id` | `DefaultPaginator` | ✅ | ❌ (no soft delete) |
+| `routineservicelevels` | `id` | `DefaultPaginator` | ✅ | ❌ (no soft delete) |
+| `routineservicetypes` | `id` | `DefaultPaginator` | ✅ | ❌ (no soft delete) |
+| `routineserviceleveltypes` | `id` | `DefaultPaginator` | ✅ | ❌ (no soft delete) |
 | `servicetasks` | `id` | `DefaultPaginator` | ✅ | ✅ |
 | `subtasks` | `id` | `DefaultPaginator` | ✅ | ✅ |
 | `task_profitability` | `task_id` | `DefaultPaginator` | ✅ | ✅ |


### PR DESCRIPTION
## What

Reverts the stream incremental sync status changes introduced in https://github.com/airbytehq/airbyte/pull/73719. The Uptick API maintainer (@aidanlister) [confirmed](https://github.com/airbytehq/airbyte/pull/73719#issuecomment-4107205319) that these 35 streams do not have soft delete capability on the Uptick platform side, so incremental sync should not be recommended for them.

## How

Restores the "Supports Incremental" column from ✅ back to ❌ (no soft delete) for the 35 affected streams in `docs/integrations/sources/uptick.md`. The changelog deduplication and date correction from PR #73719 are intentionally retained.

### Why the original change was made (and why it was wrong)

The original PR observed that all 49 streams in `manifest.yaml` have `incremental_sync` configured via `DatetimeBasedCursor` and include `show_deleted: "true"` in their request parameters. This was interpreted as evidence that the Uptick API supports soft deletes for these streams — i.e., that deleted records would still be returned with an updated timestamp, allowing incremental sync to capture deletions.

However, `show_deleted: "true"` is merely a request filter sent to the Uptick API. It does not mean the platform actually implements soft deletes on those endpoints. Without true soft-delete support, incremental sync risks missing deleted records, so these streams should remain documented as not supporting incremental sync.

## Review guide

1. `docs/integrations/sources/uptick.md` — the only file changed. Verify the 35 streams are restored to ❌ and the 14 streams that were already ✅ before PR #73719 (`tasks`, `assets`, `creditnotes`, `creditnotelineitems`, `remarks`, `assettypes`, `assettypevariants`, `products`, `rounds`, `servicetasks`, `subtasks`, `task_profitability`) remain unchanged.

## User Impact

Documentation now correctly reflects which streams support incremental sync, preventing users from enabling incremental mode on streams where it may silently miss deleted records.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

Link to Devin session: https://app.devin.ai/sessions/db93ce9472e94fc4ba376caa80e58168
Requested by: @ian-at-airbyte