### PR TITLE
fix: remove the per 1000 record flush. move compression to flush thread.

### DIFF
--- a/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/sql/SnowflakeDirectLoadSqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/sql/SnowflakeDirectLoadSqlGenerator.kt
@@ -321,8 +321,7 @@ class SnowflakeDirectLoadSqlGenerator(
         val stageName = fullyQualifiedStageName(tableName, true)
         return """
             PUT 'file://$tempFilePath' '@$stageName'
-            AUTO_COMPRESS = FALSE
-            SOURCE_COMPRESSION = GZIP
+            AUTO_COMPRESS = TRUE
             OVERWRITE = TRUE
         """
             .trimIndent()
@@ -343,7 +342,7 @@ class SnowflakeDirectLoadSqlGenerator(
             |FROM '@$stageName'
             |FILE_FORMAT = (
             |    TYPE = 'CSV'
-            |    COMPRESSION = GZIP
+            |    COMPRESSION = AUTO
             |    FIELD_DELIMITER = '$CSV_FIELD_SEPARATOR'
             |    RECORD_DELIMITER = '$CSV_LINE_DELIMITER'
             |    FIELD_OPTIONALLY_ENCLOSED_BY = '"'

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/write/load/SnowflakeInsertBuffer.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/write/load/SnowflakeInsertBuffer.kt
@@ -16,10 +16,9 @@ import io.airbyte.integrations.destination.snowflake.schema.SnowflakeColumnManag
 import io.airbyte.integrations.destination.snowflake.spec.SnowflakeConfiguration
 import io.airbyte.integrations.destination.snowflake.sql.QUOTE
 import io.github.oshai.kotlinlogging.KotlinLogging
+import java.io.BufferedOutputStream
 import java.io.File
-import java.io.OutputStream
 import java.nio.file.Path
-import java.util.zip.GZIPOutputStream
 import kotlin.io.path.deleteIfExists
 import kotlin.io.path.pathString
 
@@ -30,7 +29,7 @@ internal const val CSV_FIELD_SEPARATOR = ','
 internal const val CSV_QUOTE_CHARACTER = '"'
 internal val CSV_LINE_DELIMITER = LineDelimiter.LF
 internal const val FILE_PREFIX = "snowflake"
-internal const val FILE_SUFFIX = ".gz"
+internal const val FILE_SUFFIX = ""
 
 private const val CSV_WRITER_BUFFER_SIZE = 1024 * 1024 // 1 MB
 
@@ -61,10 +60,7 @@ class SnowflakeInsertBuffer(
         if (csvFilePath == null) {
             val csvFile = createCsvFile()
             csvFilePath = csvFile.toPath()
-            csvWriter =
-                csvWriterBuilder.build(
-                    CompressionOutputStream(outputStream = csvFile.outputStream(), level = 5)
-                )
+            csvWriter = csvWriterBuilder.build(BufferedOutputStream(csvFile.outputStream()))
         }
 
         writeToCsvFile(recordFields)
@@ -88,7 +84,14 @@ class SnowflakeInsertBuffer(
                 // Finally, copy the data from the staging table to the final table
                 // Pass column names to ensure correct mapping even after ALTER TABLE operations
                 val columnNames = columnManager.getTableColumnNames(columnSchema)
-                snowflakeClient.copyFromStage(tableName, filePath.fileName.toString(), columnNames)
+                // When PUT uses AUTO_COMPRESS = TRUE, Snowflake GZIP-compresses the file
+                // during upload and silently appends ".gz" to the staged filename.
+                // The COPY INTO files clause must reference this post-rename filename.
+                snowflakeClient.copyFromStage(
+                    tableName,
+                    filePath.fileName.toString() + ".gz",
+                    columnNames
+                )
                 logger.info {
                     "Finished insert of $recordCount row(s) into ${tableName.toPrettyString(quote = QUOTE)}."
                 }
@@ -117,13 +120,6 @@ class SnowflakeInsertBuffer(
                 snowflakeRecordFormatter.format(record, columnSchema).map { col -> col.toString() }
             )
             recordCount++
-        }
-    }
-
-    private class CompressionOutputStream(outputStream: OutputStream, level: Int) :
-        GZIPOutputStream(outputStream) {
-        init {
-            def.setLevel(level)
         }
     }
 }

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/write/load/SnowflakeInsertBuffer.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/write/load/SnowflakeInsertBuffer.kt
@@ -29,7 +29,6 @@ internal const val CSV_FILE_EXTENSION = ".csv"
 internal const val CSV_FIELD_SEPARATOR = ','
 internal const val CSV_QUOTE_CHARACTER = '"'
 internal val CSV_LINE_DELIMITER = LineDelimiter.LF
-internal const val DEFAULT_FLUSH_LIMIT = 1000
 internal const val FILE_PREFIX = "snowflake"
 internal const val FILE_SUFFIX = ".gz"
 
@@ -42,7 +41,6 @@ class SnowflakeInsertBuffer(
     val columnSchema: ColumnSchema,
     private val columnManager: SnowflakeColumnManager,
     private val snowflakeRecordFormatter: SnowflakeRecordFormatter,
-    private val flushLimit: Int = DEFAULT_FLUSH_LIMIT,
 ) {
 
     @VisibleForTesting internal var csvFilePath: Path? = null
@@ -119,9 +117,6 @@ class SnowflakeInsertBuffer(
                 snowflakeRecordFormatter.format(record, columnSchema).map { col -> col.toString() }
             )
             recordCount++
-            if ((recordCount % flushLimit) == 0) {
-                it.flush()
-            }
         }
     }
 

--- a/airbyte-integrations/connectors/destination-snowflake/src/test/kotlin/io/airbyte/integrations/destination/snowflake/client/SnowflakeAirbyteClientTest.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test/kotlin/io/airbyte/integrations/destination/snowflake/client/SnowflakeAirbyteClientTest.kt
@@ -491,9 +491,13 @@ internal class SnowflakeAirbyteClientTest {
 
         every { dataSource.connection } returns mockConnection
 
+        // Verifies delegation to sqlGenerator and proper connection cleanup.
+        // In production, the buffer appends .gz because AUTO_COMPRESS renames the staged file.
+        val filename = "test.csv.gz"
+        val columnNames = listOf("col1", "col2")
         runBlocking {
-            client.copyFromStage(tableName, "test.csv.gz", listOf())
-            verify(exactly = 1) { sqlGenerator.copyFromStage(tableName, "test.csv.gz", listOf()) }
+            client.copyFromStage(tableName, filename, columnNames)
+            verify(exactly = 1) { sqlGenerator.copyFromStage(tableName, filename, columnNames) }
             verify(exactly = 1) { mockConnection.close() }
         }
     }

--- a/airbyte-integrations/connectors/destination-snowflake/src/test/kotlin/io/airbyte/integrations/destination/snowflake/sql/SnowflakeDirectLoadSqlGeneratorTest.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test/kotlin/io/airbyte/integrations/destination/snowflake/sql/SnowflakeDirectLoadSqlGeneratorTest.kt
@@ -242,8 +242,7 @@ internal class SnowflakeDirectLoadSqlGeneratorTest {
         val expectedSql =
             """
             PUT 'file://$tempFilePath' '@$stagingTableName'
-            AUTO_COMPRESS = FALSE
-            SOURCE_COMPRESSION = GZIP
+            AUTO_COMPRESS = TRUE
             OVERWRITE = TRUE
         """.trimIndent()
         assertEquals(expectedSql, sql)
@@ -254,14 +253,14 @@ internal class SnowflakeDirectLoadSqlGeneratorTest {
         val tableName = TableName(namespace = "namespace", name = "name")
         val targetTableName = snowflakeDirectLoadSqlGenerator.fullyQualifiedName(tableName)
         val stagingTableName = snowflakeDirectLoadSqlGenerator.fullyQualifiedStageName(tableName)
-        val sql = snowflakeDirectLoadSqlGenerator.copyFromStage(tableName, "test.csv.gz")
+        val sql = snowflakeDirectLoadSqlGenerator.copyFromStage(tableName, "test.csv")
         val expectedSql =
             """
             |COPY INTO $targetTableName
             |FROM '@$stagingTableName'
             |FILE_FORMAT = (
             |    TYPE = 'CSV'
-            |    COMPRESSION = GZIP
+            |    COMPRESSION = AUTO
             |    FIELD_DELIMITER = '$CSV_FIELD_SEPARATOR'
             |    RECORD_DELIMITER = '$CSV_LINE_DELIMITER'
             |    FIELD_OPTIONALLY_ENCLOSED_BY = '"'
@@ -273,7 +272,7 @@ internal class SnowflakeDirectLoadSqlGeneratorTest {
             |)
             |ON_ERROR = 'ABORT_STATEMENT'
             |PURGE = TRUE
-            |files = ('test.csv.gz')
+            |files = ('test.csv')
         """.trimMargin()
         assertEquals(expectedSql, sql)
     }
@@ -294,14 +293,14 @@ internal class SnowflakeDirectLoadSqlGeneratorTest {
                 "COL2"
             )
         val sql =
-            snowflakeDirectLoadSqlGenerator.copyFromStage(tableName, "test.csv.gz", schemaColumns)
+            snowflakeDirectLoadSqlGenerator.copyFromStage(tableName, "test.csv", schemaColumns)
         val expectedSql =
             """
             |COPY INTO $targetTableName("_AIRBYTE_RAW_ID", "_AIRBYTE_EXTRACTED_AT", "_AIRBYTE_META", "_AIRBYTE_GENERATION_ID", "COL1", "COL2")
             |FROM '@$stagingTableName'
             |FILE_FORMAT = (
             |    TYPE = 'CSV'
-            |    COMPRESSION = GZIP
+            |    COMPRESSION = AUTO
             |    FIELD_DELIMITER = '$CSV_FIELD_SEPARATOR'
             |    RECORD_DELIMITER = '$CSV_LINE_DELIMITER'
             |    FIELD_OPTIONALLY_ENCLOSED_BY = '"'
@@ -313,7 +312,7 @@ internal class SnowflakeDirectLoadSqlGeneratorTest {
             |)
             |ON_ERROR = 'ABORT_STATEMENT'
             |PURGE = TRUE
-            |files = ('test.csv.gz')
+            |files = ('test.csv')
         """.trimMargin()
         assertEquals(expectedSql, sql)
     }
@@ -333,15 +332,14 @@ internal class SnowflakeDirectLoadSqlGeneratorTest {
                 "_airbyte_loaded_at",
                 "_airbyte_data"
             )
-        val sql =
-            snowflakeDirectLoadSqlGenerator.copyFromStage(tableName, "test.csv.gz", rawColumns)
+        val sql = snowflakeDirectLoadSqlGenerator.copyFromStage(tableName, "test.csv", rawColumns)
         val expectedSql =
             """
             |COPY INTO $targetTableName("_airbyte_raw_id", "_airbyte_extracted_at", "_airbyte_meta", "_airbyte_generation_id", "_airbyte_loaded_at", "_airbyte_data")
             |FROM '@$stagingTableName'
             |FILE_FORMAT = (
             |    TYPE = 'CSV'
-            |    COMPRESSION = GZIP
+            |    COMPRESSION = AUTO
             |    FIELD_DELIMITER = '$CSV_FIELD_SEPARATOR'
             |    RECORD_DELIMITER = '$CSV_LINE_DELIMITER'
             |    FIELD_OPTIONALLY_ENCLOSED_BY = '"'
@@ -353,7 +351,7 @@ internal class SnowflakeDirectLoadSqlGeneratorTest {
             |)
             |ON_ERROR = 'ABORT_STATEMENT'
             |PURGE = TRUE
-            |files = ('test.csv.gz')
+            |files = ('test.csv')
         """.trimMargin()
         assertEquals(expectedSql, sql)
     }
@@ -1007,8 +1005,7 @@ internal class SnowflakeDirectLoadSqlGeneratorTest {
         val expected =
             """
             PUT 'file:///tmp/test.csv' '@$expectedStageName'
-            AUTO_COMPRESS = FALSE
-            SOURCE_COMPRESSION = GZIP
+            AUTO_COMPRESS = TRUE
             OVERWRITE = TRUE
         """.trimIndent()
         assertEquals(expected, sql)

--- a/airbyte-integrations/connectors/destination-snowflake/src/test/kotlin/io/airbyte/integrations/destination/snowflake/write/load/SnowflakeInsertBufferTest.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test/kotlin/io/airbyte/integrations/destination/snowflake/write/load/SnowflakeInsertBufferTest.kt
@@ -107,7 +107,6 @@ internal class SnowflakeInsertBufferTest {
                 columnSchema = columnSchema,
                 columnManager = columnManager,
                 snowflakeRecordFormatter = snowflakeRecordFormatter,
-                flushLimit = 1,
             )
         val expectedColumnNames =
             listOf(
@@ -148,7 +147,6 @@ internal class SnowflakeInsertBufferTest {
                 columnSchema = columnSchema,
                 columnManager = columnManager,
                 snowflakeRecordFormatter = snowflakeRecordFormatter,
-                flushLimit = 1,
             )
         val expectedColumnNames =
             listOf(
@@ -189,7 +187,6 @@ internal class SnowflakeInsertBufferTest {
                 columnSchema = columnSchema,
                 columnManager = columnManager,
                 snowflakeRecordFormatter = snowflakeRecordFormatter,
-                flushLimit = 1,
             )
         runBlocking {
             buffer.accumulate(record)

--- a/airbyte-integrations/connectors/destination-snowflake/src/test/kotlin/io/airbyte/integrations/destination/snowflake/write/load/SnowflakeInsertBufferTest.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test/kotlin/io/airbyte/integrations/destination/snowflake/write/load/SnowflakeInsertBufferTest.kt
@@ -22,7 +22,6 @@ import io.mockk.every
 import io.mockk.mockk
 import java.io.BufferedReader
 import java.io.InputStreamReader
-import java.util.zip.GZIPInputStream
 import kotlin.io.path.exists
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -190,20 +189,31 @@ internal class SnowflakeInsertBufferTest {
             )
         runBlocking {
             buffer.accumulate(record)
-            // The csvFilePath is internal, we can access it for testing
             val filepath = buffer.csvFilePath
             assertNotNull(filepath)
             val file = filepath!!.toFile()
             assert(file.exists())
-            // Close the writer to ensure all data is flushed
+            // Close the writer to ensure all data is flushed to disk
             buffer.csvWriter?.close()
+
+            // Read back and verify the file contains valid, parseable CSV
             val lines = mutableListOf<String>()
-            GZIPInputStream(file.inputStream()).use { gzip ->
-                BufferedReader(InputStreamReader(gzip)).use { bufferedReader ->
-                    bufferedReader.forEachLine { line -> lines.add(line) }
-                }
+            BufferedReader(InputStreamReader(file.inputStream())).use { bufferedReader ->
+                bufferedReader.forEachLine { line -> lines.add(line) }
             }
-            assertEquals(1, lines.size)
+            assertEquals(1, lines.size, "Expected exactly 1 CSV row")
+
+            // Verify the file is readable as plain-text CSV (not binary/compressed)
+            // and has the expected number of fields (4 meta + 1 user column)
+            val csvRow = lines[0]
+            assert(csvRow.all { it.isDefined() && !it.isISOControl() || it == '\t' }) {
+                "CSV row contains non-printable characters — file may still be compressed"
+            }
+            val fields = csvRow.split(",")
+            assert(fields.size >= 5) {
+                "CSV row should have at least 5 fields (4 meta + 1 user column), got ${fields.size}"
+            }
+
             file.delete()
         }
     }


### PR DESCRIPTION
## What
Avoid extra work in the aggregate thread — esp. for narrow records

## How
Removes the per 1000 record csv file compress / write trigger

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
