### PR TITLE
chore: bump patch versions to force registry update for supportLevel changes

### DIFF
--- a/airbyte-integrations/connectors/destination-milvus/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-milvus/metadata.yaml
@@ -21,7 +21,7 @@ data:
   connectorSubtype: vectorstore
   connectorType: destination
   definitionId: 65de8962-48c9-11ee-be56-0242ac120002
-  dockerImageTag: 0.0.57
+  dockerImageTag: 0.0.58
   dockerRepository: airbyte/destination-milvus
   githubIssueLabel: destination-milvus
   icon: milvus.svg

--- a/airbyte-integrations/connectors/destination-milvus/pyproject.toml
+++ b/airbyte-integrations/connectors/destination-milvus/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "airbyte-destination-milvus"
-version = "0.0.57"
+version = "0.0.58"
 description = "Airbyte destination implementation for Milvus."
 authors = ["Airbyte <contact@airbyte.io>"]
 license = "ELv2"

--- a/airbyte-integrations/connectors/destination-motherduck/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-motherduck/metadata.yaml
@@ -4,7 +4,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 042ee9b5-eb98-4e99-a4e5-3f0d573bee66
-  dockerImageTag: 0.2.2
+  dockerImageTag: 0.2.3
   dockerRepository: airbyte/destination-motherduck
   githubIssueLabel: destination-motherduck
   icon: duckdb.svg

--- a/airbyte-integrations/connectors/destination-motherduck/pyproject.toml
+++ b/airbyte-integrations/connectors/destination-motherduck/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "airbyte-destination-motherduck"
-version = "0.2.2"
+version = "0.2.3"
 description = "Destination implementation for MotherDuck."
 authors = ["Guen Prawiroatmodjo, Simon Späti, Airbyte"]
 license = "ELv2"

--- a/airbyte-integrations/connectors/destination-pgvector/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-pgvector/metadata.yaml
@@ -12,7 +12,7 @@ data:
   connectorSubtype: vectorstore
   connectorType: destination
   definitionId: e0e06cd9-57a9-4d39-b032-bedd874ae875
-  dockerImageTag: 0.1.8
+  dockerImageTag: 0.1.9
   dockerRepository: airbyte/destination-pgvector
   documentationUrl: https://docs.airbyte.com/integrations/destinations/pgvector
   githubIssueLabel: destination-pgvector

--- a/airbyte-integrations/connectors/destination-pgvector/pyproject.toml
+++ b/airbyte-integrations/connectors/destination-pgvector/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "airbyte-destination-pgvector"
-version = "0.1.8"
+version = "0.1.9"
 description = "Airbyte destination implementation for PGVector."
 authors = ["Airbyte <contact@airbyte.io>"]
 license = "ELv2"

--- a/airbyte-integrations/connectors/destination-snowflake-cortex/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-snowflake-cortex/metadata.yaml
@@ -13,7 +13,7 @@ data:
   connectorSubtype: vectorstore
   connectorType: destination
   definitionId: d9e5418d-f0f4-4d19-a8b1-5630543638e2
-  dockerImageTag: 0.2.27
+  dockerImageTag: 0.2.28
   dockerRepository: airbyte/destination-snowflake-cortex
   documentationUrl: https://docs.airbyte.com/integrations/destinations/snowflake-cortex
   githubIssueLabel: destination-snowflake-cortex

--- a/airbyte-integrations/connectors/destination-snowflake-cortex/pyproject.toml
+++ b/airbyte-integrations/connectors/destination-snowflake-cortex/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "airbyte-destination-snowflake-cortex"
-version = "0.2.27"
+version = "0.2.28"
 description = "Airbyte destination implementation for Snowflake cortex."
 authors = ["Airbyte <contact@airbyte.io>"]
 license = "ELv2"

--- a/airbyte-integrations/connectors/destination-weaviate/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-weaviate/metadata.yaml
@@ -13,7 +13,7 @@ data:
   connectorSubtype: vectorstore
   connectorType: destination
   definitionId: 7b7d7a0d-954c-45a0-bcfc-39a634b97736
-  dockerImageTag: 0.2.60
+  dockerImageTag: 0.2.61
   dockerRepository: airbyte/destination-weaviate
   documentationUrl: https://docs.airbyte.com/integrations/destinations/weaviate
   githubIssueLabel: destination-weaviate

--- a/airbyte-integrations/connectors/destination-weaviate/pyproject.toml
+++ b/airbyte-integrations/connectors/destination-weaviate/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "airbyte-destination-weaviate"
-version = "0.2.60"
+version = "0.2.61"
 description = "Airbyte destination implementation for Weaviate."
 authors = ["Airbyte <contact@airbyte.io>"]
 license = "ELv2"

--- a/docs/integrations/destinations/milvus.md
+++ b/docs/integrations/destinations/milvus.md
@@ -120,6 +120,7 @@ This destination does not support [namespaces](https://docs.airbyte.com/platform
 
 | Version | Date       | Pull Request                                              | Subject                                                                                                                                             |
 |:--------| :--------- | :-------------------------------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 0.0.58 | 2026-03-31 | [75645](https://github.com/airbytehq/airbyte/pull/75645) | Bump version to force registry update for supportLevel change to community |
 | 0.0.57 | 2025-10-21 | [68333](https://github.com/airbytehq/airbyte/pull/68333) | Update dependencies |
 | 0.0.56 | 2025-10-14 | [61075](https://github.com/airbytehq/airbyte/pull/61075) | Update dependencies |
 | 0.0.55 | 2025-05-17 | [57175](https://github.com/airbytehq/airbyte/pull/57175) | Update dependencies |

--- a/docs/integrations/destinations/motherduck.md
+++ b/docs/integrations/destinations/motherduck.md
@@ -75,6 +75,7 @@ This destination supports [namespaces](https://docs.airbyte.com/platform/using-a
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                   |
 | :------ | :--------- | :------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------ |
+| 0.2.3 | 2026-03-31 | [75645](https://github.com/airbytehq/airbyte/pull/75645) | Bump version to force registry update for supportLevel change to certified |
 | 0.2.2 | 2025-02-02 | [70438](https://github.com/airbytehq/airbyte/pull/70438) | Fix for camelCase columns being `NULL` |
 | 0.2.1 | 2025-12-19 | [70999](https://github.com/airbytehq/airbyte/pull/70999) | Fix for empty STRUCTs |
 | 0.2.0 | 2025-12-01 | [70221](https://github.com/airbytehq/airbyte/pull/70221) | Upgrade DuckDB to v1.4.2 and duckdb-engine to v0.17.0 |

--- a/docs/integrations/destinations/pgvector.md
+++ b/docs/integrations/destinations/pgvector.md
@@ -198,6 +198,7 @@ This destination does not support [namespaces](https://docs.airbyte.com/platform
 
 | Version | Date       | Pull Request                                                  | Subject                                                                                                                                              |
 |:--------| :--------- |:--------------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| 0.1.9 | 2026-03-31 | [75645](https://github.com/airbytehq/airbyte/pull/75645) | Bump version to force registry update for supportLevel change to community |
 | 0.1.8 | 2025-10-21 | [68347](https://github.com/airbytehq/airbyte/pull/68347) | Update dependencies |
 | 0.1.7 | 2025-10-14 | [67996](https://github.com/airbytehq/airbyte/pull/67996) | Update dependencies |
 | 0.1.6 | 2025-10-07 | [67175](https://github.com/airbytehq/airbyte/pull/67175) | Update dependencies |

--- a/docs/integrations/destinations/snowflake-cortex.md
+++ b/docs/integrations/destinations/snowflake-cortex.md
@@ -88,6 +88,7 @@ This destination does not support [namespaces](https://docs.airbyte.com/platform
 
 | Version | Date       | Pull Request                                                  | Subject                                                                                                                                              |
 |:--------| :--------- |:--------------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| 0.2.28 | 2026-03-31 | [75645](https://github.com/airbytehq/airbyte/pull/75645) | Bump version to force registry update for supportLevel change to community |
 | 0.2.27 | 2025-10-21 | [68344](https://github.com/airbytehq/airbyte/pull/68344) | Update dependencies |
 | 0.2.26 | 2025-10-14 | [63066](https://github.com/airbytehq/airbyte/pull/63066) | Update dependencies |
 | 0.2.25 | 2025-05-17 | [51743](https://github.com/airbytehq/airbyte/pull/51743) | Update dependencies |

--- a/docs/integrations/destinations/weaviate.md
+++ b/docs/integrations/destinations/weaviate.md
@@ -94,6 +94,7 @@ This destination does not support [namespaces](https://docs.airbyte.com/platform
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                                                      |
 |:--------| :--------- | :--------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------- |
+| 0.2.61 | 2026-03-31 | [75645](https://github.com/airbytehq/airbyte/pull/75645) | Bump version to force registry update for supportLevel change to community |
 | 0.2.60 | 2025-09-16 | [61103](https://github.com/airbytehq/airbyte/pull/61103) | Update dependencies |
 | 0.2.59 | 2025-05-17 | [57180](https://github.com/airbytehq/airbyte/pull/57180) | Update dependencies |
 | 0.2.58 | 2025-03-29 | [56089](https://github.com/airbytehq/airbyte/pull/56089) | Update dependencies |


### PR DESCRIPTION
## What

Bumps patch versions for 5 destination connectors whose `supportLevel` was changed in #75299 and #75642 but whose registry entries were never updated. The previous PRs only modified `supportLevel` without a version bump, and the publish pipeline does not resync per-connector `latest/` metadata in GCS unless the version changes — so the cloud registry still reflects the old classification.

## How

Patch version bump via the `bump_version_in_repo` Ops MCP tool, which updates `metadata.yaml`, `pyproject.toml`, and the docs changelog for each connector:

| Connector | Old Version | New Version |
|---|---|---|
| destination-motherduck | 0.2.2 | 0.2.3 |
| destination-pgvector | 0.1.8 | 0.1.9 |
| destination-weaviate | 0.2.60 | 0.2.61 |
| destination-milvus | 0.0.57 | 0.0.58 |
| destination-snowflake-cortex | 0.2.27 | 0.2.28 |

No code changes. The version bump will cause the publish pipeline to rebuild and publish new Docker images (functionally identical) and, critically, resync the `latest/` metadata to GCS so the registry compile picks up the `supportLevel` changes from the prior PRs.

## Review guide

Each connector has three files changed — verify version consistency between `metadata.yaml` and `pyproject.toml`, and that the changelog entry in `docs/` is present:

1. `destination-milvus/metadata.yaml` + `pyproject.toml` + `docs/integrations/destinations/milvus.md`
2. `destination-motherduck/metadata.yaml` + `pyproject.toml` + `docs/integrations/destinations/motherduck.md`
3. `destination-pgvector/metadata.yaml` + `pyproject.toml` + `docs/integrations/destinations/pgvector.md`
4. `destination-snowflake-cortex/metadata.yaml` + `pyproject.toml` + `docs/integrations/destinations/snowflake-cortex.md`
5. `destination-weaviate/metadata.yaml` + `pyproject.toml` + `docs/integrations/destinations/weaviate.md`

**Note:** This will trigger full connector image builds and publishes for all 5 connectors on merge.

### Human review checklist

- [ ] Confirm version strings match between `metadata.yaml` (`dockerImageTag`) and `pyproject.toml` (`version`) for each connector
- [ ] Verify that triggering 5 connector publishes for a metadata-only change is acceptable (no code changes, images will be functionally identical)

## User Impact

After merge and publish, the cloud registry will correctly reflect:
- **destination-motherduck**: `supportLevel: certified` (promoted in #75642)
- **destination-pgvector, destination-weaviate, destination-milvus, destination-snowflake-cortex**: `supportLevel: community` (demoted in #75299)

Users will see the corrected "Airbyte Connector" vs "Marketplace" classification in the Cloud UI connector catalog.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/0d4c25fa273147bba0ed9ed9d4f76a0b
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75645" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
