### PR TITLE
feat(source-klaviyo): add lookback window for reporting streams

### DIFF
--- a/airbyte-integrations/connectors/source-klaviyo/manifest.yaml
+++ b/airbyte-integrations/connectors/source-klaviyo/manifest.yaml
@@ -1089,6 +1089,7 @@ definitions:
           datetime_format: "%Y-%m-%dT%H:%M:%S%z"
         step: P30D
         cursor_granularity: PT1S
+        lookback_window: "P{{ config.get('reporting_lookback_window', 0) }}D"
       transformations:
         - type: AddFields
           fields:
@@ -1231,6 +1232,7 @@ definitions:
           datetime_format: "%Y-%m-%dT%H:%M:%S%z"
         step: P30D
         cursor_granularity: PT1S
+        lookback_window: "P{{ config.get('reporting_lookback_window', 0) }}D"
       transformations:
         - type: AddFields
           fields:
@@ -1343,7 +1345,8 @@ spec:
         description: >-
           The number of days to look back when syncing data in incremental mode.
           This helps capture any late-arriving data. Only applies to the
-          events_detailed stream.
+          events_detailed stream. For reporting streams (flow_series_reports,
+          campaign_values_reports), use Reporting Lookback Window instead.
         title: Lookback Window (Days)
         minimum: 0
         default: 0
@@ -1351,6 +1354,21 @@ spec:
           - 0
           - 7
         order: 4
+      reporting_lookback_window:
+        type: integer
+        title: Reporting Lookback Window (Days)
+        description: >-
+          The number of days to look back when syncing reporting data
+          (flow_series_reports and campaign_values_reports) in incremental
+          mode. This helps capture late-arriving attribution data that
+          Klaviyo may update after the initial sync. Defaults to 0.
+        minimum: 0
+        default: 0
+        examples:
+          - 0
+          - 7
+          - 30
+        order: 5
       metric_ids:
         type: string
         title: Report Stream Conversion Metric IDs
@@ -1365,7 +1383,7 @@ spec:
           for Placed Order) to avoid slow syncs. Find metric IDs in your Klaviyo
           account under Analytics > Metrics, or use the metrics stream to list all
           available metrics and their IDs.
-        order: 5
+        order: 6
         examples:
           - "RESQ6t"
           - "RESQ6t,ABC123,XYZ789"


### PR DESCRIPTION
## Summary

Adds a configurable `reporting_lookback_window` parameter to `flow_series_reports` and `campaign_values_reports` streams, following the same pattern already implemented for `events_detailed`.

## Problem

Klaviyo's attribution data can be updated hours or days after initial sync. The existing `lookback_window` parameter only applies to `events_detailed`. There is no way to re-fetch reporting data within a configurable window, forcing users to either reset the entire connection (losing historical data) or accept stale attribution data in reporting streams.

## Solution

- Added `lookback_window` to the `incremental_sync` config of `flow_series_reports` and `campaign_values_reports` streams
- Added `reporting_lookback_window` config property in the spec (separate from the existing `lookback_window` to avoid breaking changes)
- Updated `lookback_window` description to clarify it only applies to `events_detailed`

## Changes

- `manifest.yaml`: 1 line added to each of the 2 reporting streams, 1 new spec property, 1 updated description
- **No Python code changes** — purely declarative YAML config

## Testing

- Existing unit tests pass (123 tests)
- Follows identical pattern to the working `events_detailed` lookback implementation

Related to #61001