### PR TITLE
fix(source-kyriba): apply API migration

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -106,6 +106,7 @@
 - [camro](https://github.com/camro)
 - [carlkibler](https://github.com/carlkibler)
 - [carlonuccio](https://github.com/carlonuccio)
+- [carloseguevara](https://github.com/carloseguevara)
 - [catpineapple](https://github.com/catpineapple)
 - [cgardens](https://github.com/cgardens)
 - [chadthman](https://github.com/chadthman)

--- a/airbyte-integrations/connectors/source-kyriba/metadata.yaml
+++ b/airbyte-integrations/connectors/source-kyriba/metadata.yaml
@@ -7,7 +7,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 547dc08e-ab51-421d-953b-8f3745201a8c
-  dockerImageTag: 0.1.59
+  dockerImageTag: 0.1.60
   dockerRepository: airbyte/source-kyriba
   documentationUrl: https://docs.airbyte.com/integrations/sources/kyriba
   githubIssueLabel: source-kyriba

--- a/airbyte-integrations/connectors/source-kyriba/pyproject.toml
+++ b/airbyte-integrations/connectors/source-kyriba/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "0.1.59"
+version = "0.1.60"
 name = "source-kyriba"
 description = "Source implementation for Kyriba."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-kyriba/source_kyriba/source.py
+++ b/airbyte-integrations/connectors/source-kyriba/source_kyriba/source.py
@@ -267,12 +267,15 @@ class CashFlows(IncrementalKyribaStream):
 
 # Source
 class SourceKyriba(AbstractSource):
-    def gateway_url(self, config: Mapping[str, Any]) -> str:
-        return f"https://{config['domain']}/gateway"
+    def get_api_url(self, config: Mapping[str, Any]) -> str:
+        return f"https://api.{config['domain']}"
+
+    def get_auth_url(self, config: Mapping[str, Any]) -> str:
+        return f"https://auth.{config['domain']}"
 
     def check_connection(self, logger, config) -> Tuple[bool, any]:
         try:
-            client = KyribaClient(config["username"], config["password"], self.gateway_url(config))
+            client = KyribaClient(config["username"], config["password"], self.get_auth_url(config))
             client.login()
             return True, None
         except Exception as e:
@@ -282,10 +285,9 @@ class SourceKyriba(AbstractSource):
             return False, repr(e)
 
     def streams(self, config: Mapping[str, Any]) -> List[Stream]:
-        gateway_url = self.gateway_url(config)
-        client = KyribaClient(config["username"], config["password"], gateway_url)
+        client = KyribaClient(config["username"], config["password"], self.get_auth_url(config))
         kwargs = {
-            "gateway_url": gateway_url,
+            "gateway_url": self.get_api_url(config),
             "client": client,
             "start_date": config.get("start_date"),
             "end_date": config.get("end_date"),

--- a/docs/integrations/sources/kyriba.md
+++ b/docs/integrations/sources/kyriba.md
@@ -69,68 +69,69 @@ The Kyriba connector should not run into API limitations under normal usage. [Cr
 <details>
   <summary>Expand to review</summary>
 
-| Version | Date       | Pull Request                                             | Subject                                                                                      |
-| :------ | :--------- | :------------------------------------------------------- | :------------------------------------------------------------------------------------------- |
-| 0.1.59 | 2025-10-14 | [68065](https://github.com/airbytehq/airbyte/pull/68065) | Update dependencies |
-| 0.1.58 | 2025-10-07 | [67525](https://github.com/airbytehq/airbyte/pull/67525) | Update dependencies |
-| 0.1.57 | 2025-09-30 | [66818](https://github.com/airbytehq/airbyte/pull/66818) | Update dependencies |
-| 0.1.56 | 2025-09-24 | [66651](https://github.com/airbytehq/airbyte/pull/66651) | Update dependencies |
-| 0.1.55 | 2025-09-09 | [66053](https://github.com/airbytehq/airbyte/pull/66053) | Update dependencies |
-| 0.1.54 | 2025-08-23 | [65343](https://github.com/airbytehq/airbyte/pull/65343) | Update dependencies |
-| 0.1.53 | 2025-08-16 | [64981](https://github.com/airbytehq/airbyte/pull/64981) | Update dependencies |
-| 0.1.52 | 2025-08-09 | [64610](https://github.com/airbytehq/airbyte/pull/64610) | Update dependencies |
-| 0.1.51 | 2025-07-19 | [63485](https://github.com/airbytehq/airbyte/pull/63485) | Update dependencies |
-| 0.1.50 | 2025-07-12 | [63140](https://github.com/airbytehq/airbyte/pull/63140) | Update dependencies |
-| 0.1.49 | 2025-07-05 | [62542](https://github.com/airbytehq/airbyte/pull/62542) | Update dependencies |
-| 0.1.48 | 2025-06-28 | [62187](https://github.com/airbytehq/airbyte/pull/62187) | Update dependencies |
-| 0.1.47 | 2025-06-21 | [61841](https://github.com/airbytehq/airbyte/pull/61841) | Update dependencies |
-| 0.1.46 | 2025-06-14 | [61113](https://github.com/airbytehq/airbyte/pull/61113) | Update dependencies |
-| 0.1.45 | 2025-05-24 | [60657](https://github.com/airbytehq/airbyte/pull/60657) | Update dependencies |
-| 0.1.44 | 2025-05-10 | [59816](https://github.com/airbytehq/airbyte/pull/59816) | Update dependencies |
-| 0.1.43 | 2025-05-03 | [59226](https://github.com/airbytehq/airbyte/pull/59226) | Update dependencies |
-| 0.1.42 | 2025-04-26 | [58751](https://github.com/airbytehq/airbyte/pull/58751) | Update dependencies |
-| 0.1.41 | 2025-04-19 | [58211](https://github.com/airbytehq/airbyte/pull/58211) | Update dependencies |
-| 0.1.40 | 2025-04-12 | [57711](https://github.com/airbytehq/airbyte/pull/57711) | Update dependencies |
-| 0.1.39 | 2025-04-05 | [57025](https://github.com/airbytehq/airbyte/pull/57025) | Update dependencies |
-| 0.1.38 | 2025-03-29 | [56654](https://github.com/airbytehq/airbyte/pull/56654) | Update dependencies |
-| 0.1.37 | 2025-03-22 | [56042](https://github.com/airbytehq/airbyte/pull/56042) | Update dependencies |
-| 0.1.36 | 2025-03-08 | [55425](https://github.com/airbytehq/airbyte/pull/55425) | Update dependencies |
-| 0.1.35 | 2025-03-01 | [54788](https://github.com/airbytehq/airbyte/pull/54788) | Update dependencies |
-| 0.1.34 | 2025-02-22 | [54320](https://github.com/airbytehq/airbyte/pull/54320) | Update dependencies |
-| 0.1.33 | 2025-02-15 | [53817](https://github.com/airbytehq/airbyte/pull/53817) | Update dependencies |
-| 0.1.32 | 2025-02-01 | [52788](https://github.com/airbytehq/airbyte/pull/52788) | Update dependencies |
-| 0.1.31 | 2025-01-25 | [51787](https://github.com/airbytehq/airbyte/pull/51787) | Update dependencies |
-| 0.1.30 | 2025-01-11 | [51171](https://github.com/airbytehq/airbyte/pull/51171) | Update dependencies |
-| 0.1.29 | 2024-12-28 | [50617](https://github.com/airbytehq/airbyte/pull/50617) | Update dependencies |
-| 0.1.28 | 2024-12-21 | [50147](https://github.com/airbytehq/airbyte/pull/50147) | Update dependencies |
-| 0.1.27 | 2024-12-14 | [48971](https://github.com/airbytehq/airbyte/pull/48971) | Update dependencies |
-| 0.1.26 | 2024-11-25 | [48670](https://github.com/airbytehq/airbyte/pull/48670) | Starting with this version, the Docker image is now rootless. Please note that this and future versions will not be compatible with Airbyte versions earlier than 0.64 |
-| 0.1.25 | 2024-11-04 | [48314](https://github.com/airbytehq/airbyte/pull/48314) | Update dependencies |
-| 0.1.24 | 2024-10-28 | [47079](https://github.com/airbytehq/airbyte/pull/47079) | Update dependencies |
-| 0.1.23 | 2024-10-12 | [46830](https://github.com/airbytehq/airbyte/pull/46830) | Update dependencies |
-| 0.1.22 | 2024-10-05 | [46459](https://github.com/airbytehq/airbyte/pull/46459) | Update dependencies |
-| 0.1.21 | 2024-09-28 | [46203](https://github.com/airbytehq/airbyte/pull/46203) | Update dependencies |
-| 0.1.20 | 2024-09-21 | [45816](https://github.com/airbytehq/airbyte/pull/45816) | Update dependencies |
-| 0.1.19 | 2024-09-14 | [45569](https://github.com/airbytehq/airbyte/pull/45569) | Update dependencies |
-| 0.1.18 | 2024-09-07 | [45306](https://github.com/airbytehq/airbyte/pull/45306) | Update dependencies |
-| 0.1.17 | 2024-08-31 | [45049](https://github.com/airbytehq/airbyte/pull/45049) | Update dependencies |
-| 0.1.16 | 2024-08-24 | [44688](https://github.com/airbytehq/airbyte/pull/44688) | Update dependencies |
-| 0.1.15 | 2024-08-17 | [44352](https://github.com/airbytehq/airbyte/pull/44352) | Update dependencies |
-| 0.1.14 | 2024-08-10 | [43546](https://github.com/airbytehq/airbyte/pull/43546) | Update dependencies |
-| 0.1.13 | 2024-08-03 | [43256](https://github.com/airbytehq/airbyte/pull/43256) | Update dependencies |
-| 0.1.12 | 2024-07-27 | [42825](https://github.com/airbytehq/airbyte/pull/42825) | Update dependencies |
-| 0.1.11 | 2024-07-20 | [42289](https://github.com/airbytehq/airbyte/pull/42289) | Update dependencies |
-| 0.1.10 | 2024-07-13 | [41885](https://github.com/airbytehq/airbyte/pull/41885) | Update dependencies |
-| 0.1.9 | 2024-07-10 | [41452](https://github.com/airbytehq/airbyte/pull/41452) | Update dependencies |
-| 0.1.8 | 2024-07-09 | [41147](https://github.com/airbytehq/airbyte/pull/41147) | Update dependencies |
-| 0.1.7 | 2024-07-06 | [40874](https://github.com/airbytehq/airbyte/pull/40874) | Update dependencies |
-| 0.1.6 | 2024-06-25 | [40367](https://github.com/airbytehq/airbyte/pull/40367) | Update dependencies |
-| 0.1.5 | 2024-06-22 | [40111](https://github.com/airbytehq/airbyte/pull/40111) | Update dependencies |
-| 0.1.4 | 2024-06-06 | [39232](https://github.com/airbytehq/airbyte/pull/39232) | [autopull] Upgrade base image to v1.2.2 |
-| 0.1.3 | 2024-04-19 | [37184](https://github.com/airbytehq/airbyte/pull/37184) | Upgrade to CDK 0.80.0 and manage dependencies with Poetry. |
-| 0.1.2 | 2024-04-12 | [37184](https://github.com/airbytehq/airbyte/pull/37184) | schema descriptions |
-| 0.1.1 | 2024-01-30 | [34545](https://github.com/airbytehq/airbyte/pull/34545) | Updates CDK, Base image migration: remove Dockerfile and use the python-connector-base image |
-| 0.1.0 | 2022-07-13 | [12748](https://github.com/airbytehq/airbyte/pull/12748) | The Kyriba Source is created |
+| Version | Date       | Pull Request                                             | Subject                                                                                                                                                                |
+|:--------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 0.1.60  | 2026-04-01 | [75950](https://github.com/airbytehq/airbyte/pull/75950) | Applying API migration                                                                                                                                                 |
+| 0.1.59  | 2025-10-14 | [68065](https://github.com/airbytehq/airbyte/pull/68065) | Update dependencies                                                                                                                                                    |
+| 0.1.58  | 2025-10-07 | [67525](https://github.com/airbytehq/airbyte/pull/67525) | Update dependencies                                                                                                                                                    |
+| 0.1.57  | 2025-09-30 | [66818](https://github.com/airbytehq/airbyte/pull/66818) | Update dependencies                                                                                                                                                    |
+| 0.1.56  | 2025-09-24 | [66651](https://github.com/airbytehq/airbyte/pull/66651) | Update dependencies                                                                                                                                                    |
+| 0.1.55  | 2025-09-09 | [66053](https://github.com/airbytehq/airbyte/pull/66053) | Update dependencies                                                                                                                                                    |
+| 0.1.54  | 2025-08-23 | [65343](https://github.com/airbytehq/airbyte/pull/65343) | Update dependencies                                                                                                                                                    |
+| 0.1.53  | 2025-08-16 | [64981](https://github.com/airbytehq/airbyte/pull/64981) | Update dependencies                                                                                                                                                    |
+| 0.1.52  | 2025-08-09 | [64610](https://github.com/airbytehq/airbyte/pull/64610) | Update dependencies                                                                                                                                                    |
+| 0.1.51  | 2025-07-19 | [63485](https://github.com/airbytehq/airbyte/pull/63485) | Update dependencies                                                                                                                                                    |
+| 0.1.50  | 2025-07-12 | [63140](https://github.com/airbytehq/airbyte/pull/63140) | Update dependencies                                                                                                                                                    |
+| 0.1.49  | 2025-07-05 | [62542](https://github.com/airbytehq/airbyte/pull/62542) | Update dependencies                                                                                                                                                    |
+| 0.1.48  | 2025-06-28 | [62187](https://github.com/airbytehq/airbyte/pull/62187) | Update dependencies                                                                                                                                                    |
+| 0.1.47  | 2025-06-21 | [61841](https://github.com/airbytehq/airbyte/pull/61841) | Update dependencies                                                                                                                                                    |
+| 0.1.46  | 2025-06-14 | [61113](https://github.com/airbytehq/airbyte/pull/61113) | Update dependencies                                                                                                                                                    |
+| 0.1.45  | 2025-05-24 | [60657](https://github.com/airbytehq/airbyte/pull/60657) | Update dependencies                                                                                                                                                    |
+| 0.1.44  | 2025-05-10 | [59816](https://github.com/airbytehq/airbyte/pull/59816) | Update dependencies                                                                                                                                                    |
+| 0.1.43  | 2025-05-03 | [59226](https://github.com/airbytehq/airbyte/pull/59226) | Update dependencies                                                                                                                                                    |
+| 0.1.42  | 2025-04-26 | [58751](https://github.com/airbytehq/airbyte/pull/58751) | Update dependencies                                                                                                                                                    |
+| 0.1.41  | 2025-04-19 | [58211](https://github.com/airbytehq/airbyte/pull/58211) | Update dependencies                                                                                                                                                    |
+| 0.1.40  | 2025-04-12 | [57711](https://github.com/airbytehq/airbyte/pull/57711) | Update dependencies                                                                                                                                                    |
+| 0.1.39  | 2025-04-05 | [57025](https://github.com/airbytehq/airbyte/pull/57025) | Update dependencies                                                                                                                                                    |
+| 0.1.38  | 2025-03-29 | [56654](https://github.com/airbytehq/airbyte/pull/56654) | Update dependencies                                                                                                                                                    |
+| 0.1.37  | 2025-03-22 | [56042](https://github.com/airbytehq/airbyte/pull/56042) | Update dependencies                                                                                                                                                    |
+| 0.1.36  | 2025-03-08 | [55425](https://github.com/airbytehq/airbyte/pull/55425) | Update dependencies                                                                                                                                                    |
+| 0.1.35  | 2025-03-01 | [54788](https://github.com/airbytehq/airbyte/pull/54788) | Update dependencies                                                                                                                                                    |
+| 0.1.34  | 2025-02-22 | [54320](https://github.com/airbytehq/airbyte/pull/54320) | Update dependencies                                                                                                                                                    |
+| 0.1.33  | 2025-02-15 | [53817](https://github.com/airbytehq/airbyte/pull/53817) | Update dependencies                                                                                                                                                    |
+| 0.1.32  | 2025-02-01 | [52788](https://github.com/airbytehq/airbyte/pull/52788) | Update dependencies                                                                                                                                                    |
+| 0.1.31  | 2025-01-25 | [51787](https://github.com/airbytehq/airbyte/pull/51787) | Update dependencies                                                                                                                                                    |
+| 0.1.30  | 2025-01-11 | [51171](https://github.com/airbytehq/airbyte/pull/51171) | Update dependencies                                                                                                                                                    |
+| 0.1.29  | 2024-12-28 | [50617](https://github.com/airbytehq/airbyte/pull/50617) | Update dependencies                                                                                                                                                    |
+| 0.1.28  | 2024-12-21 | [50147](https://github.com/airbytehq/airbyte/pull/50147) | Update dependencies                                                                                                                                                    |
+| 0.1.27  | 2024-12-14 | [48971](https://github.com/airbytehq/airbyte/pull/48971) | Update dependencies                                                                                                                                                    |
+| 0.1.26  | 2024-11-25 | [48670](https://github.com/airbytehq/airbyte/pull/48670) | Starting with this version, the Docker image is now rootless. Please note that this and future versions will not be compatible with Airbyte versions earlier than 0.64 |
+| 0.1.25  | 2024-11-04 | [48314](https://github.com/airbytehq/airbyte/pull/48314) | Update dependencies                                                                                                                                                    |
+| 0.1.24  | 2024-10-28 | [47079](https://github.com/airbytehq/airbyte/pull/47079) | Update dependencies                                                                                                                                                    |
+| 0.1.23  | 2024-10-12 | [46830](https://github.com/airbytehq/airbyte/pull/46830) | Update dependencies                                                                                                                                                    |
+| 0.1.22  | 2024-10-05 | [46459](https://github.com/airbytehq/airbyte/pull/46459) | Update dependencies                                                                                                                                                    |
+| 0.1.21  | 2024-09-28 | [46203](https://github.com/airbytehq/airbyte/pull/46203) | Update dependencies                                                                                                                                                    |
+| 0.1.20  | 2024-09-21 | [45816](https://github.com/airbytehq/airbyte/pull/45816) | Update dependencies                                                                                                                                                    |
+| 0.1.19  | 2024-09-14 | [45569](https://github.com/airbytehq/airbyte/pull/45569) | Update dependencies                                                                                                                                                    |
+| 0.1.18  | 2024-09-07 | [45306](https://github.com/airbytehq/airbyte/pull/45306) | Update dependencies                                                                                                                                                    |
+| 0.1.17  | 2024-08-31 | [45049](https://github.com/airbytehq/airbyte/pull/45049) | Update dependencies                                                                                                                                                    |
+| 0.1.16  | 2024-08-24 | [44688](https://github.com/airbytehq/airbyte/pull/44688) | Update dependencies                                                                                                                                                    |
+| 0.1.15  | 2024-08-17 | [44352](https://github.com/airbytehq/airbyte/pull/44352) | Update dependencies                                                                                                                                                    |
+| 0.1.14  | 2024-08-10 | [43546](https://github.com/airbytehq/airbyte/pull/43546) | Update dependencies                                                                                                                                                    |
+| 0.1.13  | 2024-08-03 | [43256](https://github.com/airbytehq/airbyte/pull/43256) | Update dependencies                                                                                                                                                    |
+| 0.1.12  | 2024-07-27 | [42825](https://github.com/airbytehq/airbyte/pull/42825) | Update dependencies                                                                                                                                                    |
+| 0.1.11  | 2024-07-20 | [42289](https://github.com/airbytehq/airbyte/pull/42289) | Update dependencies                                                                                                                                                    |
+| 0.1.10  | 2024-07-13 | [41885](https://github.com/airbytehq/airbyte/pull/41885) | Update dependencies                                                                                                                                                    |
+| 0.1.9   | 2024-07-10 | [41452](https://github.com/airbytehq/airbyte/pull/41452) | Update dependencies                                                                                                                                                    |
+| 0.1.8   | 2024-07-09 | [41147](https://github.com/airbytehq/airbyte/pull/41147) | Update dependencies                                                                                                                                                    |
+| 0.1.7   | 2024-07-06 | [40874](https://github.com/airbytehq/airbyte/pull/40874) | Update dependencies                                                                                                                                                    |
+| 0.1.6   | 2024-06-25 | [40367](https://github.com/airbytehq/airbyte/pull/40367) | Update dependencies                                                                                                                                                    |
+| 0.1.5   | 2024-06-22 | [40111](https://github.com/airbytehq/airbyte/pull/40111) | Update dependencies                                                                                                                                                    |
+| 0.1.4   | 2024-06-06 | [39232](https://github.com/airbytehq/airbyte/pull/39232) | [autopull] Upgrade base image to v1.2.2                                                                                                                                |
+| 0.1.3   | 2024-04-19 | [37184](https://github.com/airbytehq/airbyte/pull/37184) | Upgrade to CDK 0.80.0 and manage dependencies with Poetry.                                                                                                             |
+| 0.1.2   | 2024-04-12 | [37184](https://github.com/airbytehq/airbyte/pull/37184) | schema descriptions                                                                                                                                                    |
+| 0.1.1   | 2024-01-30 | [34545](https://github.com/airbytehq/airbyte/pull/34545) | Updates CDK, Base image migration: remove Dockerfile and use the python-connector-base image                                                                           |
+| 0.1.0   | 2022-07-13 | [12748](https://github.com/airbytehq/airbyte/pull/12748) | The Kyriba Source is created                                                                                                                                           |
 
 </details>
 


### PR DESCRIPTION
## What
API migration from Kyriba was applied and must be changed the request URLs

Solving Issue [75948](https://github.com/airbytehq/airbyte/issues/75948)

## How
The API migration of Kyriba just change the getway URLs
<img width="712" height="544" alt="image010" src="https://github.com/user-attachments/assets/6d713f4f-368d-45c7-a850-26a1528dc2b9" />


## Review guide
1. airbyte-integrations/connectors/source-kyriba/source_kyriba/source.py

## User Impact
End user doesn't have any side effects.

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
- [ ] NO ❌
