### PR TITLE
fix(bulk-extract): bump Debezium to 3.4.2.Final

### DIFF
--- a/airbyte-cdk/bulk/core/extract/changelog.md
+++ b/airbyte-cdk/bulk/core/extract/changelog.md
@@ -9,6 +9,7 @@ The Extract CDK provides functionality for source connectors including schema di
 
 | Version | Date       | Pull Request | Subject                                                                                                                                                           |
 |---------|------------|--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1.0.3   | 2026-03-27 |              | Bump Debezium to `3.4.2.Final` to avoid MySQL CDC GTID validation failures caused by null UUIDSet subtraction. |
 | 1.0.2   | 2026-02-24 | [74007](https://github.com/airbytehq/airbyte/pull/74007) | Fix infinite loop when cursor-based incremental sync encounters an empty table with prior state by caching NULL cursor upper bound values (toolkit). |
 | 1.0.1   | 2026-02-24 | | Bump bulk-cdk-core-base to 1.0.1 to pick up CVE fixes (CVE-2021-47621, CVE-2022-36944). |
 | 1.0.0   | 2026-02-02 | [#72376](https://github.com/airbytehq/airbyte/pull/72376) | Initial independent release of bulk-cdk-core-extract. Separate versioning for extract package begins. |

--- a/airbyte-cdk/bulk/core/extract/version.properties
+++ b/airbyte-cdk/bulk/core/extract/version.properties
@@ -1,1 +1,1 @@
-version=1.0.2
+version=1.0.3

--- a/airbyte-cdk/bulk/toolkits/extract-cdc/build.gradle
+++ b/airbyte-cdk/bulk/toolkits/extract-cdc/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    api platform('io.debezium:debezium-bom:3.1.2.Final')
+    api platform('io.debezium:debezium-bom:3.4.2.Final')
     api 'io.debezium:debezium-api'
     api 'io.debezium:debezium-embedded'
 

--- a/airbyte-cdk/bulk/toolkits/extract-cdc/src/testFixtures/kotlin/io/airbyte/cdk/read/cdc/AbstractCdcPartitionReaderTest.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-cdc/src/testFixtures/kotlin/io/airbyte/cdk/read/cdc/AbstractCdcPartitionReaderTest.kt
@@ -298,7 +298,7 @@ abstract class AbstractCdcPartitionReaderTest<T : Comparable<T>, C : AutoCloseab
             val offset =
                 DebeziumOffset(
                     offsetNode
-                        .fields()
+                        .properties()
                         .asSequence()
                         .map { Jsons.readTree(it.key) to Jsons.readTree(it.value.asText()) }
                         .toMap(),


### PR DESCRIPTION
## What
This PR follows up on #75558.

While investigating a MySQL CDC GTID validation failure in Airbyte, we found that the Bulk Extract CDC toolkit still depended on Debezium `3.1.2.Final`.

That older Debezium line can surface a MySQL GTID comparison failure as:

- `Incumbent CDC state is invalid`
- `other is null`
- `MySqlGtidSet$UUIDSet.getUUID()`

This PR bumps the Bulk Extract CDC toolkit to Debezium `3.4.2.Final`, which we verified locally contains the null-safe handling needed for this GTID comparison path.

Related context:
- Issue: #75558
- Airbyte discussion: https://github.com/airbytehq/airbyte/discussions/74305
- Debezium PR: https://github.com/debezium/debezium/pull/6894
- Debezium commit: https://github.com/debezium/debezium/commit/84206138cdb1983a33623f31517e2caea5d16c35
- Follow-up `source-mysql` connector PR: #75560

## How
- Update `airbyte-cdk/bulk/toolkits/extract-cdc/build.gradle` to use `io.debezium:debezium-bom:3.4.2.Final`
- Bump the Bulk Extract package version from `1.0.2` to `1.0.3`
- Add the corresponding Bulk Extract changelog entry
- Replace one deprecated Jackson `ObjectNode.fields()` usage in the extract-cdc test fixtures with `properties()` so the recompiled Kotlin path stays green under `-Werror`

## Review guide
1. `airbyte-cdk/bulk/toolkits/extract-cdc/build.gradle`
2. `airbyte-cdk/bulk/core/extract/version.properties`
3. `airbyte-cdk/bulk/core/extract/changelog.md`
4. `airbyte-cdk/bulk/toolkits/extract-cdc/src/testFixtures/kotlin/io/airbyte/cdk/read/cdc/AbstractCdcPartitionReaderTest.kt`

## User Impact
Connectors that consume the updated Bulk Extract CDC toolkit can avoid a MySQL CDC GTID validation failure path caused by null UUIDSet subtraction in Debezium handling.

This PR does not change any user-facing connector spec or config directly.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌
