### PR TITLE
chore: certify destination-motherduck

### DIFF
--- a/airbyte-integrations/connectors/destination-motherduck/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-motherduck/metadata.yaml
@@ -39,7 +39,7 @@ data:
   ab_internal:
     sl: 100
     ql: 100
-  supportLevel: community
+  supportLevel: certified
   connectorTestSuitesOptions:
     - suite: unitTests
     - suite: integrationTests


### PR DESCRIPTION
## What

Upgrades `destination-motherduck` from `community` to `certified` support level.

## How

Changed `supportLevel: community` → `supportLevel: certified` in the connector's `metadata.yaml`.

## Review guide

1. `airbyte-integrations/connectors/destination-motherduck/metadata.yaml`

**Reviewer checks:**
- The `ab_internal.sl` and `ab_internal.ql` fields are currently both `100`. Should these be increased (e.g. to `200`/`300`) to reflect certified status?
- The `releaseStage` is still `alpha`. Is this compatible with `supportLevel: certified`, or should it be bumped to `beta` / `generally_available`?
- `remoteRegistries.pypi.enabled` is `false`. Confirm this is acceptable for a certified connector.

## User Impact

`destination-motherduck` will appear as "certified" instead of "community" in the Airbyte UI and connector registry. No functional changes.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/0d4c25fa273147bba0ed9ed9d4f76a0b
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75642" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
