### PR TITLE
docs: add Airbyte 2.1.0 release notes

### DIFF
--- a/docs/release_notes/v-2.1.md
+++ b/docs/release_notes/v-2.1.md
@@ -1,0 +1,118 @@
+# Airbyte 2.1
+
+<!-- vale off -->
+
+Airbyte version 2.1 was released on April 1, 2026. This version includes breaking changes to the Helm chart, new platform features, and many improvements across the board.
+
+<!-- vale on -->
+
+## Helm chart V1 removed
+
+Helm chart V1 is removed in this version. If you haven't migrated to Helm chart V2, you must do so before upgrading to Airbyte 2.1. For help and to learn more, see the migration guides for [Self-Managed Community](/platform/deploying-airbyte/chart-v2-community) or [Self-Managed Enterprise](/platform/enterprise-setup/chart-v2-enterprise).
+
+## Helm chart V2 improvements
+
+This version includes several improvements to the Helm chart V2.
+
+- **Unified ingress support**: The V2 Helm chart now includes configurable Ingress support. You can set ingress class, annotations, hosts, paths, and TLS directly in your values.yaml. [**Learn more >**](/platform/deploying-airbyte/integrations/ingress)
+
+- **Auth enabled by default**: Authentication is now enabled by default in the V2 Helm chart. New self-managed deployments are secure out of the box. If you require unauthenticated access, you can explicitly disable auth in your values.yaml.
+
+- **Topology spread constraints**: You can now configure `topologySpreadConstraints` for `airbyte-server` in the V2 Helm chart, giving operators more control over pod distribution across availability zones.
+
+- **Workload API health check**: The `workload-api` service now exposes a health check endpoint, making it easier to configure readiness and liveness probes.
+
+- **Metrics reporter chart fix**: Fixed an issue with the metrics reporter chart configuration.
+
+- **Structured JSON log output**: You can now configure structured JSON log output for the orchestrator and sidecar containers. This makes it easier to ingest and search logs in tools like Elasticsearch and Datadog.
+
+## Connector Builder server replaced by manifest server
+
+The connector-builder-server has been removed and replaced by the manifest server. If you reference `connector-builder-server` in any custom configurations, scripts, or automation, update these references.
+
+- **Manifest server enabled by default on OSS**: The manifest server is now the default backend for Builder operations on OSS deployments. It replaces connector-builder-server entirely.
+
+- **Configuration migration**: Helm chart configuration keys previously under `connector-builder-server` have been migrated to `server.connectorBuilder.*` in values.yaml. Update your values.yaml if you use custom configuration for the Builder server.
+
+## Security improvements
+
+- **Sensitive data removed from error responses**: Airbyte no longer includes security-sensitive data in API error responses. If you have integrations that parse error message bodies, verify they still work as expected after upgrading.
+
+- **Jinjava security patch**: Bumped Jinjava to version 2.8.1 to address a security vulnerability.
+
+- **Management endpoints moved to separate port**: Micronaut management endpoints now run on a separate port, reducing the risk of accidental exposure.
+
+## Connector management
+
+- **Automatic CDC meta-field management**: CDC meta-fields (`_ab_cdc_deleted_at`, `_ab_cdc_updated_at`, `_ab_cdc_log_pos`) are now automatically selected and protected from manual deselection in the sync catalog UI. This prevents accidental data loss due to deselecting required CDC fields.
+
+- **Breaking change protection**: Airbyte now persists breaking changes in catalog diffs, improving upgrade safety. When a connector version pin is removed, actors are protected from silently crossing breaking change boundaries. Preview connector versions are excluded from breaking change pin version selection.
+
+- **15- and 30-minute sync frequencies**: You can now set sync frequencies of 15 and 30 minutes for connections that need more frequent data refreshes.
+
+- **Rejected records on status page**: The connection status page now shows rejected records statistics and provides a link to view details.
+
+- **High-frequency full refresh warning**: When configuring connections with high sync frequencies and full refresh sync mode, Airbyte now warns you about the potential impact on resource usage.
+
+## Connector Setup Agent
+
+Airbyte now offers an AI-powered Connector Setup Agent to help you configure source connectors. The agent guides you through setting up credentials, selecting authentication methods, and filling out configuration fields. It supports OAuth flows and secret inputs directly in the chat interface.
+
+- The Connector Setup Agent is disabled for custom connectors.
+- You can switch between the agent and the traditional form at any time, and your configuration state is preserved.
+
+## SSO and authentication improvements
+
+- **Self-service SSO configuration**: A new SSO setup UI allows you to configure, test, and activate single sign-on directly from Organization settings. The flow includes a two-step test and activate process.
+
+- **DNS domain verification**: You can now verify domain ownership through DNS TXT records as part of SSO activation. The UI includes options to view DNS info, delete, and reset verification requests.
+
+- **SSO activation safeguards**: Activating SSO now blocks activation if the email domain is already in use by users in another organization. A confirmation modal warns about forced logout before activation.
+
+- **Keycloak token handling**: Fixed a crash caused by invalid Keycloak token realms, improving stability for self-managed Keycloak users.
+
+## API improvements
+
+- **Public API job type filter**: The public API now returns all job types when the `jobType` filter is not specified, instead of returning an empty result.
+
+- **Stream ordering**: The public API now allows streams in any order in responses, improving compatibility with clients that don't depend on stream ordering.
+
+- **HubSpot destination mapping**: Added the HubSpot destination to the public API's name-to-definition mapper, fixing issues with programmatic destination creation.
+
+- **Connector form dropdown width**: Fixed the width of connector form dropdowns to prevent layout issues.
+
+## Support Agent
+
+Airbyte Cloud users now have access to an in-app Support Agent that replaces the previous Zendesk widget. The Support Agent can answer questions about Airbyte, troubleshoot issues, and create Zendesk support tickets on your behalf. Access it from Help > In-App Support.
+
+## Self-managed deployment fixes
+
+- **Dataplane crash fix**: Fixed a crash in v2.0.0 dataplanes caused by a missing `STORAGE_BUCKET_AUDIT_LOGGING` environment variable. This variable is now included in the Dataplane Helm chart.
+
+- **Database read replicas**: Airbyte server now supports reading from database replicas. This feature is behind a feature flag and can be configured in the Helm chart for high-availability deployments.
+
+- **Redis image update**: Updated the Redis image reference after Bitnami retired their previous Redis image.
+
+- **User settings in OSS with auth**: Fixed an issue where user settings didn't work correctly in OSS deployments with authentication enabled.
+
+## Other improvements
+
+- **Connector form multiline inputs**: Multiline secret inputs now work correctly in the Connector Builder and connector setup forms.
+
+- **OAuth scope fixes**: Fixed OAuth scope configurations for Facebook Pages (added `catalog_management` scope), Facebook Marketing (removed invalid `read_insights` scope), and HubSpot (added additional optional scope).
+
+- **Connector form enum values**: Fixed an issue where enum values in connector configuration forms didn't display the correct selection.
+
+- **Source container OOM detection**: Improved detection of source container out-of-memory errors by monitoring pipe closure, helping surface clearer error messages for resource issues.
+
+- **Permission error on schema changes**: Fixed a permission error that could occur when reviewing schema changes on connections.
+
+- **Connection creation layout shift**: Fixed layout shift caused by error messages during connection creation.
+
+- **Date picker improvements**: Improved the date picker with a 7-day default range and a 30-day maximum range for log and timeline views.
+
+- **Google Chat webhook support**: Airbyte now supports Google Chat webhook endpoints for notifications.
+
+## How to upgrade
+
+For help, see [Upgrading Airbyte](/platform/operator-guides/upgrading-airbyte).

--- a/docs/release_notes/v-2.1.md
+++ b/docs/release_notes/v-2.1.md
@@ -36,11 +36,7 @@ The connector-builder-server has been removed and replaced by the manifest serve
 
 ## Security improvements
 
-- **Sensitive data removed from error responses**: Airbyte no longer includes security-sensitive data in API error responses. If you have integrations that parse error message bodies, verify they still work as expected after upgrading.
-
-- **Jinjava security patch**: Bumped Jinjava to version 2.8.1 to address a security vulnerability.
-
-- **Management endpoints moved to separate port**: Micronaut management endpoints now run on a separate port, reducing the risk of accidental exposure.
+This version includes security improvements, including the removal of sensitive data from API error responses and updates to address security vulnerabilities in dependencies. If you have integrations that parse error message bodies, verify they still work as expected after upgrading.
 
 ## Connector management
 
@@ -80,10 +76,6 @@ Airbyte now offers an AI-powered Connector Setup Agent to help you configure sou
 - **HubSpot destination mapping**: Added the HubSpot destination to the public API's name-to-definition mapper, fixing issues with programmatic destination creation.
 
 - **Connector form dropdown width**: Fixed the width of connector form dropdowns to prevent layout issues.
-
-## Support Agent
-
-Airbyte Cloud users now have access to an in-app Support Agent that replaces the previous Zendesk widget. The Support Agent can answer questions about Airbyte, troubleshoot issues, and create Zendesk support tickets on your behalf. Access it from Help > In-App Support.
 
 ## Self-managed deployment fixes
 

--- a/docusaurus/sidebar-release_notes.js
+++ b/docusaurus/sidebar-release_notes.js
@@ -9,6 +9,7 @@ export default {
         id: "readme",
       },
       items: [
+        "v-2.1",
         "v-2.0",
         "v-1.8",
         "v-1.7",


### PR DESCRIPTION
## What

First-pass draft of public release notes for Airbyte 2.1.0, based on the categorized PR list in [airbytehq/airbyte-internal-issues#16130](https://github.com/airbytehq/airbyte-internal-issues/issues/16130).

Closes https://github.com/airbytehq/airbyte-internal-issues/issues/16130

## How

- Added `docs/release_notes/v-2.1.md` with release notes organized into logical categories (not strictly by priority).
- Added `v-2.1` entry to `docusaurus/sidebar-release_notes.js` so the page appears in the docs sidebar.

Categories chosen:
1. Helm chart V1 removal (breaking)
2. Helm chart V2 improvements
3. Connector Builder server → manifest server migration (breaking)
4. Security improvements
5. Connector management features
6. Connector Setup Agent (new)
7. SSO and authentication
8. API improvements
9. Self-managed deployment fixes
10. Other improvements / bug fixes

## Review guide

1. `docs/release_notes/v-2.1.md` — the release notes content. This is the main file to review.
2. `docusaurus/sidebar-release_notes.js` — one-line sidebar addition.

**Key items for reviewers to verify:**
- Release date accuracy ("April 1, 2026")
- Correctness of technical details (Helm config key paths, CDC meta-field names, connector-builder-server → manifest-server migration details)
- Whether any critical/high-priority items from the source issue were missed or mischaracterized
- All internal doc links point to valid pages (e.g., `/platform/deploying-airbyte/integrations/ingress`)
- No cloud-only features are inadvertently presented as self-managed features
- Connector Setup Agent section — verify this feature is available in self-managed, not Cloud-only

### Updates since last revision

- **Removed Support Agent section**: This was a Cloud-only feature and doesn't belong in self-managed release notes.
- **Simplified Security improvements section**: Replaced individual bullet points (Jinjava version, Micronaut management port) with a single concise paragraph. Only calls out the error-response change since it could affect integrations.

## User Impact

Users reading release notes will have a clear summary of what changed in Airbyte 2.1.0, organized by topic. Self-managed users will see actionable upgrade guidance for breaking changes (Helm V1 removal, connector-builder-server removal).

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/4f9e04ac3d0b4fb2bd75b75ab2cfe7e4
Requested by: @ian-at-airbyte