### PR TITLE
fix(cdk): detect namespace mapping collisions with clear ConfigErrorException

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/command/DestinationCatalog.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/command/DestinationCatalog.kt
@@ -112,11 +112,7 @@ class DefaultDestinationCatalogFactory {
 
         // Detect streams that collide after namespace mapping (e.g. different source
         // namespaces mapped to the same destination namespace).
-        val duplicates =
-            mappedDescriptorsList
-                .groupingBy { it }
-                .eachCount()
-                .filter { it.value > 1 }
+        val duplicates = mappedDescriptorsList.groupingBy { it }.eachCount().filter { it.value > 1 }
         if (duplicates.isNotEmpty()) {
             val collisionDetails =
                 duplicates.keys.joinToString("; ") { desc ->

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/command/DestinationCatalog.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/command/DestinationCatalog.kt
@@ -107,8 +107,35 @@ class DefaultDestinationCatalogFactory {
         namespaceMapper: NamespaceMapper,
     ): DestinationCatalog {
         // we resolve the table names with the properly mapped descriptors
-        val mappedDescriptors =
-            catalog.streams.map { namespaceMapper.map(it.stream.namespace, it.stream.name) }.toSet()
+        val mappedDescriptorsList =
+            catalog.streams.map { namespaceMapper.map(it.stream.namespace, it.stream.name) }
+
+        // Detect streams that collide after namespace mapping (e.g. different source
+        // namespaces mapped to the same destination namespace).
+        val duplicates =
+            mappedDescriptorsList
+                .groupingBy { it }
+                .eachCount()
+                .filter { it.value > 1 }
+        if (duplicates.isNotEmpty()) {
+            val collisionDetails =
+                duplicates.keys.joinToString("; ") { desc ->
+                    val originals =
+                        catalog.streams
+                            .filter {
+                                namespaceMapper.map(it.stream.namespace, it.stream.name) == desc
+                            }
+                            .joinToString(", ") {
+                                "(namespace=${it.stream.namespace}, name=${it.stream.name})"
+                            }
+                    "Destination descriptor ${desc.toPrettyString()} mapped from: $originals"
+                }
+            throw ConfigErrorException(
+                "Multiple streams map to the same destination name after namespace mapping. $collisionDetails"
+            )
+        }
+
+        val mappedDescriptors = mappedDescriptorsList.toSet()
         val names = tableNameResolver.getTableNameMapping(mappedDescriptors)
 
         require(


### PR DESCRIPTION
## What

When multiple source streams map to the same `DestinationStream.Descriptor` after namespace mapping (e.g., two streams with different source namespaces but the same name, where `namespaceDefinitionType=DESTINATION` collapses all namespaces to `null`), the destination fails to initialize with an unhelpful error:

```
Invariant violation: An incomplete table name mapping was generated.
```

This happens because `.toSet()` silently deduplicates the mapped descriptors, so `names.size < catalog.streams.size` and the `require` check fails. The actual root cause — a namespace mapping collision — is not surfaced to the user.

## How

Before converting the mapped descriptors list to a `Set`, we now explicitly check for duplicates using `groupingBy/eachCount`. If collisions are detected, a `ConfigErrorException` is thrown with a message identifying:
- Which destination descriptor(s) collided
- Which source streams (namespace, name) mapped to each colliding descriptor

The existing `require` check is preserved as a safety net for bugs in `getTableNameMapping`.

## Review guide

1. `airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/command/DestinationCatalog.kt` — the only changed file. Focus on:
   - Whether `ConfigErrorException` (i.e. `config_error` failure type) is correct here. This is a user-config-driven issue (namespace mapping settings) so it seems appropriate.
   - Whether the error message is clear and follows error message conventions. Note: it may exceed 120 chars due to collision details — this is a tradeoff for debuggability.
   - No new unit tests were added for `syncCatalog`. The method currently has no direct unit tests. Worth considering if one should be added.

### Human review checklist

- [ ] Verify `ConfigErrorException` is the right failure type (vs. a `system_error` invariant). The argument: collisions are caused by user namespace-mapping config, so `config_error` seems correct.
- [ ] Check that `namespaceMapper.map()` is safe to re-call during error-message construction (it caches results in `NamespaceMapper`, so this should be fine).
- [ ] Decide whether a unit test for the collision path in `syncCatalog` is needed before merge.

## User Impact

Users whose namespace mapping configuration causes stream name collisions will now see a clear error message identifying the colliding streams, instead of the opaque "Invariant violation" message. This enables them to fix their configuration (e.g., switch from `DESTINATION` to `SOURCE` namespace mode, or remove conflicting streams).

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/17befe2ebb254f33a80ba54ac29e8bb9
Requested by: @gyairbyte
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75910" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
