### PR TITLE
[Do Not Merge] fix(source-slack): fix rate limiting and add diagnostic logging for threads stream

### DIFF
--- a/airbyte-integrations/connectors/source-slack/components.py
+++ b/airbyte-integrations/connectors/source-slack/components.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2025 Airbyte, Inc., all rights reserved.
 
 import logging
-from dataclasses import InitVar, dataclass, field
+from dataclasses import InitVar, dataclass
 from datetime import timedelta
 from functools import partial
 from typing import Any, Iterable, List, Mapping, Optional, Union

--- a/airbyte-integrations/connectors/source-slack/components.py
+++ b/airbyte-integrations/connectors/source-slack/components.py
@@ -106,8 +106,9 @@ class ChannelsRetriever(SimpleRetriever):
         """
         The `is_member` property indicates whether the API Bot is already assigned / joined to the channel.
         https://api.slack.com/types/conversation#booleans
+        Archived channels cannot be joined and attempting to do so wastes rate limit budget.
         """
-        return config["join_channels"] and not record.get("is_member")
+        return config["join_channels"] and not record.get("is_member") and not record.get("is_archived")
 
     def make_join_channel_slice(self, channel: Mapping[str, Any]) -> Mapping[str, Any]:
         channel_id: str = channel.get("id")

--- a/airbyte-integrations/connectors/source-slack/components.py
+++ b/airbyte-integrations/connectors/source-slack/components.py
@@ -174,7 +174,8 @@ class RateLimitLoggingBackoffStrategy(BackoffStrategy):
             if response_or_exception.status_code == 429:
                 retry_after = response_or_exception.headers.get("Retry-After", "NOT_SET")
                 rate_limit_headers = {
-                    k: v for k, v in response_or_exception.headers.items()
+                    k: v
+                    for k, v in response_or_exception.headers.items()
                     if k.lower().startswith("retry-after") or k.lower().startswith("x-rate-limit")
                 }
                 url = ""
@@ -218,7 +219,11 @@ class ThreadsLoggingPartitionRouter(SubstreamPartitionRouter):
             if channel != current_channel and total > 0:
                 LOGGER.info(
                     "THREADS_DEBUG: channel=%s | total_messages=%d | with_replies=%d | without_replies=%d | max_reply_count=%d",
-                    current_channel, total, with_replies, without_replies, max_reply_count,
+                    current_channel,
+                    total,
+                    with_replies,
+                    without_replies,
+                    max_reply_count,
                 )
                 total = 0
                 with_replies = 0
@@ -240,7 +245,11 @@ class ThreadsLoggingPartitionRouter(SubstreamPartitionRouter):
             if total % 1000 == 0:
                 LOGGER.info(
                     "THREADS_DEBUG: channel=%s | progress=%d messages | with_replies=%d | without_replies=%d | max_reply_count=%d",
-                    current_channel, total, with_replies, without_replies, max_reply_count,
+                    current_channel,
+                    total,
+                    with_replies,
+                    without_replies,
+                    max_reply_count,
                 )
 
             yield stream_slice
@@ -249,7 +258,11 @@ class ThreadsLoggingPartitionRouter(SubstreamPartitionRouter):
         if total > 0:
             LOGGER.info(
                 "THREADS_DEBUG: channel=%s | total_messages=%d | with_replies=%d | without_replies=%d | max_reply_count=%d",
-                current_channel, total, with_replies, without_replies, max_reply_count,
+                current_channel,
+                total,
+                with_replies,
+                without_replies,
+                max_reply_count,
             )
 
 

--- a/airbyte-integrations/connectors/source-slack/components.py
+++ b/airbyte-integrations/connectors/source-slack/components.py
@@ -11,6 +11,7 @@ import requests
 from airbyte_cdk.models import SyncMode
 from airbyte_cdk.sources.declarative.extractors import DpathExtractor
 from airbyte_cdk.sources.declarative.migrations.state_migration import StateMigration
+from airbyte_cdk.sources.declarative.partition_routers.substream_partition_router import SubstreamPartitionRouter
 from airbyte_cdk.sources.declarative.retrievers import SimpleRetriever
 from airbyte_cdk.sources.declarative.types import Record, StreamSlice
 from airbyte_cdk.sources.streams.core import StreamData
@@ -126,6 +127,31 @@ class ChannelsRetriever(SimpleRetriever):
                 self.join_channel(self.config, stream_data)
 
             yield stream_data
+
+
+class ThreadsPartitionRouter(SubstreamPartitionRouter):
+    """
+    Custom partition router for the threads stream that skips parent messages
+    with no thread replies. This avoids making unnecessary conversations.replies
+    API calls for messages that have no threads, significantly reducing rate
+    limit consumption.
+
+    The reply_count field from the parent channel_messages record is passed via
+    extra_fields. Messages with reply_count < 2 are skipped because:
+    - reply_count == 0 or null: message has no thread at all
+    - reply_count == 1: only the parent message itself, no actual replies
+    """
+
+    def stream_slices(self) -> Iterable[StreamSlice]:
+        for stream_slice in super().stream_slices():
+            reply_count = stream_slice.extra_fields.get("reply_count")
+            if reply_count is not None and int(reply_count) >= 2:
+                yield stream_slice
+            else:
+                LOGGER.debug(
+                    "Skipping threads partition for message with reply_count=%s",
+                    reply_count,
+                )
 
 
 class ThreadsStateMigration(StateMigration):

--- a/airbyte-integrations/connectors/source-slack/components.py
+++ b/airbyte-integrations/connectors/source-slack/components.py
@@ -1,43 +1,27 @@
 # Copyright (c) 2025 Airbyte, Inc., all rights reserved.
 
 import logging
-from copy import deepcopy
 from dataclasses import dataclass
 from datetime import timedelta
 from functools import partial
-from typing import Any, Dict, Iterable, List, Mapping, Optional
+from typing import Any, Iterable, List, Mapping, Optional
 
 import requests
 
 from airbyte_cdk.models import SyncMode
-from airbyte_cdk.sources.declarative.auth.declarative_authenticator import (
-    NoAuth,
-)
+from airbyte_cdk.sources.declarative.auth.declarative_authenticator import NoAuth
 from airbyte_cdk.sources.declarative.extractors import DpathExtractor
-from airbyte_cdk.sources.declarative.interpolation.interpolated_string import (
-    InterpolatedString,
-)
+from airbyte_cdk.sources.declarative.interpolation.interpolated_string import InterpolatedString
 from airbyte_cdk.sources.declarative.migrations.state_migration import StateMigration
-from airbyte_cdk.sources.declarative.partition_routers import SinglePartitionRouter, SubstreamPartitionRouter
-from airbyte_cdk.sources.declarative.requesters import HttpRequester
 from airbyte_cdk.sources.declarative.requesters.request_options.interpolated_request_options_provider import (
     InterpolatedRequestOptionsProvider,
 )
-from airbyte_cdk.sources.declarative.requesters.requester import HttpMethod
 from airbyte_cdk.sources.declarative.retrievers import SimpleRetriever
 from airbyte_cdk.sources.declarative.types import Record, StreamSlice
-from airbyte_cdk.sources.streams.call_rate import (
-    APIBudget,
-    HttpRequestMatcher,
-    LimiterMixin,
-    MovingWindowCallRatePolicy,
-    Rate,
-    UnlimitedCallRatePolicy,
-)
 from airbyte_cdk.sources.streams.core import StreamData
-from airbyte_cdk.sources.streams.http import HttpClient, HttpStream
+from airbyte_cdk.sources.streams.http import HttpStream
 from airbyte_cdk.sources.streams.http.requests_native_auth import TokenAuthenticator
-from airbyte_cdk.sources.types import Config, EmptyString, StreamState
+from airbyte_cdk.sources.types import Config
 from airbyte_cdk.utils.datetime_helpers import ab_datetime_parse
 
 
@@ -190,83 +174,3 @@ class ThreadsStateMigration(StateMigration):
         stream_state["parent_state"] = {"channel_messages": final_state}
 
         return stream_state
-
-
-MESSAGES_AND_THREADS_RATE = Rate(limit=1, interval=timedelta(seconds=60))
-
-
-class MessagesAndThreadsApiBudget(APIBudget, LimiterMixin):
-    """
-    Switches to MovingWindowCallRatePolicy 1 request per minute if rate limits were exceeded.
-    """
-
-    def update_from_response(self, request: Any, response: Any) -> None:
-        current_policy = self.get_matching_policy(request)
-        if response.status_code == 429 and isinstance(current_policy, UnlimitedCallRatePolicy):
-            matchers = current_policy._matchers
-            self._policies = [
-                MovingWindowCallRatePolicy(
-                    matchers=matchers,
-                    rates=[MESSAGES_AND_THREADS_RATE],
-                )
-            ]
-
-
-@dataclass
-class MessagesAndThreadsHttpRequester(HttpRequester):
-    """
-    Redefines Custom API Budget to handle rate limits.
-    """
-
-    url_match: str = None
-    # redefine this here to set up in InterpolatedRequestOptionsProvider in __post_init__
-    request_parameters: Dict[str, Any] = None
-
-    def __post_init__(self, parameters: Mapping[str, Any]) -> None:
-        self._url = InterpolatedString.create(self.url if self.url else EmptyString, parameters=parameters)
-        # deprecated
-        self._url_base = InterpolatedString.create(self.url_base if self.url_base else EmptyString, parameters=parameters)
-        # deprecated
-        self._path = InterpolatedString.create(self.path if self.path else EmptyString, parameters=parameters)
-        if self.request_options_provider is None:
-            self._request_options_provider = InterpolatedRequestOptionsProvider(
-                config=self.config,
-                parameters=parameters,
-                request_parameters=self.request_parameters,
-            )
-        elif isinstance(self.request_options_provider, dict):
-            self._request_options_provider = InterpolatedRequestOptionsProvider(config=self.config, **self.request_options_provider)
-        else:
-            self._request_options_provider = self.request_options_provider
-        self._authenticator = self.authenticator or NoAuth(parameters=parameters)
-        self._http_method = HttpMethod[self.http_method] if isinstance(self.http_method, str) else self.http_method
-        self.error_handler = self.error_handler
-        self._parameters = parameters
-
-        if self.error_handler is not None and hasattr(self.error_handler, "backoff_strategies"):
-            backoff_strategies = self.error_handler.backoff_strategies  # type: ignore
-        else:
-            backoff_strategies = None
-
-        api_budget = (
-            MessagesAndThreadsApiBudget(
-                policies=[
-                    UnlimitedCallRatePolicy(
-                        matchers=[HttpRequestMatcher(url=self.url_match)],
-                    )
-                ]
-            )
-            if self.config.get("credentials", {}).get("option_title") == "Default OAuth2.0 authorization"
-            else None
-        )
-        self._http_client = HttpClient(
-            name=self.name,
-            logger=self.logger,
-            error_handler=self.error_handler,
-            api_budget=api_budget,
-            authenticator=self._authenticator,
-            use_cache=self.use_cache,
-            backoff_strategy=backoff_strategies,
-            disable_retries=self.disable_retries,
-            message_repository=self.message_repository,
-        )

--- a/airbyte-integrations/connectors/source-slack/components.py
+++ b/airbyte-integrations/connectors/source-slack/components.py
@@ -9,13 +9,8 @@ from typing import Any, Iterable, List, Mapping, Optional
 import requests
 
 from airbyte_cdk.models import SyncMode
-from airbyte_cdk.sources.declarative.auth.declarative_authenticator import NoAuth
 from airbyte_cdk.sources.declarative.extractors import DpathExtractor
-from airbyte_cdk.sources.declarative.interpolation.interpolated_string import InterpolatedString
 from airbyte_cdk.sources.declarative.migrations.state_migration import StateMigration
-from airbyte_cdk.sources.declarative.requesters.request_options.interpolated_request_options_provider import (
-    InterpolatedRequestOptionsProvider,
-)
 from airbyte_cdk.sources.declarative.retrievers import SimpleRetriever
 from airbyte_cdk.sources.declarative.types import Record, StreamSlice
 from airbyte_cdk.sources.streams.core import StreamData

--- a/airbyte-integrations/connectors/source-slack/components.py
+++ b/airbyte-integrations/connectors/source-slack/components.py
@@ -1,21 +1,23 @@
 # Copyright (c) 2025 Airbyte, Inc., all rights reserved.
 
 import logging
-from dataclasses import dataclass
+from dataclasses import InitVar, dataclass, field
 from datetime import timedelta
 from functools import partial
-from typing import Any, Iterable, List, Mapping, Optional
+from typing import Any, Iterable, List, Mapping, Optional, Union
 
 import requests
 
 from airbyte_cdk.models import SyncMode
 from airbyte_cdk.sources.declarative.extractors import DpathExtractor
+from airbyte_cdk.sources.declarative.interpolation.interpolated_string import InterpolatedString
 from airbyte_cdk.sources.declarative.migrations.state_migration import StateMigration
-from airbyte_cdk.sources.declarative.partition_routers.substream_partition_router import SubstreamPartitionRouter
+from airbyte_cdk.sources.declarative.partition_routers import SubstreamPartitionRouter
 from airbyte_cdk.sources.declarative.retrievers import SimpleRetriever
 from airbyte_cdk.sources.declarative.types import Record, StreamSlice
 from airbyte_cdk.sources.streams.core import StreamData
 from airbyte_cdk.sources.streams.http import HttpStream
+from airbyte_cdk.sources.streams.http.error_handlers import BackoffStrategy
 from airbyte_cdk.sources.streams.http.requests_native_auth import TokenAuthenticator
 from airbyte_cdk.sources.types import Config
 from airbyte_cdk.utils.datetime_helpers import ab_datetime_parse
@@ -129,30 +131,126 @@ class ChannelsRetriever(SimpleRetriever):
             yield stream_data
 
 
-class ThreadsPartitionRouter(SubstreamPartitionRouter):
+@dataclass
+class RateLimitLoggingBackoffStrategy(BackoffStrategy):
     """
-    Custom partition router for the threads stream that skips parent messages
-    with no thread replies. This avoids making unnecessary conversations.replies
-    API calls for messages that have no threads, significantly reducing rate
-    limit consumption.
+    Custom backoff strategy that wraps WaitTimeFromHeader behavior and logs
+    Slack rate-limit response headers on every 429 response. This helps
+    diagnose whether the connection is on Tier 3 (Marketplace, 50+ req/min)
+    or the lower non-Marketplace rate (1 req/min).
 
-    The reply_count field from the parent channel_messages record is passed via
-    extra_fields. Messages with reply_count < 1 are skipped because:
-    - reply_count absent or 0: message has no thread replies at all
-    - reply_count >= 1: at least one reply exists (reply_count excludes the
-      parent message per Slack's API — see conversations.replies docs)
+    Emits RATE_LIMIT_DEBUG log lines with Retry-After values, the API method
+    that was rate-limited, and all X-Rate-Limit-* headers from Slack's response.
+    """
+
+    header: Union[InterpolatedString, str]
+    parameters: InitVar[Mapping[str, Any]]
+    config: Config
+
+    def __post_init__(self, parameters: Mapping[str, Any]) -> None:
+        self.header = InterpolatedString.create(self.header, parameters=parameters)
+
+    @staticmethod
+    def _get_numeric_value_from_header(response: requests.Response, header_name: str) -> Optional[float]:
+        header_value = response.headers.get(header_name)
+        if header_value is None:
+            return None
+        try:
+            return float(header_value)
+        except ValueError:
+            return None
+
+    def backoff_time(
+        self,
+        response_or_exception: Optional[Union[requests.Response, requests.RequestException]],
+        attempt_count: int,
+    ) -> Optional[float]:
+        header_value = None
+        if isinstance(response_or_exception, requests.Response):
+            header = self.header.eval(config=self.config)
+            header_value = self._get_numeric_value_from_header(response_or_exception, header)
+
+            # Log all rate-limit-related headers for diagnostics
+            if response_or_exception.status_code == 429:
+                retry_after = response_or_exception.headers.get("Retry-After", "NOT_SET")
+                rate_limit_headers = {
+                    k: v for k, v in response_or_exception.headers.items()
+                    if k.lower().startswith("retry-after") or k.lower().startswith("x-rate-limit")
+                }
+                url = ""
+                if response_or_exception.request:
+                    url = str(response_or_exception.request.url or "")
+                    if "?" in url:
+                        url = url.split("?")[0]
+                LOGGER.info(
+                    "RATE_LIMIT_DEBUG: 429 received | Retry-After=%s | backoff_time=%s | attempt=%d | url=%s | all_rate_headers=%s",
+                    retry_after,
+                    header_value,
+                    attempt_count,
+                    url,
+                    rate_limit_headers,
+                )
+        return header_value
+
+
+@dataclass
+class ThreadsLoggingPartitionRouter(SubstreamPartitionRouter):
+    """
+    Thin wrapper around SubstreamPartitionRouter that logs reply_count stats
+    from parent messages. Emits a summary every 1000 parent records so we can
+    confirm the threads stream behavior without affecting normal performance.
+
+    Log format: THREADS_DEBUG: channel=<id> | total_messages=N | with_replies=N | without_replies=N | max_reply_count=N
     """
 
     def stream_slices(self) -> Iterable[StreamSlice]:
+        total = 0
+        with_replies = 0
+        without_replies = 0
+        max_reply_count = 0
+        current_channel = ""
+
         for stream_slice in super().stream_slices():
-            reply_count = stream_slice.extra_fields.get("reply_count")
-            if reply_count is not None and int(reply_count) >= 1:
-                yield stream_slice
-            else:
-                LOGGER.debug(
-                    "Skipping threads partition for message with reply_count=%s",
-                    reply_count,
+            parent_slice = stream_slice.partition.get("parent_slice", {})
+            channel = parent_slice.get("channel", "unknown")
+
+            # When channel changes, flush the summary for the previous channel
+            if channel != current_channel and total > 0:
+                LOGGER.info(
+                    "THREADS_DEBUG: channel=%s | total_messages=%d | with_replies=%d | without_replies=%d | max_reply_count=%d",
+                    current_channel, total, with_replies, without_replies, max_reply_count,
                 )
+                total = 0
+                with_replies = 0
+                without_replies = 0
+                max_reply_count = 0
+            current_channel = channel
+
+            # Count reply_count from the extra_fields if present, otherwise
+            # we can't tell — but the slice itself was created from a parent record
+            reply_count = stream_slice.extra_fields.get("reply_count", 0) if stream_slice.extra_fields else 0
+            total += 1
+            if reply_count and int(reply_count) >= 1:
+                with_replies += 1
+                max_reply_count = max(max_reply_count, int(reply_count))
+            else:
+                without_replies += 1
+
+            # Periodic log every 1000 messages to avoid flooding
+            if total % 1000 == 0:
+                LOGGER.info(
+                    "THREADS_DEBUG: channel=%s | progress=%d messages | with_replies=%d | without_replies=%d | max_reply_count=%d",
+                    current_channel, total, with_replies, without_replies, max_reply_count,
+                )
+
+            yield stream_slice
+
+        # Final flush for the last channel
+        if total > 0:
+            LOGGER.info(
+                "THREADS_DEBUG: channel=%s | total_messages=%d | with_replies=%d | without_replies=%d | max_reply_count=%d",
+                current_channel, total, with_replies, without_replies, max_reply_count,
+            )
 
 
 class ThreadsStateMigration(StateMigration):

--- a/airbyte-integrations/connectors/source-slack/components.py
+++ b/airbyte-integrations/connectors/source-slack/components.py
@@ -106,9 +106,8 @@ class ChannelsRetriever(SimpleRetriever):
         """
         The `is_member` property indicates whether the API Bot is already assigned / joined to the channel.
         https://api.slack.com/types/conversation#booleans
-        Archived channels cannot be joined and attempting to do so wastes rate limit budget.
         """
-        return config["join_channels"] and not record.get("is_member") and not record.get("is_archived")
+        return config["join_channels"] and not record.get("is_member")
 
     def make_join_channel_slice(self, channel: Mapping[str, Any]) -> Mapping[str, Any]:
         channel_id: str = channel.get("id")

--- a/airbyte-integrations/connectors/source-slack/components.py
+++ b/airbyte-integrations/connectors/source-slack/components.py
@@ -23,7 +23,7 @@ from airbyte_cdk.sources.types import Config
 from airbyte_cdk.utils.datetime_helpers import ab_datetime_parse
 
 
-LOGGER = logging.getLogger("airbyte_logger")
+LOGGER = logging.getLogger("airbyte")
 
 
 class JoinChannelsStream(HttpStream):

--- a/airbyte-integrations/connectors/source-slack/components.py
+++ b/airbyte-integrations/connectors/source-slack/components.py
@@ -137,15 +137,16 @@ class ThreadsPartitionRouter(SubstreamPartitionRouter):
     limit consumption.
 
     The reply_count field from the parent channel_messages record is passed via
-    extra_fields. Messages with reply_count < 2 are skipped because:
-    - reply_count == 0 or null: message has no thread at all
-    - reply_count == 1: only the parent message itself, no actual replies
+    extra_fields. Messages with reply_count < 1 are skipped because:
+    - reply_count absent or 0: message has no thread replies at all
+    - reply_count >= 1: at least one reply exists (reply_count excludes the
+      parent message per Slack's API — see conversations.replies docs)
     """
 
     def stream_slices(self) -> Iterable[StreamSlice]:
         for stream_slice in super().stream_slices():
             reply_count = stream_slice.extra_fields.get("reply_count")
-            if reply_count is not None and int(reply_count) >= 2:
+            if reply_count is not None and int(reply_count) >= 1:
                 yield stream_slice
             else:
                 LOGGER.debug(

--- a/airbyte-integrations/connectors/source-slack/manifest.yaml
+++ b/airbyte-integrations/connectors/source-slack/manifest.yaml
@@ -52,9 +52,11 @@ definitions:
     error_handler:
       type: DefaultErrorHandler
       backoff_strategies:
-        - type: "WaitTimeFromHeader"
+        - type: "CustomBackoffStrategy"
+          class_name: "source_declarative_manifest.components.RateLimitLoggingBackoffStrategy"
           header: "retry-after"
-        - type: "WaitTimeFromHeader"
+        - type: "CustomBackoffStrategy"
+          class_name: "source_declarative_manifest.components.RateLimitLoggingBackoffStrategy"
           header: "Retry-After"
       response_filters:
         - error_message_contains: "invalid_auth"
@@ -98,9 +100,11 @@ definitions:
         error_handler:
           type: DefaultErrorHandler
           backoff_strategies:
-            - type: "WaitTimeFromHeader"
+            - type: "CustomBackoffStrategy"
+              class_name: "source_declarative_manifest.components.RateLimitLoggingBackoffStrategy"
               header: "retry-after"
-            - type: "WaitTimeFromHeader"
+            - type: "CustomBackoffStrategy"
+              class_name: "source_declarative_manifest.components.RateLimitLoggingBackoffStrategy"
               header: "Retry-After"
           response_filters:
             - error_message_contains: "invalid_auth"
@@ -147,9 +151,11 @@ definitions:
           type: DefaultErrorHandler
           max_retries: 10
           backoff_strategies:
-            - type: "WaitTimeFromHeader"
+            - type: "CustomBackoffStrategy"
+              class_name: "source_declarative_manifest.components.RateLimitLoggingBackoffStrategy"
               header: "retry-after"
-            - type: "WaitTimeFromHeader"
+            - type: "CustomBackoffStrategy"
+              class_name: "source_declarative_manifest.components.RateLimitLoggingBackoffStrategy"
               header: "Retry-After"
         request_parameters:
           types: "{{ 'public_channel,private_channel' if config['include_private_channels'] == true else 'public_channel' }}"
@@ -302,7 +308,7 @@ definitions:
         $ref: "#/definitions/default_paginator"
       partition_router:
         type: CustomPartitionRouter
-        class_name: "source_declarative_manifest.components.ThreadsPartitionRouter"
+        class_name: "source_declarative_manifest.components.ThreadsLoggingPartitionRouter"
         parent_stream_configs:
           - type: ParentStreamConfig
             stream:
@@ -314,8 +320,7 @@ definitions:
             incremental_dependency: true
             parent_key: ts
             partition_field: float_ts
-            # Extract reply_count from parent records so ThreadsPartitionRouter can
-            # skip messages with no thread replies, avoiding unnecessary API calls
+            # Pass reply_count for diagnostic logging only (not used for filtering)
             extra_fields:
               - ["reply_count"]
             request_option:

--- a/airbyte-integrations/connectors/source-slack/manifest.yaml
+++ b/airbyte-integrations/connectors/source-slack/manifest.yaml
@@ -216,25 +216,9 @@ definitions:
     retriever:
       $ref: "#/definitions/retriever"
       requester:
-        type: CustomRequester
-        class_name: "source_declarative_manifest.components.MessagesAndThreadsHttpRequester"
-        url_match: "https://slack.com/api/conversations.history?.+"
-        url_base: https://slack.com/api/
-        path: "{{ parameters['path'] }}"
-        http_method: GET
+        $ref: "#/definitions/requester"
         request_parameters:
           inclusive: "True"
-        request_headers: {}
-        authenticator:
-          $ref: "#/definitions/authenticator"
-        request_body_json: {}
-        error_handler:
-          type: DefaultErrorHandler
-          backoff_strategies:
-            - type: "WaitTimeFromHeader"
-              header: "retry-after"
-            - type: "WaitTimeFromHeader"
-              header: "Retry-After"
         use_cache: true
       record_selector:
         $ref: "#/definitions/selector"
@@ -309,26 +293,9 @@ definitions:
     retriever:
       $ref: "#/definitions/retriever"
       requester:
-        type: CustomRequester
-        class_name: "source_declarative_manifest.components.MessagesAndThreadsHttpRequester"
-        url_match: "https://slack.com/api/conversations.replies?.+"
-        url_base: https://slack.com/api/
-        path: "{{ parameters['path'] }}"
-        http_method: GET
+        $ref: "#/definitions/requester"
         request_parameters:
           channel: "{{ stream_partition['parent_slice']['channel'] }}"
-        request_headers: {}
-        authenticator:
-          $ref: "#/definitions/authenticator"
-        request_body_json: {}
-        error_handler:
-          type: DefaultErrorHandler
-          max_retries: 20
-          backoff_strategies:
-            - type: "WaitTimeFromHeader"
-              header: "retry-after"
-            - type: "WaitTimeFromHeader"
-              header: "Retry-After"
       record_selector:
         $ref: "#/definitions/selector"
       paginator:

--- a/airbyte-integrations/connectors/source-slack/manifest.yaml
+++ b/airbyte-integrations/connectors/source-slack/manifest.yaml
@@ -51,12 +51,17 @@ definitions:
     request_body_json: {}
     error_handler:
       type: DefaultErrorHandler
+      backoff_strategies:
+        - type: "WaitTimeFromHeader"
+          header: "retry-after"
+        - type: "WaitTimeFromHeader"
+          header: "Retry-After"
       response_filters:
         - error_message_contains: "invalid_auth"
           action: FAIL
           error_message: Authentication has failed, please update your credentials.
         - http_codes: [429]
-          action: RETRY
+          action: RATE_LIMITED
           error_message: Failed to perform a request due to rate limits.
         - http_codes: [500, 503]
           action: RETRY
@@ -92,12 +97,17 @@ definitions:
         $ref: "#/definitions/requester"
         error_handler:
           type: DefaultErrorHandler
+          backoff_strategies:
+            - type: "WaitTimeFromHeader"
+              header: "retry-after"
+            - type: "WaitTimeFromHeader"
+              header: "Retry-After"
           response_filters:
             - error_message_contains: "invalid_auth"
               action: FAIL
               error_message: Authentication has failed, please update your credentials.
             - http_codes: [429]
-              action: RETRY
+              action: RATE_LIMITED
               error_message: Failed to perform a request due to rate limits.
             - http_codes: [403, 400]
               action: FAIL

--- a/airbyte-integrations/connectors/source-slack/manifest.yaml
+++ b/airbyte-integrations/connectors/source-slack/manifest.yaml
@@ -301,7 +301,8 @@ definitions:
       paginator:
         $ref: "#/definitions/default_paginator"
       partition_router:
-        type: SubstreamPartitionRouter
+        type: CustomPartitionRouter
+        class_name: "source_declarative_manifest.components.ThreadsPartitionRouter"
         parent_stream_configs:
           - type: ParentStreamConfig
             stream:
@@ -313,6 +314,10 @@ definitions:
             incremental_dependency: true
             parent_key: ts
             partition_field: float_ts
+            # Extract reply_count from parent records so ThreadsPartitionRouter can
+            # skip messages with no thread replies, avoiding unnecessary API calls
+            extra_fields:
+              - ["reply_count"]
             request_option:
               type: RequestOption
               field_name: "ts"

--- a/airbyte-integrations/connectors/source-slack/metadata.yaml
+++ b/airbyte-integrations/connectors/source-slack/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: c2281cee-86f9-4a86-bb48-d23286b4c7bd
-  dockerImageTag: 3.1.15
+  dockerImageTag: 3.1.16
   dockerRepository: airbyte/source-slack
   documentationUrl: https://docs.airbyte.com/integrations/sources/slack
   externalDocumentationUrls:

--- a/airbyte-integrations/connectors/source-slack/metadata.yaml
+++ b/airbyte-integrations/connectors/source-slack/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: c2281cee-86f9-4a86-bb48-d23286b4c7bd
-  dockerImageTag: 3.1.14
+  dockerImageTag: 3.1.15
   dockerRepository: airbyte/source-slack
   documentationUrl: https://docs.airbyte.com/integrations/sources/slack
   externalDocumentationUrls:

--- a/airbyte-integrations/connectors/source-slack/metadata.yaml
+++ b/airbyte-integrations/connectors/source-slack/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: c2281cee-86f9-4a86-bb48-d23286b4c7bd
-  dockerImageTag: 3.1.16
+  dockerImageTag: 3.1.17
   dockerRepository: airbyte/source-slack
   documentationUrl: https://docs.airbyte.com/integrations/sources/slack
   externalDocumentationUrls:

--- a/airbyte-integrations/connectors/source-slack/unit_tests/test_streams.py
+++ b/airbyte-integrations/connectors/source-slack/unit_tests/test_streams.py
@@ -27,7 +27,7 @@ def authenticator(token_config):
         (
             "2020-01-01T00:00:00Z",
             "2020-01-02T00:00:00Z",
-            [{"ts": 1577866844, "reply_count": 3}, {"ts": 1577877406, "reply_count": 2}],
+            [{"ts": 1577866844}, {"ts": 1577877406}],
             {},
             [
                 {
@@ -95,12 +95,12 @@ def test_get_updated_state(requests_mock, authenticator, token_config, current_s
     requests_mock.register_uri(
         "GET",
         "https://slack.com/api/conversations.history?limit=1000&channel=airbyte-for-beginners",
-        [{"json": {"messages": [{"ts": 1507866847, "reply_count": 3}]}}, {"json": {"messages": []}}],
+        [{"json": {"messages": [{"ts": 1507866847}]}}, {"json": {"messages": []}}],
     )
     requests_mock.register_uri(
         "GET",
         "https://slack.com/api/conversations.history?limit=1000&channel=good-reads",
-        [{"json": {"messages": [{"ts": 1507866847, "reply_count": 3}]}}, {"json": {"messages": []}}],
+        [{"json": {"messages": [{"ts": 1507866847}]}}, {"json": {"messages": []}}],
     )
     requests_mock.register_uri(
         "GET",
@@ -142,12 +142,12 @@ def test_threads_parse_response(requests_mock, authenticator, token_config):
     requests_mock.register_uri(
         "GET",
         "https://slack.com/api/conversations.history?limit=1000&channel=airbyte-for-beginners",
-        [{"json": {"messages": [{"ts": 1507866847, "reply_count": 3}]}}, {"json": {"messages": []}}],
+        [{"json": {"messages": [{"ts": 1507866847}]}}, {"json": {"messages": []}}],
     )
     requests_mock.register_uri(
         "GET",
         "https://slack.com/api/conversations.history?limit=1000&channel=good-reads",
-        [{"json": {"messages": [{"ts": 1507866847, "reply_count": 3}]}}, {"json": {"messages": []}}],
+        [{"json": {"messages": [{"ts": 1507866847}]}}, {"json": {"messages": []}}],
     )
 
     requests_mock.register_uri(
@@ -237,12 +237,12 @@ def test_backoff(requests_mock, token_config, authenticator, headers, expected_r
     requests_mock.register_uri(
         "GET",
         "https://slack.com/api/conversations.history?limit=1000&channel=airbyte-for-beginners",
-        [{"json": {"messages": [{"ts": 1507866847, "reply_count": 3}]}}, {"json": {"messages": []}}],
+        [{"json": {"messages": [{"ts": 1507866847}]}}, {"json": {"messages": []}}],
     )
     requests_mock.register_uri(
         "GET",
         "https://slack.com/api/conversations.history?limit=1000&channel=good-reads",
-        [{"json": {"messages": [{"ts": 1507866847, "reply_count": 3}]}}, {"json": {"messages": []}}],
+        [{"json": {"messages": [{"ts": 1507866847}]}}, {"json": {"messages": []}}],
     )
 
     catalog = ConfiguredAirbyteCatalogSerializer.load(

--- a/airbyte-integrations/connectors/source-slack/unit_tests/test_streams.py
+++ b/airbyte-integrations/connectors/source-slack/unit_tests/test_streams.py
@@ -27,7 +27,7 @@ def authenticator(token_config):
         (
             "2020-01-01T00:00:00Z",
             "2020-01-02T00:00:00Z",
-            [{"ts": 1577866844}, {"ts": 1577877406}],
+            [{"ts": 1577866844, "reply_count": 3}, {"ts": 1577877406, "reply_count": 2}],
             {},
             [
                 {
@@ -95,12 +95,12 @@ def test_get_updated_state(requests_mock, authenticator, token_config, current_s
     requests_mock.register_uri(
         "GET",
         "https://slack.com/api/conversations.history?limit=1000&channel=airbyte-for-beginners",
-        [{"json": {"messages": [{"ts": 1507866847}]}}, {"json": {"messages": []}}],
+        [{"json": {"messages": [{"ts": 1507866847, "reply_count": 3}]}}, {"json": {"messages": []}}],
     )
     requests_mock.register_uri(
         "GET",
         "https://slack.com/api/conversations.history?limit=1000&channel=good-reads",
-        [{"json": {"messages": [{"ts": 1507866847}]}}, {"json": {"messages": []}}],
+        [{"json": {"messages": [{"ts": 1507866847, "reply_count": 3}]}}, {"json": {"messages": []}}],
     )
     requests_mock.register_uri(
         "GET",
@@ -142,12 +142,12 @@ def test_threads_parse_response(requests_mock, authenticator, token_config):
     requests_mock.register_uri(
         "GET",
         "https://slack.com/api/conversations.history?limit=1000&channel=airbyte-for-beginners",
-        [{"json": {"messages": [{"ts": 1507866847}]}}, {"json": {"messages": []}}],
+        [{"json": {"messages": [{"ts": 1507866847, "reply_count": 3}]}}, {"json": {"messages": []}}],
     )
     requests_mock.register_uri(
         "GET",
         "https://slack.com/api/conversations.history?limit=1000&channel=good-reads",
-        [{"json": {"messages": [{"ts": 1507866847}]}}, {"json": {"messages": []}}],
+        [{"json": {"messages": [{"ts": 1507866847, "reply_count": 3}]}}, {"json": {"messages": []}}],
     )
 
     requests_mock.register_uri(
@@ -237,12 +237,12 @@ def test_backoff(requests_mock, token_config, authenticator, headers, expected_r
     requests_mock.register_uri(
         "GET",
         "https://slack.com/api/conversations.history?limit=1000&channel=airbyte-for-beginners",
-        [{"json": {"messages": [{"ts": 1507866847}]}}, {"json": {"messages": []}}],
+        [{"json": {"messages": [{"ts": 1507866847, "reply_count": 3}]}}, {"json": {"messages": []}}],
     )
     requests_mock.register_uri(
         "GET",
         "https://slack.com/api/conversations.history?limit=1000&channel=good-reads",
-        [{"json": {"messages": [{"ts": 1507866847}]}}, {"json": {"messages": []}}],
+        [{"json": {"messages": [{"ts": 1507866847, "reply_count": 3}]}}, {"json": {"messages": []}}],
     )
 
     catalog = ConfiguredAirbyteCatalogSerializer.load(

--- a/docs/integrations/sources/slack.md
+++ b/docs/integrations/sources/slack.md
@@ -183,6 +183,7 @@ These two streams are effectively limited to **one request per minute**. Conside
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:-----------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 3.1.15 | 2026-03-28 | [75551](https://github.com/airbytehq/airbyte/pull/75551) | Fix rate limiting for all streams by mapping 429 responses to RATE_LIMITED instead of RETRY, and add WaitTimeFromHeader backoff strategies |
 | 3.1.14 | 2026-03-27 | [75197](https://github.com/airbytehq/airbyte/pull/75197) | Add declarative OAuth with `oauth_connector_input_specification` and granular scopes |
 | 3.1.13 | 2026-03-24 | [75329](https://github.com/airbytehq/airbyte/pull/75329) | Update dependencies |
 | 3.1.12 | 2026-03-10 | [74598](https://github.com/airbytehq/airbyte/pull/74598) | Update dependencies |
@@ -198,72 +199,72 @@ These two streams are effectively limited to **one request per minute**. Conside
 | 3.1.2 | 2025-09-30 | [66566](https://github.com/airbytehq/airbyte/pull/66566) | Update to CDK v7 |
 | 3.1.1 | 2025-09-24 | [66640](https://github.com/airbytehq/airbyte/pull/66640) | Update dependencies |
 | 3.1.0 | 2025-09-18 | [66501](https://github.com/airbytehq/airbyte/pull/66501) | Promoting release candidate 3.1.0-rc.1 to a main version. |
-| 3.1.0-rc.1 | 2025-09-10 | [64160](https://github.com/airbytehq/airbyte/pull/64160) | Migrate to manifest-only.                                                                                                                                              |
-| 3.0.0      | 2025-09-10 | [65937](https://github.com/airbytehq/airbyte/pull/65937) | Add migration guide for missing state issue                                                                                                                            |
-| 2.2.0      | 2025-09-10 | [66155](https://github.com/airbytehq/airbyte/pull/66155) | Promoting release candidate 2.2.0-rc.7 to a main version.                                                                                                              |
-| 2.2.0-rc.7 | 2025-08-21 | [65132](https://github.com/airbytehq/airbyte/pull/65132) | Update API budget to depend on auth method (rate limits apply only with OAuth).                                                                                        |
-| 2.2.0-rc.6 | 2025-08-14 | [64553](https://github.com/airbytehq/airbyte/pull/64553) | Add API budget for Threads and Channel Messages streams.                                                                                                               |
-| 2.2.0-rc.5 | 2025-08-06 | [64530](https://github.com/airbytehq/airbyte/pull/64530) | Set use_cache = true for Channels and Channel Messages streams.                                                                                                        |
-| 2.2.0-rc.4 | 2025-08-04 | [64486](https://github.com/airbytehq/airbyte/pull/64486) | Add backoff strategy for Channels stream.                                                                                                                              |
-| 2.2.0-rc.3 | 2025-07-29 | [64107](https://github.com/airbytehq/airbyte/pull/64107) | Add custom partition router.                                                                                                                                           |
-| 2.2.0-rc.2 | 2025-07-23 | [63732](https://github.com/airbytehq/airbyte/pull/63732) | Enable progressive rollout.                                                                                                                                            |
-| 2.2.0-rc.1 | 2025-07-23 | [63278](https://github.com/airbytehq/airbyte/pull/63278) | Migrate Threads stream to manifest.                                                                                                                                    |
-| 2.1.0      | 2025-07-11 | [62930](https://github.com/airbytehq/airbyte/pull/62930) | Promoting release candidate 2.1.0-rc.1 to a main version.                                                                                                              |
-| 2.1.0-rc.1 | 2025-07-07 | [62110](https://github.com/airbytehq/airbyte/pull/62110) | Bump cdk v6                                                                                                                                                            |
-| 2.0.2      | 2025-07-05 | [62709](https://github.com/airbytehq/airbyte/pull/62709) | Update dependencies                                                                                                                                                    |
-| 2.0.1      | 2025-06-28 | [51965](https://github.com/airbytehq/airbyte/pull/51965) | Update dependencies                                                                                                                                                    |
-| 2.0.0      | 2025-06-25 | [62055](https://github.com/airbytehq/airbyte/pull/62055) | Add breaking change notification for migrating to the new Slack Marketplace application to retain higher rate limits.                                                  |
-| 1.3.2      | 2025-01-11 | [43812](https://github.com/airbytehq/airbyte/pull/43812) | Starting with this version, the Docker image is now rootless. Please note that this and future versions will not be compatible with Airbyte versions earlier than 0.64 |
-| 1.3.1      | 2024-07-24 | [42485](https://github.com/airbytehq/airbyte/pull/42485) | Fix MRO error for `IncrementalMessageStream`                                                                                                                           |
-| 1.3.0      | 2024-07-17 | [41994](https://github.com/airbytehq/airbyte/pull/41994) | Migrate to CDK v3.5.1                                                                                                                                                  |
-| 1.2.0      | 2024-07-16 | [41970](https://github.com/airbytehq/airbyte/pull/41970) | Migrate to CDK v2.4.0                                                                                                                                                  |
-| 1.1.13     | 2024-07-13 | [41863](https://github.com/airbytehq/airbyte/pull/41863) | Update dependencies                                                                                                                                                    |
-| 1.1.12     | 2024-07-10 | [41485](https://github.com/airbytehq/airbyte/pull/41485) | Update dependencies                                                                                                                                                    |
-| 1.1.11     | 2024-07-09 | [41231](https://github.com/airbytehq/airbyte/pull/41231) | Update dependencies                                                                                                                                                    |
-| 1.1.10     | 2024-07-06 | [40839](https://github.com/airbytehq/airbyte/pull/40839) | Update dependencies                                                                                                                                                    |
-| 1.1.9      | 2024-06-25 | [40347](https://github.com/airbytehq/airbyte/pull/40347) | Update dependencies                                                                                                                                                    |
-| 1.1.8      | 2024-06-22 | [40166](https://github.com/airbytehq/airbyte/pull/40166) | Update dependencies                                                                                                                                                    |
-| 1.1.7      | 2025-06-14 | [39343](https://github.com/airbytehq/airbyte/pull/39343) | Update state handling for `threads` Python stream                                                                                                                      |
-| 1.1.6      | 2024-06-12 | [39416](https://github.com/airbytehq/airbyte/pull/39416) | Respect `include_private_channels` option in `threads` stream                                                                                                          |
-| 1.1.5      | 2024-06-10 | [39132](https://github.com/airbytehq/airbyte/pull/39132) | Convert string state to float for `threads` stream                                                                                                                     |
-| 1.1.4      | 2024-06-06 | [39271](https://github.com/airbytehq/airbyte/pull/39271) | [autopull] Upgrade base image to v1.2.2                                                                                                                                |
-| 1.1.3      | 2024-06-05 | [39121](https://github.com/airbytehq/airbyte/pull/39121) | Change cursor format for `channel_messages` stream to `%s_as_float`                                                                                                    |
-| 1.1.2      | 2024-05-23 | [38619](https://github.com/airbytehq/airbyte/pull/38619) | Fix cursor granularity for the `channel_messages` stream                                                                                                               |
-| 1.1.1      | 2024-05-02 | [36661](https://github.com/airbytehq/airbyte/pull/36661) | Schema descriptions                                                                                                                                                    |
-| 1.1.0      | 2024-04-18 | [37332](https://github.com/airbytehq/airbyte/pull/37332) | Add the capability to sync from private channels                                                                                                                       |
-| 1.0.0      | 2024-04-02 | [35477](https://github.com/airbytehq/airbyte/pull/35477) | Migration to low-code CDK                                                                                                                                              |
-| 0.4.1      | 2024-03-27 | [36579](https://github.com/airbytehq/airbyte/pull/36579) | Upgrade airbyte-cdk version to emit record counts as floats                                                                                                            |
-| 0.4.0      | 2024-03-19 | [36267](https://github.com/airbytehq/airbyte/pull/36267) | Pin airbyte-cdk version to `^0`                                                                                                                                        |
-| 0.3.9      | 2024-02-12 | [35157](https://github.com/airbytehq/airbyte/pull/35157) | Manage dependencies with Poetry                                                                                                                                        |
-| 0.3.8      | 2024-02-09 | [35131](https://github.com/airbytehq/airbyte/pull/35131) | Fixed the issue when `schema discovery` fails with `502` due to the platform timeout                                                                                   |
-| 0.3.7      | 2024-01-10 | [1234](https://github.com/airbytehq/airbyte/pull/1234)   | Prepare for airbyte-lib                                                                                                                                                |
-| 0.3.6      | 2023-11-21 | [32707](https://github.com/airbytehq/airbyte/pull/32707) | Threads: do not use client-side record filtering                                                                                                                       |
-| 0.3.5      | 2023-10-19 | [31599](https://github.com/airbytehq/airbyte/pull/31599) | Base image migration: remove Dockerfile and use the python-connector-base image                                                                                        |
-| 0.3.4      | 2023-10-06 | [31134](https://github.com/airbytehq/airbyte/pull/31134) | Update CDK and remove non iterable return from records                                                                                                                 |
-| 0.3.3      | 2023-09-28 | [30580](https://github.com/airbytehq/airbyte/pull/30580) | Add `bot_id` field to threads schema                                                                                                                                   |
-| 0.3.2      | 2023-09-20 | [30613](https://github.com/airbytehq/airbyte/pull/30613) | Set default value for channel_filters during discover                                                                                                                  |
-| 0.3.1      | 2023-09-19 | [30570](https://github.com/airbytehq/airbyte/pull/30570) | Use default availability strategy                                                                                                                                      |
-| 0.3.0      | 2023-09-18 | [30521](https://github.com/airbytehq/airbyte/pull/30521) | Add unexpected fields to streams `channel_messages`, `channels`, `threads`, `users`                                                                                    |
-| 0.2.0      | 2023-05-24 | [26497](https://github.com/airbytehq/airbyte/pull/26497) | Fixed `lookback window` value limitations                                                                                                                              |
-| 0.1.26     | 2023-05-17 | [26186](https://github.com/airbytehq/airbyte/pull/26186) | Limited the `lookback window` range for input configuration                                                                                                            |
-| 0.1.25     | 2023-03-20 | [22889](https://github.com/airbytehq/airbyte/pull/22889) | Specified date formatting in specification                                                                                                                             |
-| 0.1.24     | 2023-03-20 | [24126](https://github.com/airbytehq/airbyte/pull/24126) | Increase page size to 1000                                                                                                                                             |
-| 0.1.23     | 2023-02-21 | [21907](https://github.com/airbytehq/airbyte/pull/21907) | Do not join channels that not gonna be synced                                                                                                                          |
-| 0.1.22     | 2023-01-27 | [22022](https://github.com/airbytehq/airbyte/pull/22022) | Set `AvailabilityStrategy` for streams explicitly to `None`                                                                                                            |
-| 0.1.21     | 2023-01-12 | [21321](https://github.com/airbytehq/airbyte/pull/21321) | Retry Timeout error                                                                                                                                                    |
-| 0.1.20     | 2022-12-21 | [20767](https://github.com/airbytehq/airbyte/pull/20767) | Update schema                                                                                                                                                          |
-| 0.1.19     | 2022-12-01 | [19970](https://github.com/airbytehq/airbyte/pull/19970) | Remove OAuth2.0 broken `refresh_token` support                                                                                                                         |
-| 0.1.18     | 2022-09-28 | [17315](https://github.com/airbytehq/airbyte/pull/17315) | Always install latest version of Airbyte CDK                                                                                                                           |
-| 0.1.17     | 2022-08-28 | [16085](https://github.com/airbytehq/airbyte/pull/16085) | Increase unit test coverage                                                                                                                                            |
-| 0.1.16     | 2022-08-28 | [16050](https://github.com/airbytehq/airbyte/pull/16050) | Fix SATs                                                                                                                                                               |
-| 0.1.15     | 2022-03-31 | [11613](https://github.com/airbytehq/airbyte/pull/11613) | Add 'channel_filter' config and improve performance                                                                                                                    |
-| 0.1.14     | 2022-01-26 | [9575](https://github.com/airbytehq/airbyte/pull/9575)   | Correct schema                                                                                                                                                         |
-| 0.1.13     | 2021-11-08 | [7499](https://github.com/airbytehq/airbyte/pull/7499)   | Remove base-python dependencies                                                                                                                                        |
-| 0.1.12     | 2021-10-07 | [6570](https://github.com/airbytehq/airbyte/pull/6570)   | Implement OAuth support with OAuth authenticator                                                                                                                       |
-| 0.1.11     | 2021-08-27 | [5830](https://github.com/airbytehq/airbyte/pull/5830)   | Fix sync operations hang forever issue                                                                                                                                 |
-| 0.1.10     | 2021-08-27 | [5697](https://github.com/airbytehq/airbyte/pull/5697)   | Fix max retries issue                                                                                                                                                  |
-| 0.1.9      | 2021-07-20 | [4860](https://github.com/airbytehq/airbyte/pull/4860)   | Fix reading threads issue                                                                                                                                              |
-| 0.1.8      | 2021-07-14 | [4683](https://github.com/airbytehq/airbyte/pull/4683)   | Add float_ts primary key                                                                                                                                               |
-| 0.1.7      | 2021-06-25 | [3978](https://github.com/airbytehq/airbyte/pull/3978)   | Release Slack CDK Connector                                                                                                                                            |
+| 3.1.0-rc.1 | 2025-09-10 | [64160](https://github.com/airbytehq/airbyte/pull/64160) | Migrate to manifest-only. |
+| 3.0.0 | 2025-09-10 | [65937](https://github.com/airbytehq/airbyte/pull/65937) | Add migration guide for missing state issue |
+| 2.2.0 | 2025-09-10 | [66155](https://github.com/airbytehq/airbyte/pull/66155) | Promoting release candidate 2.2.0-rc.7 to a main version. |
+| 2.2.0-rc.7 | 2025-08-21 | [65132](https://github.com/airbytehq/airbyte/pull/65132) | Update API budget to depend on auth method (rate limits apply only with OAuth). |
+| 2.2.0-rc.6 | 2025-08-14 | [64553](https://github.com/airbytehq/airbyte/pull/64553) | Add API budget for Threads and Channel Messages streams. |
+| 2.2.0-rc.5 | 2025-08-06 | [64530](https://github.com/airbytehq/airbyte/pull/64530) | Set use_cache = true for Channels and Channel Messages streams. |
+| 2.2.0-rc.4 | 2025-08-04 | [64486](https://github.com/airbytehq/airbyte/pull/64486) | Add backoff strategy for Channels stream. |
+| 2.2.0-rc.3 | 2025-07-29 | [64107](https://github.com/airbytehq/airbyte/pull/64107) | Add custom partition router. |
+| 2.2.0-rc.2 | 2025-07-23 | [63732](https://github.com/airbytehq/airbyte/pull/63732) | Enable progressive rollout. |
+| 2.2.0-rc.1 | 2025-07-23 | [63278](https://github.com/airbytehq/airbyte/pull/63278) | Migrate Threads stream to manifest. |
+| 2.1.0 | 2025-07-11 | [62930](https://github.com/airbytehq/airbyte/pull/62930) | Promoting release candidate 2.1.0-rc.1 to a main version. |
+| 2.1.0-rc.1 | 2025-07-07 | [62110](https://github.com/airbytehq/airbyte/pull/62110) | Bump cdk v6 |
+| 2.0.2 | 2025-07-05 | [62709](https://github.com/airbytehq/airbyte/pull/62709) | Update dependencies |
+| 2.0.1 | 2025-06-28 | [51965](https://github.com/airbytehq/airbyte/pull/51965) | Update dependencies |
+| 2.0.0 | 2025-06-25 | [62055](https://github.com/airbytehq/airbyte/pull/62055) | Add breaking change notification for migrating to the new Slack Marketplace application to retain higher rate limits. |
+| 1.3.2 | 2025-01-11 | [43812](https://github.com/airbytehq/airbyte/pull/43812) | Starting with this version, the Docker image is now rootless. Please note that this and future versions will not be compatible with Airbyte versions earlier than 0.64 |
+| 1.3.1 | 2024-07-24 | [42485](https://github.com/airbytehq/airbyte/pull/42485) | Fix MRO error for `IncrementalMessageStream` |
+| 1.3.0 | 2024-07-17 | [41994](https://github.com/airbytehq/airbyte/pull/41994) | Migrate to CDK v3.5.1 |
+| 1.2.0 | 2024-07-16 | [41970](https://github.com/airbytehq/airbyte/pull/41970) | Migrate to CDK v2.4.0 |
+| 1.1.13 | 2024-07-13 | [41863](https://github.com/airbytehq/airbyte/pull/41863) | Update dependencies |
+| 1.1.12 | 2024-07-10 | [41485](https://github.com/airbytehq/airbyte/pull/41485) | Update dependencies |
+| 1.1.11 | 2024-07-09 | [41231](https://github.com/airbytehq/airbyte/pull/41231) | Update dependencies |
+| 1.1.10 | 2024-07-06 | [40839](https://github.com/airbytehq/airbyte/pull/40839) | Update dependencies |
+| 1.1.9 | 2024-06-25 | [40347](https://github.com/airbytehq/airbyte/pull/40347) | Update dependencies |
+| 1.1.8 | 2024-06-22 | [40166](https://github.com/airbytehq/airbyte/pull/40166) | Update dependencies |
+| 1.1.7 | 2025-06-14 | [39343](https://github.com/airbytehq/airbyte/pull/39343) | Update state handling for `threads` Python stream |
+| 1.1.6 | 2024-06-12 | [39416](https://github.com/airbytehq/airbyte/pull/39416) | Respect `include_private_channels` option in `threads` stream |
+| 1.1.5 | 2024-06-10 | [39132](https://github.com/airbytehq/airbyte/pull/39132) | Convert string state to float for `threads` stream |
+| 1.1.4 | 2024-06-06 | [39271](https://github.com/airbytehq/airbyte/pull/39271) | [autopull] Upgrade base image to v1.2.2 |
+| 1.1.3 | 2024-06-05 | [39121](https://github.com/airbytehq/airbyte/pull/39121) | Change cursor format for `channel_messages` stream to `%s_as_float` |
+| 1.1.2 | 2024-05-23 | [38619](https://github.com/airbytehq/airbyte/pull/38619) | Fix cursor granularity for the `channel_messages` stream |
+| 1.1.1 | 2024-05-02 | [36661](https://github.com/airbytehq/airbyte/pull/36661) | Schema descriptions |
+| 1.1.0 | 2024-04-18 | [37332](https://github.com/airbytehq/airbyte/pull/37332) | Add the capability to sync from private channels |
+| 1.0.0 | 2024-04-02 | [35477](https://github.com/airbytehq/airbyte/pull/35477) | Migration to low-code CDK |
+| 0.4.1 | 2024-03-27 | [36579](https://github.com/airbytehq/airbyte/pull/36579) | Upgrade airbyte-cdk version to emit record counts as floats |
+| 0.4.0 | 2024-03-19 | [36267](https://github.com/airbytehq/airbyte/pull/36267) | Pin airbyte-cdk version to `^0` |
+| 0.3.9 | 2024-02-12 | [35157](https://github.com/airbytehq/airbyte/pull/35157) | Manage dependencies with Poetry |
+| 0.3.8 | 2024-02-09 | [35131](https://github.com/airbytehq/airbyte/pull/35131) | Fixed the issue when `schema discovery` fails with `502` due to the platform timeout |
+| 0.3.7 | 2024-01-10 | [1234](https://github.com/airbytehq/airbyte/pull/1234) | Prepare for airbyte-lib |
+| 0.3.6 | 2023-11-21 | [32707](https://github.com/airbytehq/airbyte/pull/32707) | Threads: do not use client-side record filtering |
+| 0.3.5 | 2023-10-19 | [31599](https://github.com/airbytehq/airbyte/pull/31599) | Base image migration: remove Dockerfile and use the python-connector-base image |
+| 0.3.4 | 2023-10-06 | [31134](https://github.com/airbytehq/airbyte/pull/31134) | Update CDK and remove non iterable return from records |
+| 0.3.3 | 2023-09-28 | [30580](https://github.com/airbytehq/airbyte/pull/30580) | Add `bot_id` field to threads schema |
+| 0.3.2 | 2023-09-20 | [30613](https://github.com/airbytehq/airbyte/pull/30613) | Set default value for channel_filters during discover |
+| 0.3.1 | 2023-09-19 | [30570](https://github.com/airbytehq/airbyte/pull/30570) | Use default availability strategy |
+| 0.3.0 | 2023-09-18 | [30521](https://github.com/airbytehq/airbyte/pull/30521) | Add unexpected fields to streams `channel_messages`, `channels`, `threads`, `users` |
+| 0.2.0 | 2023-05-24 | [26497](https://github.com/airbytehq/airbyte/pull/26497) | Fixed `lookback window` value limitations |
+| 0.1.26 | 2023-05-17 | [26186](https://github.com/airbytehq/airbyte/pull/26186) | Limited the `lookback window` range for input configuration |
+| 0.1.25 | 2023-03-20 | [22889](https://github.com/airbytehq/airbyte/pull/22889) | Specified date formatting in specification |
+| 0.1.24 | 2023-03-20 | [24126](https://github.com/airbytehq/airbyte/pull/24126) | Increase page size to 1000 |
+| 0.1.23 | 2023-02-21 | [21907](https://github.com/airbytehq/airbyte/pull/21907) | Do not join channels that not gonna be synced |
+| 0.1.22 | 2023-01-27 | [22022](https://github.com/airbytehq/airbyte/pull/22022) | Set `AvailabilityStrategy` for streams explicitly to `None` |
+| 0.1.21 | 2023-01-12 | [21321](https://github.com/airbytehq/airbyte/pull/21321) | Retry Timeout error |
+| 0.1.20 | 2022-12-21 | [20767](https://github.com/airbytehq/airbyte/pull/20767) | Update schema |
+| 0.1.19 | 2022-12-01 | [19970](https://github.com/airbytehq/airbyte/pull/19970) | Remove OAuth2.0 broken `refresh_token` support |
+| 0.1.18 | 2022-09-28 | [17315](https://github.com/airbytehq/airbyte/pull/17315) | Always install latest version of Airbyte CDK |
+| 0.1.17 | 2022-08-28 | [16085](https://github.com/airbytehq/airbyte/pull/16085) | Increase unit test coverage |
+| 0.1.16 | 2022-08-28 | [16050](https://github.com/airbytehq/airbyte/pull/16050) | Fix SATs |
+| 0.1.15 | 2022-03-31 | [11613](https://github.com/airbytehq/airbyte/pull/11613) | Add 'channel_filter' config and improve performance |
+| 0.1.14 | 2022-01-26 | [9575](https://github.com/airbytehq/airbyte/pull/9575) | Correct schema |
+| 0.1.13 | 2021-11-08 | [7499](https://github.com/airbytehq/airbyte/pull/7499) | Remove base-python dependencies |
+| 0.1.12 | 2021-10-07 | [6570](https://github.com/airbytehq/airbyte/pull/6570) | Implement OAuth support with OAuth authenticator |
+| 0.1.11 | 2021-08-27 | [5830](https://github.com/airbytehq/airbyte/pull/5830) | Fix sync operations hang forever issue |
+| 0.1.10 | 2021-08-27 | [5697](https://github.com/airbytehq/airbyte/pull/5697) | Fix max retries issue |
+| 0.1.9 | 2021-07-20 | [4860](https://github.com/airbytehq/airbyte/pull/4860) | Fix reading threads issue |
+| 0.1.8 | 2021-07-14 | [4683](https://github.com/airbytehq/airbyte/pull/4683) | Add float_ts primary key |
+| 0.1.7 | 2021-06-25 | [3978](https://github.com/airbytehq/airbyte/pull/3978) | Release Slack CDK Connector |
 
 </details>

--- a/docs/integrations/sources/slack.md
+++ b/docs/integrations/sources/slack.md
@@ -183,6 +183,7 @@ These two streams are effectively limited to **one request per minute**. Conside
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:-----------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 3.1.16 | 2026-03-28 | [75551](https://github.com/airbytehq/airbyte/pull/75551) | Remove MessagesAndThreadsApiBudget that permanently throttled channel_messages and threads to 1 req/60s on first 429; rely on RATE_LIMITED action with Retry-After header backoff instead |
 | 3.1.15 | 2026-03-28 | [75551](https://github.com/airbytehq/airbyte/pull/75551) | Fix rate limiting for all streams by mapping 429 responses to RATE_LIMITED instead of RETRY, and add WaitTimeFromHeader backoff strategies |
 | 3.1.14 | 2026-03-27 | [75197](https://github.com/airbytehq/airbyte/pull/75197) | Add declarative OAuth with `oauth_connector_input_specification` and granular scopes |
 | 3.1.13 | 2026-03-24 | [75329](https://github.com/airbytehq/airbyte/pull/75329) | Update dependencies |


### PR DESCRIPTION
## What

Two related rate-limiting bugs in the Slack connector caused syncs to fail or stall on workspaces with moderate-to-high activity. Additionally, diagnostic logging is needed to confirm rate limit tier and threads stream behavior:

1. **429 → `RETRY` instead of `RATE_LIMITED`**: The base requester and `users_stream` error handlers mapped HTTP 429 to `RETRY` (limited retries → permanent failure) instead of `RATE_LIMITED` (infinite retries). This caused `channel_members`, `users`, and `channels` to permanently fail after hitting Slack rate limits.

2. **`MessagesAndThreadsApiBudget` permanent 1 req/60s throttle**: On the first 429 response, `channel_messages` and `threads` were permanently throttled to 1 request per 60 seconds for the rest of the sync via a custom `MessagesAndThreadsApiBudget` class. This was designed for non-Marketplace apps but remained in effect after Airbyte migrated to a Slack Marketplace app (v2.0.0), where the actual limit is 50+ req/min for Tier 3 endpoints. The throttle never recovered within a sync, making large workspace syncs take days.

3. **No visibility into actual rate limit behavior**: There was no logging of Slack's `Retry-After` header values or rate limit tier, making it impossible to confirm whether connections are hitting Tier 3 (Marketplace) or lower limits. Additionally, the `threads` stream calls `conversations.replies` for every parent message — we need to understand what fraction of messages actually have threads to assess the impact of potential optimizations.

Production evidence from [connection `8239226b`](https://cloud.airbyte.com/workspaces/df5fa524-ed3a-4f59-90ef-0906f3b945c0/connections/8239226b-c243-4a6a-9251-03f203954cb1/timeline): 1,169 `DefaultBackoffException` events, 0 `RateLimitBackoffException` events, 13 "retries exhausted" permanent failures on `channel_members`, and `channel_messages`/`threads` stalled at 1 req/60s.

## How

**`components.py`**:
- Removed `MessagesAndThreadsApiBudget`, `MessagesAndThreadsHttpRequester`, and `MESSAGES_AND_THREADS_RATE` (~80 lines of custom rate-limiting code)
- Cleaned up unused imports (`call_rate`, `HttpRequester`, `HttpMethod`, `HttpClient`, `deepcopy`, `Dict`, `NoAuth`, `SinglePartitionRouter`, `InterpolatedRequestOptionsProvider`, `EmptyString`, `StreamState`, etc.)
- Added `RateLimitLoggingBackoffStrategy` — custom `BackoffStrategy` that extracts wait time from a response header (same as `WaitTimeFromHeader`) and logs `RATE_LIMIT_DEBUG` lines on every 429 with `Retry-After`, all `X-Rate-Limit-*` headers, the URL, and attempt count
- Added `ThreadsLoggingPartitionRouter` — thin wrapper around `SubstreamPartitionRouter` that counts `reply_count` stats per channel and emits `THREADS_DEBUG` summary lines every 1000 messages and on channel transitions. Does not filter or skip any messages — purely diagnostic, zero impact on sync behavior

**`manifest.yaml`**:
- Changed `action: RETRY` → `action: RATE_LIMITED` for HTTP 429 in the base `requester` and `users_stream` error handlers
- Replaced all `WaitTimeFromHeader` backoff strategies with `CustomBackoffStrategy` pointing to `RateLimitLoggingBackoffStrategy` — functionally identical header-based backoff but with diagnostic logging on 429s
- Replaced `CustomRequester` (`MessagesAndThreadsHttpRequester`) with the standard `$ref: "#/definitions/requester"` for both `channel_messages` and `threads` streams — they now inherit the same `RATE_LIMITED` + logging backoff as all other streams
- Replaced `SubstreamPartitionRouter` with `CustomPartitionRouter` (`ThreadsLoggingPartitionRouter`) for the `threads` stream, with `extra_fields: [["reply_count"]]` to pass reply counts for diagnostic logging

**`unit_tests/test_streams.py`**:
- No logic changes to test assertions. Mock data unchanged from base.

**`metadata.yaml`** + **`docs/integrations/sources/slack.md`**: Version bump 3.1.14 → 3.1.17 with changelog entries.

## Review guide

1. `components.py` — Two new classes plus deletions:
   - `RateLimitLoggingBackoffStrategy` (~60 lines): Reimplements `WaitTimeFromHeader` header extraction inline (since `get_numeric_value_from_header` is not available in CDK 7.8.1) plus logging. **Verify the `_get_numeric_value_from_header` static method correctly handles missing headers (returns `None`) and non-numeric values (returns `None`).**
   - `ThreadsLoggingPartitionRouter` (~58 lines): Extends `SubstreamPartitionRouter`, overrides `stream_slices()` to count reply_count stats. All slices are yielded unchanged — no filtering. **Verify `super().stream_slices()` delegation is correct and that counter overhead is negligible.**
   - Deletion of `MessagesAndThreadsApiBudget`, `MessagesAndThreadsHttpRequester`, and associated imports (~80 lines removed).
2. `manifest.yaml` — Four types of changes: (a) `RETRY` → `RATE_LIMITED` in error handlers, (b) `WaitTimeFromHeader` → `CustomBackoffStrategy` with `RateLimitLoggingBackoffStrategy` in all error handler backoff strategies, (c) `channel_messages` and `threads` requesters simplified from `CustomRequester` to `$ref: "#/definitions/requester"`, (d) `threads` partition router changed to `CustomPartitionRouter` with `ThreadsLoggingPartitionRouter` and `extra_fields` for reply_count logging.
3. `unit_tests/test_streams.py` — No substantive changes.

### Human review checklist
- [ ] **Verify `RateLimitLoggingBackoffStrategy` correctly returns backoff time.** It reimplements header extraction inline rather than using a CDK utility. Check that `_get_numeric_value_from_header` returns `None` (not `0` or an exception) when the header is missing, which tells the CDK to fall back to default/exponential backoff.
- [ ] **Confirm `ThreadsLoggingPartitionRouter` has no side effects.** It should yield every slice from `super().stream_slices()` unchanged. The only additions are counter increments and periodic `LOGGER.info()` calls. Verify no slices are dropped or modified.
- [ ] **`extra_fields` for `reply_count` is logging-only.** The `ThreadsLoggingPartitionRouter` reads `reply_count` from `stream_slice.extra_fields` but never uses it to skip or filter slices. If `reply_count` is absent (non-threaded messages), it defaults to `0` and counts as "without_replies".
- [ ] **Confirm removing the 1 req/60s throttle is safe.** The `RATE_LIMITED` action + header-based backoff now handles all 429s with Slack's `Retry-After` header, making the proactive throttle redundant. Platform-level job timeouts prevent truly infinite hangs.
- [ ] **Verify `channel_messages` still has `use_cache: true`** after the requester change (it does — line ~222 in the updated manifest).
- [ ] **Note that `threads` previously had `max_retries: 20` in its custom error handler.** This is dropped in favor of the CDK default. Since 429s now use `RATE_LIMITED` (infinite retries), the `max_retries` cap was only relevant for 5xx errors — the base requester does not set a custom `max_retries`, so the CDK default applies.
- [ ] The changelog diff is noisy due to whitespace reformatting by the version bump tool — only the new 3.1.15, 3.1.16, and 3.1.17 entries are real changes.

## User Impact

- Streams that previously failed permanently after hitting Slack rate limits (`channel_members`, `users`, `channels`) will now retry indefinitely with proper backoff
- `channel_messages` and `threads` will no longer be permanently throttled to 1 req/60s — syncs on Marketplace-app workspaces should complete in hours instead of days
- All streams now respect Slack's `Retry-After` header for efficient backoff
- Diagnostic logging (`RATE_LIMIT_DEBUG` and `THREADS_DEBUG` prefixes) in sync logs provides visibility into actual rate limit behavior and thread distribution — this is temporary instrumentation to inform future optimizations

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/3c08bc9390ec469d9d882803f500b3b5
Requested by: @davinchia