### PR TITLE
docs: Clarify Datadog integration status for Airbyte Cloud

### DIFF
--- a/docs/platform/operator-guides/collecting-metrics.md
+++ b/docs/platform/operator-guides/collecting-metrics.md
@@ -12,7 +12,7 @@ All Airbyte instances include extensive logging for each connector. These logs g
 
 ## OpenTelemetry metrics monitoring {#otel}
 
-Self-Managed Enterprise customers can configure Airbyte to send telemetry data to an OpenTelemetry collector endpoint so you can consume these metrics in your downstream monitoring tool of choice. See [OpenTelemetry metrics monitoring](open-telemetry).
+Self-Managed Enterprise customers can configure Airbyte to send telemetry data to an OpenTelemetry collector endpoint so you can consume these metrics in your downstream monitoring tool of choice. See [OpenTelemetry metrics monitoring](open-telemetry). Airbyte Cloud does not currently support a an OTEL integration.
 
 ## Datadog Integration
 

--- a/docs/platform/operator-guides/collecting-metrics.md
+++ b/docs/platform/operator-guides/collecting-metrics.md
@@ -16,6 +16,12 @@ Self-Managed Enterprise customers can configure Airbyte to send telemetry data t
 
 ## Datadog Integration
 
+:::note
+
+Datadog integration is not currently supported in Airbyte Cloud.
+
+:::
+
 Airbyte uses Datadog to monitor Airbyte Cloud performance on a [number of metrics](https://docs.datadoghq.com/integrations/airbyte/#data-collected) important to your experience. This integration only works on legacy Docker deployments of Airbyte. Airbyte is working on an improved version for abctl and Kubernetes. This could become available later as an enterprise feature to help you monitor your own deployment. If you're an enterprise customer and Datadog integration is important to you, let us know.
 
 Currently, you can send metrics to Datadog using [OpenTelemetry](open-telemetry).

--- a/docs/platform/operator-guides/collecting-metrics.md
+++ b/docs/platform/operator-guides/collecting-metrics.md
@@ -16,12 +16,6 @@ Self-Managed Enterprise customers can configure Airbyte to send telemetry data t
 
 ## Datadog Integration
 
-:::note
-
-Datadog integration is not currently supported in Airbyte Cloud.
-
-:::
-
 
 Self-Managed Enterprise customers can send metrics to Datadog using [OpenTelemetry](open-telemetry). Airbyte Cloud does not currently support a Datadog integration.
 

--- a/docs/platform/operator-guides/collecting-metrics.md
+++ b/docs/platform/operator-guides/collecting-metrics.md
@@ -24,6 +24,6 @@ Datadog integration is not currently supported in Airbyte Cloud.
 
 Airbyte uses Datadog to monitor Airbyte Cloud performance on a [number of metrics](https://docs.datadoghq.com/integrations/airbyte/#data-collected) important to your experience. This integration only works on legacy Docker deployments of Airbyte. Airbyte is working on an improved version for abctl and Kubernetes. This could become available later as an enterprise feature to help you monitor your own deployment. If you're an enterprise customer and Datadog integration is important to you, let us know.
 
-Currently, you can send metrics to Datadog using [OpenTelemetry](open-telemetry).
+Self-Managed Enterprise customers can send metrics to Datadog using [OpenTelemetry](open-telemetry). Airbyte Cloud does not currently support a Datadog integration.
 
 ![Datadog's Airbyte Integration Dashboard](assets/DatadogAirbyteIntegration_OutOfTheBox_Dashboard.png)

--- a/docs/platform/operator-guides/collecting-metrics.md
+++ b/docs/platform/operator-guides/collecting-metrics.md
@@ -22,7 +22,6 @@ Datadog integration is not currently supported in Airbyte Cloud.
 
 :::
 
-Airbyte uses Datadog to monitor Airbyte Cloud performance on a [number of metrics](https://docs.datadoghq.com/integrations/airbyte/#data-collected) important to your experience. This integration only works on legacy Docker deployments of Airbyte. Airbyte is working on an improved version for abctl and Kubernetes. This could become available later as an enterprise feature to help you monitor your own deployment. If you're an enterprise customer and Datadog integration is important to you, let us know.
 
 Self-Managed Enterprise customers can send metrics to Datadog using [OpenTelemetry](open-telemetry). Airbyte Cloud does not currently support a Datadog integration.
 


### PR DESCRIPTION
Added note about Datadog integration not being supported in Airbyte Cloud. 