### PR TITLE
fix(ci): use correct CLI command name for progressive rollout operations

### DIFF
--- a/.github/workflows/finalize_rollout.yml
+++ b/.github/workflows/finalize_rollout.yml
@@ -58,7 +58,7 @@ jobs:
           GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
           REGISTRY_STORE: "coral:prod"
         run: >
-          airbyte-ops registry rc cleanup
+          airbyte-ops registry progressive-rollout cleanup
           --name "${CONNECTOR_NAME}"
           --store "${REGISTRY_STORE}"
 

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -443,7 +443,7 @@ jobs:
         run: |
           echo "Creating RC metadata marker for ${{ matrix.connector }}"
           airbyte-ops \
-            registry rc create \
+            registry progressive-rollout create \
             --name "${{ matrix.connector }}" \
             --store "${REGISTRY_STORE}"
 


### PR DESCRIPTION
## What

Fixes the CLI command name used in `publish_connectors.yml` and `finalize_rollout.yml` for progressive rollout GCS operations. The ops CLI uses `registry progressive-rollout create/cleanup`, but both workflows were calling `registry rc create/cleanup`, which doesn't exist.

This caused the publish workflow to fail at "Create RC metadata marker" when publishing `source-faker` 7.1.0-rc.1: [failed run](https://github.com/airbytehq/airbyte/actions/runs/23815919205).

## How

Renamed:
- `registry rc create` → `registry progressive-rollout create` (in `publish_connectors.yml`)
- `registry rc cleanup` → `registry progressive-rollout cleanup` (in `finalize_rollout.yml`)

## Review guide

1. `.github/workflows/publish_connectors.yml` — one-line command rename
2. `.github/workflows/finalize_rollout.yml` — one-line command rename

Verify that `progressive-rollout` is the correct subcommand group name in the published `airbyte-internal-ops` package (`airbyte-ops registry --help`).

## User Impact

RC connector publishes will no longer fail at the metadata marker step. The finalize rollout workflow (promote/rollback) will correctly clean up GCS markers.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/fa9a671420024a6d9de68563cd5a1951
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75916" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
