### PR TITLE
test: progressive rollout e2e test — bump source-faker to RC2 (7.1.0-rc.2)

### DIFF
--- a/airbyte-integrations/connectors/source-faker/metadata.yaml
+++ b/airbyte-integrations/connectors/source-faker/metadata.yaml
@@ -9,7 +9,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: dfd88b22-b603-4c3d-aad7-3701784586b1
-  dockerImageTag: 7.1.0-rc.1
+  dockerImageTag: 7.1.0-rc.2
   dockerRepository: airbyte/source-faker
   documentationUrl: https://docs.airbyte.com/integrations/sources/faker
   externalDocumentationUrls:

--- a/airbyte-integrations/connectors/source-faker/pyproject.toml
+++ b/airbyte-integrations/connectors/source-faker/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "7.1.0-rc.1"
+version = "7.1.0-rc.2"
 name = "source-faker"
 description = "Source implementation for fake but realistic looking data."
 authors = [ "Airbyte <evan@airbyte.io>",]


### PR DESCRIPTION
## What

Bumps source-faker from `7.1.0-rc.1` to `7.1.0-rc.2` as part of the progressive rollout end-to-end test. RC1 was canceled in Phase 2; this creates RC2 to test the promote (succeeded) flow in Phase 4.

This is a **test-only PR** — no functional connector changes.

## How

Version bump in two files:
- `metadata.yaml`: `dockerImageTag` → `7.1.0-rc.2`
- `pyproject.toml`: `version` → `7.1.0-rc.2`

`registryOverrides` remain pinned to `7.0.4` (previous GA), and `enableProgressiveRollout: true` is already set from the RC1 bump.

## Review guide

1. `airbyte-integrations/connectors/source-faker/metadata.yaml` — version bump only
2. `airbyte-integrations/connectors/source-faker/pyproject.toml` — version bump only

Verify that `registryOverrides.cloud.dockerImageTag` and `registryOverrides.oss.dockerImageTag` are still `7.0.4` (not shown in diff because they're unchanged — they were set during the RC1 bump).

## User Impact

None. source-faker is a test/sample connector. This RC will be promoted back to GA as part of the e2e test cleanup.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/fa9a671420024a6d9de68563cd5a1951
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75926" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
