### PR TITLE
fix(connectors): prevent step summary exit code 1 from short-circuit evaluation

### DIFF
--- a/.github/workflows/connectors_up_to_date.yml
+++ b/.github/workflows/connectors_up_to_date.yml
@@ -338,8 +338,8 @@ jobs:
           if [ "$HAS_CHANGES" = "true" ] && [ -n "$PR_URL" ]; then
             echo "### ✅ \`$CONNECTOR_NAME\` — PR created" >> $GITHUB_STEP_SUMMARY
             echo "- **PR:** [#${PR_NUMBER}](${PR_URL})" >> $GITHUB_STEP_SUMMARY
-            [ "$DEPS_UPDATED" = "true" ] && echo "- Dependencies updated: $OUTDATED_PKGS" >> $GITHUB_STEP_SUMMARY
-            [ "$IMAGE_UPDATED" = "true" ] && echo "- Base image updated" >> $GITHUB_STEP_SUMMARY
+            [ "$DEPS_UPDATED" = "true" ] && echo "- Dependencies updated: $OUTDATED_PKGS" >> $GITHUB_STEP_SUMMARY || true
+            [ "$IMAGE_UPDATED" = "true" ] && echo "- Base image updated" >> $GITHUB_STEP_SUMMARY || true
           elif [ "$HAS_CHANGES" = "true" ]; then
             echo "### ❌ \`$CONNECTOR_NAME\` — changes detected but PR creation failed" >> $GITHUB_STEP_SUMMARY
           else


### PR DESCRIPTION
## What

Fixes the `connectors_up_to_date` workflow failing at the "Write step summary" step due to bash `set -e` interacting with the `[ ... ] && echo` pattern.

Observed in workflow run: https://github.com/airbytehq/airbyte/actions/runs/23820304083 — the source-github job completed all substantive work (deps bumped, PR created) but the job was marked as failed because the step summary step exited with code 1.

## How

When `IMAGE_UPDATED` or `DEPS_UPDATED` is `"false"`, the `[ "$VAR" = "true" ]` test returns exit code 1. Under GitHub Actions' default `set -e`, the `&&` short-circuit propagates that exit code and kills the step.

Appending `|| true` ensures the expression always returns exit code 0 regardless of the condition result.

## Review guide

1. `.github/workflows/connectors_up_to_date.yml` — two lines changed (lines 341–342)

**Key thing to verify:** The `A && B || true` pattern will also swallow failures from `B` (the `echo >>` command). This is acceptable here since `echo >> $GITHUB_STEP_SUMMARY` failing is not actionable, but worth noting.

## User Impact

The workflow will no longer spuriously fail when only one of deps/base-image was updated. No functional change — only the step summary reporting is affected.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/fac9d893990a479d897e6be184945942
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75931" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
