### PR TITLE
feat(source-gitlab): Re-enable HTTPAPIBudget with concurrency 10 (4.4.23-rc.4)

### DIFF
--- a/airbyte-integrations/connectors/source-gitlab/manifest.yaml
+++ b/airbyte-integrations/connectors/source-gitlab/manifest.yaml
@@ -893,56 +893,56 @@ definitions:
 #   GET /projects/:id/members/all        — 200/min
 #   GET /groups/:id/members/all          — 200/min
 #   All other authenticated API traffic  — 2,000/min
-# api_budget:
-#   type: HTTPAPIBudget
-#   policies:
-#     # Members endpoints: 200 requests/min (most restrictive)
-#     - type: MovingWindowCallRatePolicy
-#       rates:
-#         - limit: 200
-#           interval: PT1M
-#       matchers:
-#         - method: GET
-#           url_path_pattern: "/members"
-#     # GET /groups (list) and /descendant_groups: 200 requests/min
-#     - type: MovingWindowCallRatePolicy
-#       rates:
-#         - limit: 200
-#           interval: PT1M
-#       matchers:
-#         - method: GET
-#           url_path_pattern: "^groups$"
-#     - type: MovingWindowCallRatePolicy
-#       rates:
-#         - limit: 200
-#           interval: PT1M
-#       matchers:
-#         - method: GET
-#           url_path_pattern: "/descendant_groups$"
-#     # GET /groups/:id and GET /projects/:id: 400 requests/min
-#     - type: MovingWindowCallRatePolicy
-#       rates:
-#         - limit: 400
-#           interval: PT1M
-#       matchers:
-#         - method: GET
-#           url_path_pattern: "^groups/[^/]+$"
-#     - type: MovingWindowCallRatePolicy
-#       rates:
-#         - limit: 400
-#           interval: PT1M
-#       matchers:
-#         - method: GET
-#           url_path_pattern: "^projects/[^/]+$"
-#     # Catch-all: 2,000 requests/min for all other authenticated API traffic
-#     - type: MovingWindowCallRatePolicy
-#       rates:
-#         - limit: 2000
-#           interval: PT1M
-#       matchers: []
-#   ratelimit_reset_header: "RateLimit-Reset"
-#   ratelimit_remaining_header: "RateLimit-Remaining"
-#   status_codes_for_ratelimit_hit: [429]
+api_budget:
+  type: HTTPAPIBudget
+  policies:
+    # Members endpoints: 200 requests/min (most restrictive)
+    - type: MovingWindowCallRatePolicy
+      rates:
+        - limit: 200
+          interval: PT1M
+      matchers:
+        - method: GET
+          url_path_pattern: "/members"
+    # GET /groups (list) and /descendant_groups: 200 requests/min
+    - type: MovingWindowCallRatePolicy
+      rates:
+        - limit: 200
+          interval: PT1M
+      matchers:
+        - method: GET
+          url_path_pattern: "^groups$"
+    - type: MovingWindowCallRatePolicy
+      rates:
+        - limit: 200
+          interval: PT1M
+      matchers:
+        - method: GET
+          url_path_pattern: "/descendant_groups$"
+    # GET /groups/:id and GET /projects/:id: 400 requests/min
+    - type: MovingWindowCallRatePolicy
+      rates:
+        - limit: 400
+          interval: PT1M
+      matchers:
+        - method: GET
+          url_path_pattern: "^groups/[^/]+$"
+    - type: MovingWindowCallRatePolicy
+      rates:
+        - limit: 400
+          interval: PT1M
+      matchers:
+        - method: GET
+          url_path_pattern: "^projects/[^/]+$"
+    # Catch-all: 2,000 requests/min for all other authenticated API traffic
+    - type: MovingWindowCallRatePolicy
+      rates:
+        - limit: 2000
+          interval: PT1M
+      matchers: []
+  ratelimit_reset_header: "RateLimit-Reset"
+  ratelimit_remaining_header: "RateLimit-Remaining"
+  status_codes_for_ratelimit_hit: [429]
 
 concurrency_level:
   type: ConcurrencyLevel

--- a/airbyte-integrations/connectors/source-gitlab/metadata.yaml
+++ b/airbyte-integrations/connectors/source-gitlab/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 5e6175e5-68e1-4c17-bff9-56103bbb0d80
-  dockerImageTag: 4.4.23-rc.3
+  dockerImageTag: 4.4.23-rc.4
   dockerRepository: airbyte/source-gitlab
   documentationUrl: https://docs.airbyte.com/integrations/sources/gitlab
   externalDocumentationUrls:

--- a/docs/integrations/sources/gitlab.md
+++ b/docs/integrations/sources/gitlab.md
@@ -135,7 +135,7 @@ The connector silently skips any group, project, or resource that returns an HTT
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                                                            |
 | :------ | :--------- | :------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 4.4.23-rc.4 | 2026-03-31 | [75538](https://github.com/airbytehq/airbyte/pull/75538) | Re-enable HTTPAPIBudget with concurrency 10 for rate limit protection during progressive rollout |
+| 4.4.23-rc.4 | 2026-03-31 | [75915](https://github.com/airbytehq/airbyte/pull/75915) | Re-enable HTTPAPIBudget with concurrency 10 for rate limit protection during progressive rollout |
 | 4.4.23-rc.3 | 2026-03-27 | [75537](https://github.com/airbytehq/airbyte/pull/75537) | Increase default concurrency from 8 to 10 for progressive rollout tuning |
 | 4.4.23-rc.2 | 2026-03-25 | [75480](https://github.com/airbytehq/airbyte/pull/75480) | Comment out HTTPAPIBudget to isolate concurrency tuning during progressive rollout |
 | 4.4.23-rc.1 | 2026-03-09 | [70858](https://github.com/airbytehq/airbyte/pull/70858) | Add HTTPAPIBudget and concurrency_level for improved sync performance |

--- a/docs/integrations/sources/gitlab.md
+++ b/docs/integrations/sources/gitlab.md
@@ -135,6 +135,7 @@ The connector silently skips any group, project, or resource that returns an HTT
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                                                            |
 | :------ | :--------- | :------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 4.4.23-rc.4 | 2026-03-31 | [75538](https://github.com/airbytehq/airbyte/pull/75538) | Re-enable HTTPAPIBudget with concurrency 10 for rate limit protection during progressive rollout |
 | 4.4.23-rc.3 | 2026-03-27 | [75537](https://github.com/airbytehq/airbyte/pull/75537) | Increase default concurrency from 8 to 10 for progressive rollout tuning |
 | 4.4.23-rc.2 | 2026-03-25 | [75480](https://github.com/airbytehq/airbyte/pull/75480) | Comment out HTTPAPIBudget to isolate concurrency tuning during progressive rollout |
 | 4.4.23-rc.1 | 2026-03-09 | [70858](https://github.com/airbytehq/airbyte/pull/70858) | Add HTTPAPIBudget and concurrency_level for improved sync performance |


### PR DESCRIPTION
## What

Re-enable the `HTTPAPIBudget` rate limit configuration for `source-gitlab` alongside `default_concurrency=10`, as the next step in the progressive rollout tuning sequence. Bumps version to `4.4.23-rc.4`.

**Context:** During the rc.3 rollout (concurrency=10, no budget), one connection (Pallon/`d6fef635`) failed 3 consecutive days with HTTP 429 "Too Many Requests" errors. The other 6 daily connections were flat or faster. Re-enabling the budget should prevent rate limit exhaustion while preserving the concurrency gains.

Related: [#15307](https://github.com/airbytehq/airbyte-internal-issues/issues/15307)

## How

1. **`manifest.yaml`**: Uncomments the `api_budget` block (previously commented out in rc.2/[#75480](https://github.com/airbytehq/airbyte/pull/75480)). No changes to the rate limit values or matchers themselves — identical to the original rc.1 config.
2. **`metadata.yaml`**: Bumps `dockerImageTag` from `4.4.23-rc.3` → `4.4.23-rc.4`.
3. **`gitlab.md`**: Adds changelog entry.

## Review guide

1. `airbyte-integrations/connectors/source-gitlab/manifest.yaml` — Verify the uncommented YAML matches the original rc.1 budget config (no accidental edits to rate limits, matchers, or indentation). Note that `default_concurrency` remains at 10 (unchanged from rc.3).
2. `airbyte-integrations/connectors/source-gitlab/metadata.yaml` — Version bump only.
3. `docs/integrations/sources/gitlab.md` — Changelog entry.

### Human review checklist
- [ ] Uncommented `api_budget` block indentation is correct (2-space YAML) and structure matches the [original rc.1 config](https://github.com/airbytehq/airbyte/pull/70858)
- [ ] No stray edits outside the `api_budget` block (the `concurrency_level` section should be untouched)

## User Impact

Connections pinned to rc.4 will have both concurrency=10 and API rate limit protection. This should eliminate the 429 failures seen on rc.3 for rate-limited GitLab instances while maintaining the ~7% performance improvement over rc.2 observed for non-rate-limited connections.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/4462c8953c3c483084a62a7240f6973f
Requested by: @sophiecuiy