### PR TITLE
fix(ci): add checkout step to finalize_rollout rc-cleanup job

### DIFF
--- a/.github/workflows/finalize_rollout.yml
+++ b/.github/workflows/finalize_rollout.yml
@@ -44,6 +44,13 @@ jobs:
           fi
         shell: bash
 
+      # The cleanup CLI reads metadata.yaml from the local repo to
+      # resolve the connector's dockerRepository.
+      - name: Checkout Airbyte repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
       - name: Install uv
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
 


### PR DESCRIPTION
## What

The `rc-registry-cleanup` job in `finalize_rollout.yml` fails with `FileNotFoundError` because the Airbyte repo is not checked out before the CLI runs.

```
FileNotFoundError: Connector directory not found:
  /home/runner/work/airbyte/airbyte/airbyte-integrations/connectors/source-faker
```

Failed run: https://github.com/airbytehq/airbyte/actions/runs/23821424648

## How

Added a `checkout@v4` step (with `fetch-depth: 1`) to the `rc-registry-cleanup` job, before the CLI is invoked. The `progressive-rollout cleanup` command calls `get_connector_metadata()` which reads `metadata.yaml` from disk to resolve `dockerRepository`.

Job 2 (`create-promotion-pr`) already had a checkout step; Job 1 was missing one.

## Review guide

1. `.github/workflows/finalize_rollout.yml` — the only change. Verify the checkout step is positioned correctly (after validation, before CLI install/invocation) and uses default token (read-only access is sufficient for this job).

**Note:** A deeper fix would be to make the ops CLI's `progressive-rollout cleanup` command not require local repo access at all (it could derive `docker_repo` from the connector name convention). That's tracked separately in the ops repo.

## User Impact

Unblocks the `finalize_rollout.yml` workflow for all connector progressive rollouts (both promote and rollback). Without this fix, every finalization dispatched by the platform fails at the "Delete RC metadata marker" step.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/fa9a671420024a6d9de68563cd5a1951
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75934" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
