### PR TITLE
ci(connectors): use admin bot for PR approval in connectors_up_to_date

### DIFF
--- a/.github/workflows/connectors_up_to_date.yml
+++ b/.github/workflows/connectors_up_to_date.yml
@@ -271,7 +271,15 @@ jobs:
           PR_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
         run: gh pr ready "$PR_NUMBER"
 
-      # --- Step 9: Apply bot approval ---
+      # --- Step 9: Enable auto-merge ---
+      - name: Enable auto-merge on PR
+        if: steps.check-changes.outputs.has_changes == 'true'
+        env:
+          GH_TOKEN: ${{ steps.get-app-token.outputs.token }}
+          PR_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
+        run: gh pr merge "$PR_NUMBER" --squash --auto
+
+      # --- Step 10: Apply bot approval ---
       # Use a different bot identity (admin) to approve, because the hoard bot
       # that created the PR cannot approve its own PRs.
       - name: Authenticate as 'octavia-bot-admin' GitHub App
@@ -291,11 +299,3 @@ jobs:
           GH_TOKEN: ${{ steps.get-admin-token.outputs.token }}
           PR_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
         run: gh pr review "$PR_NUMBER" --approve --body "Auto-approved by connectors up-to-date workflow."
-
-      # --- Step 10: Enable auto-merge ---
-      - name: Enable auto-merge on PR
-        if: steps.check-changes.outputs.has_changes == 'true'
-        env:
-          GH_TOKEN: ${{ steps.get-app-token.outputs.token }}
-          PR_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
-        run: gh pr merge "$PR_NUMBER" --squash --auto

--- a/.github/workflows/connectors_up_to_date.yml
+++ b/.github/workflows/connectors_up_to_date.yml
@@ -272,11 +272,23 @@ jobs:
         run: gh pr ready "$PR_NUMBER"
 
       # --- Step 9: Apply bot approval ---
+      # Use a different bot identity (admin) to approve, because the hoard bot
+      # that created the PR cannot approve its own PRs.
+      - name: Authenticate as 'octavia-bot-admin' GitHub App
+        if: steps.check-changes.outputs.has_changes == 'true'
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        id: get-admin-token
+        with:
+          owner: "airbytehq"
+          repositories: ${{ inputs.repo || github.event.repository.name }}
+          app-id: ${{ secrets.OCTAVIA_BOT_ADMIN_APP_ID }}
+          private-key: ${{ secrets.OCTAVIA_BOT_ADMIN_PRIVATE_KEY }}
+
       - name: Apply bot approval
         if: steps.check-changes.outputs.has_changes == 'true'
         continue-on-error: true
         env:
-          GH_TOKEN: ${{ steps.get-app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.get-admin-token.outputs.token }}
           PR_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
         run: gh pr review "$PR_NUMBER" --approve --body "Auto-approved by connectors up-to-date workflow."
 


### PR DESCRIPTION
## What

Fixes the "you cannot approve your own PRs" error in the `connectors_up_to_date` workflow's bot approval step. The `octavia-bot-hoard` identity creates the PR and was also being used to approve it, which GitHub rejects.

## How

Adds a separate `actions/create-github-app-token` step that authenticates as `octavia-bot-admin` (a different bot identity), and uses that admin token exclusively for the `gh pr review --approve` call. All other steps (PR creation, push, auto-merge) continue using the `octavia-bot-hoard` token.

Also reorders the final steps so that auto-merge is enabled (step 9) _before_ retrieving admin bot credentials and applying the approval (step 10). This way the cheaper/faster auto-merge call happens first, and the extra token fetch only happens afterward.

## Review guide

1. `.github/workflows/connectors_up_to_date.yml` — the only file changed.
   - Step 9 (formerly 10): `Enable auto-merge on PR` — moved up, still uses `get-app-token` (hoard bot)
   - Step 10 (formerly 9): New `Authenticate as 'octavia-bot-admin'` token step + `Apply bot approval` — now last, uses `get-admin-token`

### Things to verify
- [ ] `OCTAVIA_BOT_ADMIN_APP_ID` and `OCTAVIA_BOT_ADMIN_PRIVATE_KEY` secrets exist in the repo (they do — `force-merge-command.yml` already uses them)
- [ ] The admin bot has permission to approve PRs on this repo
- [ ] `continue-on-error: true` is still present on the approval step as a safety net

## User Impact

The `connectors_up_to_date` workflow will now successfully auto-approve its generated dependency update PRs, unblocking auto-merge.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/fac9d893990a479d897e6be184945942
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75920" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
