### PR TITLE
feat(source-gong): migrate OAuth scope to scopes object array

### DIFF
--- a/airbyte-integrations/connectors/source-gong/manifest.yaml
+++ b/airbyte-integrations/connectors/source-gong/manifest.yaml
@@ -548,7 +548,13 @@ spec:
     predicate_value: OAuth2.0
     oauth_config_specification:
       oauth_connector_input_specification:
-        consent_url: https://app.gong.io/oauth2/authorize?client_id={{client_id_value}}&redirect_uri={{redirect_uri_value}}&response_type=code&state={{state_value}}&scope={{scope_value | urlEncode}}
+        scopes:
+          - scope: "api:calls:read:basic"
+          - scope: "api:calls:read:extensive"
+          - scope: "api:users:read"
+          - scope: "api:stats:scorecards"
+          - scope: "api:stats:interaction"
+        consent_url: https://app.gong.io/oauth2/authorize?client_id={{client_id_value}}&redirect_uri={{redirect_uri_value}}&response_type=code&state={{state_value}}&{{scopes_param}}
         access_token_url: https://app.gong.io/oauth2/generate-customer-token
         access_token_headers:
           Authorization: "Basic {{ (client_id_value ~ ':' ~ client_secret_value) | b64encode }}"
@@ -557,7 +563,6 @@ spec:
           grant_type: authorization_code
           redirect_uri: "{{ redirect_uri_value }}"
           code: "{{ auth_code_value }}"
-        scope: api:calls:read:basic api:calls:read:extensive api:users:read api:stats:scorecards api:stats:interaction
         extract_output:
           - access_token
           - refresh_token

--- a/airbyte-integrations/connectors/source-gong/metadata.yaml
+++ b/airbyte-integrations/connectors/source-gong/metadata.yaml
@@ -7,7 +7,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 32382e40-3b49-4b99-9c5c-4076501914e7
-  dockerImageTag: 0.6.2
+  dockerImageTag: 0.6.3
   dockerRepository: airbyte/source-gong
   documentationUrl: https://docs.airbyte.com/integrations/sources/gong
   githubIssueLabel: source-gong


### PR DESCRIPTION
## Summary
- Convert `scope` string to `scopes` array format with `{{scopes_param}}` template variable
- Replaces `scope: api:calls:read:basic api:calls:read:extensive...` with individual scope objects
- Updates consent URL from `{{scope_value | urlEncode}}` to `{{scopes_param}}`
- Version bump 0.6.2 → 0.6.3

Related: https://github.com/airbytehq/airbyte-internal-issues/issues/16023
Supersedes: https://github.com/airbytehq/airbyte/pull/75195

## Test plan
- [ ] Verify consent URL includes all 5 scopes URL-encoded
- [ ] Verify full OAuth flow: consent → callback → token exchange → access_token + refresh_token
- [ ] Confirm scopes match production Gong OAuth configuration