### PR TITLE
fix: upgrade dest postgres CDK to 1.0.6. Fix duplicate records in dedup+tr…

### DIFF
--- a/airbyte-integrations/connectors/destination-postgres/gradle.properties
+++ b/airbyte-integrations/connectors/destination-postgres/gradle.properties
@@ -1,4 +1,4 @@
-cdkVersion=1.0.2
+cdkVersion=1.0.6
 # our testcontainer has issues with too much concurrency.
 # 4 threads seems to be the sweet spot.
 testExecutionConcurrency=4

--- a/airbyte-integrations/connectors/destination-postgres/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-postgres/metadata.yaml
@@ -6,7 +6,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 25c5221d-dce2-4163-ade9-739ef790f503
-  dockerImageTag: 3.0.11
+  dockerImageTag: 3.0.12
   dockerRepository: airbyte/destination-postgres
   documentationUrl: https://docs.airbyte.com/integrations/destinations/postgres
   githubIssueLabel: destination-postgres

--- a/docs/integrations/destinations/postgres.md
+++ b/docs/integrations/destinations/postgres.md
@@ -298,6 +298,7 @@ This destination supports [namespaces](https://docs.airbyte.com/platform/using-a
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                                                                                                |
 |:--------|:-----------|:-----------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 3.0.12  | 2026-03-25 | | Upgrade CDK to 1.0.6; fix duplicate records in dedup+truncate mode by dropping temp tables after successful upsert |
 | 3.0.11  | 2026-02-25 | | Upgrade CDK to 1.0.2 and base image to 2.0.4 for CVE patches |
 | 3.0.10  | 2026-02-04 | [72858](https://github.com/airbytehq/airbyte/pull/72858)   | Upgrade CDK to 0.2.8                                                                                                                                                                   |
 | 3.0.9   | 2026-01-28 | [72292](https://github.com/airbytehq/airbyte/pull/72292)   | Upgrade CDK to 0.2.0                                                                                                                                                                   |


### PR DESCRIPTION
## What
Propagate the duplicate-records fix ([#74715](https://github.com/airbytehq/airbyte/pull/74715)) to destination-postgres by bumping bulk-cdk-core-load from 1.0.2 to 1.0.6.

## How
CDK version bump. The fix (dropping temp tables after successful upsert in `DedupTruncateStreamLoader.performUpsertWithTemporaryTable()`) already exists in the CDK; postgres just hadn't picked it up.

## User Impact
Postgres users syncing in dedup+truncate mode will no longer see duplicate records across successive syncs. No negative side effects expected.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌