### PR TITLE
ci: migrate bump-version-command workflow from airbyte-ci to ops CLI

### DIFF
--- a/.github/workflows/bump-progressive-rollout-version-command.yml
+++ b/.github/workflows/bump-progressive-rollout-version-command.yml
@@ -46,10 +46,9 @@ jobs:
         id: job-vars
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.inputs.pr }}
         shell: bash
         run: |
-          PR_JSON=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER")
+          PR_JSON=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.inputs.pr }})
           echo "repo=$(echo "$PR_JSON" | jq -r .head.repo.full_name)" >> $GITHUB_OUTPUT
           echo "branch=$(echo "$PR_JSON" | jq -r .head.ref)" >> $GITHUB_OUTPUT
           echo "pr_title=$(echo "$PR_JSON" | jq -r .title)" >> $GITHUB_OUTPUT
@@ -86,81 +85,29 @@ jobs:
 
             [1]: ${{ steps.job-vars.outputs.run-url }}
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
-
-      - name: Install airbyte-ops CLI
-        run: uv tool install airbyte-internal-ops
-
-      - name: Detect modified connectors, bump RC versions, and configure progressive rollout
-        env:
-          BUMP_TYPE: ${{ github.event.inputs.type }}
-          CHANGELOG_MSG: ${{ github.event.inputs.changelog }}
-          PR_TITLE: ${{ steps.job-vars.outputs.pr_title }}
-          PR_NUMBER: ${{ github.event.inputs.pr }}
+      - name: Log changelog source
         run: |
-          # Resolve changelog message: user-provided or PR title fallback
-          MSG="${CHANGELOG_MSG:-$PR_TITLE}"
-          echo "Changelog message: $MSG"
-          echo "Bump type: ${BUMP_TYPE}_rc"
-
-          # List modified connectors in this PR
-          CONNECTORS=$(
-            airbyte-ops local connector list \
-              --repo-path "$GITHUB_WORKSPACE" \
-              --modified-only \
-              --pr "$PR_NUMBER" \
-              --output-format lines
-          )
-
-          if [ -z "$CONNECTORS" ]; then
-            echo "No modified connectors found in PR #$PR_NUMBER."
-            exit 0
+          if [ -n "${{ github.event.inputs.changelog }}" ]; then
+            echo "Using user-provided changelog: ${{ github.event.inputs.changelog }}"
+          else
+            echo "Using PR title as changelog: ${{ steps.job-vars.outputs.pr_title }}"
           fi
 
-          echo "Modified connectors:"
-          echo "$CONNECTORS"
-          echo ""
-
-          # For each modified connector:
-          # 1. Record the current (stable) version for pinning
-          # 2. Bump version with RC suffix and update changelog
-          # 3. Configure progressive rollout metadata
-          echo "$CONNECTORS" | while IFS= read -r connector; do
-            [ -z "$connector" ] && continue
-            echo "--- Processing $connector for progressive rollout ---"
-
-            # 1. Record current stable version (used as pin version)
-            CURRENT_VERSION=$(
-              airbyte-ops local connector get-version \
-                --name "$connector" \
-                --repo-path "$GITHUB_WORKSPACE"
-            )
-            echo "  Current version: $CURRENT_VERSION"
-
-            # 2. Bump version with RC suffix (e.g., patch -> patch_rc)
-            airbyte-ops local connector bump-version \
-              --name "$connector" \
-              --repo-path "$GITHUB_WORKSPACE" \
-              --bump-type "${BUMP_TYPE}_rc" \
-              --changelog-message "$MSG" \
-              --pr-number "$PR_NUMBER"
-
-            # 3. Read back the new RC version
-            RC_VERSION=$(
-              airbyte-ops local connector get-version \
-                --name "$connector" \
-                --repo-path "$GITHUB_WORKSPACE"
-            )
-            echo "  RC version: $RC_VERSION"
-
-            # 4. Configure progressive rollout (pin cloud/oss to stable, enable rollout flag)
-            airbyte-ops local connector setup-progressive-rollout \
-              --name "$connector" \
-              --repo-path "$GITHUB_WORKSPACE" \
-              --rc-version "$RC_VERSION" \
-              --pin-version "$CURRENT_VERSION"
-          done
+      - name: Run airbyte-ci connectors --modified bump-version with --rc flag
+        uses: ./.github/actions/run-airbyte-ci
+        continue-on-error: true
+        with:
+          context: "manual"
+          gcs_credentials: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
+          sentry_dsn: ${{ secrets.SENTRY_AIRBYTE_CI_DSN }}
+          github_token: ${{ secrets.GH_PAT_APPROVINGTON_OCTAVIA }}
+          git_repo_url: https://github.com/${{ steps.job-vars.outputs.repo }}.git
+          subcommand: |
+            connectors --modified bump-version \
+              ${{ github.event.inputs.type }} \
+              "${{ github.event.inputs.changelog != '' && github.event.inputs.changelog || steps.job-vars.outputs.pr_title }}" \
+              --pr-number ${{ github.event.inputs.pr }} \
+              --rc
 
       # This is helpful in the case that we change a previously committed generated file to be ignored by git.
       - name: Remove any files that have been gitignored

--- a/.github/workflows/bump-progressive-rollout-version-command.yml
+++ b/.github/workflows/bump-progressive-rollout-version-command.yml
@@ -46,9 +46,10 @@ jobs:
         id: job-vars
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.inputs.pr }}
         shell: bash
         run: |
-          PR_JSON=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.inputs.pr }})
+          PR_JSON=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER")
           echo "repo=$(echo "$PR_JSON" | jq -r .head.repo.full_name)" >> $GITHUB_OUTPUT
           echo "branch=$(echo "$PR_JSON" | jq -r .head.ref)" >> $GITHUB_OUTPUT
           echo "pr_title=$(echo "$PR_JSON" | jq -r .title)" >> $GITHUB_OUTPUT
@@ -85,29 +86,81 @@ jobs:
 
             [1]: ${{ steps.job-vars.outputs.run-url }}
 
-      - name: Log changelog source
+      - name: Install uv
+        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
+
+      - name: Install airbyte-ops CLI
+        run: uv tool install airbyte-internal-ops
+
+      - name: Detect modified connectors, bump RC versions, and configure progressive rollout
+        env:
+          BUMP_TYPE: ${{ github.event.inputs.type }}
+          CHANGELOG_MSG: ${{ github.event.inputs.changelog }}
+          PR_TITLE: ${{ steps.job-vars.outputs.pr_title }}
+          PR_NUMBER: ${{ github.event.inputs.pr }}
         run: |
-          if [ -n "${{ github.event.inputs.changelog }}" ]; then
-            echo "Using user-provided changelog: ${{ github.event.inputs.changelog }}"
-          else
-            echo "Using PR title as changelog: ${{ steps.job-vars.outputs.pr_title }}"
+          # Resolve changelog message: user-provided or PR title fallback
+          MSG="${CHANGELOG_MSG:-$PR_TITLE}"
+          echo "Changelog message: $MSG"
+          echo "Bump type: ${BUMP_TYPE}_rc"
+
+          # List modified connectors in this PR
+          CONNECTORS=$(
+            airbyte-ops local connector list \
+              --repo-path "$GITHUB_WORKSPACE" \
+              --modified-only \
+              --pr "$PR_NUMBER" \
+              --output-format lines
+          )
+
+          if [ -z "$CONNECTORS" ]; then
+            echo "No modified connectors found in PR #$PR_NUMBER."
+            exit 0
           fi
 
-      - name: Run airbyte-ci connectors --modified bump-version with --rc flag
-        uses: ./.github/actions/run-airbyte-ci
-        continue-on-error: true
-        with:
-          context: "manual"
-          gcs_credentials: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
-          sentry_dsn: ${{ secrets.SENTRY_AIRBYTE_CI_DSN }}
-          github_token: ${{ secrets.GH_PAT_APPROVINGTON_OCTAVIA }}
-          git_repo_url: https://github.com/${{ steps.job-vars.outputs.repo }}.git
-          subcommand: |
-            connectors --modified bump-version \
-              ${{ github.event.inputs.type }} \
-              "${{ github.event.inputs.changelog != '' && github.event.inputs.changelog || steps.job-vars.outputs.pr_title }}" \
-              --pr-number ${{ github.event.inputs.pr }} \
-              --rc
+          echo "Modified connectors:"
+          echo "$CONNECTORS"
+          echo ""
+
+          # For each modified connector:
+          # 1. Record the current (stable) version for pinning
+          # 2. Bump version with RC suffix and update changelog
+          # 3. Configure progressive rollout metadata
+          echo "$CONNECTORS" | while IFS= read -r connector; do
+            [ -z "$connector" ] && continue
+            echo "--- Processing $connector for progressive rollout ---"
+
+            # 1. Record current stable version (used as pin version)
+            CURRENT_VERSION=$(
+              airbyte-ops local connector get-version \
+                --name "$connector" \
+                --repo-path "$GITHUB_WORKSPACE"
+            )
+            echo "  Current version: $CURRENT_VERSION"
+
+            # 2. Bump version with RC suffix (e.g., patch -> patch_rc)
+            airbyte-ops local connector bump-version \
+              --name "$connector" \
+              --repo-path "$GITHUB_WORKSPACE" \
+              --bump-type "${BUMP_TYPE}_rc" \
+              --changelog-message "$MSG" \
+              --pr-number "$PR_NUMBER"
+
+            # 3. Read back the new RC version
+            RC_VERSION=$(
+              airbyte-ops local connector get-version \
+                --name "$connector" \
+                --repo-path "$GITHUB_WORKSPACE"
+            )
+            echo "  RC version: $RC_VERSION"
+
+            # 4. Configure progressive rollout (pin cloud/oss to stable, enable rollout flag)
+            airbyte-ops local connector setup-progressive-rollout \
+              --name "$connector" \
+              --repo-path "$GITHUB_WORKSPACE" \
+              --rc-version "$RC_VERSION" \
+              --pin-version "$CURRENT_VERSION"
+          done
 
       # This is helpful in the case that we change a previously committed generated file to be ignored by git.
       - name: Remove any files that have been gitignored

--- a/.github/workflows/bump-version-command.yml
+++ b/.github/workflows/bump-version-command.yml
@@ -110,11 +110,15 @@ jobs:
             echo "$CONNECTORS"
           fi
 
-          # Pass the connector list to the next step via GITHUB_OUTPUT
-          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
-          echo "connectors<<$EOF" >> $GITHUB_OUTPUT
-          echo "$CONNECTORS" >> $GITHUB_OUTPUT
-          echo "$EOF" >> $GITHUB_OUTPUT
+          # Pass the connector list to the next step via GITHUB_OUTPUT.
+          # Only set the multiline output when CONNECTORS is non-empty so that
+          # the downstream `if:` reliably evaluates to false for empty lists.
+          if [ -n "$CONNECTORS" ]; then
+            EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+            echo "connectors<<$EOF" >> $GITHUB_OUTPUT
+            echo "$CONNECTORS" >> $GITHUB_OUTPUT
+            echo "$EOF" >> $GITHUB_OUTPUT
+          fi
 
       - name: Bump versions for modified connectors
         if: steps.detect-connectors.outputs.connectors != ''

--- a/.github/workflows/bump-version-command.yml
+++ b/.github/workflows/bump-version-command.yml
@@ -90,19 +90,11 @@ jobs:
       - name: Install airbyte-ops CLI
         run: uv tool install airbyte-internal-ops
 
-      - name: Detect modified connectors and bump versions
+      - name: Detect modified connectors
+        id: detect-connectors
         env:
-          BUMP_TYPE: ${{ github.event.inputs.type }}
-          CHANGELOG_MSG: ${{ github.event.inputs.changelog }}
-          PR_TITLE: ${{ steps.job-vars.outputs.pr_title }}
           PR_NUMBER: ${{ github.event.inputs.pr }}
         run: |
-          # Resolve changelog message: user-provided or PR title fallback
-          MSG="${CHANGELOG_MSG:-$PR_TITLE}"
-          echo "Changelog message: $MSG"
-          echo "Bump type: $BUMP_TYPE"
-
-          # List modified connectors in this PR
           CONNECTORS=$(
             airbyte-ops local connector list \
               --repo-path "$GITHUB_WORKSPACE" \
@@ -113,14 +105,31 @@ jobs:
 
           if [ -z "$CONNECTORS" ]; then
             echo "No modified connectors found in PR #$PR_NUMBER."
-            exit 0
+          else
+            echo "Modified connectors:"
+            echo "$CONNECTORS"
           fi
 
-          echo "Modified connectors:"
-          echo "$CONNECTORS"
+          # Pass the connector list to the next step via GITHUB_OUTPUT
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          echo "connectors<<$EOF" >> $GITHUB_OUTPUT
+          echo "$CONNECTORS" >> $GITHUB_OUTPUT
+          echo "$EOF" >> $GITHUB_OUTPUT
+
+      - name: Bump versions for modified connectors
+        if: steps.detect-connectors.outputs.connectors != ''
+        env:
+          BUMP_TYPE: ${{ github.event.inputs.type }}
+          CHANGELOG_MSG: ${{ github.event.inputs.changelog }}
+          PR_TITLE: ${{ steps.job-vars.outputs.pr_title }}
+          PR_NUMBER: ${{ github.event.inputs.pr }}
+          CONNECTORS: ${{ steps.detect-connectors.outputs.connectors }}
+        run: |
+          MSG="${CHANGELOG_MSG:-$PR_TITLE}"
+          echo "Changelog message: $MSG"
+          echo "Bump type: $BUMP_TYPE"
           echo ""
 
-          # Bump version for each modified connector
           echo "$CONNECTORS" | while IFS= read -r connector; do
             [ -z "$connector" ] && continue
             echo "--- Bumping version for $connector ---"

--- a/.github/workflows/bump-version-command.yml
+++ b/.github/workflows/bump-version-command.yml
@@ -47,9 +47,10 @@ jobs:
         id: job-vars
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.inputs.pr }}
         shell: bash
         run: |
-          PR_JSON=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.inputs.pr }})
+          PR_JSON=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER")
           echo "repo=$(echo "$PR_JSON" | jq -r .head.repo.full_name)" >> $GITHUB_OUTPUT
           echo "branch=$(echo "$PR_JSON" | jq -r .head.ref)" >> $GITHUB_OUTPUT
           echo "pr_title=$(echo "$PR_JSON" | jq -r .title)" >> $GITHUB_OUTPUT
@@ -83,28 +84,53 @@ jobs:
 
             [1]: ${{ steps.job-vars.outputs.run-url }}
 
-      - name: Log changelog source
+      - name: Install uv
+        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
+
+      - name: Install airbyte-ops CLI
+        run: uv tool install airbyte-internal-ops
+
+      - name: Detect modified connectors and bump versions
+        env:
+          BUMP_TYPE: ${{ github.event.inputs.type }}
+          CHANGELOG_MSG: ${{ github.event.inputs.changelog }}
+          PR_TITLE: ${{ steps.job-vars.outputs.pr_title }}
+          PR_NUMBER: ${{ github.event.inputs.pr }}
         run: |
-          if [ -n "${{ github.event.inputs.changelog }}" ]; then
-            echo "Using user-provided changelog: ${{ github.event.inputs.changelog }}"
-          else
-            echo "Using PR title as changelog: ${{ steps.job-vars.outputs.pr_title }}"
+          # Resolve changelog message: user-provided or PR title fallback
+          MSG="${CHANGELOG_MSG:-$PR_TITLE}"
+          echo "Changelog message: $MSG"
+          echo "Bump type: $BUMP_TYPE"
+
+          # List modified connectors in this PR
+          CONNECTORS=$(
+            airbyte-ops local connector list \
+              --repo-path "$GITHUB_WORKSPACE" \
+              --modified-only \
+              --pr "$PR_NUMBER" \
+              --output-format lines
+          )
+
+          if [ -z "$CONNECTORS" ]; then
+            echo "No modified connectors found in PR #$PR_NUMBER."
+            exit 0
           fi
 
-      - name: Run airbyte-ci connectors --modified bump-version
-        uses: ./.github/actions/run-airbyte-ci
-        continue-on-error: true
-        with:
-          context: "manual"
-          gcs_credentials: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
-          sentry_dsn: ${{ secrets.SENTRY_AIRBYTE_CI_DSN }}
-          github_token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
-          git_repo_url: https://github.com/${{ steps.job-vars.outputs.repo }}.git
-          subcommand: |
-            connectors --modified bump-version \
-              ${{ github.event.inputs.type }} \
-              "${{ github.event.inputs.changelog != '' && github.event.inputs.changelog || steps.job-vars.outputs.pr_title }}" \
-              --pr-number ${{ github.event.inputs.pr }}
+          echo "Modified connectors:"
+          echo "$CONNECTORS"
+          echo ""
+
+          # Bump version for each modified connector
+          echo "$CONNECTORS" | while IFS= read -r connector; do
+            [ -z "$connector" ] && continue
+            echo "--- Bumping version for $connector ---"
+            airbyte-ops local connector bump-version \
+              --name "$connector" \
+              --repo-path "$GITHUB_WORKSPACE" \
+              --bump-type "$BUMP_TYPE" \
+              --changelog-message "$MSG" \
+              --pr-number "$PR_NUMBER"
+          done
 
       # This is helpful in the case that we change a previously committed generated file to be ignored by git.
       - name: Remove any files that have been gitignored
@@ -121,11 +147,13 @@ jobs:
       - name: Commit changes
         id: commit-step
         if: steps.git-diff.outputs.changes == 'true'
+        env:
+          BUMP_TYPE: ${{ github.event.inputs.type }}
         run: |
           git config --global user.name "Octavia Squidington III"
           git config --global user.email "octavia-squidington-iii@users.noreply.github.com"
           git add .
-          git commit -m "chore: bump-version ${{ github.event.inputs.bump-type }}"
+          git commit -m "chore: bump-version $BUMP_TYPE"
           echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
       - name: Push changes to '(${{ steps.job-vars.outputs.repo }})'


### PR DESCRIPTION
## What

Migrates `bump-version-command.yml` from the legacy Dagger-based `airbyte-ci` tool to the `airbyte-ops` CLI. Addresses https://github.com/airbytehq/airbyte-ops-mcp/issues/634.

This is PR 1 of 2. The progressive rollout workflow (`bump-progressive-rollout-version-command.yml`) will follow in a separate PR after this one is merged and tested.

## How

Replaces the `run-airbyte-ci` composite action with direct `airbyte-ops` CLI calls:

1. Install `uv` + `airbyte-internal-ops` (same pattern as #75524)
2. **"Detect modified connectors"** step: calls `airbyte-ops local connector list --modified-only --pr $PR_NUMBER` and writes the result to `GITHUB_OUTPUT`
3. **"Bump versions for modified connectors"** step: guarded by `if: steps.detect-connectors.outputs.connectors != ''`, loops over each connector and calls `airbyte-ops local connector bump-version`

Secondary improvements:
- All user inputs are passed through `env:` blocks instead of direct `${{ }}` interpolation in shell scripts (script injection hardening)
- Fixed a bug in the commit step that referenced non-existent input `bump-type` instead of `type`
- Removed dependency on `METADATA_SERVICE_PROD_GCS_CREDENTIALS` and `SENTRY_AIRBYTE_CI_DSN` secrets (no longer needed without Dagger)

## Review guide

1. `.github/workflows/bump-version-command.yml` — the only file changed

**Items worth reviewer attention:**
- **Verify ops CLI flags**: The `airbyte-ops local connector list --modified-only --pr --output-format lines` and `airbyte-ops local connector bump-version --name --repo-path --bump-type --changelog-message --pr-number` interfaces were inferred from CLI exploration. Confirm these match the actual CLI.
- **`continue-on-error` removed**: The old `run-airbyte-ci` step had `continue-on-error: true`. The new steps do not, so a failure in any connector bump will now fail the workflow. This seems like better behavior but is a behavioral change.
- **Pipe-subshell loop**: `echo "$CONNECTORS" | while read` runs in a subshell. A failure inside the loop won't propagate to the outer step unless explicitly handled. This is consistent with the previous `continue-on-error` behavior.
- **Not testable without live run**: This is a `workflow_dispatch` workflow — the only way to fully test it is to merge and invoke the `/bump-version` slash command on a real PR.

## User Impact

No user-facing impact. This is an internal CI workflow triggered by the `/bump-version` slash command. The workflow will now run faster (no Dagger container overhead) and require fewer secrets.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/771e1717779949218a11710707cbaeb4
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75554" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._

> [!NOTE]
> **Auto-merge may have been disabled. Please check the PR status to confirm.**