### PR TITLE
feat(source-google-analytics-data-api): add oauth_connector_input_specification with granular scopes

### DIFF
--- a/airbyte-integrations/connectors/source-google-analytics-data-api/manifest.yaml
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/manifest.yaml
@@ -2985,6 +2985,13 @@ spec:
       - auth_type
     predicate_value: Client
     oauth_config_specification:
+      oauth_connector_input_specification:
+        scopes:
+          - scope: "https://www.googleapis.com/auth/analytics.readonly"
+        consent_url: "https://accounts.google.com/o/oauth2/v2/auth?{{client_id_param}}&{{redirect_uri_param}}&response_type=code&{{scopes_param}}&access_type=offline&{{state_param}}&include_granted_scopes=true&prompt=consent"
+        access_token_url: "https://oauth2.googleapis.com/token?{{client_id_param}}&{{client_secret_param}}&{{auth_code_param}}&{{redirect_uri_param}}&grant_type=authorization_code"
+        extract_output:
+          - refresh_token
       complete_oauth_output_specification:
         type: object
         properties:

--- a/airbyte-integrations/connectors/source-google-analytics-data-api/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/metadata.yaml
@@ -12,7 +12,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 3cc2eafd-84aa-4dca-93af-322d9dfeec1a
-  dockerImageTag: 2.9.28
+  dockerImageTag: 2.9.29
   dockerRepository: airbyte/source-google-analytics-data-api
   documentationUrl: https://docs.airbyte.com/integrations/sources/google-analytics-data-api
   externalDocumentationUrls:

--- a/docs/integrations/sources/google-analytics-data-api.md
+++ b/docs/integrations/sources/google-analytics-data-api.md
@@ -280,6 +280,7 @@ The Google Analytics connector is subject to Google Analytics Data API quotas. P
 
 | Version        | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:---------------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 2.9.29 | 2026-04-01 | [75580](https://github.com/airbytehq/airbyte/pull/75580) | Add `oauth_connector_input_specification` with granular scopes |
 | 2.9.28 | 2026-03-31 | [75678](https://github.com/airbytehq/airbyte/pull/75678) | Update dependencies |
 | 2.9.27 | 2026-03-24 | [74568](https://github.com/airbytehq/airbyte/pull/74568) | Update dependencies |
 | 2.9.26 | 2026-02-25 | [73632](https://github.com/airbytehq/airbyte/pull/73632) | fix(source-google-analytics-data-api): use GA4 today keyword for timezone-correct end dates (AI-Triage PR) |


### PR DESCRIPTION
## Summary
- Add `oauth_connector_input_specification` with Google OAuth
- Scope: `analytics.readonly`
- Standard Google OAuth: offline access, `prompt=consent`
- Extracts `refresh_token`
- Version bump 2.9.27 → 2.9.28

Related: https://github.com/airbytehq/airbyte-internal-issues/issues/16023

## Test plan
- [x] Verify OAuth consent URL includes analytics.readonly scope
- [x] Verify full OAuth flow returns refresh_token