### PR TITLE
ci: fix empty permissions block on auto-ai-review caller workflow

### DIFF
--- a/.github/workflows/auto-ai-review-label.yml
+++ b/.github/workflows/auto-ai-review-label.yml
@@ -12,7 +12,10 @@ on:
 
 run-name: "Auto AI Review for PR #${{ github.event.pull_request.number }}"
 
-permissions: {}
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
 
 jobs:
   dispatch-ai-review:


### PR DESCRIPTION
## What

Fixes the `auto-ai-review-label.yml` caller workflow so that the called reusable workflow (`ai-review-command.yml`) receives the `GITHUB_TOKEN` scopes it needs.

The previous PR (#75567) set `permissions: {}` on the caller. When using `workflow_call`, the effective `GITHUB_TOKEN` permissions in the called workflow are the **intersection** of the caller's and callee's grants. An empty caller block zeroes out all scopes, which breaks `actions/checkout@v4` (needs `contents: read`) before the GitHub App token is even created.

## How

Replace `permissions: {}` with the explicit set that `ai-review-command.yml` declares:

```yaml
permissions:
  contents: read
  issues: write
  pull-requests: write
```

## Review guide

1. `.github/workflows/auto-ai-review-label.yml` — the only change (3-line diff)

### Human review checklist

- [ ] Verify that `contents: read` is sufficient for `actions/checkout@v4` to clone this repo (it is — this is the standard minimum).
- [ ] Consider whether `issues: write` and `pull-requests: write` are strictly needed on the caller's `GITHUB_TOKEN`, or whether the called workflow's App token handles all write operations. Mirroring the callee's declaration is the safe default, but the set could potentially be narrowed to just `contents: read`.

## User Impact

Without this fix, the label-triggered auto-AI-review feature is non-functional — the checkout step in `ai-review-command.yml` would fail due to insufficient `GITHUB_TOKEN` permissions.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/ebe01ef3320647c59eec7e74be843d57
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75641" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
