### PR TITLE
ci: update stale playbook links from oncall to ai-skills

### DIFF
--- a/.github/workflows/ai-canary-prerelease-command.yml
+++ b/.github/workflows/ai-canary-prerelease-command.yml
@@ -69,6 +69,6 @@ jobs:
           github-token: ${{ steps.get-app-token.outputs.token }}
           api-version: v3
           org-id: ${{ vars.DEVIN_AI_ORG_ID }}
-          start-message: "🐤 **AI Canary Prerelease session starting...** Rolling out to 5-10 connections, watching results, and reporting findings. [View playbook](https://github.com/airbytehq/oncall/blob/main/prompts/playbooks/canary_prerelease.md)"
+          start-message: "🐤 **AI Canary Prerelease session starting...** Rolling out to 5-10 connections, watching results, and reporting findings. [View playbook](https://github.com/airbytehq/ai-skills/blob/main/devin/playbooks/canary_prerelease.md)"
           tags: |
             ai-oncall

--- a/.github/workflows/ai-create-docs-pr-command.yml
+++ b/.github/workflows/ai-create-docs-pr-command.yml
@@ -67,7 +67,7 @@ jobs:
 
           This will create a documentation PR stacked on top of PR #${PR_NUMBER}.
 
-          [View playbook](https://github.com/airbytehq/oncall/blob/main/prompts/playbooks/connectordocs.md)
+          [View playbook](https://github.com/airbytehq/ai-skills/blob/main/devin/playbooks/connectordocs.md)
           STARTMSG
               echo "EOF"
             } >> $GITHUB_OUTPUT
@@ -105,7 +105,7 @@ jobs:
 
           This will create a documentation PR targeting the master branch.
 
-          [View playbook](https://github.com/airbytehq/oncall/blob/main/prompts/playbooks/connectordocs.md)
+          [View playbook](https://github.com/airbytehq/ai-skills/blob/main/devin/playbooks/connectordocs.md)
           STARTMSG
               echo "EOF"
             } >> $GITHUB_OUTPUT

--- a/.github/workflows/ai-prove-fix-command.yml
+++ b/.github/workflows/ai-prove-fix-command.yml
@@ -69,6 +69,6 @@ jobs:
           github-token: ${{ steps.get-app-token.outputs.token }}
           api-version: v3
           org-id: ${{ vars.DEVIN_AI_ORG_ID }}
-          start-message: "🔍 **AI Prove Fix session starting...** Running readiness checks and testing against customer connections. [View playbook](https://github.com/airbytehq/oncall/blob/main/prompts/playbooks/prove_fix.md)"
+          start-message: "🔍 **AI Prove Fix session starting...** Running readiness checks and testing against customer connections. [View playbook](https://github.com/airbytehq/ai-skills/blob/main/devin/playbooks/prove_fix.md)"
           tags: |
             ai-oncall

--- a/.github/workflows/ai-release-watch-command.yml
+++ b/.github/workflows/ai-release-watch-command.yml
@@ -69,6 +69,6 @@ jobs:
           github-token: ${{ steps.get-app-token.outputs.token }}
           api-version: v3
           org-id: ${{ vars.DEVIN_AI_ORG_ID }}
-          start-message: "👁️ **AI Release Watch session starting...** Monitoring rollout and tracking sync success rates. [View playbook](https://github.com/airbytehq/oncall/blob/main/prompts/playbooks/release_watch.md)"
+          start-message: "👁️ **AI Release Watch session starting...** Monitoring rollout and tracking sync success rates. [View playbook](https://github.com/airbytehq/ai-skills/blob/main/devin/playbooks/release_watch.md)"
           tags: |
             ai-oncall

--- a/.github/workflows/ai-review-command.yml
+++ b/.github/workflows/ai-review-command.yml
@@ -103,7 +103,7 @@ jobs:
             **AI PR Review** starting...
 
             Reviewing PR for connector safety and quality.
-            [View playbook](https://github.com/airbytehq/oncall/blob/main/prompts/playbooks/pr_ai_review.md)
+            [View playbook](https://github.com/airbytehq/ai-skills/blob/main/devin/playbooks/pr_ai_review.md)
           tags: |
             ai-oncall
             pr-review

--- a/.github/workflows/oss-issue-triage.yml
+++ b/.github/workflows/oss-issue-triage.yml
@@ -105,7 +105,7 @@ jobs:
             - Join the [Airbyte Community Slack](https://slack.airbyte.com) to connect with other users and community members
             - If you're an Airbyte Cloud customer, you can [open a support ticket](https://support.airbyte.com) or contact your account representative, referencing this issue URL
 
-            [View playbook](https://github.com/airbytehq/oncall/blob/main/prompts/playbooks/oss_issue_triage.md)
+            [View playbook](https://github.com/airbytehq/ai-skills/blob/main/devin/playbooks/oss_issue_triage.md)
           tags: |
             oss-issue-triage
             community-issue


### PR DESCRIPTION
## What

Playbooks were migrated from `airbytehq/oncall` (under `prompts/playbooks/`) to `airbytehq/ai-skills` (under `devin/playbooks/`). The "View playbook" links in workflow `start-message` fields still point to the old location, resulting in broken links when users click them.

## How

Find-and-replace of the base URL in all affected workflow files:
- **Old:** `https://github.com/airbytehq/oncall/blob/main/prompts/playbooks/`
- **New:** `https://github.com/airbytehq/ai-skills/blob/main/devin/playbooks/`

No logic or structural changes — only the URL strings in `start-message` fields are updated.

## Review guide

All 6 files have the same mechanical change. Spot-check any one to confirm the pattern, then skim the rest:

1. `.github/workflows/ai-create-docs-pr-command.yml` — two occurrences (PR context + standalone context)
2. `.github/workflows/ai-canary-prerelease-command.yml`
3. `.github/workflows/ai-release-watch-command.yml`
4. `.github/workflows/ai-prove-fix-command.yml`
5. `.github/workflows/oss-issue-triage.yml`
6. `.github/workflows/ai-review-command.yml`

**Worth verifying:** Confirm that `release_watch.md` exists at the new `ai-skills` location — it may not have been migrated yet.

## User Impact

"View playbook" links shown in GitHub PR/issue comments when AI workflows start will now point to the correct, resolvable URLs instead of 404s.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/9611b909985b457e9cb01c1776b366f8
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75568" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
