### PR TITLE
docs: add connector descriptions and OAuth flow to MCP server docs

### DIFF
--- a/docs/ai-agents/mcp-server/readme.md
+++ b/docs/ai-agents/mcp-server/readme.md
@@ -35,6 +35,21 @@ The MCP server uses a two-layer authentication model: one layer to authenticate 
 
 When your AI client first connects to the MCP server, it initiates an [OAuth 2.0](https://oauth.net/2/) authorization flow with Airbyte:
 
+```mermaid
+sequenceDiagram
+    participant Client as AI Client
+    participant Browser as Browser
+    participant Airbyte as Airbyte Agent Engine
+
+    Client->>Airbyte: Connect to MCP server
+    Airbyte-->>Client: Authentication required
+    Client->>Browser: Open Airbyte login page
+    Browser->>Airbyte: User logs in and grants access
+    Airbyte-->>Browser: Redirect with OAuth token
+    Browser-->>Client: OAuth token delivered
+    Client->>Airbyte: Authenticated MCP requests
+```
+
 1. Your client detects that the MCP server at `https://mcp.airbyte.ai/mcp` requires authentication.
 2. Your client opens a browser window to the Airbyte login page.
 3. You log in with your [Agent Engine](https://app.airbyte.ai) account (or create one).
@@ -47,6 +62,27 @@ This token authorizes the MCP server to act on your behalf within the Agent Engi
 ### Layer 2: Authenticating with third-party services
 
 After you authenticate with the MCP server, you still need to connect each third-party service individually. When you ask your agent to connect a service (for example, "Connect my Salesforce account"), a second credential flow begins:
+
+```mermaid
+sequenceDiagram
+    participant User as You
+    participant Agent as AI Agent
+    participant MCP as MCP Server
+    participant Browser as Browser
+    participant Service as Third-Party Service
+
+    User->>Agent: "Connect my Salesforce account"
+    Agent->>MCP: Initiate credential flow
+    MCP-->>Agent: Credential URL
+    Agent-->>User: Visit this URL
+    User->>Browser: Open credential URL
+    Browser->>Service: OAuth consent or credential form
+    Note over Service: User authorizes access
+    Service-->>MCP: Credentials delivered
+    Note over MCP: Connector created
+    MCP-->>Agent: Connector ready
+    Agent-->>User: "Salesforce is connected"
+```
 
 1. The agent calls the MCP server to initiate a credential flow for the requested service.
 2. The MCP server returns a secure URL for you to visit in your browser.

--- a/docs/ai-agents/mcp-server/readme.md
+++ b/docs/ai-agents/mcp-server/readme.md
@@ -25,6 +25,8 @@ For example:
 
 Connectors handle authentication, pagination, schema validation, and error handling so the agent can focus on answering questions and performing tasks. The agent automatically discovers which entities and actions are available for each connector you've added, so you only need to describe what you want in natural language.
 
+When you connect a service through the MCP server, the Agent Engine can copy key data from that connector into a [context store](../platform/context-store). The context store is Airbyte-managed object storage that enables fast search across your connected data. This improves search speed and reduces token consumption compared to querying third-party APIs directly, especially for prompts that involve filtering or searching large datasets.
+
 For the complete list of connectors and their supported entities, see [Agent connectors](../connectors).
 
 ## How authentication works

--- a/docs/ai-agents/mcp-server/readme.md
+++ b/docs/ai-agents/mcp-server/readme.md
@@ -11,6 +11,57 @@ The Airbyte Agent Engine MCP server connects your AI agent to your data through 
 
 Airbyte hosts and manages this remote MCP server, so there's nothing to install.
 
+## What connectors do
+
+Each connector is a type-safe integration that gives your AI agent direct access to a third-party platform's API. Connectors let your agent list, search, retrieve, and in some cases create or update records in the connected service. Every connector exposes a set of **entities** (such as contacts, deals, issues, or invoices) and **actions** (such as list, get, search, create, or update) that the agent can call.
+
+For example:
+
+- A **CRM connector** like Salesforce or HubSpot lets your agent query contacts, companies, deals, and tickets.
+- A **billing connector** like Stripe lets your agent look up customers, invoices, charges, and subscriptions.
+- A **communication connector** like Slack lets your agent read channel messages and threads, and send or update messages.
+- A **revenue intelligence connector** like Gong lets your agent retrieve call recordings, transcripts, and activity statistics.
+- A **project management connector** like Jira or Linear lets your agent search issues, projects, and comments.
+
+Connectors handle authentication, pagination, schema validation, and error handling so the agent can focus on answering questions and performing tasks. The agent automatically discovers which entities and actions are available for each connector you've added, so you only need to describe what you want in natural language.
+
+For the complete list of connectors and their supported entities, see [Agent connectors](../connectors).
+
+## How authentication works
+
+The MCP server uses a two-layer authentication model: one layer to authenticate you with the Airbyte Agent Engine, and a second layer to authenticate with each third-party service you connect.
+
+### Layer 1: Authenticating with the MCP server
+
+When your AI client first connects to the MCP server, it initiates an [OAuth 2.0](https://oauth.net/2/) authorization flow with Airbyte:
+
+1. Your client detects that the MCP server at `https://mcp.airbyte.ai/mcp` requires authentication.
+2. Your client opens a browser window to the Airbyte login page.
+3. You log in with your [Agent Engine](https://app.airbyte.ai) account (or create one).
+4. You grant the MCP server access to your Airbyte account.
+5. The browser redirects back to your client with an OAuth token.
+6. Your client stores the token and uses it for all subsequent MCP requests.
+
+This token authorizes the MCP server to act on your behalf within the Agent Engine. The token is scoped to your Airbyte account and organization, so the MCP server can only access connectors and data that belong to you. If the token expires, your client automatically triggers a new OAuth flow.
+
+### Layer 2: Authenticating with third-party services
+
+After you authenticate with the MCP server, you still need to connect each third-party service individually. When you ask your agent to connect a service (for example, "Connect my Salesforce account"), a second credential flow begins:
+
+1. The agent calls the MCP server to initiate a credential flow for the requested service.
+2. The MCP server returns a secure URL for you to visit in your browser.
+3. You open the URL and authenticate directly with the third-party service. Depending on the connector, this is either:
+   - An **OAuth consent screen** where you authorize Airbyte to access your account (used by services like Salesforce, HubSpot, GitHub, Google, and Slack), or
+   - A **credential form** where you enter an API key or access token (used by services like Stripe, Gong, and Linear).
+4. After you complete the flow, Airbyte securely stores your credentials and creates a connector.
+5. The agent confirms the connector is ready and you can begin querying data.
+
+:::note
+Your third-party credentials are always entered in the browser, never in the agent chat. Airbyte stores credentials securely on the server side and the MCP server never exposes them to the AI agent.
+:::
+
+Once a connector is created, the agent uses it for all subsequent queries to that service. You don't need to re-authenticate unless your credentials expire or are revoked by the third-party service.
+
 ## Requirements
 
 Before you begin, make sure you have the following:
@@ -199,11 +250,12 @@ The agent uses field selection to return only the data you need, which reduces t
 
 ## Troubleshooting
 
-### Authentication fails
+### MCP server authentication fails
 
 - Make sure you have an active account at [app.airbyte.ai](https://app.airbyte.ai).
 - Try logging out of your agent's MCP integration and reconnecting to trigger a fresh OAuth flow.
 - If you joined a new Airbyte organization, authenticate again to refresh your access.
+- If your client reports a token error, remove and re-add the MCP server to clear stored tokens.
 
 ### Agent can't find the MCP server
 


### PR DESCRIPTION
## What

Adds new documentation sections to the Agent Engine MCP server page to support Anthropic and OpenAI marketplace verification. Our current docs were rejected for not sufficiently describing what the connectors do and how the end-user authentication flow works.

## How

Added sections to `docs/ai-agents/mcp-server/readme.md`, placed between the intro and the Requirements section:

1. **"What connectors do"** — Describes the entity/action model that connectors expose, with categorized examples (CRM, billing, communication, revenue intelligence, project management). Mentions the [context store](../platform/context-store) for improved search speed and reduced token consumption. Links to the existing connector catalog for the full list.

2. **"How authentication works"** — Documents the two-layer OAuth model:
   - *Layer 1*: OAuth 2.0 flow between the AI client and the Airbyte Agent Engine (user logs in at app.airbyte.ai, grants access, client receives token).
   - *Layer 2*: Per-connector credential flows (OAuth consent screen or API key form in the browser, credentials stored server-side).

   Each layer includes a mermaid sequence diagram illustrating the flow between participants (AI client, browser, Airbyte, third-party service).

Also made a small update to the Troubleshooting section: renamed "Authentication fails" → "MCP server authentication fails" for clarity and added a tip about clearing stored tokens.

## Review guide

1. `docs/ai-agents/mcp-server/readme.md` — the only file changed. Key things to verify:
   - Do the mermaid sequence diagrams accurately represent the actual OAuth flows? The Layer 2 diagram simplifies the two authentication paths (OAuth consent vs. API key form) into a single flow — verify this is an acceptable simplification.
   - Does the Layer 1 OAuth flow description accurately match the actual MCP server auth implementation?
   - Does the Layer 2 connector credential flow accurately reflect how connectors are authenticated? In particular, verify that the examples of which services use OAuth consent vs. API key forms are correct.
   - Is the context store paragraph accurate in the MCP server context? It states the Agent Engine "can copy key data from that connector into a context store" — confirm this applies to MCP-connected services specifically.
   - Does this content address the specific rejection feedback from Anthropic/OpenAI?
   - The heading rename from "Authentication fails" to "MCP server authentication fails" changes the anchor — check if anything links to the old anchor.

## User Impact

Documentation-only change. End users visiting the MCP server docs page will see clearer descriptions of connector capabilities, the context store, and the authentication flow, now with visual sequence diagrams. No functional changes.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/4e3d7010b9e7494da6f721682feb1396
Requested by: @ian-at-airbyte
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75949" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
