### PR TITLE
ci(connectors): fix multiline JSON matrix output in connectors_up_to_date

### DIFF
--- a/.github/workflows/connectors_up_to_date.yml
+++ b/.github/workflows/connectors_up_to_date.yml
@@ -51,7 +51,11 @@ jobs:
               $CONNECTOR_OPTIONS \
               --output-format=json-gh-matrix
           )
-          echo "generated_matrix=$MATRIX" | tee -a $GITHUB_OUTPUT
+          echo "Matrix: $MATRIX"
+          # Use heredoc delimiter for multiline JSON
+          echo "generated_matrix<<MATRIX_EOF" >> $GITHUB_OUTPUT
+          echo "$MATRIX" >> $GITHUB_OUTPUT
+          echo "MATRIX_EOF" >> $GITHUB_OUTPUT
 
       # Default path — Call 1: Sources (all support levels)
       - name: List source connectors
@@ -96,7 +100,11 @@ jobs:
               --connectors-filter="${{ steps.list-sources.outputs.sources }},${{ steps.list-destinations.outputs.destinations }}" \
               --output-format=json-gh-matrix
           )
-          echo "generated_matrix=$MATRIX" | tee -a $GITHUB_OUTPUT
+          echo "Matrix: $MATRIX"
+          # Use heredoc delimiter for multiline JSON
+          echo "generated_matrix<<MATRIX_EOF" >> $GITHUB_OUTPUT
+          echo "$MATRIX" >> $GITHUB_OUTPUT
+          echo "MATRIX_EOF" >> $GITHUB_OUTPUT
 
       # Merge: pick whichever path ran, and validate non-empty
       - name: Set final matrix output
@@ -110,7 +118,11 @@ jobs:
             echo "::error::Matrix generation produced empty output. Check CLI commands above for errors."
             exit 1
           fi
-          echo "generated_matrix=$FINAL_MATRIX" | tee -a $GITHUB_OUTPUT
+          echo "Final matrix: $FINAL_MATRIX"
+          # Use heredoc delimiter for multiline JSON
+          echo "generated_matrix<<MATRIX_EOF" >> $GITHUB_OUTPUT
+          echo "$FINAL_MATRIX" >> $GITHUB_OUTPUT
+          echo "MATRIX_EOF" >> $GITHUB_OUTPUT
 
   run_connectors_up_to_date:
     needs: generate_matrix


### PR DESCRIPTION
## What

Fixes `connectors_up_to_date` workflow failing at matrix generation because the `json-gh-matrix` CLI output is pretty-printed (multiline) JSON, which breaks `$GITHUB_OUTPUT`'s `key=value` single-line format.

Discovered during live testing on `source-github` — the CLI correctly found the connector but GitHub Actions rejected the multiline value:
```
##[error]Unable to process file command 'output' successfully.
##[error]Invalid format '  "include": ['
```

## How

Replaced `echo "generated_matrix=$MATRIX" | tee -a $GITHUB_OUTPUT` with the [heredoc delimiter pattern](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#multiline-strings) for multiline output values in all three matrix-producing steps. Added explicit `echo` logging before each heredoc block to maintain step output visibility (previously provided by `tee`).

## Review guide

1. `.github/workflows/connectors_up_to_date.yml` — all changes are in the `generate_matrix` job. Three identical substitutions:
   - Line ~54: override path
   - Line ~103: default path (combine sources + destinations)
   - Line ~121: final merge step

### Things to verify
- [ ] The heredoc delimiter `MATRIX_EOF` won't collide with JSON content (it won't — no connector metadata contains this string)
- [ ] Logging is still adequate now that `tee -a` is replaced with separate `echo` + `>>` (the explicit `echo "Matrix: ..."` line provides equivalent visibility)

## User Impact

The `connectors_up_to_date` workflow will now successfully pass the matrix to the downstream job instead of failing at output parsing.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/fac9d893990a479d897e6be184945942
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75918" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
