### PR TITLE
fix: write SSL client keystore to temp dir instead of CWD

### DIFF
--- a/airbyte-integrations/connectors/source-postgres/src/main/kotlin/io/airbyte/integrations/source/postgres/config/PostgresSourceConfiguration.kt
+++ b/airbyte-integrations/connectors/source-postgres/src/main/kotlin/io/airbyte/integrations/source/postgres/config/PostgresSourceConfiguration.kt
@@ -327,7 +327,7 @@ constructor(
                     sslData.clientCertificate,
                     sslData.clientKey,
                     password,
-                    directory = ""
+                    directory = Files.createTempDirectory("ssl-keystore").toString()
                 )
             }
         extraJdbcProperties[CLIENT_KEY_STORE_URL] =


### PR DESCRIPTION
The PKCS12 keystore for SSL client certificates was being written to the current working directory (directory=""). In Docker integration tests, the CWD is a mounted volume that may not be writable by the container's airbyte user on Linux Docker (strict bind mount permissions), causing the check connection to fail with a ConfigErrorException.

Write to a temp directory instead, consistent with how the CA certificate file is already handled.

https://claude.ai/code/session_0134GX4pRMvgvHHqSsWDpPEx

## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->

## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
