### PR TITLE
chore: remove dead airbyte-ci targets from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,7 @@
 ##@ Makefile
 
-##@ Define the default airbyte-ci version
-AIRBYTE_CI_VERSION ?= latest
-
 ## Detect the operating system
 OS := $(shell uname)
-
-tools.airbyte-ci.install: tools.airbyte-ci.clean tools.airbyte-ci-binary.install tools.airbyte-ci.check
-
-tools.airbyte-ci-binary.install: ## Install airbyte-ci binary
-	@python airbyte-ci/connectors/pipelines/pipelines/external_scripts/airbyte_ci_install.py ${AIRBYTE_CI_VERSION}
-
-tools.airbyte-ci-dev.install: ## Install the local development version of airbyte-ci
-	@python airbyte-ci/connectors/pipelines/pipelines/external_scripts/airbyte_ci_dev_install.py
-
-tools.airbyte-ci.check: ## Check if airbyte-ci is installed correctly
-	@./airbyte-ci/connectors/pipelines/pipelines/external_scripts/airbyte_ci_check.sh
-
-tools.airbyte-ci.clean: ## Clean airbyte-ci installations
-	@./airbyte-ci/connectors/pipelines/pipelines/external_scripts/airbyte_ci_clean.sh
 
 tools.git-hooks.clean: ## Clean git hooks
 	@echo "Unset core.hooksPath"
@@ -39,14 +22,14 @@ tools.pre-commit.install.Darwin:
 	@brew install pre-commit maven
 	@echo "Pre-commit installation complete"
 
-tools.git-hooks.install: tools.airbyte-ci.install tools.pre-commit.install.$(OS) tools.git-hooks.clean ## Setup pre-commit hooks
+tools.git-hooks.install: tools.pre-commit.install.$(OS) tools.git-hooks.clean ## Setup pre-commit hooks
 	@echo "Installing pre-commit hooks..."
 	@pre-commit install --hook-type pre-push
 	@echo "Pre-push hooks installed."
 
-tools.install: tools.airbyte-ci.install tools.pre-commit.install.$(OS)
+tools.install: tools.pre-commit.install.$(OS)
 
 version.bulk.cdk:
 	@echo "Latest version of the Bulk CDK is $(shell curl -k --silent "https://airbyte.mycloudrepo.io/public/repositories/airbyte-public-jars/io/airbyte/bulk-cdk/bulk-cdk-core-load/maven-metadata.xml" | sed -ne 's:.*<latest>\(.*\)</latest>:\1:p')"
 
-.PHONY: tools.install tools.pre-commit.install tools.git-hooks.install tools.git-hooks.clean tools.airbyte-ci.install tools.airbyte-ci-dev.install tools.airbyte-ci.check tools.airbyte-ci.clean
+.PHONY: tools.install tools.pre-commit.install tools.git-hooks.install tools.git-hooks.clean


### PR DESCRIPTION
## What

Removes all `airbyte-ci`-related Makefile targets that reference scripts deleted in #75935 (the `airbyte-ci/` directory deletion). Part of the ongoing cleanup tracked in airbytehq/airbyte-ops-mcp#635.

## How

- Deleted 5 targets: `tools.airbyte-ci.install`, `tools.airbyte-ci-binary.install`, `tools.airbyte-ci-dev.install`, `tools.airbyte-ci.check`, `tools.airbyte-ci.clean`
- Deleted the `AIRBYTE_CI_VERSION` variable (no longer consumed)
- Removed `tools.airbyte-ci.install` as a dependency from `tools.git-hooks.install` and `tools.install`
- Cleaned up `.PHONY` declarations

All remaining targets (git hooks, pre-commit, `version.bulk.cdk`) are unchanged.

## Review guide

1. `Makefile` — only file changed. Verify the remaining dependency chains for `tools.install` and `tools.git-hooks.install` are correct after removing the `airbyte-ci` prerequisite.

**Reviewer checklist:**
- [ ] No other files in the repo reference the deleted Makefile targets (`tools.airbyte-ci.*`)
- [ ] `make tools.install` and `make tools.git-hooks.install` dependency chains still make sense

## User Impact

`make tools.install` and `make tools.git-hooks.install` no longer fail due to missing `airbyte-ci/` scripts. Developers who were running these commands were already broken post-#75935; this PR fixes that.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/44d56dceda5247f5a2eebab1c147f190
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75956" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
