### PR TITLE
fix: update sort order before columns to handle dropped columns in PK. Drop sort order when not-dedupe.

### DIFF
--- a/airbyte-cdk/bulk/core/load/changelog.md
+++ b/airbyte-cdk/bulk/core/load/changelog.md
@@ -9,6 +9,7 @@ The Load CDK provides functionality for destination connectors including stream-
 
 | Version | Date       | Pull Request | Subject                                                                                         |
 |---------|------------|--------------|-------------------------------------------------------------------------------------------------|
+| 1.0.7   | 2026-03-27 | | Fix: update Iceberg sort order before schema evolution to prevent ValidationException when deleting columns referenced by the sort order. Handles Dedupe-to-Append mode switches and PK changes. |
 | 1.0.6   | 2026-03-12 | [#74715](https://github.com/airbytehq/airbyte/pull/74715) | Fix: drop temp table after successful upsert to prevent duplicate records across syncs. |
 | 1.0.5   | 2026-03-10 | [#74723](https://github.com/airbytehq/airbyte/pull/74723) | Fix schema evolution: defer identifier field update when replacing columns to avoid Iceberg conflict. |
 | 1.0.4   | 2026-03-05 | [#74328](https://github.com/airbytehq/airbyte/pull/74328) | Fix iceberg dedup: map PK NumberType to StringType instead of DecimalType for identifier field compatibility. |

--- a/airbyte-cdk/bulk/core/load/version.properties
+++ b/airbyte-cdk/bulk/core/load/version.properties
@@ -1,1 +1,1 @@
-version=1.0.6
+version=1.0.7

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/IcebergTableSynchronizer.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/IcebergTableSynchronizer.kt
@@ -368,6 +368,7 @@ class IcebergTableSynchronizer(
                 when (sortField.direction()) {
                     SortDirection.ASC -> builder.asc(fieldName, sortField.nullOrder())
                     SortDirection.DESC -> builder.desc(fieldName, sortField.nullOrder())
+                    else -> builder.asc(fieldName, sortField.nullOrder())
                 }
             }
         }

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/IcebergTableSynchronizer.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/IcebergTableSynchronizer.kt
@@ -7,12 +7,16 @@ package io.airbyte.cdk.load.toolkits.iceberg.parquet
 import io.airbyte.cdk.ConfigErrorException
 import io.airbyte.cdk.load.toolkits.iceberg.parquet.IcebergTypesComparator.Companion.PARENT_CHILD_SEPARATOR
 import io.airbyte.cdk.load.toolkits.iceberg.parquet.IcebergTypesComparator.Companion.splitIntoParentAndLeaf
+import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.inject.Singleton
 import org.apache.iceberg.Schema
+import org.apache.iceberg.SortDirection
 import org.apache.iceberg.Table
 import org.apache.iceberg.UpdateSchema
 import org.apache.iceberg.types.Type
 import org.apache.iceberg.types.Type.PrimitiveType
+
+private val logger = KotlinLogging.logger {}
 
 /** Describes how the [IcebergTableSynchronizer] handles column type changes. */
 enum class ColumnTypeChangeBehavior {
@@ -85,6 +89,27 @@ class IcebergTableSynchronizer(
             // If no differences, return the existing schema as-is.
             return SchemaUpdateResult(existingSchema, pendingUpdates = emptyList())
         }
+
+        // Update the sort order before creating the UpdateSchema, because:
+        // 1. Deleting a column referenced by the sort order will cause
+        //    SortOrder.checkCompatibility to throw ValidationException on commit.
+        // 2. UpdateSchema captures the table's metadata version at creation time.
+        //    If we replace the sort order after creating it, the commit would fail
+        //    with a stale metadata error.
+        val columnsBeingDeleted = buildList {
+            addAll(diff.removedColumns)
+            if (columnTypeChangeBehavior == ColumnTypeChangeBehavior.OVERWRITE) {
+                // In OVERWRITE mode, type-changed columns are deleted and re-added
+                // with new field IDs. The old sort field references become invalid.
+                addAll(diff.updatedDataTypes)
+            }
+        }
+        replaceSortOrderIfNeeded(
+            table = table,
+            columnsBeingDeleted = columnsBeingDeleted,
+            identifierFieldsChanged = diff.identifierFieldsChanged,
+            incomingIdentifierFieldNames = incomingSchema.identifierFieldNames(),
+        )
 
         val update: UpdateSchema = table.updateSchema().allowIncompatibleChanges()
 
@@ -266,6 +291,89 @@ class IcebergTableSynchronizer(
         } else {
             return SchemaUpdateResult(newSchema, pendingUpdates = listOf(update))
         }
+    }
+
+    /**
+     * Update the table's sort order if it would conflict with pending schema changes.
+     *
+     * Sort orders are set at table creation from identifier fields (PKs) and never updated. This
+     * causes [org.apache.iceberg.exceptions.ValidationException] when schema evolution deletes a
+     * column referenced by the sort order.
+     *
+     * This method handles three cases:
+     * 1. Identifier fields changed → rebuild sort order from new identifiers (covers
+     * ```
+     *    Dedupe→Append, PK changes within Dedupe)
+     * ```
+     * 2. Columns being deleted conflict with sort order → remove those fields
+     * 3. Neither → no-op
+     *
+     * Must be called BEFORE creating the [UpdateSchema], since this commits a metadata change and
+     * the subsequent UpdateSchema needs the refreshed metadata version.
+     */
+    private fun replaceSortOrderIfNeeded(
+        table: Table,
+        columnsBeingDeleted: List<String>,
+        identifierFieldsChanged: Boolean,
+        incomingIdentifierFieldNames: Set<String>,
+    ) {
+        val currentSortOrder = table.sortOrder()
+
+        // If the table has no sort order, there's nothing to conflict and nothing to update.
+        // (Append→Dedupe would need a sort order added, but that case requires a reset.)
+        if (currentSortOrder.isUnsorted) {
+            return
+        }
+
+        if (identifierFieldsChanged) {
+            // Rebuild sort order from the new identifier fields.
+            // For Dedupe→Append: incoming identifiers are empty → unsorted.
+            // For PK changes within Dedupe: new identifiers → new sort order.
+            val builder = table.replaceSortOrder()
+            for (fieldName in incomingIdentifierFieldNames) {
+                // Only include fields that exist in the current schema. Fields being
+                // added in the same schema change can't be referenced yet.
+                if (table.schema().findField(fieldName) != null) {
+                    builder.asc(fieldName)
+                }
+            }
+            logger.info {
+                "Replacing sort order due to identifier field change. " +
+                    "New sort fields: ${incomingIdentifierFieldNames.ifEmpty { setOf("(unsorted)") }}"
+            }
+            builder.commit()
+            table.refresh()
+            return
+        }
+
+        // No identifier change — check if any deleted columns conflict with the sort order.
+        if (columnsBeingDeleted.isEmpty()) {
+            return
+        }
+
+        val schema = table.schema()
+        val fieldIdsBeingDeleted =
+            columnsBeingDeleted.mapNotNull { schema.findField(it)?.fieldId() }.toSet()
+
+        val hasConflict = currentSortOrder.fields().any { it.sourceId() in fieldIdsBeingDeleted }
+        if (!hasConflict) {
+            return
+        }
+
+        // Rebuild the sort order, keeping only fields that aren't being deleted.
+        val builder = table.replaceSortOrder()
+        for (sortField in currentSortOrder.fields()) {
+            if (sortField.sourceId() !in fieldIdsBeingDeleted) {
+                val fieldName = schema.findColumnName(sortField.sourceId())
+                when (sortField.direction()) {
+                    SortDirection.ASC -> builder.asc(fieldName, sortField.nullOrder())
+                    SortDirection.DESC -> builder.desc(fieldName, sortField.nullOrder())
+                }
+            }
+        }
+        logger.info { "Replacing sort order to remove fields being deleted: $columnsBeingDeleted" }
+        builder.commit()
+        table.refresh()
     }
 }
 

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/test/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/IcebergTableSynchronizerTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/test/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/IcebergTableSynchronizerTest.kt
@@ -12,9 +12,16 @@ import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.spyk
 import io.mockk.verify
+import java.nio.file.Files
+import org.apache.hadoop.conf.Configuration
+import org.apache.iceberg.FileFormat
 import org.apache.iceberg.Schema
+import org.apache.iceberg.SortOrder
 import org.apache.iceberg.Table
+import org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT
 import org.apache.iceberg.UpdateSchema
+import org.apache.iceberg.catalog.TableIdentifier
+import org.apache.iceberg.hadoop.HadoopCatalog
 import org.apache.iceberg.types.Type.PrimitiveType
 import org.apache.iceberg.types.Types
 import org.assertj.core.api.Assertions.assertThat
@@ -49,6 +56,9 @@ class IcebergTableSynchronizerTest {
 
         // By default, let table.schema() return an empty schema. Tests can override this as needed.
         every { mockTable.schema() } returns Schema(listOf())
+
+        // By default, the table has no sort order. Tests using real tables handle this themselves.
+        every { mockTable.sortOrder() } returns SortOrder.unsorted()
 
         // Table.updateSchema() should return the mock UpdateSchema
         every { mockTable.updateSchema().allowIncompatibleChanges() } returns mockUpdateSchema
@@ -472,5 +482,276 @@ class IcebergTableSynchronizerTest {
         assertThat(schema).isSameAs(mockIdentifierNewSchema)
         assertThat(pendingUpdates).hasSize(1)
         assertThat(pendingUpdates.first()).isSameAs(mockIdentifierUpdateSchema)
+    }
+
+    // ==================================================================================
+    // Sort order tests — use real HadoopCatalog tables (not mocks) because mocked tests
+    // never exercise Iceberg's SortOrder.checkCompatibility validation.
+    // ==================================================================================
+
+    private fun createRealSynchronizer() =
+        IcebergTableSynchronizer(
+            IcebergTypesComparator(),
+            IcebergSuperTypeFinder(IcebergTypesComparator()),
+        )
+
+    /** Schema matching the customer's custom insight streams (Dedupe with 3 PKs). */
+    private fun dedupeSchema() =
+        Schema(
+            listOf(
+                Types.NestedField.required(1, "_airbyte_raw_id", Types.StringType.get()),
+                Types.NestedField.required(
+                    2,
+                    "_airbyte_extracted_at",
+                    Types.TimestampType.withZone()
+                ),
+                Types.NestedField.required(3, "_airbyte_meta", Types.StringType.get()),
+                Types.NestedField.required(4, "_airbyte_generation_id", Types.LongType.get()),
+                Types.NestedField.required(5, "ad_id", Types.StringType.get()),
+                Types.NestedField.required(6, "date_start", Types.DateType.get()),
+                Types.NestedField.required(7, "account_id", Types.StringType.get()),
+                Types.NestedField.optional(8, "impressions", Types.LongType.get()),
+            ),
+            setOf(5, 6, 7), // identifier fields: ad_id, date_start, account_id
+        )
+
+    private fun dedupeSortOrder(schema: Schema): SortOrder =
+        SortOrder.builderFor(schema).asc("ad_id").asc("date_start").asc("account_id").build()
+
+    private fun createTableWithSortOrder(
+        catalog: HadoopCatalog,
+        tableId: TableIdentifier,
+        schema: Schema,
+        sortOrder: SortOrder,
+    ): Table {
+        catalog.createNamespace(tableId.namespace())
+        return catalog
+            .buildTable(tableId, schema)
+            .withProperty(DEFAULT_FILE_FORMAT, FileFormat.PARQUET.name.lowercase())
+            .withSortOrder(sortOrder)
+            .create()
+    }
+
+    private fun createTableWithoutSortOrder(
+        catalog: HadoopCatalog,
+        tableId: TableIdentifier,
+        schema: Schema,
+    ): Table {
+        catalog.createNamespace(tableId.namespace())
+        return catalog
+            .buildTable(tableId, schema)
+            .withProperty(DEFAULT_FILE_FORMAT, FileFormat.PARQUET.name.lowercase())
+            .create()
+    }
+
+    /**
+     * Scenario A: Source upgrade removes a PK column (ad_id) that the sort order references. After
+     * fix: schema evolution should succeed and sort order should retain only the remaining PK
+     * columns.
+     */
+    @Test
+    fun `scenario A - removing a sort-order column should update sort order and succeed`() {
+        val warehousePath = Files.createTempDirectory("iceberg-test-warehouse")
+        val catalog = HadoopCatalog(Configuration(), warehousePath.toString())
+        val tableId = TableIdentifier.of("db", "scenario_a")
+
+        val schema = dedupeSchema()
+        val table = createTableWithSortOrder(catalog, tableId, schema, dedupeSortOrder(schema))
+
+        // Incoming schema: ad_id removed, identifiers updated
+        val incomingSchema =
+            Schema(
+                listOf(
+                    Types.NestedField.required(1, "_airbyte_raw_id", Types.StringType.get()),
+                    Types.NestedField.required(
+                        2,
+                        "_airbyte_extracted_at",
+                        Types.TimestampType.withZone()
+                    ),
+                    Types.NestedField.required(3, "_airbyte_meta", Types.StringType.get()),
+                    Types.NestedField.required(4, "_airbyte_generation_id", Types.LongType.get()),
+                    // ad_id (field 5) removed
+                    Types.NestedField.required(6, "date_start", Types.DateType.get()),
+                    Types.NestedField.required(7, "account_id", Types.StringType.get()),
+                    Types.NestedField.optional(8, "impressions", Types.LongType.get()),
+                ),
+                setOf(6, 7), // identifier fields: date_start, account_id
+            )
+
+        val synchronizer = createRealSynchronizer()
+        synchronizer.maybeApplySchemaChanges(
+            table,
+            incomingSchema,
+            ColumnTypeChangeBehavior.SAFE_SUPERTYPE,
+        )
+
+        // ad_id should be gone from the schema
+        table.refresh()
+        assertThat(table.schema().findField("ad_id")).isNull()
+
+        // Sort order should have 2 remaining fields (date_start, account_id)
+        val updatedSortOrder = table.sortOrder()
+        assertThat(updatedSortOrder.fields()).hasSize(2)
+        assertThat(updatedSortOrder.fields().map { table.schema().findColumnName(it.sourceId()) })
+            .containsExactly("date_start", "account_id")
+
+        catalog.dropTable(tableId)
+        warehousePath.toFile().deleteRecursively()
+    }
+
+    /**
+     * Scenario B: Stream switches from Dedupe to Append. Incoming schema has no identifier fields.
+     * The sort order should be cleared to unsorted.
+     */
+    @Test
+    fun `scenario B - dedupe to append should clear sort order`() {
+        val warehousePath = Files.createTempDirectory("iceberg-test-warehouse")
+        val catalog = HadoopCatalog(Configuration(), warehousePath.toString())
+        val tableId = TableIdentifier.of("db", "scenario_b")
+
+        val schema = dedupeSchema()
+        val table = createTableWithSortOrder(catalog, tableId, schema, dedupeSortOrder(schema))
+
+        // Incoming schema: same columns but NO identifier fields (Append mode)
+        val incomingSchema =
+            Schema(
+                listOf(
+                    Types.NestedField.required(1, "_airbyte_raw_id", Types.StringType.get()),
+                    Types.NestedField.required(
+                        2,
+                        "_airbyte_extracted_at",
+                        Types.TimestampType.withZone()
+                    ),
+                    Types.NestedField.required(3, "_airbyte_meta", Types.StringType.get()),
+                    Types.NestedField.required(4, "_airbyte_generation_id", Types.LongType.get()),
+                    Types.NestedField.optional(5, "ad_id", Types.StringType.get()),
+                    Types.NestedField.optional(6, "date_start", Types.DateType.get()),
+                    Types.NestedField.optional(7, "account_id", Types.StringType.get()),
+                    Types.NestedField.optional(8, "impressions", Types.LongType.get()),
+                ),
+                // No identifier fields — Append mode
+                )
+
+        val synchronizer = createRealSynchronizer()
+        synchronizer.maybeApplySchemaChanges(
+            table,
+            incomingSchema,
+            ColumnTypeChangeBehavior.SAFE_SUPERTYPE,
+        )
+
+        table.refresh()
+        assertThat(table.sortOrder().isUnsorted).isTrue()
+
+        catalog.dropTable(tableId)
+        warehousePath.toFile().deleteRecursively()
+    }
+
+    /**
+     * Scenario D (with column deletion): PKs change within Dedupe and the old PK column is also
+     * removed from the schema. Sort order should be updated to match new PKs, and the column
+     * deletion should succeed.
+     *
+     * This is the exact customer scenario: ad_id removed from both PKs and schema.
+     */
+    @Test
+    fun `scenario D - pk change with column deletion should update sort order`() {
+        val warehousePath = Files.createTempDirectory("iceberg-test-warehouse")
+        val catalog = HadoopCatalog(Configuration(), warehousePath.toString())
+        val tableId = TableIdentifier.of("db", "scenario_d_with_delete")
+
+        val schema = dedupeSchema()
+        val table = createTableWithSortOrder(catalog, tableId, schema, dedupeSortOrder(schema))
+
+        // Incoming schema: ad_id removed from both columns and identifiers
+        val incomingSchema =
+            Schema(
+                listOf(
+                    Types.NestedField.required(1, "_airbyte_raw_id", Types.StringType.get()),
+                    Types.NestedField.required(
+                        2,
+                        "_airbyte_extracted_at",
+                        Types.TimestampType.withZone()
+                    ),
+                    Types.NestedField.required(3, "_airbyte_meta", Types.StringType.get()),
+                    Types.NestedField.required(4, "_airbyte_generation_id", Types.LongType.get()),
+                    // ad_id removed
+                    Types.NestedField.required(6, "date_start", Types.DateType.get()),
+                    Types.NestedField.required(7, "account_id", Types.StringType.get()),
+                    Types.NestedField.optional(8, "impressions", Types.LongType.get()),
+                ),
+                setOf(6, 7), // identifier fields: date_start, account_id
+            )
+
+        val synchronizer = createRealSynchronizer()
+        synchronizer.maybeApplySchemaChanges(
+            table,
+            incomingSchema,
+            ColumnTypeChangeBehavior.SAFE_SUPERTYPE,
+        )
+
+        table.refresh()
+        assertThat(table.schema().findField("ad_id")).isNull()
+
+        val updatedSortOrder = table.sortOrder()
+        assertThat(updatedSortOrder.fields()).hasSize(2)
+        assertThat(updatedSortOrder.fields().map { table.schema().findColumnName(it.sourceId()) })
+            .containsExactly("date_start", "account_id")
+
+        catalog.dropTable(tableId)
+        warehousePath.toFile().deleteRecursively()
+    }
+
+    /**
+     * Scenario D (standalone): PKs change within Dedupe but the old PK column remains in the schema
+     * as a non-PK column. Sort order should be updated to match new PKs.
+     */
+    @Test
+    fun `scenario D - pk change without column deletion should update sort order`() {
+        val warehousePath = Files.createTempDirectory("iceberg-test-warehouse")
+        val catalog = HadoopCatalog(Configuration(), warehousePath.toString())
+        val tableId = TableIdentifier.of("db", "scenario_d_standalone")
+
+        val schema = dedupeSchema()
+        val table = createTableWithSortOrder(catalog, tableId, schema, dedupeSortOrder(schema))
+
+        // Incoming schema: ad_id still present but no longer an identifier
+        val incomingSchema =
+            Schema(
+                listOf(
+                    Types.NestedField.required(1, "_airbyte_raw_id", Types.StringType.get()),
+                    Types.NestedField.required(
+                        2,
+                        "_airbyte_extracted_at",
+                        Types.TimestampType.withZone()
+                    ),
+                    Types.NestedField.required(3, "_airbyte_meta", Types.StringType.get()),
+                    Types.NestedField.required(4, "_airbyte_generation_id", Types.LongType.get()),
+                    Types.NestedField.optional(5, "ad_id", Types.StringType.get()),
+                    Types.NestedField.required(6, "date_start", Types.DateType.get()),
+                    Types.NestedField.required(7, "account_id", Types.StringType.get()),
+                    Types.NestedField.optional(8, "impressions", Types.LongType.get()),
+                ),
+                setOf(6, 7), // identifier fields: date_start, account_id (ad_id removed from PKs)
+            )
+
+        val synchronizer = createRealSynchronizer()
+        synchronizer.maybeApplySchemaChanges(
+            table,
+            incomingSchema,
+            ColumnTypeChangeBehavior.SAFE_SUPERTYPE,
+        )
+
+        table.refresh()
+        // ad_id should still exist as a column
+        assertThat(table.schema().findField("ad_id")).isNotNull()
+
+        // Sort order should reflect new PKs only
+        val updatedSortOrder = table.sortOrder()
+        assertThat(updatedSortOrder.fields()).hasSize(2)
+        assertThat(updatedSortOrder.fields().map { table.schema().findColumnName(it.sourceId()) })
+            .containsExactly("date_start", "account_id")
+
+        catalog.dropTable(tableId)
+        warehousePath.toFile().deleteRecursively()
     }
 }


### PR DESCRIPTION
## What
Fix `ValidationException` when deleting an Iceberg column referenced by the table's sort order. Sort orders are set at table creation and never updated, causing crashes on schema evolution.

## How
New `replaceSortOrderIfNeeded` method in `IcebergTableSynchronizer`, called before schema commits. Strips deleted columns from the sort order, clears it on Dedupe→Append, rebuilds it on PK changes.

## Review guide
1. `IcebergTableSynchronizer.kt` — `replaceSortOrderIfNeeded` + wiring
2. `IcebergTableSynchronizerTest.kt` — 4 new real-table tests

## User Impact
Iceberg no longer crash when schema propagation removes a sort-order column.

## Next steps
Cut connector releases and rollout

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌
