### PR TITLE
ci(connectors): fix error handling in connectors_up_to_date matrix generation

### DIFF
--- a/.github/workflows/connectors_up_to_date.yml
+++ b/.github/workflows/connectors_up_to_date.yml
@@ -13,7 +13,7 @@ on:
         description: >-
           Override: pass these flags directly to `airbyte-ops local connector list`
           instead of the default source/destination selection.
-          Examples: `--connector-name=source-github` (one connector),
+          Examples: `--connectors-filter=source-github` (one connector),
           `--connectors-filter=source-github,source-stripe` (multiple by name),
           `--certified-only --connector-type=destination` (custom query).
         default: ""

--- a/.github/workflows/connectors_up_to_date.yml
+++ b/.github/workflows/connectors_up_to_date.yml
@@ -13,7 +13,7 @@ on:
         description: >-
           Override: pass these flags directly to `airbyte-ops local connector list`
           instead of the default source/destination selection.
-          Examples: `--name=source-github` (one connector),
+          Examples: `--connector-name=source-github` (one connector),
           `--connectors-filter=source-github,source-stripe` (multiple by name),
           `--certified-only --connector-type=destination` (custom query).
         default: ""
@@ -45,12 +45,13 @@ jobs:
         env:
           CONNECTOR_OPTIONS: ${{ github.event.inputs.connectors-options }}
         run: |
-          echo "generated_matrix=$( \
+          MATRIX=$(
             airbyte-ops local connector list \
               --repo-path "$GITHUB_WORKSPACE" \
               $CONNECTOR_OPTIONS \
-              --output-format=json-gh-matrix \
-          )" | tee -a $GITHUB_OUTPUT
+              --output-format=json-gh-matrix
+          )
+          echo "generated_matrix=$MATRIX" | tee -a $GITHUB_OUTPUT
 
       # Default path — Call 1: Sources (all support levels)
       - name: List source connectors
@@ -65,6 +66,7 @@ jobs:
               --exclude-connectors=source-declarative-manifest \
               --output-format=csv
           )
+          echo "Sources: $SOURCES"
           echo "sources=$SOURCES" | tee -a $GITHUB_OUTPUT
 
       # Default path — Call 2: Destinations (certified only)
@@ -80,6 +82,7 @@ jobs:
               --language python --language low-code --language manifest-only \
               --output-format=csv
           )
+          echo "Destinations: $DESTINATIONS"
           echo "destinations=$DESTINATIONS" | tee -a $GITHUB_OUTPUT
 
       # Default path — Call 3: Combine both sets into GH Actions matrix
@@ -87,21 +90,27 @@ jobs:
         id: list-default
         if: github.event.inputs.connectors-options == '' || github.event_name == 'schedule'
         run: |
-          echo "generated_matrix=$( \
+          MATRIX=$(
             airbyte-ops local connector list \
               --repo-path "$GITHUB_WORKSPACE" \
               --connectors-filter="${{ steps.list-sources.outputs.sources }},${{ steps.list-destinations.outputs.destinations }}" \
-              --output-format=json-gh-matrix \
-          )" | tee -a $GITHUB_OUTPUT
+              --output-format=json-gh-matrix
+          )
+          echo "generated_matrix=$MATRIX" | tee -a $GITHUB_OUTPUT
 
-      # Merge: pick whichever path ran
+      # Merge: pick whichever path ran, and validate non-empty
       - name: Set final matrix output
         id: generate_matrix
         env:
           OVERRIDE_MATRIX: ${{ steps.list-override.outputs.generated_matrix }}
           DEFAULT_MATRIX: ${{ steps.list-default.outputs.generated_matrix }}
         run: |
-          echo "generated_matrix=${OVERRIDE_MATRIX:-$DEFAULT_MATRIX}" | tee -a $GITHUB_OUTPUT
+          FINAL_MATRIX="${OVERRIDE_MATRIX:-$DEFAULT_MATRIX}"
+          if [ -z "$FINAL_MATRIX" ]; then
+            echo "::error::Matrix generation produced empty output. Check CLI commands above for errors."
+            exit 1
+          fi
+          echo "generated_matrix=$FINAL_MATRIX" | tee -a $GITHUB_OUTPUT
 
   run_connectors_up_to_date:
     needs: generate_matrix


### PR DESCRIPTION
## What

Fixes a bug where CLI errors in the `connectors_up_to_date` workflow's matrix generation were silently swallowed, producing an empty matrix and a misleading "success" on the generate_matrix job while the downstream matrix job silently skipped.

Also fixes incorrect `--name` flag in the workflow input description (should be `--connectors-filter`), discovered during the first live test of the workflow.

## How

1. **Error propagation**: Refactored CLI calls from inline command substitution inside `echo` (`echo "key=$(cmd)"`) to separate variable assignment (`VAR=$(cmd)`) followed by `echo "key=$VAR"`. When `cmd` fails, `set -e` (GitHub Actions default) now correctly fails the step instead of the `echo` swallowing the exit code.

2. **Empty matrix guard**: Added an explicit check in the "Set final matrix output" step that fails with `::error::` annotation if the final matrix is empty. This is defense-in-depth in case a future refactor accidentally re-introduces the swallowed-exit-code pattern.

3. **Flag name fix**: `--name=source-github` → `--connectors-filter=source-github` in the `connectors-options` input description. The `list` subcommand uses `--connectors-filter` for name-based filtering (not `--name`, which is only on `bump-*` subcommands).

4. **Logging**: Added `echo "Sources: ..."` and `echo "Destinations: ..."` lines for visibility in default-path runs.

## Review guide

1. `.github/workflows/connectors_up_to_date.yml` — single file change. Focus on:
   - Lines 48-54: override path error propagation
   - Lines 93-99: default path error propagation
   - Lines 107-113: empty matrix validation guard
   - Line 16: `--connectors-filter` flag fix

### Human review checklist
- [ ] Confirm `set -e` is indeed the default shell behavior for GitHub Actions `run` steps (it is — [docs](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell)). This is what makes the variable-assignment pattern propagate failures.
- [ ] The `$CONNECTOR_OPTIONS` on line 51 is intentionally unquoted to allow word-splitting of multi-flag inputs like `--certified-only --connector-type=destination`. Verify this is acceptable for expected input patterns.

## User Impact

- Workflow failures due to invalid CLI flags will now correctly fail the `generate_matrix` job instead of silently producing an empty matrix.
- Workflow input description now shows the correct flag name (`--connectors-filter`).

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/fac9d893990a479d897e6be184945942
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75917" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
