### PR TITLE
ci(connectors): add step summary with PR links and no-op notes to connectors_up_to_date

### DIFF
--- a/.github/workflows/connectors_up_to_date.yml
+++ b/.github/workflows/connectors_up_to_date.yml
@@ -312,6 +312,8 @@ jobs:
           if [ "$HAS_CHANGES" = "true" ] && [ -n "$PR_URL" ]; then
             echo "### ✅ \`$CONNECTOR_NAME\` — PR created" >> $GITHUB_STEP_SUMMARY
             echo "- **PR:** [#${PR_NUMBER}](${PR_URL})" >> $GITHUB_STEP_SUMMARY
+          elif [ "$HAS_CHANGES" = "true" ]; then
+            echo "### ❌ \`$CONNECTOR_NAME\` — changes detected but PR creation failed" >> $GITHUB_STEP_SUMMARY
           else
             echo "### ⏭️ \`$CONNECTOR_NAME\` — no changes (no-op)" >> $GITHUB_STEP_SUMMARY
           fi

--- a/.github/workflows/connectors_up_to_date.yml
+++ b/.github/workflows/connectors_up_to_date.yml
@@ -210,6 +210,7 @@ jobs:
           else
             echo "has_changes=true" >> $GITHUB_OUTPUT
             echo "Changes detected for $CONNECTOR_NAME"
+            git diff --stat
           fi
 
       # --- Step 5: Create or update PR ---
@@ -299,3 +300,18 @@ jobs:
           GH_TOKEN: ${{ steps.get-admin-token.outputs.token }}
           PR_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
         run: gh pr review "$PR_NUMBER" --approve --body "Auto-approved by connectors up-to-date workflow."
+
+      # --- Step 11: Write job summary ---
+      - name: Write step summary
+        if: always()
+        env:
+          PR_URL: ${{ steps.create-pr.outputs.pull-request-url }}
+          PR_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
+          HAS_CHANGES: ${{ steps.check-changes.outputs.has_changes }}
+        run: |
+          if [ "$HAS_CHANGES" = "true" ] && [ -n "$PR_URL" ]; then
+            echo "### ✅ \`$CONNECTOR_NAME\` — PR created" >> $GITHUB_STEP_SUMMARY
+            echo "- **PR:** [#${PR_NUMBER}](${PR_URL})" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "### ⏭️ \`$CONNECTOR_NAME\` — no changes (no-op)" >> $GITHUB_STEP_SUMMARY
+          fi


### PR DESCRIPTION
## What

Adds a GitHub Actions [step summary](https://github.blog/2022-05-09-supercharging-github-actions-with-job-summaries/) to the `connectors_up_to_date` workflow so each matrix job reports whether it created a PR, failed, or was a no-op. Also adds `git diff --stat` output when changes are detected for better log visibility.

## How

- New final step (`Write step summary`, `if: always()`) appends to `$GITHUB_STEP_SUMMARY` with three branches:
  - **✅ PR created**: connector name + clickable PR link
  - **❌ Failed**: connector name + "changes detected but PR creation failed" (when `has_changes=true` but no PR URL)
  - **⏭️ No-op**: connector name + "no changes" note
- Added `git diff --stat` in the "Check for changes" step so the log shows which files were modified before PR creation.

## Review guide

1. `.github/workflows/connectors_up_to_date.yml` — only file changed.

Things to verify:
- [ ] If the job fails _before_ the `check-changes` step, `HAS_CHANGES` will be empty and the summary will show "no-op" rather than "failed". Acceptable tradeoff since this is a rare edge case, or worth adding a fourth branch checking `job.status`?
- [ ] `CONNECTOR_NAME` (job-level env) is accessible in the `always()` step.

## User Impact

Workflow run summary pages now show a per-connector table of PR links, failures, and no-ops, making it easy to see results at a glance instead of drilling into individual job logs.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/fac9d893990a479d897e6be184945942
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75924" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
