### PR TITLE
feat(source-intercom): add oauth_connector_input_specification for declarative OAuth

### DIFF
--- a/airbyte-integrations/connectors/source-intercom/manifest.yaml
+++ b/airbyte-integrations/connectors/source-intercom/manifest.yaml
@@ -879,17 +879,17 @@ spec:
   advanced_auth:
       auth_flow_type: "oauth2.0"
       oauth_config_specification:
-        oauth_authorization_url: "https://app.intercom.com/oauth"
-        oauth_token_url: "https://api.intercom.io/auth/eagle/token"
-        oauth_user_input_from_connector_config_specification:
-          type: object
-          properties:
-            client_id:
-              type: string
-              path_in_connector_config: ["client_id"]
-            client_secret:
-              type: string
-              path_in_connector_config: ["client_secret"]
+        oauth_connector_input_specification:
+          consent_url: "https://app.intercom.com/a/oauth/connect?{{client_id_param}}&{{redirect_uri_param}}&response_type=code&{{state_param}}"
+          access_token_url: "https://api.intercom.io/auth/eagle/token"
+          access_token_headers:
+            Content-Type: "application/x-www-form-urlencoded"
+          access_token_params:
+            code: "{{ auth_code_value }}"
+            client_id: "{{ client_id_value }}"
+            client_secret: "{{ client_secret_value }}"
+          extract_output:
+            - access_token
         complete_oauth_output_specification:
           type: object
           properties:

--- a/airbyte-integrations/connectors/source-intercom/metadata.yaml
+++ b/airbyte-integrations/connectors/source-intercom/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: d8313939-3782-41b0-be29-b3ca20d8dd3a
-  dockerImageTag: 0.13.16
+  dockerImageTag: 0.13.17
   dockerRepository: airbyte/source-intercom
   documentationUrl: https://docs.airbyte.com/integrations/sources/intercom
   externalDocumentationUrls:

--- a/docs/integrations/sources/intercom.md
+++ b/docs/integrations/sources/intercom.md
@@ -123,6 +123,7 @@ Because these streams must read all records on every sync, syncing Companies and
 
 | Version      | Date       | Pull Request                                             | Subject                                                                                                                              |
 |:-------------|:-----------|:---------------------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------|
+| 0.13.17 | 2026-03-30 | [75575](https://github.com/airbytehq/airbyte/pull/75575) | Add `oauth_connector_input_specification` for declarative OAuth |
 | 0.13.16 | 2026-03-24 | [75419](https://github.com/airbytehq/airbyte/pull/75419) | Promote 0.13.16-rc.6 to GA — includes CDK 7.13.0 upgrade, block_simultaneous_read for companies, rate limiter fix, step size/end_datetime for incremental streams, and heartbeat timeout bump |
 | 0.13.16-rc.6 | 2026-03-19 | [75216](https://github.com/airbytehq/airbyte/pull/75216) | Bump CDK base image to 7.13.0 (includes block_simultaneous_read support and cursor field fix) |
 | 0.13.16-rc.5 | 2026-03-11 | [71141](https://github.com/airbytehq/airbyte/pull/71141) | Block simultaneous reading from companies endpoint |


### PR DESCRIPTION
## Summary
- Add `oauth_connector_input_specification` to manifest.yaml
- Consent URL: `https://app.intercom.com/a/oauth/connect`
- Token URL: `https://api.intercom.io/auth/eagle/token`
- No scopes (Intercom doesn't use OAuth scopes)
- Extracts `access_token` only (no refresh token — long-lived tokens)
- Version bump 0.13.16 → 0.13.17

Related: https://github.com/airbytehq/airbyte-internal-issues/issues/16023

## Test plan
- [x] Verify full OAuth flow: consent → callback → token exchange → access_token returned
- [x] Confirm no scopes are sent in consent URL (Intercom doesn't use them)