### PR TITLE
ci: add `auto-ai-review` label trigger for AI review workflow

### DIFF
--- a/.github/workflows/ai-review-command.yml
+++ b/.github/workflows/ai-review-command.yml
@@ -15,6 +15,16 @@ on:
       comment-id:
         description: "Comment ID"
         required: false
+  workflow_call:
+    inputs:
+      pr:
+        description: "PR number"
+        required: true
+        type: string
+      comment-id:
+        description: "Comment ID"
+        required: false
+        type: string
 
 run-name: "PR AI Review for PR #${{ inputs.pr }}"
 

--- a/.github/workflows/auto-ai-review-label.yml
+++ b/.github/workflows/auto-ai-review-label.yml
@@ -12,6 +12,8 @@ on:
 
 run-name: "Auto AI Review for PR #${{ github.event.pull_request.number }}"
 
+permissions: {}
+
 jobs:
   dispatch-ai-review:
     if: |

--- a/.github/workflows/auto-ai-review-label.yml
+++ b/.github/workflows/auto-ai-review-label.yml
@@ -1,7 +1,9 @@
 # Triggers the AI Review workflow when the 'auto-ai-review' label is present.
 # Two triggers:
-#   1. Label added to a PR  -> immediately dispatch AI review.
-#   2. PR marked ready for review -> dispatch AI review if label is already set.
+#   1. Label added to a non-draft PR -> immediately call AI review.
+#   2. PR marked ready for review    -> call AI review if label is already set.
+# Draft PRs are skipped on `labeled` to avoid a double-dispatch: ai-review-command.yml
+# marks drafts as ready, which would re-trigger this workflow via `ready_for_review`.
 name: Auto AI Review on Label
 
 on:
@@ -10,40 +12,12 @@ on:
 
 run-name: "Auto AI Review for PR #${{ github.event.pull_request.number }}"
 
-permissions:
-  contents: read
-  actions: write
-
 jobs:
   dispatch-ai-review:
-    # Run when 'auto-ai-review' label is added, OR when a PR with the label is marked ready.
     if: |
-      (github.event.action == 'labeled' && github.event.label.name == 'auto-ai-review') ||
+      (github.event.action == 'labeled' && github.event.label.name == 'auto-ai-review' && github.event.pull_request.draft != true) ||
       (github.event.action == 'ready_for_review' && contains(github.event.pull_request.labels.*.name, 'auto-ai-review'))
-    runs-on: ubuntu-latest
-    steps:
-      - name: Authenticate as GitHub App
-        uses: actions/create-github-app-token@v2
-        id: get-app-token
-        with:
-          owner: "airbytehq"
-          repositories: "airbyte"
-          app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
-          private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
-
-      - name: Dispatch AI Review workflow
-        env:
-          GH_TOKEN: ${{ steps.get-app-token.outputs.token }}
-        run: |
-          echo "Dispatching AI Review for PR #${{ github.event.pull_request.number }} (trigger: ${{ github.event.action }})"
-          curl -sS -X POST \
-            -H "Authorization: Bearer $GH_TOKEN" \
-            -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/${{ github.repository }}/actions/workflows/ai-review-command.yml/dispatches" \
-            -d '{
-              "ref": "${{ github.event.pull_request.base.ref }}",
-              "inputs": {
-                "pr": "${{ github.event.pull_request.number }}"
-              }
-            }'
-          echo "AI Review workflow dispatched successfully."
+    uses: ./.github/workflows/ai-review-command.yml
+    with:
+      pr: "${{ github.event.pull_request.number }}"
+    secrets: inherit

--- a/.github/workflows/auto-ai-review-label.yml
+++ b/.github/workflows/auto-ai-review-label.yml
@@ -1,0 +1,49 @@
+# Triggers the AI Review workflow when the 'auto-ai-review' label is present.
+# Two triggers:
+#   1. Label added to a PR  -> immediately dispatch AI review.
+#   2. PR marked ready for review -> dispatch AI review if label is already set.
+name: Auto AI Review on Label
+
+on:
+  pull_request:
+    types: [labeled, ready_for_review]
+
+run-name: "Auto AI Review for PR #${{ github.event.pull_request.number }}"
+
+permissions:
+  contents: read
+  actions: write
+
+jobs:
+  dispatch-ai-review:
+    # Run when 'auto-ai-review' label is added, OR when a PR with the label is marked ready.
+    if: |
+      (github.event.action == 'labeled' && github.event.label.name == 'auto-ai-review') ||
+      (github.event.action == 'ready_for_review' && contains(github.event.pull_request.labels.*.name, 'auto-ai-review'))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Authenticate as GitHub App
+        uses: actions/create-github-app-token@v2
+        id: get-app-token
+        with:
+          owner: "airbytehq"
+          repositories: "airbyte"
+          app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
+          private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
+
+      - name: Dispatch AI Review workflow
+        env:
+          GH_TOKEN: ${{ steps.get-app-token.outputs.token }}
+        run: |
+          echo "Dispatching AI Review for PR #${{ github.event.pull_request.number }} (trigger: ${{ github.event.action }})"
+          curl -sS -X POST \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${{ github.repository }}/actions/workflows/ai-review-command.yml/dispatches" \
+            -d '{
+              "ref": "${{ github.event.pull_request.base.ref }}",
+              "inputs": {
+                "pr": "${{ github.event.pull_request.number }}"
+              }
+            }'
+          echo "AI Review workflow dispatched successfully."


### PR DESCRIPTION
## What

Adds a new workflow that automatically triggers AI PR review when the `auto-ai-review` label is used on a PR. Two trigger paths:

1. **Label added to a non-draft PR** — When `auto-ai-review` is added, the AI review workflow is called immediately.
2. **PR marked ready for review** — When a draft PR with the `auto-ai-review` label transitions to ready, the AI review workflow is called.

Draft PRs are intentionally skipped on `labeled` to prevent double-dispatch: `ai-review-command.yml` marks drafts as ready, which would re-fire this workflow via `ready_for_review`.

## How

Two files are changed:

1. **`.github/workflows/ai-review-command.yml`** — Added a `workflow_call` trigger (alongside the existing `workflow_dispatch`) so other workflows can call it directly with `pr` and `comment-id` inputs.
2. **`.github/workflows/auto-ai-review-label.yml`** *(new)* — Listens for `pull_request` events of type `labeled` and `ready_for_review`. Uses `workflow_call` to invoke `ai-review-command.yml` with `secrets: inherit`, avoiding any raw API calls. Declares `permissions: {}` since the caller itself needs no `GITHUB_TOKEN` permissions — the called workflow declares its own.

No `comment-id` is passed (since there is no originating slash command comment), so the "Post start comment" step in the target workflow will be skipped gracefully.

## Review guide

1. `.github/workflows/ai-review-command.yml` — the `workflow_call` trigger addition (lines 18–27)
2. `.github/workflows/auto-ai-review-label.yml` — the new label-triggered caller workflow

### Human review checklist

- [ ] Verify `secrets: inherit` correctly passes secrets (e.g. `OCTAVIA_BOT_APP_ID`, `DEVIN_AI_API_KEY`) through the `workflow_call` boundary to the called workflow's steps.
- [ ] Verify that `permissions: {}` on the caller does not restrict the called workflow's own `permissions` block when invoked via `workflow_call`. The called workflow declares `contents: read`, `issues: write`, `pull-requests: write` — confirm these still apply.
- [ ] Confirm the draft guard (`github.event.pull_request.draft != true`) behaves as expected — label added to a draft should be a no-op; the `ready_for_review` path picks it up later.
- [ ] Confirm adding `workflow_call` to `ai-review-command.yml` does not change behavior for existing `workflow_dispatch` callers (slash commands).
- [ ] The `auto-ai-review` label needs to be created in the repo for this to be usable.

## User Impact

Users can add the `auto-ai-review` label to any PR to automatically trigger an AI review, without needing to type the `/ai-review` slash command. PRs that already have the label will also get reviewed when moved out of draft status.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/ebe01ef3320647c59eec7e74be843d57
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75567" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
