### PR TITLE
ci(publish): fix RC metadata marker command after airbyte-ops rename

### DIFF
--- a/.github/workflows/finalize_rollout.yml
+++ b/.github/workflows/finalize_rollout.yml
@@ -58,6 +58,6 @@ jobs:
           GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
           REGISTRY_STORE: "coral:prod"
         run: >
-          airbyte-ops registry rc cleanup
+          airbyte-ops registry progressive-rollout cleanup
           --name "${CONNECTOR_NAME}"
           --store "${REGISTRY_STORE}"

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -443,7 +443,7 @@ jobs:
         run: |
           echo "Creating RC metadata marker for ${{ matrix.connector }}"
           airbyte-ops \
-            registry rc create \
+            registry progressive-rollout create \
             --name "${{ matrix.connector }}" \
             --store "${REGISTRY_STORE}"
 


### PR DESCRIPTION
## What

Fixes connector workflow failures caused by calling a renamed CLI command. This was the direct cause of the `source-typeform` publish failure in [workflow run #23806623372](https://github.com/airbytehq/airbyte/actions/runs/23806623372).

The `airbyte-ops registry rc` subcommand was renamed to `registry progressive-rollout` in `airbyte-internal-ops` v0.39.0 ([airbytehq/airbyte-ops-mcp#623](https://github.com/airbytehq/airbyte-ops-mcp/pull/623)), but neither workflow that calls this CLI was updated to match.

## How

Two one-line changes updating the old `registry rc` command to `registry progressive-rollout`:
- `.github/workflows/publish_connectors.yml`: `registry rc create` → `registry progressive-rollout create`
- `.github/workflows/finalize_rollout.yml`: `registry rc cleanup` → `registry progressive-rollout cleanup`

## Review guide

1. `.github/workflows/publish_connectors.yml` — confirm `registry progressive-rollout create` matches the CLI in [airbyte-ops-mcp `cli/registry.py`](https://github.com/airbytehq/airbyte-ops-mcp/blob/main/src/airbyte_ops_mcp/cli/registry.py#L100-L105) and that `--name` / `--store` flags are unchanged.
2. `.github/workflows/finalize_rollout.yml` — same rename for the `cleanup` subcommand. Confirm flags are unchanged.

### Human review checklist
- [ ] Verify there are no other references to `registry rc` in the repo (e.g. other workflows, scripts, or docs)
- [ ] Confirm the latest published `airbyte-internal-ops` on PyPI (currently v0.39.1) includes both `progressive-rollout create` and `progressive-rollout cleanup` commands

## User Impact

Unblocks RC connector publishes (like `source-typeform 1.4.7-rc.2`) that are currently failing at the "Create RC metadata marker" step, and prevents the same failure from hitting the rollout finalization workflow.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/051bdfc588f2483ba1979f2bff8e90e9
Requested by: @agarctfi
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75907" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
