### PR TITLE
chore(source-jira): bump SDM base image for memory monitor (CDK PR #962)

### DIFF
--- a/airbyte-integrations/connectors/source-jira/metadata.yaml
+++ b/airbyte-integrations/connectors/source-jira/metadata.yaml
@@ -6,11 +6,11 @@ data:
     hosts:
       - ${domain}
   connectorBuildOptions:
-    baseImage: docker.io/airbyte/source-declarative-manifest:7.13.0.post7.dev23659658197@sha256:5d5ff52e47c4a84f758e4036a14ef826ca04024fde5c8997163bb6c1bcae1e0c
+    baseImage: docker.io/airbyte/source-declarative-manifest:7.13.0.post13.dev23823332086@sha256:dc8f1d054d9b0ee5ed6afe1b6732151ddd4dfa58ee32ca39c608ee2dd50dadf5
   connectorSubtype: api
   connectorType: source
   definitionId: 68e63de2-bb83-4c7e-93fa-a8a9051e3993
-  dockerImageTag: 4.3.18
+  dockerImageTag: 4.3.19
   dockerRepository: airbyte/source-jira
   documentationUrl: https://docs.airbyte.com/integrations/sources/jira
   externalDocumentationUrls:

--- a/airbyte-integrations/connectors/source-jira/metadata.yaml
+++ b/airbyte-integrations/connectors/source-jira/metadata.yaml
@@ -6,7 +6,7 @@ data:
     hosts:
       - ${domain}
   connectorBuildOptions:
-    baseImage: docker.io/airbyte/source-declarative-manifest:7.13.0.post7.dev23659658197@sha256:2b062d562159704b757ce4653bde33ef6f8619545f24552dc1a8fd7186e5d2cc
+    baseImage: docker.io/airbyte/source-declarative-manifest:7.13.0.post7.dev23659658197@sha256:5d5ff52e47c4a84f758e4036a14ef826ca04024fde5c8997163bb6c1bcae1e0c
   connectorSubtype: api
   connectorType: source
   definitionId: 68e63de2-bb83-4c7e-93fa-a8a9051e3993

--- a/airbyte-integrations/connectors/source-jira/metadata.yaml
+++ b/airbyte-integrations/connectors/source-jira/metadata.yaml
@@ -6,11 +6,11 @@ data:
     hosts:
       - ${domain}
   connectorBuildOptions:
-    baseImage: docker.io/airbyte/source-declarative-manifest:7.13.0@sha256:949b0f3efefbd66e6222f279f36b2fb1c796b06e0e712b1a80124b49769862c4
+    baseImage: docker.io/airbyte/source-declarative-manifest:7.13.0.post7.dev23659658197@sha256:2b062d562159704b757ce4653bde33ef6f8619545f24552dc1a8fd7186e5d2cc
   connectorSubtype: api
   connectorType: source
   definitionId: 68e63de2-bb83-4c7e-93fa-a8a9051e3993
-  dockerImageTag: 4.3.17
+  dockerImageTag: 4.3.18
   dockerRepository: airbyte/source-jira
   documentationUrl: https://docs.airbyte.com/integrations/sources/jira
   externalDocumentationUrls:

--- a/docs/integrations/sources/jira.md
+++ b/docs/integrations/sources/jira.md
@@ -169,6 +169,7 @@ The Jira connector should not run into Jira API limitations under normal usage. 
 
 | Version    | Date       | Pull Request                                               | Subject                                                                                                                                                                |
 |:-----------|:-----------|:-----------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 4.3.18 | 2026-03-27 | | Update dependencies; improve graceful shutdown handling for out-of-memory errors |
 | 4.3.17 | 2026-03-17 | [75080](https://github.com/airbytehq/airbyte/pull/75080) | Update dependencies |
 | 4.3.16 | 2026-03-10 | [74500](https://github.com/airbytehq/airbyte/pull/74500) | Update dependencies |
 | 4.3.15 | 2026-02-24 | [73898](https://github.com/airbytehq/airbyte/pull/73898) | Update dependencies |

--- a/docs/integrations/sources/jira.md
+++ b/docs/integrations/sources/jira.md
@@ -169,6 +169,7 @@ The Jira connector should not run into Jira API limitations under normal usage. 
 
 | Version    | Date       | Pull Request                                               | Subject                                                                                                                                                                |
 |:-----------|:-----------|:-----------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 4.3.19 | 2026-03-31 | [75535](https://github.com/airbytehq/airbyte/pull/75535) | Update SDM base image for memory monitor (CDK PR #962) |
 | 4.3.18 | 2026-03-27 | | Update dependencies; improve graceful shutdown handling for out-of-memory errors |
 | 4.3.17 | 2026-03-17 | [75080](https://github.com/airbytehq/airbyte/pull/75080) | Update dependencies |
 | 4.3.16 | 2026-03-10 | [74500](https://github.com/airbytehq/airbyte/pull/74500) | Update dependencies |


### PR DESCRIPTION
## What

Updates `source-jira` to use the dev build of `source-declarative-manifest` from [airbyte-python-cdk#962](https://github.com/airbytehq/airbyte-python-cdk/pull/962), which introduces the dual-condition memory monitor with fail-fast shutdown on memory threshold.

This supersedes the earlier OOM graceful shutdown base image bump (4.3.18) with a newer prerelease that includes the full memory monitor feature.

## How

- Swaps the `source-declarative-manifest` base image from released `7.13.0` to dev build `7.13.0.post13.dev23823332086` (published from CDK PR #962 prerelease [workflow run 23823332086](https://github.com/airbytehq/airbyte-python-cdk/actions/runs/23823332086))
- Bumps `dockerImageTag` from `4.3.17` → `4.3.19`
- Adds changelog entries for both 4.3.18 (original OOM handling) and 4.3.19 (memory monitor)

## Review guide

1. `airbyte-integrations/connectors/source-jira/metadata.yaml` — base image and version bump
   - ⚠️ The base image is a **dev build** (`7.13.0.post13.dev...`), not a released version — verify the `@sha256:dc8f1d05...` digest matches the published dev image
   - Version jumps from `4.3.17` → `4.3.19` (intermediate `4.3.18` changelog entry exists but was never published as a separate image)
2. `docs/integrations/sources/jira.md` — two new changelog rows

## User Impact

Connectors built from this PR will use the dev SDM image containing the new memory monitor, enabling fail-fast shutdown when Python process memory exceeds the container threshold.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/070ecb51ceee4f9189e1c09a83ba31cb