### PR TITLE
chore: bump source-faker to 7.0.4 (test ops CLI publish with deps + SBOM)

### DIFF
--- a/airbyte-integrations/connectors/source-faker/metadata.yaml
+++ b/airbyte-integrations/connectors/source-faker/metadata.yaml
@@ -9,7 +9,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: dfd88b22-b603-4c3d-aad7-3701784586b1
-  dockerImageTag: 7.0.3
+  dockerImageTag: 7.0.4
   dockerRepository: airbyte/source-faker
   documentationUrl: https://docs.airbyte.com/integrations/sources/faker
   externalDocumentationUrls:

--- a/airbyte-integrations/connectors/source-faker/pyproject.toml
+++ b/airbyte-integrations/connectors/source-faker/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "7.0.3"
+version = "7.0.4"
 name = "source-faker"
 description = "Source implementation for fake but realistic looking data."
 authors = [ "Airbyte <evan@airbyte.io>",]

--- a/docs/integrations/sources/faker.md
+++ b/docs/integrations/sources/faker.md
@@ -47,6 +47,7 @@ Each purchase record includes: `id`, `user_id`, `product_id`, `created_at`, `upd
 
 | Version     | Date       | Pull Request                                                                                                          | Subject                                                                                                         |
 |:------------|:-----------| :-------------------------------------------------------------------------------------------------------------------- |:----------------------------------------------------------------------------------------------------------------|
+| 7.0.4 | 2026-03-31 | [75646](https://github.com/airbytehq/airbyte/pull/75646) | Patch version bump (test ops CLI publish with deps + SBOM) |
 | 7.0.3 | 2026-03-20 | [75256](https://github.com/airbytehq/airbyte/pull/75256) | Re-release to verify yank/un-yank behavior in ops CLI registry pipeline |
 | 7.0.2 | 2026-03-19 | [75232](https://github.com/airbytehq/airbyte/pull/75232) | Patch version bump (ops CLI registry post-launch test) |
 | 7.0.1 | 2026-03-13 | [74818](https://github.com/airbytehq/airbyte/pull/74818) | Patch version bump (publish test) |

--- a/docs/integrations/sources/faker.md
+++ b/docs/integrations/sources/faker.md
@@ -47,7 +47,7 @@ Each purchase record includes: `id`, `user_id`, `product_id`, `created_at`, `upd
 
 | Version     | Date       | Pull Request                                                                                                          | Subject                                                                                                         |
 |:------------|:-----------| :-------------------------------------------------------------------------------------------------------------------- |:----------------------------------------------------------------------------------------------------------------|
-| 7.0.4 | 2026-03-31 | [75646](https://github.com/airbytehq/airbyte/pull/75646) | Patch version bump (test ops CLI publish with deps + SBOM) |
+| 7.0.4 | 2026-03-31 | [75646](https://github.com/airbytehq/airbyte/pull/75646) | Patch version bump (test publish) |
 | 7.0.3 | 2026-03-20 | [75256](https://github.com/airbytehq/airbyte/pull/75256) | Re-release to verify yank/un-yank behavior in ops CLI registry pipeline |
 | 7.0.2 | 2026-03-19 | [75232](https://github.com/airbytehq/airbyte/pull/75232) | Patch version bump (ops CLI registry post-launch test) |
 | 7.0.1 | 2026-03-13 | [74818](https://github.com/airbytehq/airbyte/pull/74818) | Patch version bump (publish test) |


### PR DESCRIPTION
## What

No-op patch version bump of `source-faker` from 7.0.3 → 7.0.4 to validate the publish workflow after removing legacy upload scripts in #75646.

This tests that the ops CLI now correctly generates and publishes `dependencies.json` and SBOM (`spdx.json`) via the new `--with-sbom` and `--with-dependency-dump` flags ([airbyte-ops-mcp#574](https://github.com/airbytehq/airbyte-ops-mcp/pull/574)).

## How

Standard three-file version bump — no connector code changes:
1. `metadata.yaml` — `dockerImageTag: 7.0.4`
2. `pyproject.toml` — `version = "7.0.4"`
3. `docs/integrations/sources/faker.md` — changelog entry

## Review guide

1. Verify version is consistent across all three files (7.0.4)
2. After merge, monitor the publish workflow to confirm:
   - `dependencies.json` is generated and uploaded to `connector_dependencies/source-faker/7.0.4/`
   - `spdx.json` is generated and uploaded to `sbom/airbyte/source-faker/7.0.4.spdx.json`
   - No errors from the removed legacy steps (gcloud, spec cache, shell scripts)

## User Impact

None — no connector behavior changes. This is a test release to validate CI/CD infrastructure.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/c46ec35bef7e4ff4a73f2cbf6fc748ee
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75657" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
