### PR TITLE
docs: remove deprecated airbyte-ci references from local-connector-development.md

### DIFF
--- a/docs/platform/connector-development/local-connector-development.md
+++ b/docs/platform/connector-development/local-connector-development.md
@@ -17,7 +17,6 @@ When developing connectors locally, you'll want to ensure the following tools ar
 1. [`docker`](#docker) - Used when building and running connector container images.
 1. [`gradle`](#gradle) - Required when working with Java and Kotlin connectors.
 1. [Airbyte CDKs](#airbyte-connector-development-kits-cdks) - The Airbyte Connector Development Kit (CDK) tools, including the [`airbyte-cdk` CLI](#the-airbyte-cdk-cli).
-1. [`airbyte-ci` (deprecated)](#airbyte-ci-deprecated) - Used for a large number of tasks such as building and publishing.
 
 ### Poe the Poet
 
@@ -94,14 +93,6 @@ uv tool install --upgrade 'airbyte-cdk[dev]'
 ```
 
 For a list of available commands in the `airbyte-cdk` CLI, run `airbyte-cdk --help`.
-
-### airbyte-ci (deprecated)
-
-Airbyte CI `(airbyte-ci`) is a Dagger-based tool for accomplishing specific tasks. See `airbyte-ci --help` for a list of commands you can run.
-
-:::warning
-The Airbyte CI tool is now deprecated and will be phased out shortly. Most airbyte-ci commands have a simpler equivalent in Poe, which you can discover using `poe --help`.
-:::
 
 ## Common Development Tasks
 
@@ -193,7 +184,6 @@ Maintainers can execute any of the following connector admin commands upon reque
 - `/bump-version` - Run the bump version command, which advances the connector version(s) and adds a changelog entry for any modified connector(s).
 - `/format-fix` - Fixes any formatting issues.
 - `/run-connector-tests` - Run the connector tests for any modified connectors.
-- `/run-cat-tests` - Run the legacy connector acceptance tests (CAT) for any modified connectors. This is helpful if the connector has poor test coverage overall.
 - `/build-connector-images` - Builds and publishes a pre-release docker image for the modified connector(s).
 - `/poe` - Run a Poe task.
 


### PR DESCRIPTION
## What

Removes dead `airbyte-ci` references from `local-connector-development.md` now that the `airbyte-ci/` directory has been deleted from the repo (#75935).

Also removes the `/run-cat-tests` slash command reference — CAT tests have been dead for months.

## How

Pure documentation deletions:
1. Remove `airbyte-ci` from the tooling list
2. Remove the entire "airbyte-ci (deprecated)" section
3. Remove `/run-cat-tests` from the slash commands list

## Review guide

1. `docs/platform/connector-development/local-connector-development.md` — the only file changed. Verify the remaining doc reads coherently after the removals.

**Reviewer checklist:**
- [ ] No other internal anchors or links in this file reference `#airbyte-ci-deprecated`
- [ ] `/run-cat-tests` slash command is confirmed dead
- [ ] Docs generation CI passes (this PR also serves to prove docs build works post-`airbyte-ci` deletion)

## User Impact

Dead links and references to a deleted tool are removed from user-facing documentation. No functional impact.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/decda100f5744b958e7d31aeaa54f232
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75943" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
