### PR TITLE
fix: bump cdk in gcs data lake to 1.0.7. Fixes sort order handling during …

### DIFF
--- a/airbyte-integrations/connectors/destination-gcs-data-lake/gradle.properties
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/gradle.properties
@@ -1,3 +1,3 @@
 testExecutionConcurrency=1
-cdkVersion=0.2.8
+cdkVersion=1.0.7
 JunitMethodExecutionTimeout=10m

--- a/airbyte-integrations/connectors/destination-gcs-data-lake/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/metadata.yaml
@@ -21,7 +21,7 @@ data:
             alias: airbyte-connector-testing-secret-store
   connectorType: destination
   definitionId: 8c8a2d3e-1b4f-4a9c-9e7d-6f5a4b3c2d1e
-  dockerImageTag: 1.0.7
+  dockerImageTag: 1.0.8
   dockerRepository: airbyte/destination-gcs-data-lake
   documentationUrl: https://docs.airbyte.com/integrations/destinations/gcs-data-lake
   githubIssueLabel: destination-gcs-data-lake

--- a/docs/integrations/destinations/gcs-data-lake.md
+++ b/docs/integrations/destinations/gcs-data-lake.md
@@ -218,7 +218,7 @@ This destination supports [namespaces](https://docs.airbyte.com/platform/using-a
 
 | Version | Date       | Pull Request                                                 | Subject                                                                               |
 |:--------|:-----------|:-------------------------------------------------------------|:--------------------------------------------------------------------------------------|
-| 1.0.8   | 2026-03-30 |                                                              | Upgrade CDK to 1.0.7: fix sort order handling during schema evolution.                |
+| 1.0.8   | 2026-03-30 | [75630](https://github.com/airbytehq/airbyte/pull/75630)     | Upgrade CDK to 1.0.7: fix sort order handling during schema evolution.                |
 | 1.0.7   | 2026-02-04 | [72855](https://github.com/airbytehq/airbyte/pull/72855)     | Upgrade CDK to 0.2.8                                                                  |
 | 1.0.6   | 2026-01-23 | [72300](https://github.com/airbytehq/airbyte/pull/72300)     | Upgrade CDK to 0.2.0                                                                  |
 | 1.0.5   | 2026-01-14 | [71760](https://github.com/airbytehq/airbyte/pull/71760)     | Restore integration tests in CI. Workaround DI error.                                 |

--- a/docs/integrations/destinations/gcs-data-lake.md
+++ b/docs/integrations/destinations/gcs-data-lake.md
@@ -218,6 +218,7 @@ This destination supports [namespaces](https://docs.airbyte.com/platform/using-a
 
 | Version | Date       | Pull Request                                                 | Subject                                                                               |
 |:--------|:-----------|:-------------------------------------------------------------|:--------------------------------------------------------------------------------------|
+| 1.0.8   | 2026-03-30 |                                                              | Upgrade CDK to 1.0.7: fix sort order handling during schema evolution.                |
 | 1.0.7   | 2026-02-04 | [72855](https://github.com/airbytehq/airbyte/pull/72855)     | Upgrade CDK to 0.2.8                                                                  |
 | 1.0.6   | 2026-01-23 | [72300](https://github.com/airbytehq/airbyte/pull/72300)     | Upgrade CDK to 0.2.0                                                                  |
 | 1.0.5   | 2026-01-14 | [71760](https://github.com/airbytehq/airbyte/pull/71760)     | Restore integration tests in CI. Workaround DI error.                                 |


### PR DESCRIPTION
## What
Improves sort order handling to no longer crash when deleting columns referenced by the sort order.

## How
- Bumped `cdkVersion` to 1.0.7 and `dockerImageTag` to 1.0.8

## Review guide
1. `gradle.properties`
2. `metadata.yaml`
3. `gcs-data-lake.md`

## User Impact
Iceberg schema evolution no longer crashes when deleting columns referenced by the sort order.

## Can this PR be safely reverted and rolled back?
- [x] YES
- [ ] NO

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._