### PR TITLE
test: progressive rollout e2e test on source-faker

### DIFF
--- a/airbyte-integrations/connectors/source-faker/README.md
+++ b/airbyte-integrations/connectors/source-faker/README.md
@@ -102,3 +102,4 @@ You've checked out the repo, implemented a million dollar feature, and you're re
 6. Pat yourself on the back for being an awesome contributor.
 7. Someone from Airbyte will take a look at your PR and iterate with you to merge it into master.
 8. Once your PR is merged, the new version of the connector will be automatically published to Docker Hub and our connector registry.
+# Progressive rollout e2e test 20260331

--- a/airbyte-integrations/connectors/source-faker/metadata.yaml
+++ b/airbyte-integrations/connectors/source-faker/metadata.yaml
@@ -9,16 +9,16 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: dfd88b22-b603-4c3d-aad7-3701784586b1
-  dockerImageTag: 7.0.4
+  dockerImageTag: 7.1.0-rc.1
   dockerRepository: airbyte/source-faker
   documentationUrl: https://docs.airbyte.com/integrations/sources/faker
   externalDocumentationUrls:
-    - title: Python Faker Library Documentation
-      url: https://faker.readthedocs.io/en/master/
-      type: api_reference
-    - title: Faker Changelog
-      url: https://github.com/joke2k/faker/blob/master/CHANGELOG.md
-      type: api_release_history
+  - title: Python Faker Library Documentation
+    url: https://faker.readthedocs.io/en/master/
+    type: api_reference
+  - title: Faker Changelog
+    url: https://github.com/joke2k/faker/blob/master/CHANGELOG.md
+    type: api_release_history
   githubIssueLabel: source-faker
   icon: icon.svg
   license: ELv2
@@ -31,57 +31,58 @@ data:
   releaseStage: beta
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
     breakingChanges:
       4.0.0:
         message: This is a breaking change message
-        upgradeDeadline: "2023-07-19"
+        upgradeDeadline: '2023-07-19'
       5.0.0:
-        message: ID and products.year fields are changing to be integers instead of floats.
-        upgradeDeadline: "2023-08-31"
+        message: ID and products.year fields are changing to be integers instead of
+          floats.
+        upgradeDeadline: '2023-08-31'
       6.0.0:
         message: Declare 'id' columns as primary keys.
-        upgradeDeadline: "2024-04-01"
+        upgradeDeadline: '2024-04-01'
       7.0.0:
         message: This is a test breaking change to validate breaking change infrastructure.
-        upgradeDeadline: "2026-03-19"
-        deadlineAction: "disable"
+        upgradeDeadline: '2026-03-19'
+        deadlineAction: disable
         scopedImpact:
-          - scopeType: stream
-            impactedScopes:
-              - users
-              - products
-              - purchases
+        - scopeType: stream
+          impactedScopes:
+          - users
+          - products
+          - purchases
   remoteRegistries:
     pypi:
       enabled: true
       packageName: airbyte-source-faker
   resourceRequirements:
     jobSpecific:
-      - jobType: sync
-        resourceRequirements:
-          cpu_limit: "4.0"
-          cpu_request: "1.0"
+    - jobType: sync
+      resourceRequirements:
+        cpu_limit: '4.0'
+        cpu_request: '1.0'
   suggestedStreams:
     streams:
-      - users
-      - products
-      - purchases
+    - users
+    - products
+    - purchases
   supportLevel: community
   tags:
-    - language:python
-    - cdk:python
+  - language:python
+  - cdk:python
   connectorTestSuitesOptions:
-    - suite: liveTests
-      testConnections:
-        - name: faker_config_dev_null
-          id: 73abc3a9-3fea-4e7c-b58d-2c8236464a95
-    - suite: unitTests
-    - suite: acceptanceTests
-      testSecrets:
-        - name: SECRET_SOURCE-FAKER_CREDS
-          fileName: config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-metadataSpecVersion: "1.0"
+  - suite: liveTests
+    testConnections:
+    - name: faker_config_dev_null
+      id: 73abc3a9-3fea-4e7c-b58d-2c8236464a95
+  - suite: unitTests
+  - suite: acceptanceTests
+    testSecrets:
+    - name: SECRET_SOURCE-FAKER_CREDS
+      fileName: config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/source-faker/metadata.yaml
+++ b/airbyte-integrations/connectors/source-faker/metadata.yaml
@@ -9,16 +9,16 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: dfd88b22-b603-4c3d-aad7-3701784586b1
-  dockerImageTag: 7.0.4
+  dockerImageTag: 7.1.0-rc.1
   dockerRepository: airbyte/source-faker
   documentationUrl: https://docs.airbyte.com/integrations/sources/faker
   externalDocumentationUrls:
-    - title: Python Faker Library Documentation
-      url: https://faker.readthedocs.io/en/master/
-      type: api_reference
-    - title: Faker Changelog
-      url: https://github.com/joke2k/faker/blob/master/CHANGELOG.md
-      type: api_release_history
+  - title: Python Faker Library Documentation
+    url: https://faker.readthedocs.io/en/master/
+    type: api_reference
+  - title: Faker Changelog
+    url: https://github.com/joke2k/faker/blob/master/CHANGELOG.md
+    type: api_release_history
   githubIssueLabel: source-faker
   icon: icon.svg
   license: ELv2
@@ -26,62 +26,65 @@ data:
   registryOverrides:
     cloud:
       enabled: true
+      dockerImageTag: 7.0.4
     oss:
       enabled: true
+      dockerImageTag: 7.0.4
   releaseStage: beta
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
     breakingChanges:
       4.0.0:
         message: This is a breaking change message
-        upgradeDeadline: "2023-07-19"
+        upgradeDeadline: '2023-07-19'
       5.0.0:
-        message: ID and products.year fields are changing to be integers instead of floats.
-        upgradeDeadline: "2023-08-31"
+        message: ID and products.year fields are changing to be integers instead of
+          floats.
+        upgradeDeadline: '2023-08-31'
       6.0.0:
         message: Declare 'id' columns as primary keys.
-        upgradeDeadline: "2024-04-01"
+        upgradeDeadline: '2024-04-01'
       7.0.0:
         message: This is a test breaking change to validate breaking change infrastructure.
-        upgradeDeadline: "2026-03-19"
-        deadlineAction: "disable"
+        upgradeDeadline: '2026-03-19'
+        deadlineAction: disable
         scopedImpact:
-          - scopeType: stream
-            impactedScopes:
-              - users
-              - products
-              - purchases
+        - scopeType: stream
+          impactedScopes:
+          - users
+          - products
+          - purchases
   remoteRegistries:
     pypi:
       enabled: true
       packageName: airbyte-source-faker
   resourceRequirements:
     jobSpecific:
-      - jobType: sync
-        resourceRequirements:
-          cpu_limit: "4.0"
-          cpu_request: "1.0"
+    - jobType: sync
+      resourceRequirements:
+        cpu_limit: '4.0'
+        cpu_request: '1.0'
   suggestedStreams:
     streams:
-      - users
-      - products
-      - purchases
+    - users
+    - products
+    - purchases
   supportLevel: community
   tags:
-    - language:python
-    - cdk:python
+  - language:python
+  - cdk:python
   connectorTestSuitesOptions:
-    - suite: liveTests
-      testConnections:
-        - name: faker_config_dev_null
-          id: 73abc3a9-3fea-4e7c-b58d-2c8236464a95
-    - suite: unitTests
-    - suite: acceptanceTests
-      testSecrets:
-        - name: SECRET_SOURCE-FAKER_CREDS
-          fileName: config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-metadataSpecVersion: "1.0"
+  - suite: liveTests
+    testConnections:
+    - name: faker_config_dev_null
+      id: 73abc3a9-3fea-4e7c-b58d-2c8236464a95
+  - suite: unitTests
+  - suite: acceptanceTests
+    testSecrets:
+    - name: SECRET_SOURCE-FAKER_CREDS
+      fileName: config.json
+      secretStore:
+        type: GSM
+        alias: airbyte-connector-testing-secret-store
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/source-faker/metadata.yaml
+++ b/airbyte-integrations/connectors/source-faker/metadata.yaml
@@ -9,7 +9,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: dfd88b22-b603-4c3d-aad7-3701784586b1
-  dockerImageTag: 7.1.0-rc.1
+  dockerImageTag: 7.1.0-rc.2
   dockerRepository: airbyte/source-faker
   documentationUrl: https://docs.airbyte.com/integrations/sources/faker
   externalDocumentationUrls:

--- a/airbyte-integrations/connectors/source-faker/metadata.yaml
+++ b/airbyte-integrations/connectors/source-faker/metadata.yaml
@@ -13,12 +13,12 @@ data:
   dockerRepository: airbyte/source-faker
   documentationUrl: https://docs.airbyte.com/integrations/sources/faker
   externalDocumentationUrls:
-  - title: Python Faker Library Documentation
-    url: https://faker.readthedocs.io/en/master/
-    type: api_reference
-  - title: Faker Changelog
-    url: https://github.com/joke2k/faker/blob/master/CHANGELOG.md
-    type: api_release_history
+    - title: Python Faker Library Documentation
+      url: https://faker.readthedocs.io/en/master/
+      type: api_reference
+    - title: Faker Changelog
+      url: https://github.com/joke2k/faker/blob/master/CHANGELOG.md
+      type: api_release_history
   githubIssueLabel: source-faker
   icon: icon.svg
   license: ELv2
@@ -37,54 +37,55 @@ data:
     breakingChanges:
       4.0.0:
         message: This is a breaking change message
-        upgradeDeadline: '2023-07-19'
+        upgradeDeadline: "2023-07-19"
       5.0.0:
-        message: ID and products.year fields are changing to be integers instead of
+        message:
+          ID and products.year fields are changing to be integers instead of
           floats.
-        upgradeDeadline: '2023-08-31'
+        upgradeDeadline: "2023-08-31"
       6.0.0:
         message: Declare 'id' columns as primary keys.
-        upgradeDeadline: '2024-04-01'
+        upgradeDeadline: "2024-04-01"
       7.0.0:
         message: This is a test breaking change to validate breaking change infrastructure.
-        upgradeDeadline: '2026-03-19'
+        upgradeDeadline: "2026-03-19"
         deadlineAction: disable
         scopedImpact:
-        - scopeType: stream
-          impactedScopes:
-          - users
-          - products
-          - purchases
+          - scopeType: stream
+            impactedScopes:
+              - users
+              - products
+              - purchases
   remoteRegistries:
     pypi:
       enabled: true
       packageName: airbyte-source-faker
   resourceRequirements:
     jobSpecific:
-    - jobType: sync
-      resourceRequirements:
-        cpu_limit: '4.0'
-        cpu_request: '1.0'
+      - jobType: sync
+        resourceRequirements:
+          cpu_limit: "4.0"
+          cpu_request: "1.0"
   suggestedStreams:
     streams:
-    - users
-    - products
-    - purchases
+      - users
+      - products
+      - purchases
   supportLevel: community
   tags:
-  - language:python
-  - cdk:python
+    - language:python
+    - cdk:python
   connectorTestSuitesOptions:
-  - suite: liveTests
-    testConnections:
-    - name: faker_config_dev_null
-      id: 73abc3a9-3fea-4e7c-b58d-2c8236464a95
-  - suite: unitTests
-  - suite: acceptanceTests
-    testSecrets:
-    - name: SECRET_SOURCE-FAKER_CREDS
-      fileName: config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
-metadataSpecVersion: '1.0'
+    - suite: liveTests
+      testConnections:
+        - name: faker_config_dev_null
+          id: 73abc3a9-3fea-4e7c-b58d-2c8236464a95
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-FAKER_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-faker/metadata.yaml
+++ b/airbyte-integrations/connectors/source-faker/metadata.yaml
@@ -9,16 +9,16 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: dfd88b22-b603-4c3d-aad7-3701784586b1
-  dockerImageTag: 7.1.0-rc.2
+  dockerImageTag: 7.0.4
   dockerRepository: airbyte/source-faker
   documentationUrl: https://docs.airbyte.com/integrations/sources/faker
   externalDocumentationUrls:
-  - title: Python Faker Library Documentation
-    url: https://faker.readthedocs.io/en/master/
-    type: api_reference
-  - title: Faker Changelog
-    url: https://github.com/joke2k/faker/blob/master/CHANGELOG.md
-    type: api_release_history
+    - title: Python Faker Library Documentation
+      url: https://faker.readthedocs.io/en/master/
+      type: api_reference
+    - title: Faker Changelog
+      url: https://github.com/joke2k/faker/blob/master/CHANGELOG.md
+      type: api_release_history
   githubIssueLabel: source-faker
   icon: icon.svg
   license: ELv2
@@ -31,58 +31,57 @@ data:
   releaseStage: beta
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: true
+      enableProgressiveRollout: false
     breakingChanges:
       4.0.0:
         message: This is a breaking change message
-        upgradeDeadline: '2023-07-19'
+        upgradeDeadline: "2023-07-19"
       5.0.0:
-        message: ID and products.year fields are changing to be integers instead of
-          floats.
-        upgradeDeadline: '2023-08-31'
+        message: ID and products.year fields are changing to be integers instead of floats.
+        upgradeDeadline: "2023-08-31"
       6.0.0:
         message: Declare 'id' columns as primary keys.
-        upgradeDeadline: '2024-04-01'
+        upgradeDeadline: "2024-04-01"
       7.0.0:
         message: This is a test breaking change to validate breaking change infrastructure.
-        upgradeDeadline: '2026-03-19'
-        deadlineAction: disable
+        upgradeDeadline: "2026-03-19"
+        deadlineAction: "disable"
         scopedImpact:
-        - scopeType: stream
-          impactedScopes:
-          - users
-          - products
-          - purchases
+          - scopeType: stream
+            impactedScopes:
+              - users
+              - products
+              - purchases
   remoteRegistries:
     pypi:
       enabled: true
       packageName: airbyte-source-faker
   resourceRequirements:
     jobSpecific:
-    - jobType: sync
-      resourceRequirements:
-        cpu_limit: '4.0'
-        cpu_request: '1.0'
+      - jobType: sync
+        resourceRequirements:
+          cpu_limit: "4.0"
+          cpu_request: "1.0"
   suggestedStreams:
     streams:
-    - users
-    - products
-    - purchases
+      - users
+      - products
+      - purchases
   supportLevel: community
   tags:
-  - language:python
-  - cdk:python
+    - language:python
+    - cdk:python
   connectorTestSuitesOptions:
-  - suite: liveTests
-    testConnections:
-    - name: faker_config_dev_null
-      id: 73abc3a9-3fea-4e7c-b58d-2c8236464a95
-  - suite: unitTests
-  - suite: acceptanceTests
-    testSecrets:
-    - name: SECRET_SOURCE-FAKER_CREDS
-      fileName: config.json
-      secretStore:
-        type: GSM
-        alias: airbyte-connector-testing-secret-store
-metadataSpecVersion: '1.0'
+    - suite: liveTests
+      testConnections:
+        - name: faker_config_dev_null
+          id: 73abc3a9-3fea-4e7c-b58d-2c8236464a95
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-FAKER_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-faker/pyproject.toml
+++ b/airbyte-integrations/connectors/source-faker/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "7.1.0-rc.2"
+version = "7.0.4"
 name = "source-faker"
 description = "Source implementation for fake but realistic looking data."
 authors = [ "Airbyte <evan@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-faker/pyproject.toml
+++ b/airbyte-integrations/connectors/source-faker/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "7.0.4"
+version = "7.1.0-rc.1"
 name = "source-faker"
 description = "Source implementation for fake but realistic looking data."
 authors = [ "Airbyte <evan@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-faker/pyproject.toml
+++ b/airbyte-integrations/connectors/source-faker/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "7.1.0-rc.1"
+version = "7.1.0-rc.2"
 name = "source-faker"
 description = "Source implementation for fake but realistic looking data."
 authors = [ "Airbyte <evan@airbyte.io>",]

--- a/docs/integrations/sources/faker.md
+++ b/docs/integrations/sources/faker.md
@@ -47,6 +47,7 @@ Each purchase record includes: `id`, `user_id`, `product_id`, `created_at`, `upd
 
 | Version     | Date       | Pull Request                                                                                                          | Subject                                                                                                         |
 |:------------|:-----------| :-------------------------------------------------------------------------------------------------------------------- |:----------------------------------------------------------------------------------------------------------------|
+| 7.1.0-rc.1 | 2026-03-31 | [75908](https://github.com/airbytehq/airbyte/pull/75908) | test: progressive rollout e2e test on source-faker |
 | 7.0.4 | 2026-03-31 | [75657](https://github.com/airbytehq/airbyte/pull/75657) | Patch version bump (test publish) |
 | 7.0.3 | 2026-03-20 | [75256](https://github.com/airbytehq/airbyte/pull/75256) | Re-release to verify yank/un-yank behavior in ops CLI registry pipeline |
 | 7.0.2 | 2026-03-19 | [75232](https://github.com/airbytehq/airbyte/pull/75232) | Patch version bump (ops CLI registry post-launch test) |

--- a/docs/integrations/sources/faker.md
+++ b/docs/integrations/sources/faker.md
@@ -47,8 +47,6 @@ Each purchase record includes: `id`, `user_id`, `product_id`, `created_at`, `upd
 
 | Version     | Date       | Pull Request                                                                                                          | Subject                                                                                                         |
 |:------------|:-----------| :-------------------------------------------------------------------------------------------------------------------- |:----------------------------------------------------------------------------------------------------------------|
-| 7.1.0-rc.2 | 2026-03-31 | [75908](https://github.com/airbytehq/airbyte/pull/75908) | test: progressive rollout e2e test on source-faker |
-| 7.1.0-rc.1 | 2026-03-31 | [75908](https://github.com/airbytehq/airbyte/pull/75908) | test: progressive rollout e2e test on source-faker |
 | 7.0.4 | 2026-03-31 | [75657](https://github.com/airbytehq/airbyte/pull/75657) | Patch version bump (test publish) |
 | 7.0.3 | 2026-03-20 | [75256](https://github.com/airbytehq/airbyte/pull/75256) | Re-release to verify yank/un-yank behavior in ops CLI registry pipeline |
 | 7.0.2 | 2026-03-19 | [75232](https://github.com/airbytehq/airbyte/pull/75232) | Patch version bump (ops CLI registry post-launch test) |

--- a/docs/integrations/sources/faker.md
+++ b/docs/integrations/sources/faker.md
@@ -47,6 +47,7 @@ Each purchase record includes: `id`, `user_id`, `product_id`, `created_at`, `upd
 
 | Version     | Date       | Pull Request                                                                                                          | Subject                                                                                                         |
 |:------------|:-----------| :-------------------------------------------------------------------------------------------------------------------- |:----------------------------------------------------------------------------------------------------------------|
+| 7.1.0-rc.2 | 2026-03-31 | [75908](https://github.com/airbytehq/airbyte/pull/75908) | test: progressive rollout e2e test on source-faker |
 | 7.1.0-rc.1 | 2026-03-31 | [75908](https://github.com/airbytehq/airbyte/pull/75908) | test: progressive rollout e2e test on source-faker |
 | 7.0.4 | 2026-03-31 | [75657](https://github.com/airbytehq/airbyte/pull/75657) | Patch version bump (test publish) |
 | 7.0.3 | 2026-03-20 | [75256](https://github.com/airbytehq/airbyte/pull/75256) | Re-release to verify yank/un-yank behavior in ops CLI registry pipeline |


### PR DESCRIPTION
## What

Trivial change to `source-faker` to serve as a vehicle for end-to-end testing of the progressive rollout workflow (`finalize_rollout.yml`). This PR will be used to:

1. Run `/bump-progressive-rollout-version type=minor` to create an RC version
2. Merge to trigger the publish pipeline
3. Test rollback and promote flows via `finalize_connector_rollout`

## How

Appends a single comment line to `source-faker/README.md`. The change itself is a no-op — the purpose is to create a PR that modifies source-faker so the slash command can bump its version.

## Review guide

1. `airbyte-integrations/connectors/source-faker/README.md` — single line addition (test marker)

## User Impact

No user impact. This is an infrastructure test. The README comment will be cleaned up after the e2e test completes (the promote flow will overwrite the version back to GA).

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/fa9a671420024a6d9de68563cd5a1951
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75908" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
