### PR TITLE
fix(iceberg): cast IntegerValue to Double/Float when target column type requires it

### DIFF
--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/data/iceberg/parquet/AirbyteValueToIcebergRecord.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/data/iceberg/parquet/AirbyteValueToIcebergRecord.kt
@@ -61,7 +61,15 @@ class AirbyteValueToIcebergRecord {
             }
             is BooleanValue -> return airbyteValue.value
             is DateValue -> return airbyteValue.value
-            is IntegerValue -> return airbyteValue.value.toLong()
+            is IntegerValue ->
+                return when (type.typeId()) {
+                    // When an integer value lands in a DOUBLE/FLOAT column (e.g. source emits
+                    // whole-number floats as JSON integers like `1` instead of `1.0`), convert
+                    // explicitly so the value is stored as a floating-point type, not as a long.
+                    Type.TypeID.DOUBLE -> airbyteValue.value.toBigDecimal().toDouble()
+                    Type.TypeID.FLOAT -> airbyteValue.value.toBigDecimal().toFloat()
+                    else -> airbyteValue.value.toLong()
+                }
             is NullValue -> return null
             is NumberValue ->
                 return when (type.typeId()) {

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/testFixtures/kotlin/io/airbyte/cdk/load/data/icerberg/parquet/AirbyteValueToIcebergRecordTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/testFixtures/kotlin/io/airbyte/cdk/load/data/icerberg/parquet/AirbyteValueToIcebergRecordTest.kt
@@ -109,6 +109,23 @@ class AirbyteValueToIcebergRecordTest {
     }
 
     @Test
+    fun `convert handles IntegerValue for DoubleType column (whole-number float emitted as integer JSON)`() {
+        // Sources may emit whole-number float values as JSON integers (e.g. `1` instead of `1.0`).
+        // After JsonToAirbyteValue parsing, these arrive as IntegerValue. The destination should
+        // store them as Double in DOUBLE columns, not as Long.
+        val result = converter.convert(IntegerValue(1L), Types.DoubleType.get())
+        assertEquals(1.0, result)
+        assert(result is Double) { "Expected Double but got ${result?.javaClass}" }
+    }
+
+    @Test
+    fun `convert handles IntegerValue for FloatType column`() {
+        val result = converter.convert(IntegerValue(2L), Types.FloatType.get())
+        assertEquals(2.0f, result)
+        assert(result is Float) { "Expected Float but got ${result?.javaClass}" }
+    }
+
+    @Test
     fun `convert handles StringValue`() {
         val result = converter.convert(StringValue("test string"), Types.StringType.get())
         assertEquals("test string", result)


### PR DESCRIPTION
## Summary
- Sources may emit whole-number float values as JSON integers (e.g. `1` instead of `1.0`)
- After `JsonToAirbyteValue` parsing these arrive as `IntegerValue`; without this fix they were stored as `Long` in `DOUBLE`/`FLOAT` Iceberg columns, causing type mismatches at write time
- Added explicit type-ID check in `AirbyteValueToIcebergRecord` to convert `IntegerValue` → `Double` or `Float` when the target Iceberg column requires it

## Test plan
- [ ] `convert handles IntegerValue for DoubleType column` — verifies `IntegerValue(1L)` in a `DOUBLE` column produces `1.0` as `Double`
- [ ] `convert handles IntegerValue for FloatType column` — verifies `IntegerValue(2L)` in a `FLOAT` column produces `2.0f` as `Float`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)