### PR TITLE
docs(ai-agents): rewrite enable-connector doc to use connectors API

### DIFF
--- a/docs/ai-agents/platform/enable-connector.md
+++ b/docs/ai-agents/platform/enable-connector.md
@@ -13,7 +13,7 @@ When you add a connector to a customer, that customer can use the connector to r
 
 ### Add a new connector
 
-Enable a connector through the Agent Engine dashboard.
+Add a connector through the Agent Engine dashboard.
 
 1. Click **Connector Credentials**.
 

--- a/docs/ai-agents/platform/enable-connector.md
+++ b/docs/ai-agents/platform/enable-connector.md
@@ -5,67 +5,27 @@ sidebar_position: 1
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# Enable a connector
+# Add a connector
 
-Agent Engine uses a three-layer model for connectors:
-
-- **Definition**: A connector type available in the Airbyte catalog, like GitHub or Salesforce. Each definition has a `sourceDefinitionId`. List definitions with `GET /api/v1/integrations/definitions/sources`.
-- **Source template**: An organization-level configuration for a connector type, including default settings and connector mode. Managed through `GET/POST/PATCH/DELETE /api/v1/integrations/templates/sources`.
-- **Connector**: A per-user instance with actual credentials, created when an end user authenticates. Managed through `/api/v1/integrations/connectors`.
-
-Many connectors work out of the box using Airbyte's standard (global) templates. When you create a connector with `POST /api/v1/integrations/connectors`, the system automatically resolves the appropriate template. You only need to explicitly enable a connector by creating an org-specific source template when you want to:
-
-- Override default configuration values for your organization
-- Set a specific [connector mode](#connector-modes), like switching from Replication to Direct
-- Restrict or customize which connectors are available to your end users
-
-## Connector modes
-
-Agent Engine connectors operate in one of three modes:
-
-- **Direct** (`DIRECT`): AI agents execute real-time queries against connected data sources. When a user asks a question, the agent calls the third-party API directly to fetch fresh data. This mode is ideal for operational queries, real-time lookups, and actions that need current information.
-
-- **Replication** (`REPLICATION`): Data syncs from connected sources to object storage like S3, GCS, or Azure Blob Storage. This mode is useful for analytics, RAG pipelines, and scenarios where you need to process large volumes of historical data.
-
-- **Multi** (`MULTI`): Both Direct and Replication modes are active. Agents can query the API in real time and data also syncs to object storage.
-
-Some connectors support all three modes, while others support only one. If you don't specify a mode when creating a source template, it defaults to `REPLICATION`.
+When you add a connector to a customer, that customer can use the connector to read and/or write data through your agent.
 
 ## With the UI
 
-### Enable a new connector
+### Add a new connector
 
 Enable a connector through the Agent Engine dashboard.
 
-1. Click **Connectors**.
+1. Click **Connector Credentials**.
 
-2. Click **Manage Connectors** (or **Enable Connector** if you haven't enabled any connectors yet).
+2. Click **Add Credential**.
 
-3. In the slide-out panel, the **Add Connector** tab displays available connectors. Browse or search for the connector you want to enable, and click it to enable it.
-
-   The system automatically determines the connector mode based on the connector's capabilities and your organization's configuration.
+3. In the slide-out panel, select the customer you want to add the connector to, then search for and click the connector you want to add.
 
 4. Click **Done**.
 
-The connector appears in your active connectors list. Your end users can now authenticate with this connector.
+Your end users can now authenticate with this connector.
 
 ![Managing connectors in the user interface](img/managing-connectors.png)
-
-### Update connector modes
-
-To modify the modes of connectors you've already enabled:
-
-1. Click **Connectors** > **Manage Connectors**.
-
-2. Click the **Existing Connectors** tab.
-
-3. For each connector, you can:
-
-   - Toggle Direct mode on or off
-
-   - Toggle Replication mode on or off, if data replication is configured
-
-At least one mode must remain enabled for each active connector.
 
 ### Remove a connector
 
@@ -73,7 +33,7 @@ To remove a connector, click the trash icon next to it on the **Existing Connect
 
 ## With the API
 
-You can also manage connectors programmatically using the Agent Engine API. This approach is useful for automation, infrastructure-as-code workflows, or when building custom admin interfaces.
+You can manage connectors programmatically using the Agent Engine API. This approach is useful for automation, infrastructure-as-code workflows, or when building custom admin interfaces.
 
 ### Get an application token
 
@@ -90,74 +50,30 @@ curl --location 'https://api.airbyte.ai/api/v1/account/applications/token' \
 
 Save the returned access token for subsequent API calls.
 
-### List available connector definitions
+### List available connectors
 
 To see which connector types are available in the Airbyte catalog:
 
 ```bash title="Request"
-curl 'https://api.airbyte.ai/api/v1/integrations/definitions/sources' \
-  --header 'Authorization: Bearer <APPLICATION_TOKEN>'
+
+```
+
+```bash title="Response"
+
 ```
 
 Each definition includes a `sourceDefinitionId` that you use when creating source templates.
 
-### List source templates
+### Create a new connector
 
-To see which connectors have source templates for your organization:
+To create a connector for your organization, create a source template.
 
 ```bash title="Request"
-curl 'https://api.airbyte.ai/api/v1/integrations/templates/sources' \
-  --header 'Authorization: Bearer <APPLICATION_TOKEN>'
+
 ```
 
-By default, this returns your organization's source templates. To list Airbyte's standard global templates instead, add `?use_global=true`.
+```bash title="Response"
 
-### Create a source template
-
-To customize a connector for your organization, create a source template.
-
-```bash title="Request"
-curl -X POST 'https://api.airbyte.ai/api/v1/integrations/templates/sources' \
-  --header 'Authorization: Bearer <APPLICATION_TOKEN>' \
-  --header 'Content-Type: application/json' \
-  --data '{
-    "actor_definition_id": "<connector_definition_id>",
-    "partial_default_config": {},
-    "mode": "DIRECT"
-  }'
-```
-
-| Field | Required | Description |
-| --- | --- | --- |
-| `actor_definition_id` | Yes | The connector type identifier. This corresponds to the `sourceDefinitionId` returned by the [definitions endpoint](/ai-agents/api/#make-your-first-request). You can also find these IDs in the [Airbyte Connector Registry](https://connectors.airbyte.com/files/registries/v0/cloud_registry.json). |
-| `partial_default_config` | Yes | Default configuration values for the connector, so your users don't need to provide them during authentication. Pass `{}` for no defaults. |
-| `mode` | No | The connector mode: `DIRECT`, `REPLICATION`, or `MULTI`. Defaults to `REPLICATION`. |
-| `name` | No | A display name for the source template. |
-
-### Update a source template
-
-To modify an existing source template:
-
-```bash title="Request"
-curl -X PATCH 'https://api.airbyte.ai/api/v1/integrations/templates/sources/<template_id>' \
-  --header 'Authorization: Bearer <APPLICATION_TOKEN>' \
-  --header 'Content-Type: application/json' \
-  --data '{
-    "partial_default_config": {
-      "some_field": "new_default_value"
-    }
-  }'
-```
-
-By default, updates apply only to the source template itself. Existing connectors created from this template are not modified. To propagate default config changes to existing connectors, include `"propagate": true` in the request body.
-
-### Delete a source template
-
-To delete a source template and prevent end users from creating new connections with this connector type:
-
-```bash title="Request"
-curl -X DELETE 'https://api.airbyte.ai/api/v1/integrations/templates/sources/<template_id>' \
-  --header 'Authorization: Bearer <APPLICATION_TOKEN>'
 ```
 
 ## Next steps

--- a/docs/ai-agents/platform/enable-connector.md
+++ b/docs/ai-agents/platform/enable-connector.md
@@ -78,4 +78,4 @@ To create a connector for your organization, create a source template.
 
 ## Next steps
 
-After enabling connectors, set up [authentication](authenticate) to let users connect their accounts.
+After adding connectors, set up [authentication](authenticate) to let users connect their accounts.

--- a/docs/ai-agents/platform/enable-connector.md
+++ b/docs/ai-agents/platform/enable-connector.md
@@ -55,25 +55,73 @@ Save the returned access token for subsequent API calls.
 To see which connector types are available in the Airbyte catalog:
 
 ```bash title="Request"
-
+curl 'https://api.airbyte.ai/api/v1/integrations/definitions/sources' \
+  --header 'Authorization: Bearer <APPLICATION_TOKEN>'
 ```
 
-```bash title="Response"
-
+```json title="Response"
+{
+  "definitions": [
+    {
+      "sourceDefinitionId": "<uuid>",
+      "name": "Hubspot",
+      "iconUrl": "https://...",
+      "supportLevel": "certified"
+    }
+  ]
+}
 ```
 
-Each definition includes a `sourceDefinitionId` that you use when creating source templates.
+| Field | Description |
+| --- | --- |
+| `sourceDefinitionId` | Unique identifier for this connector type. Use this as the `definition_id` when creating a connector. |
+| `name` | Display name of the connector. |
+| `iconUrl` | URL to the connector's icon. |
+| `supportLevel` | Support tier: `certified`, `community`, or `archived`. |
+
+You can filter by name with the `name` query parameter, for example `?name=hubspot`.
 
 ### Create a new connector
 
-To create a connector for your organization, create a source template.
+To create a connector for a customer, send a POST request to the connectors endpoint. You must identify the connector type using one of `connector_type` or `definition_id`, and provide the `customer_name` to associate the connector with a specific customer.
 
 ```bash title="Request"
-
+curl -X POST 'https://api.airbyte.ai/api/v1/integrations/connectors' \
+  --header 'Authorization: Bearer <APPLICATION_TOKEN>' \
+  --header 'Content-Type: application/json' \
+  --data '{
+    "connector_type": "hubspot",
+    "customer_name": "<customer_name>",
+    "credentials": {
+      "api_key": "<api_key>"
+    }
+  }'
 ```
 
-```bash title="Response"
+| Field | Required | Description |
+| --- | --- | --- |
+| `connector_type` | Yes (or `definition_id`) | Connector name, case-insensitive (for example, `hubspot`). Exactly one of `connector_type` or `definition_id` must be provided. |
+| `definition_id` | Yes (or `connector_type`) | The `sourceDefinitionId` from the [definitions endpoint](#list-available-connectors). Exactly one of `connector_type` or `definition_id` must be provided. |
+| `customer_name` | Yes | The customer to associate this connector with. |
+| `credentials` | Conditional | Authentication credentials for the connector. Required unless using OAuth (`server_side_oauth_secret_id`). |
+| `replication_config` | No | Configuration for data replication. For replication-mode connectors, this is the full config. For direct-mode connectors, this can contain settings like `start_date` or `lookback_window`. |
+| `name` | No | A display name for the connector. |
+| `server_side_oauth_secret_id` | No | OAuth secret ID from the OAuth callback. When provided, `credentials` is not required. |
 
+```json title="Response"
+{
+  "id": "<connector_id>",
+  "name": "Hubspot",
+  "source_template": {
+    "id": "<source_template_id>",
+    "name": "Hubspot",
+    "source_definition_id": "<uuid>",
+    "mode": "DIRECT"
+  },
+  "replication_config": {},
+  "created_at": "2025-01-01T00:00:00Z",
+  "updated_at": "2025-01-01T00:00:00Z"
+}
 ```
 
 ## Next steps

--- a/docs/ai-agents/platform/enable-connector.md
+++ b/docs/ai-agents/platform/enable-connector.md
@@ -7,33 +7,29 @@ import TabItem from '@theme/TabItem';
 
 # Enable a connector
 
-Before your AI agents can interact with external data sources, you need to enable connectors in the Agent Engine. Enabling a connector makes it available for your end users to authenticate and use with their own credentials.
+Agent Engine uses a three-layer model for connectors:
 
-## What enabling a connector does
-
-When you enable a connector in Agent Engine, you're configuring which data sources your app supports. This is separate from authentication, which happens when individual users connect their accounts.
-
-Enabling a connector creates a **source template** in the API, which is the organization-level configuration for a connector type. The Agent Engine uses three layers:
-
-- **Definition**: A connector type available in the Airbyte catalog (for example, GitHub or Salesforce), identified by a `sourceDefinitionId`. List definitions with `GET /api/v1/integrations/definitions/sources`.
-- **Source template**: Your organization's configuration of a definition, including default settings and enabled modes. Managed through `GET/POST/PATCH/DELETE /api/v1/integrations/templates/sources`.
+- **Definition**: A connector type available in the Airbyte catalog, like GitHub or Salesforce. Each definition has a `sourceDefinitionId`. List definitions with `GET /api/v1/integrations/definitions/sources`.
+- **Source template**: An organization-level configuration for a connector type, including default settings and connector mode. Managed through `GET/POST/PATCH/DELETE /api/v1/integrations/templates/sources`.
 - **Connector**: A per-user instance with actual credentials, created when an end user authenticates. Managed through `/api/v1/integrations/connectors`.
 
-Enabling a connector (creating a source template) does the following.
+Many connectors work out of the box using Airbyte's standard (global) templates. When you create a connector with `POST /api/v1/integrations/connectors`, the system automatically resolves the appropriate template. You only need to explicitly enable a connector by creating an org-specific source template when you want to:
 
-- Makes the connector available in your organization's connector catalog
-- Allows your end users to authenticate with their own credentials for that data source
-- Configures which modes the connector operates in: direct, replication, or both
+- Override default configuration values for your organization
+- Set a specific [connector mode](#connector-modes), like switching from Replication to Direct
+- Restrict or customize which connectors are available to your end users
 
 ## Connector modes
 
-Agent Engine connectors can operate in two modes:
+Agent Engine connectors operate in one of three modes:
 
-- **Direct mode** allows AI agents to execute real-time queries against connected data sources. When a user asks a question, the agent calls the third-party API directly to fetch fresh data. This mode is ideal for operational queries, real-time lookups, and actions that need current information.
+- **Direct** (`DIRECT`): AI agents execute real-time queries against connected data sources. When a user asks a question, the agent calls the third-party API directly to fetch fresh data. This mode is ideal for operational queries, real-time lookups, and actions that need current information.
 
-- **Replication mode** syncs data from connected sources to object storage like S3, GCS, or Azure Blob Storage. This mode is useful for analytics, RAG pipelines, and scenarios where you need to process large volumes of historical data.
+- **Replication** (`REPLICATION`): Data syncs from connected sources to object storage like S3, GCS, or Azure Blob Storage. This mode is useful for analytics, RAG pipelines, and scenarios where you need to process large volumes of historical data.
 
-Some connectors support both modes, while others support only one. When enabling a connector, you can choose which modes to activate based on your application's needs.
+- **Multi** (`MULTI`): Both Direct and Replication modes are active. Agents can query the API in real time and data also syncs to object storage.
+
+Some connectors support all three modes, while others support only one. If you don't specify a mode when creating a source template, it defaults to `REPLICATION`.
 
 ## With the UI
 
@@ -45,39 +41,39 @@ Enable a connector through the Agent Engine dashboard.
 
 2. Click **Manage Connectors** (or **Enable Connector** if you haven't enabled any connectors yet).
 
-3. In the slide-out panel, browse or search for the connector you want to enable, and click it.
+3. In the slide-out panel, the **Add Connector** tab displays available connectors. Browse or search for the connector you want to enable, and click it to enable it.
 
-4. Click the **Existing Connectors** tab and select the modes you want to enable for the connector:
+   The system automatically determines the connector mode based on the connector's capabilities and your organization's configuration.
 
-   - Check **Direct** to enable real-time agent queries
+4. Click **Done**.
 
-   - Check **Replication** to enable replicating data to object storage
-
-5. Click **Done**.
-
-The connector appears in your active connectors list. Your end users can authenticate with this connector and use it in the modes you defined.
+The connector appears in your active connectors list. Your end users can now authenticate with this connector.
 
 ![Managing connectors in the user interface](img/managing-connectors.png)
 
-### Update connectors
+### Update connector modes
 
-To modify or delete connectors you've already enabled, follow these steps.
+To modify the modes of connectors you've already enabled:
 
-1. Click **Connectors** > **Manage Connectors** > **Existing Connectors**.
+1. Click **Connectors** > **Manage Connectors**.
 
-2. For each connector, you can:
+2. Click the **Existing Connectors** tab.
+
+3. For each connector, you can:
 
    - Toggle Direct mode on or off
 
-   - Toggle Replication mode on or off, if data replication is enabled
-
-   - Remove the connector entirely by clicking the trash icon
+   - Toggle Replication mode on or off, if data replication is configured
 
 At least one mode must remain enabled for each active connector.
 
+### Remove a connector
+
+To remove a connector, click the trash icon next to it on the **Existing Connectors** tab. This removes the source template and prevents end users from creating new connections with that connector type.
+
 ## With the API
 
-You can also enable connectors programmatically using the Agent Engine API. This approach is useful for automation, infrastructure-as-code workflows, or when building custom admin interfaces.
+You can also manage connectors programmatically using the Agent Engine API. This approach is useful for automation, infrastructure-as-code workflows, or when building custom admin interfaces.
 
 ### Get an application token
 
@@ -94,39 +90,53 @@ curl --location 'https://api.airbyte.ai/api/v1/account/applications/token' \
 
 Save the returned access token for subsequent API calls.
 
+### List available connector definitions
+
+To see which connector types are available in the Airbyte catalog:
+
+```bash title="Request"
+curl 'https://api.airbyte.ai/api/v1/integrations/definitions/sources' \
+  --header 'Authorization: Bearer <APPLICATION_TOKEN>'
+```
+
+Each definition includes a `sourceDefinitionId` that you use when creating source templates.
+
 ### List source templates
 
-To see which connectors are enabled (as source templates) for your organization:
+To see which connectors have source templates for your organization:
 
 ```bash title="Request"
 curl 'https://api.airbyte.ai/api/v1/integrations/templates/sources' \
   --header 'Authorization: Bearer <APPLICATION_TOKEN>'
 ```
 
-This returns both source templates you've created and standard source templates available to all Agent Engine users.
+By default, this returns your organization's source templates. To list Airbyte's standard global templates instead, add `?use_global=true`.
 
 ### Create a source template
 
-If you don't see the connector you need, create a source template for it.
+To customize a connector for your organization, create a source template.
 
 ```bash title="Request"
 curl -X POST 'https://api.airbyte.ai/api/v1/integrations/templates/sources' \
   --header 'Authorization: Bearer <APPLICATION_TOKEN>' \
   --header 'Content-Type: application/json' \
   --data '{
-    "organization_id": "<your_organization_id>",
     "actor_definition_id": "<connector_definition_id>",
-    "partial_default_config": {}
+    "partial_default_config": {},
+    "mode": "DIRECT"
   }'
 ```
 
-The `actor_definition_id` is the identifier for the connector type. This corresponds to the `sourceDefinitionId` returned by the [definitions endpoint](/ai-agents/api/#make-your-first-request). You can also find these IDs in the [Airbyte Connector Registry](https://connectors.airbyte.com/files/registries/v0/cloud_registry.json).
-
-The `partial_default_config` object lets you pre-configure default values for the source template, so your users don't need to provide them during authentication.
+| Field | Required | Description |
+| --- | --- | --- |
+| `actor_definition_id` | Yes | The connector type identifier. This corresponds to the `sourceDefinitionId` returned by the [definitions endpoint](/ai-agents/api/#make-your-first-request). You can also find these IDs in the [Airbyte Connector Registry](https://connectors.airbyte.com/files/registries/v0/cloud_registry.json). |
+| `partial_default_config` | Yes | Default configuration values for the connector, so your users don't need to provide them during authentication. Pass `{}` for no defaults. |
+| `mode` | No | The connector mode: `DIRECT`, `REPLICATION`, or `MULTI`. Defaults to `REPLICATION`. |
+| `name` | No | A display name for the source template. |
 
 ### Update a source template
 
-To modify an existing source template.
+To modify an existing source template:
 
 ```bash title="Request"
 curl -X PATCH 'https://api.airbyte.ai/api/v1/integrations/templates/sources/<template_id>' \
@@ -139,11 +149,11 @@ curl -X PATCH 'https://api.airbyte.ai/api/v1/integrations/templates/sources/<tem
   }'
 ```
 
-When you update a source template, the changes apply to all connectors created from it.
+By default, updates apply only to the source template itself. Existing connectors created from this template are not modified. To propagate default config changes to existing connectors, include `"propagate": true` in the request body.
 
 ### Delete a source template
 
-To delete a source template, follow these steps. Once you do this, the connector type is no longer available for end users to authenticate with.
+To delete a source template and prevent end users from creating new connections with this connector type:
 
 ```bash title="Request"
 curl -X DELETE 'https://api.airbyte.ai/api/v1/integrations/templates/sources/<template_id>' \

--- a/docs/ai-agents/platform/enable-connector.md
+++ b/docs/ai-agents/platform/enable-connector.md
@@ -29,7 +29,7 @@ Your end users can now authenticate with this connector.
 
 ### Remove a connector
 
-To remove a connector, click the trash icon next to it on the **Existing Connectors** tab. This removes the source template and prevents end users from creating new connections with that connector type.
+To remove a connector, click the trash icon next to it on the **Existing Connectors** tab.
 
 ## With the API
 
@@ -79,7 +79,7 @@ curl 'https://api.airbyte.ai/api/v1/integrations/definitions/sources' \
 | `iconUrl` | URL to the connector's icon. |
 | `supportLevel` | Support tier: `certified`, `community`, or `archived`. |
 
-You can filter by name with the `name` query parameter, for example `?name=hubspot`.
+You can filter by name with the `name` query parameter (case-insensitive partial match), for example `?name=hub` returns Hubspot.
 
 ### Create a new connector
 
@@ -100,8 +100,8 @@ curl -X POST 'https://api.airbyte.ai/api/v1/integrations/connectors' \
 
 | Field | Required | Description |
 | --- | --- | --- |
-| `connector_type` | Yes (or `definition_id`) | Connector name, case-insensitive (for example, `hubspot`). Exactly one of `connector_type` or `definition_id` must be provided. |
-| `definition_id` | Yes (or `connector_type`) | The `sourceDefinitionId` from the [definitions endpoint](#list-available-connectors). Exactly one of `connector_type` or `definition_id` must be provided. |
+| `connector_type` | Yes (or `definition_id`) | Connector name, case-insensitive (for example, `hubspot`). Provide either `connector_type` or `definition_id` to identify the connector. |
+| `definition_id` | Yes (or `connector_type`) | The `sourceDefinitionId` from the [definitions endpoint](#list-available-connectors). Provide either `connector_type` or `definition_id` to identify the connector. |
 | `customer_name` | Yes | The customer to associate this connector with. |
 | `credentials` | Conditional | Authentication credentials for the connector. Required unless using OAuth (`server_side_oauth_secret_id`). |
 | `replication_config` | No | Configuration for data replication. For replication-mode connectors, this is the full config. For direct-mode connectors, this can contain settings like `start_date` or `lookback_window`. |


### PR DESCRIPTION
## What

The "Enable a connector" doc was built around source template management, which is an advanced feature. This PR rewrites the doc to focus on the primary workflow: creating connectors directly via the `POST /integrations/connectors` endpoint. Source templates are removed from this page entirely.

Time-boxed project since this is not a priority - just wanted the docs to reflect intended behavior for simpler use cases. API docs exist for source template management.

## How

- **Renamed page** from "Enable a connector" to "Add a connector" to match the simplified mental model.
- **Simplified UI section**: Updated to reflect the current dashboard flow (Connector Credentials → Add Credential). Removed mode selection and update sections.
- **Replaced API section**: Removed all source template CRUD operations. Added:
  - "List available connectors" using `GET /integrations/definitions/sources` with response schema and field table.
  - "Create a new connector" using `POST /integrations/connectors` with request/response schemas and field reference table covering `connector_type`, `definition_id`, `customer_name`, `credentials`, `replication_config`, and `server_side_oauth_secret_id`.
- **Removed connector modes section**: Modes are no longer discussed on this page.

## Review guide

1. `docs/ai-agents/platform/enable-connector.md` — single file change. Key areas to verify:
   - **Lines 53-82**: "List available connectors" — uses the definitions endpoint. Response fields derived from `ConnectorDefinitionSummarized` model.
   - **Lines 84-125**: "Create a new connector" — uses the connectors endpoint. Request fields derived from `ConnectorSourceCreateRequest`. Response fields derived from `ConnectorDetailedSource`.
   - **Lines 14-28**: UI instructions — updated by @ian-at-airbyte to match current dashboard. Worth a quick visual check against the live UI.

## User Impact

Users reading this doc get a streamlined guide focused on the common path: listing available connectors and creating one for a customer. They are no longer required to understand source templates to get started.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/3e3a9a6426704e488aad3201d6c235fb
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75909" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
