### PR TITLE
feat(source-gitlab): Increase default concurrency from 8 to 10 (4.4.23-rc.3)

### DIFF
--- a/airbyte-integrations/connectors/source-gitlab/manifest.yaml
+++ b/airbyte-integrations/connectors/source-gitlab/manifest.yaml
@@ -946,7 +946,7 @@ definitions:
 
 concurrency_level:
   type: ConcurrencyLevel
-  default_concurrency: "{{ config.get('num_workers', 8) }}"
+  default_concurrency: "{{ config.get('num_workers', 10) }}"
   max_concurrency: 25
 
 streams:

--- a/airbyte-integrations/connectors/source-gitlab/metadata.yaml
+++ b/airbyte-integrations/connectors/source-gitlab/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 5e6175e5-68e1-4c17-bff9-56103bbb0d80
-  dockerImageTag: 4.4.23-rc.2
+  dockerImageTag: 4.4.23-rc.3
   dockerRepository: airbyte/source-gitlab
   documentationUrl: https://docs.airbyte.com/integrations/sources/gitlab
   externalDocumentationUrls:

--- a/docs/integrations/sources/gitlab.md
+++ b/docs/integrations/sources/gitlab.md
@@ -131,7 +131,7 @@ You can adjust the **Number of Concurrent Workers** setting to control how many 
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                                                            |
 | :------ | :--------- | :------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 4.4.23-rc.3 | 2026-03-27 | [75535](https://github.com/airbytehq/airbyte/pull/75535) | Increase default concurrency from 8 to 10 for progressive rollout tuning |
+| 4.4.23-rc.3 | 2026-03-27 | [75537](https://github.com/airbytehq/airbyte/pull/75537) | Increase default concurrency from 8 to 10 for progressive rollout tuning |
 | 4.4.23-rc.2 | 2026-03-25 | [75480](https://github.com/airbytehq/airbyte/pull/75480) | Comment out HTTPAPIBudget to isolate concurrency tuning during progressive rollout |
 | 4.4.23-rc.1 | 2026-03-09 | [70858](https://github.com/airbytehq/airbyte/pull/70858) | Add HTTPAPIBudget and concurrency_level for improved sync performance |
 | 4.4.22 | 2026-02-24 | [73774](https://github.com/airbytehq/airbyte/pull/73774) | Update dependencies |

--- a/docs/integrations/sources/gitlab.md
+++ b/docs/integrations/sources/gitlab.md
@@ -131,6 +131,7 @@ You can adjust the **Number of Concurrent Workers** setting to control how many 
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                                                            |
 | :------ | :--------- | :------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 4.4.23-rc.3 | 2026-03-27 | [75535](https://github.com/airbytehq/airbyte/pull/75535) | Increase default concurrency from 8 to 10 for progressive rollout tuning |
 | 4.4.23-rc.2 | 2026-03-25 | [75480](https://github.com/airbytehq/airbyte/pull/75480) | Comment out HTTPAPIBudget to isolate concurrency tuning during progressive rollout |
 | 4.4.23-rc.1 | 2026-03-09 | [70858](https://github.com/airbytehq/airbyte/pull/70858) | Add HTTPAPIBudget and concurrency_level for improved sync performance |
 | 4.4.22 | 2026-02-24 | [73774](https://github.com/airbytehq/airbyte/pull/73774) | Update dependencies |


### PR DESCRIPTION
## What
Increases the default concurrency level for source-gitlab from 8 to 10 as the next step in the progressive rollout concurrency tuning process ([epic](https://github.com/airbytehq/airbyte-internal-issues/issues/15307)).

RC.2 (which commented out HTTPAPIBudget) showed stable or slightly improved performance vs RC.1 across all pinned actors with zero failures. This RC bumps concurrency to measure the effect of higher parallelism without rate limiting.

## How
- `manifest.yaml`: Change `default_concurrency` fallback from `8` to `10` (users who set `num_workers` in config are unaffected)
- `metadata.yaml`: Bump `dockerImageTag` from `4.4.23-rc.2` to `4.4.23-rc.3`
- `gitlab.md`: Add changelog entry

## Review guide
1. `manifest.yaml` — single-line concurrency default change
2. `metadata.yaml` — version bump
3. `docs/integrations/sources/gitlab.md` — changelog entry (⚠️ verify the PR number `75535` matches this PR's actual number)

## User Impact
No immediate user impact — this RC will only be deployed to ~15 pinned actors via progressive rollout. Users who have explicitly configured `num_workers` are unaffected. If the concurrency increase causes issues (rate limiting, failures), it will be caught during rollout monitoring before wider release.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/4462c8953c3c483084a62a7240f6973f
Requested by: @sophiecuiy
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75537" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
