### PR TITLE
fix(ci): use admin bot for approval and force-merge in finalize_rollout

### DIFF
--- a/.github/workflows/finalize_rollout.yml
+++ b/.github/workflows/finalize_rollout.yml
@@ -218,10 +218,33 @@ jobs:
           GH_TOKEN: ${{ steps.get-app-token.outputs.token }}
         run: gh pr ready "${{ steps.create-pr.outputs.pull-request-number }}"
 
+      # Use a different bot identity (admin) to approve and merge,
+      # because the bot that created the PR cannot approve its own PRs
+      # and needs admin privileges to bypass branch protection.
+      - name: Authenticate as GitHub App (Admin)
+        if: steps.create-pr.outputs.pull-request-number
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        id: get-admin-token
+        with:
+          owner: "airbytehq"
+          repositories: "airbyte"
+          app-id: ${{ secrets.OCTAVIA_BOT_ADMIN_APP_ID }}
+          private-key: ${{ secrets.OCTAVIA_BOT_ADMIN_PRIVATE_KEY }}
+
+      - name: Approve cleanup PR
+        if: steps.create-pr.outputs.pull-request-number
+        env:
+          GH_TOKEN: ${{ steps.get-admin-token.outputs.token }}
+        run: >
+          gh pr review "${{ steps.create-pr.outputs.pull-request-number }}"
+          --repo "${{ github.repository }}"
+          --approve
+          --body "Auto-approved by finalize_rollout workflow."
+
       - name: Force-merge cleanup PR
         if: steps.create-pr.outputs.pull-request-number
         env:
-          GH_TOKEN: ${{ steps.get-app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.get-admin-token.outputs.token }}
         run: |
           gh pr merge "${{ steps.create-pr.outputs.pull-request-number }}" \
             --repo "${{ github.repository }}" \


### PR DESCRIPTION
## What

The `finalize_rollout.yml` workflow's "Force-merge cleanup PR" step fails because the regular Octavia bot (`OCTAVIA_BOT_APP_ID`) cannot bypass branch protection rules (requires approving review + passing status checks).

Observed failure on [run 23822486442](https://github.com/airbytehq/airbyte/actions/runs/23822486442):
```
GraphQL: Repository rule violations found
At least 1 approving review is required by reviewers with write access.
7 of 7 required status checks have not succeeded: 4 expected.
```

## How

Follows the established pattern from `connectors_up_to_date.yml` and `force-merge-command.yml`:

1. Adds a second authentication step using `OCTAVIA_BOT_ADMIN_APP_ID` / `OCTAVIA_BOT_ADMIN_PRIVATE_KEY` (the admin bot identity).
2. Adds an "Approve cleanup PR" step using the admin token — necessary because the bot that *created* the PR cannot approve its own PR.
3. Switches the "Force-merge cleanup PR" step from the regular bot token to the admin bot token, so `--admin` actually works.

## Review guide

1. `.github/workflows/finalize_rollout.yml` — only file changed. Three new steps inserted between "Mark PR ready for review" and "Force-merge cleanup PR".

Key things to verify:
- The `OCTAVIA_BOT_ADMIN_*` secrets are the same ones already used by [`force-merge-command.yml`](https://github.com/airbytehq/airbyte/blob/master/.github/workflows/force-merge-command.yml#L51-L52) and [`connectors_up_to_date.yml`](https://github.com/airbytehq/airbyte/blob/master/.github/workflows/connectors_up_to_date.yml#L316-L317).
- The approval step runs *before* the merge step.
- All three new steps share the same `if` guard as the existing steps.

## User Impact

Connector progressive rollout promotions will auto-merge their cleanup PRs instead of failing at the force-merge step. No user-facing behavior change — this is CI-only.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/fa9a671420024a6d9de68563cd5a1951
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75937" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
