### PR TITLE
deps(source-typeform): update CDK to 7.15.0

### DIFF
--- a/airbyte-integrations/connectors/source-typeform/metadata.yaml
+++ b/airbyte-integrations/connectors/source-typeform/metadata.yaml
@@ -4,19 +4,19 @@ data:
     sl: 200
   allowedHosts:
     hosts:
-      - api.typeform.com
+    - api.typeform.com
   connectorBuildOptions:
     baseImage: docker.io/airbyte/source-declarative-manifest:7.15.0@sha256:eecde84a1c8efced5b35f04900ed983eb306028d262cdb0673f26526aaabd7fc
   connectorSubtype: api
   connectorType: source
   definitionId: e7eff203-90bf-43e5-a240-19ea3056c474
-  dockerImageTag: 1.4.7-rc.1
+  dockerImageTag: 1.4.7
   dockerRepository: airbyte/source-typeform
   documentationUrl: https://docs.airbyte.com/integrations/sources/typeform
   externalDocumentationUrls:
-    - title: Changelog
-      url: https://www.typeform.com/developers/changelog/
-      type: api_release_history
+  - title: Changelog
+    url: https://www.typeform.com/developers/changelog/
+    type: api_release_history
   githubIssueLabel: source-typeform
   icon: typeform.svg
   license: ELv2
@@ -35,54 +35,53 @@ data:
   releaseStage: generally_available
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: true
+      enableProgressiveRollout: false
     breakingChanges:
       1.1.0:
-        message:
-          This version migrates the Typeform connector to the low-code framework
+        message: This version migrates the Typeform connector to the low-code framework
           for greater maintainability. This introduces a breaking change to the state
           format for the `responses` stream. If you are using the incremental sync
           mode for this stream, you will need to reset affected connections after
           upgrading to prevent sync failures.
-        upgradeDeadline: "2023-09-25"
+        upgradeDeadline: '2023-09-25'
   suggestedStreams:
     streams:
-      - responses
-      - forms
+    - responses
+    - forms
   supportLevel: certified
   tags:
-    - cdk:low-code
-    - language:manifest-only
+  - cdk:low-code
+  - language:manifest-only
   connectorTestSuitesOptions:
-    - suite: liveTests
-      testConnections:
-        - name: typeform_config_oauth_dev_null
-          id: 1522cc4d-04d2-4d44-9152-0854b38e15ee
-        - name: typeform_config_dev_null
-          id: 2b707284-7c35-46da-b1ed-1cb09779a43c
-        - name: typeform_incremental_config_dev_null
-          id: 681b2010-52af-4d44-b2e1-1b5f50581509
-    - suite: unitTests
-    - suite: acceptanceTests
-      testSecrets:
-        - name: SECRET_SOURCE-TYPEFORM_OAUTH__CREDS
-          fileName: config_oauth.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-        - name: SECRET_SOURCE-TYPEFORM__CREDS
-          fileName: config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-        - name: SECRET_SOURCE-TYPEFORM__CREDS_INCREMENTAL
-          fileName: incremental_config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-        - name: SECRET_SOURCE-TYPEFORM__CREDS_TOKEN
-          fileName: config_token.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-metadataSpecVersion: "1.0"
+  - suite: liveTests
+    testConnections:
+    - name: typeform_config_oauth_dev_null
+      id: 1522cc4d-04d2-4d44-9152-0854b38e15ee
+    - name: typeform_config_dev_null
+      id: 2b707284-7c35-46da-b1ed-1cb09779a43c
+    - name: typeform_incremental_config_dev_null
+      id: 681b2010-52af-4d44-b2e1-1b5f50581509
+  - suite: unitTests
+  - suite: acceptanceTests
+    testSecrets:
+    - name: SECRET_SOURCE-TYPEFORM_OAUTH__CREDS
+      fileName: config_oauth.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+    - name: SECRET_SOURCE-TYPEFORM__CREDS
+      fileName: config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+    - name: SECRET_SOURCE-TYPEFORM__CREDS_INCREMENTAL
+      fileName: incremental_config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+    - name: SECRET_SOURCE-TYPEFORM__CREDS_TOKEN
+      fileName: config_token.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/source-typeform/metadata.yaml
+++ b/airbyte-integrations/connectors/source-typeform/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: e7eff203-90bf-43e5-a240-19ea3056c474
-  dockerImageTag: 1.4.7
+  dockerImageTag: 1.4.7-rc.2
   dockerRepository: airbyte/source-typeform
   documentationUrl: https://docs.airbyte.com/integrations/sources/typeform
   externalDocumentationUrls:
@@ -35,7 +35,7 @@ data:
   releaseStage: generally_available
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
     breakingChanges:
       1.1.0:
         message: This version migrates the Typeform connector to the low-code framework

--- a/airbyte-integrations/connectors/source-typeform/metadata.yaml
+++ b/airbyte-integrations/connectors/source-typeform/metadata.yaml
@@ -4,7 +4,7 @@ data:
     sl: 200
   allowedHosts:
     hosts:
-    - api.typeform.com
+      - api.typeform.com
   connectorBuildOptions:
     baseImage: docker.io/airbyte/source-declarative-manifest:7.15.0@sha256:eecde84a1c8efced5b35f04900ed983eb306028d262cdb0673f26526aaabd7fc
   connectorSubtype: api
@@ -14,9 +14,9 @@ data:
   dockerRepository: airbyte/source-typeform
   documentationUrl: https://docs.airbyte.com/integrations/sources/typeform
   externalDocumentationUrls:
-  - title: Changelog
-    url: https://www.typeform.com/developers/changelog/
-    type: api_release_history
+    - title: Changelog
+      url: https://www.typeform.com/developers/changelog/
+      type: api_release_history
   githubIssueLabel: source-typeform
   icon: typeform.svg
   license: ELv2
@@ -38,50 +38,51 @@ data:
       enableProgressiveRollout: true
     breakingChanges:
       1.1.0:
-        message: This version migrates the Typeform connector to the low-code framework
+        message:
+          This version migrates the Typeform connector to the low-code framework
           for greater maintainability. This introduces a breaking change to the state
           format for the `responses` stream. If you are using the incremental sync
           mode for this stream, you will need to reset affected connections after
           upgrading to prevent sync failures.
-        upgradeDeadline: '2023-09-25'
+        upgradeDeadline: "2023-09-25"
   suggestedStreams:
     streams:
-    - responses
-    - forms
+      - responses
+      - forms
   supportLevel: certified
   tags:
-  - cdk:low-code
-  - language:manifest-only
+    - cdk:low-code
+    - language:manifest-only
   connectorTestSuitesOptions:
-  - suite: liveTests
-    testConnections:
-    - name: typeform_config_oauth_dev_null
-      id: 1522cc4d-04d2-4d44-9152-0854b38e15ee
-    - name: typeform_config_dev_null
-      id: 2b707284-7c35-46da-b1ed-1cb09779a43c
-    - name: typeform_incremental_config_dev_null
-      id: 681b2010-52af-4d44-b2e1-1b5f50581509
-  - suite: unitTests
-  - suite: acceptanceTests
-    testSecrets:
-    - name: SECRET_SOURCE-TYPEFORM_OAUTH__CREDS
-      fileName: config_oauth.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
-    - name: SECRET_SOURCE-TYPEFORM__CREDS
-      fileName: config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
-    - name: SECRET_SOURCE-TYPEFORM__CREDS_INCREMENTAL
-      fileName: incremental_config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
-    - name: SECRET_SOURCE-TYPEFORM__CREDS_TOKEN
-      fileName: config_token.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
-metadataSpecVersion: '1.0'
+    - suite: liveTests
+      testConnections:
+        - name: typeform_config_oauth_dev_null
+          id: 1522cc4d-04d2-4d44-9152-0854b38e15ee
+        - name: typeform_config_dev_null
+          id: 2b707284-7c35-46da-b1ed-1cb09779a43c
+        - name: typeform_incremental_config_dev_null
+          id: 681b2010-52af-4d44-b2e1-1b5f50581509
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-TYPEFORM_OAUTH__CREDS
+          fileName: config_oauth.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-TYPEFORM__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-TYPEFORM__CREDS_INCREMENTAL
+          fileName: incremental_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-TYPEFORM__CREDS_TOKEN
+          fileName: config_token.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-typeform/metadata.yaml
+++ b/airbyte-integrations/connectors/source-typeform/metadata.yaml
@@ -6,7 +6,7 @@ data:
     hosts:
       - api.typeform.com
   connectorBuildOptions:
-    baseImage: docker.io/airbyte/source-declarative-manifest:7.13.0.post30.dev23303933335@sha256:266dda691d2928e00adc6401ac43823be107b5ae39364047ce03d4031c95e1cd
+    baseImage: docker.io/airbyte/source-declarative-manifest:7.15.0@sha256:eecde84a1c8efced5b35f04900ed983eb306028d262cdb0673f26526aaabd7fc
   connectorSubtype: api
   connectorType: source
   definitionId: e7eff203-90bf-43e5-a240-19ea3056c474

--- a/docs/integrations/sources/typeform.md
+++ b/docs/integrations/sources/typeform.md
@@ -99,6 +99,7 @@ The connector makes an additional API call per sync to fetch the list of form ID
 
 | Version | Date       | Pull Request                                             | Subject                                                                                         |
 |:--------|:-----------|:---------------------------------------------------------|:------------------------------------------------------------------------------------------------|
+| 1.4.7 | 2026-03-31 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Update CDK to 7.15.0 |
 | 1.4.7-rc.1 | 2026-03-26 | [75506](https://github.com/airbytehq/airbyte/pull/75506) | Upgrade CDK version to 7.13.0 |
 | 1.4.6 | 2026-03-03 | [61473](https://github.com/airbytehq/airbyte/pull/61473) | Update dependencies |
 | 1.4.5 | 2026-01-22 | [72261](https://github.com/airbytehq/airbyte/pull/72261) | Update CDK version from 7.0.1 to 7.6.5 |

--- a/docs/integrations/sources/typeform.md
+++ b/docs/integrations/sources/typeform.md
@@ -99,7 +99,7 @@ The connector makes an additional API call per sync to fetch the list of form ID
 
 | Version | Date       | Pull Request                                             | Subject                                                                                         |
 |:--------|:-----------|:---------------------------------------------------------|:------------------------------------------------------------------------------------------------|
-| 1.4.7 | 2026-03-31 | [75898](https://github.com/airbytehq/airbyte/pull/75898) | Update CDK to 7.15.0 |
+| 1.4.7-rc.2 | 2026-03-31 | [75898](https://github.com/airbytehq/airbyte/pull/75898) | Update CDK to 7.15.0 |
 | 1.4.7-rc.1 | 2026-03-26 | [75506](https://github.com/airbytehq/airbyte/pull/75506) | Upgrade CDK version to 7.13.0 |
 | 1.4.6 | 2026-03-03 | [61473](https://github.com/airbytehq/airbyte/pull/61473) | Update dependencies |
 | 1.4.5 | 2026-01-22 | [72261](https://github.com/airbytehq/airbyte/pull/72261) | Update CDK version from 7.0.1 to 7.6.5 |

--- a/docs/integrations/sources/typeform.md
+++ b/docs/integrations/sources/typeform.md
@@ -99,7 +99,7 @@ The connector makes an additional API call per sync to fetch the list of form ID
 
 | Version | Date       | Pull Request                                             | Subject                                                                                         |
 |:--------|:-----------|:---------------------------------------------------------|:------------------------------------------------------------------------------------------------|
-| 1.4.7 | 2026-03-31 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Update CDK to 7.15.0 |
+| 1.4.7 | 2026-03-31 | [75898](https://github.com/airbytehq/airbyte/pull/75898) | Update CDK to 7.15.0 |
 | 1.4.7-rc.1 | 2026-03-26 | [75506](https://github.com/airbytehq/airbyte/pull/75506) | Upgrade CDK version to 7.13.0 |
 | 1.4.6 | 2026-03-03 | [61473](https://github.com/airbytehq/airbyte/pull/61473) | Update dependencies |
 | 1.4.5 | 2026-01-22 | [72261](https://github.com/airbytehq/airbyte/pull/72261) | Update CDK version from 7.0.1 to 7.6.5 |


### PR DESCRIPTION
## What
Updates the CDK base image for `source-typeform` from `7.13.0.post30.dev23303933335` to `7.15.0` and bumps the connector version from `1.4.7-rc.1` to `1.4.7-rc.2`.

Related: https://github.com/airbytehq/oncall/issues/10604

## How
- Updated `baseImage` in `metadata.yaml` to `source-declarative-manifest:7.15.0@sha256:eecde84a1c8efced5b35f04900ed983eb306028d262cdb0673f26526aaabd7fc`
- Bumped `dockerImageTag` from `1.4.7-rc.1` → `1.4.7-rc.2`
- Added changelog entry in `docs/integrations/sources/typeform.md`

## Review guide
1. `airbyte-integrations/connectors/source-typeform/metadata.yaml` — only two fields changed: `baseImage` and `dockerImageTag`. No formatting or other field changes.
2. `docs/integrations/sources/typeform.md` — changelog entry added for `1.4.7-rc.2`

**Human review checklist:**
- [ ] Confirm SHA256 digest (`eecde84a1c8efced5b35f04900ed983eb306028d262cdb0673f26526aaabd7fc`) matches the published `source-declarative-manifest:7.15.0` image
- [ ] Confirm `enableProgressiveRollout` remains `true` (not touched by this diff — still set for RC)

## User Impact
Connector will run on CDK 7.15.0 instead of a dev post-release of 7.13.0. No user-facing behavior change expected.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/75d23337f87746258bf52daf418c4132
Requested by: @agarctfi