### PR TITLE
fix: bump s3-data-lake to 1.0.7 to get sort order fix.

### DIFF
--- a/airbyte-integrations/connectors/destination-s3-data-lake/gradle.properties
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/gradle.properties
@@ -1,3 +1,3 @@
 testExecutionConcurrency=-1
-cdkVersion=1.0.5
+cdkVersion=1.0.7
 JunitMethodExecutionTimeout=10m

--- a/airbyte-integrations/connectors/destination-s3-data-lake/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/metadata.yaml
@@ -37,7 +37,7 @@ data:
             alias: airbyte-connector-testing-secret-store
   connectorType: destination
   definitionId: 716ca874-520b-4902-9f80-9fad66754b89
-  dockerImageTag: 0.3.45
+  dockerImageTag: 0.3.46
   dockerRepository: airbyte/destination-s3-data-lake
   documentationUrl: https://docs.airbyte.com/integrations/destinations/s3-data-lake
   githubIssueLabel: destination-s3-data-lake

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/test/kotlin/io/airbyte/integrations/destination/s3_data_lake/write/S3DataLakeStreamLoaderTest.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/test/kotlin/io/airbyte/integrations/destination/s3_data_lake/write/S3DataLakeStreamLoaderTest.kt
@@ -44,6 +44,7 @@ import io.mockk.verify
 import kotlin.test.assertEquals
 import kotlinx.coroutines.runBlocking
 import org.apache.iceberg.Schema
+import org.apache.iceberg.SortOrder
 import org.apache.iceberg.Table
 import org.apache.iceberg.UpdateSchema
 import org.apache.iceberg.catalog.Catalog
@@ -261,7 +262,10 @@ internal class S3DataLakeStreamLoaderTest {
             every { s3BucketConfiguration } returns bucketConfiguration
         }
         val catalog: Catalog = mockk()
-        val table: Table = mockk { every { schema() } returns icebergSchema }
+        val table: Table = mockk {
+            every { schema() } returns icebergSchema
+            every { sortOrder() } returns SortOrder.unsorted()
+        }
         val updateSchema: UpdateSchema = mockk()
         every { table.updateSchema().allowIncompatibleChanges() } returns updateSchema
         every {
@@ -433,7 +437,10 @@ internal class S3DataLakeStreamLoaderTest {
             every { s3BucketConfiguration } returns bucketConfiguration
         }
         val catalog: Catalog = mockk()
-        val table: Table = mockk { every { schema() } returns icebergSchema }
+        val table: Table = mockk {
+            every { schema() } returns icebergSchema
+            every { sortOrder() } returns SortOrder.unsorted()
+        }
         val updateSchema: UpdateSchema = mockk()
         every { table.updateSchema().allowIncompatibleChanges() } returns updateSchema
         every {

--- a/docs/integrations/destinations/s3-data-lake.md
+++ b/docs/integrations/destinations/s3-data-lake.md
@@ -392,6 +392,7 @@ This destination supports [namespaces](https://docs.airbyte.com/platform/using-a
 
 | Version     | Date       | Pull Request                                               | Subject                                                                                                                         |
 |:------------|:-----------|:-----------------------------------------------------------|:--------------------------------------------------------------------------------------------------------------------------------|
+| 0.3.46      | 2026-03-30 |                                                           | Upgrade CDK to 1.0.7: fix sort order handling during schema evolution. |
 | 0.3.45      | 2026-03-12 | [74326](https://github.com/airbytehq/airbyte/pull/74326) | Upgrade CDK to 1.0.5: Number-type primary keys are now stored as String (enabling dedup on numeric PKs); fix schema evolution when replacing identifier columns |
 | 0.3.44      | 2026-02-04 | [72848](https://github.com/airbytehq/airbyte/pull/72848)   | Enable Speed.                                                                                                               |
 | 0.3.43      | 2026-01-29 | [72482](https://github.com/airbytehq/airbyte/pull/72482)   | Release on dataflow.                                                                                                            |


### PR DESCRIPTION
## What
Bump destination-s3-data-lake to CDK 1.0.7 and fix test mocks for new sort order handling.

## How
- Added `table.sortOrder()` mock returning `SortOrder.unsorted()` to two tests in `S3DataLakeStreamLoaderTest`
- Bumped `cdkVersion` to 1.0.7 and `dockerImageTag` to 0.3.46

## Review guide
1. `S3DataLakeStreamLoaderTest.kt` — mock fixes
2. `gradle.properties` — CDK version bump
3. `metadata.yaml` — connector version bump
4. `docs/integrations/destinations/s3-data-lake.md` — changelog entry

## User Impact
Iceberg schema evolution no longer crashes when deleting columns referenced by the sort order.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌