### PR TITLE
ci: use GitHub API for modified-connector detection in bump-version workflow

### DIFF
--- a/.github/workflows/bump-version-command.yml
+++ b/.github/workflows/bump-version-command.yml
@@ -90,22 +90,18 @@ jobs:
       - name: Install airbyte-ops CLI
         run: uv tool install airbyte-internal-ops
 
-      - name: Fetch base branch for diff
-        # The checkout uses fetch-depth:1 (shallow clone) for speed, so the
-        # default branch ref (origin/master) is not available. Fetch just
-        # enough history for the ops CLI to compute a git diff.
-        run: git fetch origin master --depth=1
-
       - name: Detect modified connectors
         id: detect-connectors
         env:
           PR_NUMBER: ${{ github.event.inputs.pr }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           CONNECTORS=$(
             airbyte-ops local connector list \
               --repo-path "$GITHUB_WORKSPACE" \
               --modified-only \
               --pr "$PR_NUMBER" \
+              --gh-token "$GH_TOKEN" \
               --output-format lines
           )
 

--- a/.github/workflows/bump-version-command.yml
+++ b/.github/workflows/bump-version-command.yml
@@ -90,6 +90,12 @@ jobs:
       - name: Install airbyte-ops CLI
         run: uv tool install airbyte-internal-ops
 
+      - name: Fetch base branch for diff
+        # The checkout uses fetch-depth:1 (shallow clone) for speed, so the
+        # default branch ref (origin/master) is not available. Fetch just
+        # enough history for the ops CLI to compute a git diff.
+        run: git fetch origin master --depth=1
+
       - name: Detect modified connectors
         id: detect-connectors
         env:


### PR DESCRIPTION
## What

Fixes the `bump-version-command.yml` workflow failing at the "Detect modified connectors" step when triggered via `workflow_dispatch`.

The `airbyte-ops` CLI previously ran `git diff --name-only origin/master HEAD` to detect modified connectors, but shallow clones (`fetch-depth: 1`) make this unreliable — `origin/master` may be missing or lack a common ancestor, producing false positives from unrelated commits.

Related: airbytehq/airbyte-ops-mcp#638 (fixes the companion CLI bug where `GITHUB_BASE_REF` empty string was not handled correctly in `workflow_dispatch` context).

**Depends on:** airbytehq/airbyte-ops-mcp#639 (adds `--gh-token` flag to the ops CLI).

Failed E2E runs that exposed this:
- https://github.com/airbytehq/airbyte/actions/runs/23759869791
- https://github.com/airbytehq/airbyte/actions/runs/23759876470

## How

Passes `--gh-token` (via `${{ secrets.GITHUB_TOKEN }}`) to the `airbyte-ops local connector list` command. When both `--gh-token` and `--pr` are provided, the CLI uses the GitHub API (`GET /repos/{owner}/{repo}/pulls/{pr}/files`) to determine changed files instead of local `git diff`. This avoids shallow-clone depth issues entirely.

The CLI falls back to local `git diff` if the API call fails.

## Review guide

1. `.github/workflows/bump-version-command.yml` — two additions to the "Detect modified connectors" step:
   - `GH_TOKEN` env var from `secrets.GITHUB_TOKEN`
   - `--gh-token "$GH_TOKEN"` flag on the CLI invocation

Things to verify:
- [ ] airbytehq/airbyte-ops-mcp#639 is merged before this PR, otherwise `--gh-token` flag won't be recognized
- [ ] `secrets.GITHUB_TOKEN` has sufficient permissions to read PR file lists (it should by default)

## User Impact

The `/bump-version` slash command will stop failing. No user-facing behavioral change beyond that.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/771e1717779949218a11710707cbaeb4
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75604" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
