### PR TITLE
ci(connectors): use structured CLI output instead of git diff for change detection

### DIFF
--- a/.github/workflows/connectors_up_to_date.yml
+++ b/.github/workflows/connectors_up_to_date.yml
@@ -188,29 +188,48 @@ jobs:
 
       # --- Step 2: Bump dependencies (CDK + external) ---
       - name: Bump dependencies
+        id: bump-deps
         run: |
-          airbyte-ops local connector bump-deps \
-            --name "$CONNECTOR_NAME" \
-            --repo-path "$GITHUB_WORKSPACE"
+          BUMP_DEPS_OUTPUT=$(
+            airbyte-ops local connector bump-deps \
+              --name "$CONNECTOR_NAME" \
+              --repo-path "$GITHUB_WORKSPACE"
+          )
+          echo "$BUMP_DEPS_OUTPUT"
+          DEPS_UPDATED=$(echo "$BUMP_DEPS_OUTPUT" | jq -r '.updated')
+          echo "updated=$DEPS_UPDATED" | tee -a $GITHUB_OUTPUT
 
       # --- Step 3: Update base image ---
       - name: Update base image in metadata.yaml
+        id: bump-base-image
         run: |
-          airbyte-ops local connector bump-base-image \
-            --name "$CONNECTOR_NAME" \
-            --repo-path "$GITHUB_WORKSPACE"
+          BUMP_IMAGE_OUTPUT=$(
+            airbyte-ops local connector bump-base-image \
+              --name "$CONNECTOR_NAME" \
+              --repo-path "$GITHUB_WORKSPACE"
+          )
+          echo "$BUMP_IMAGE_OUTPUT"
+          IMAGE_UPDATED=$(echo "$BUMP_IMAGE_OUTPUT" | jq -r '.updated')
+          echo "updated=$IMAGE_UPDATED" | tee -a $GITHUB_OUTPUT
 
       # --- Step 4: Check for changes ---
+      # Use structured output from CLI commands instead of git diff to avoid
+      # false positives from Poetry lock file reformatting across versions.
       - name: Check for changes
         id: check-changes
+        env:
+          DEPS_UPDATED: ${{ steps.bump-deps.outputs.updated }}
+          IMAGE_UPDATED: ${{ steps.bump-base-image.outputs.updated }}
         run: |
-          if git diff --quiet; then
-            echo "has_changes=false" >> $GITHUB_OUTPUT
-            echo "No changes detected for $CONNECTOR_NAME"
-          else
+          echo "bump-deps updated: $DEPS_UPDATED"
+          echo "bump-base-image updated: $IMAGE_UPDATED"
+          if [ "$DEPS_UPDATED" = "true" ] || [ "$IMAGE_UPDATED" = "true" ]; then
             echo "has_changes=true" >> $GITHUB_OUTPUT
             echo "Changes detected for $CONNECTOR_NAME"
             git diff --stat
+          else
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+            echo "No changes detected for $CONNECTOR_NAME (CLI reports no updates)"
           fi
 
       # --- Step 5: Create or update PR ---
@@ -308,10 +327,14 @@ jobs:
           PR_URL: ${{ steps.create-pr.outputs.pull-request-url }}
           PR_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
           HAS_CHANGES: ${{ steps.check-changes.outputs.has_changes }}
+          DEPS_UPDATED: ${{ steps.bump-deps.outputs.updated }}
+          IMAGE_UPDATED: ${{ steps.bump-base-image.outputs.updated }}
         run: |
           if [ "$HAS_CHANGES" = "true" ] && [ -n "$PR_URL" ]; then
             echo "### ✅ \`$CONNECTOR_NAME\` — PR created" >> $GITHUB_STEP_SUMMARY
             echo "- **PR:** [#${PR_NUMBER}](${PR_URL})" >> $GITHUB_STEP_SUMMARY
+            [ "$DEPS_UPDATED" = "true" ] && echo "- Dependencies updated" >> $GITHUB_STEP_SUMMARY
+            [ "$IMAGE_UPDATED" = "true" ] && echo "- Base image updated" >> $GITHUB_STEP_SUMMARY
           elif [ "$HAS_CHANGES" = "true" ]; then
             echo "### ❌ \`$CONNECTOR_NAME\` — changes detected but PR creation failed" >> $GITHUB_STEP_SUMMARY
           else


### PR DESCRIPTION
## What

Resolves [airbytehq/airbyte-ops-mcp#657](https://github.com/airbytehq/airbyte-ops-mcp/issues/657).

Replaces `git diff --quiet` with structured JSON output from `bump-deps` and `bump-base-image` CLI commands to determine whether a PR should be created. The old approach produced false positives when different Poetry versions reformatted `poetry.lock` without actually changing any dependencies.

## How

- Captures JSON stdout from `airbyte-ops local connector bump-deps` and `bump-base-image`, extracts the `.updated` boolean via `jq`, and exports it as a step output.
- The "Check for changes" step now checks `steps.bump-deps.outputs.updated` / `steps.bump-base-image.outputs.updated` instead of `git diff --quiet`.
- Step summary now includes which update types occurred (deps, base image, or both).

## Review guide

1. `.github/workflows/connectors_up_to_date.yml` — only file changed.

Things to verify:
- [ ] **`jq` availability on `connector-up-to-date-medium` runners.** If `jq` is not installed on these custom runners, both bump steps will fail.
- [ ] **CLI stdout cleanliness.** The `jq` parse assumes the *entire* stdout from each CLI command is valid JSON. If either command prints warnings, progress messages, or Rich formatting to stdout (not stderr), `jq` will fail. Both commands currently use `print_json()` which writes to stdout, but verify no other stdout writes exist.
- [ ] **No git-diff fallback.** This intentionally removes the `git diff` safety net. If a CLI bug causes `updated: false` when files *were* changed, no PR is created. Acceptable tradeoff or worth keeping a `git diff` as a secondary check?

## User Impact

Fewer noisy no-change PRs when Poetry reformats `poetry.lock` without bumping any actual dependencies. Step summary now shows exactly what was updated per connector.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/fac9d893990a479d897e6be184945942
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75925" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
