### PR TITLE
docs: add Airbyte 2.1.0 release notes

### DIFF
--- a/docs/release_notes/v-2.1.md
+++ b/docs/release_notes/v-2.1.md
@@ -1,0 +1,27 @@
+# Airbyte 2.1
+
+<!-- vale off -->
+
+Airbyte version 2.1 was released on April 1, 2026.
+
+<!-- vale on -->
+
+## Helm chart V1 removed
+
+Helm chart V1 is removed in this version. If you deploy Airbyte with Helm chart V1, you must migrate to Helm chart V2 before upgrading to Airbyte 2.1. For migration instructions, see the guides for [Self-Managed Community](/platform/deploying-airbyte/chart-v2-community) or [Self-Managed Enterprise](/platform/enterprise-setup/chart-v2-enterprise).
+
+## Helm chart V2 improvements
+
+- **Authentication enabled by default**: New deployments using Helm chart V2 now have authentication enabled by default. If you need unauthenticated access, you can explicitly disable auth in your values.yaml.
+
+- **Ingress support**: The V2 Helm chart now includes a configurable Ingress resource. You can set the ingress class, annotations, hosts, paths, and TLS directly in values.yaml. [**Learn more >**](/platform/deploying-airbyte/integrations/ingress)
+
+## Connector Builder server replaced by manifest server
+
+The `connector-builder-server` component is removed from the Helm chart and replaced by the manifest server. If you reference `connector-builder-server` in custom configurations, scripts, or automation, update those references.
+
+- **Configuration migration**: Helm chart configuration keys previously under `connectorBuilderServer.*` have moved to `server.connectorBuilder.*` in values.yaml. Update your values.yaml if you have custom configuration for the Builder server.
+
+## Security improvements
+
+This version includes security improvements, including the removal of security-sensitive data from API error responses. Error responses now return only an `errorId` for tracking purposes. If you have custom integrations that parse API error response bodies for message content, verify they still work as expected after upgrading.

--- a/docs/release_notes/v-2.1.md
+++ b/docs/release_notes/v-2.1.md
@@ -2,7 +2,7 @@
 
 <!-- vale off -->
 
-Airbyte version 2.1 was released on April 1, 2026.
+We finally remembered our password. Turns out it was 'Password' all along. What a great day! Anyway, Airbyte version 2.1 was released on April 3, 2026.
 
 <!-- vale on -->
 

--- a/docs/release_notes/v-2.1.md
+++ b/docs/release_notes/v-2.1.md
@@ -28,6 +28,16 @@ It's not possible to deploy this or any future version of Airbyte with Helm char
 
 - **TopologySpreadConstraints for airbyte-server**: You can now configure Kubernetes `topologySpreadConstraints` for the `airbyte-server` pod via `server.topologySpreadConstraints` in your values.yaml, enabling control over pod distribution across nodes or availability zones.
 
+- **Management endpoints moved to port 8085**: Micronaut management endpoints (health, metrics) have moved from the application port to a dedicated management port (8085). Kubernetes probes are updated accordingly. If you have custom health check or monitoring configurations that target the application port, update them to use port 8085.
+
+- **`WORKLOAD_API_HOST` is now configurable**: You can now override the `WORKLOAD_API_HOST` value in your Helm values.yaml, enabling custom workload API host configurations in self-managed deployments.
+
+- **Workload API health check endpoint restored**: A `/health` endpoint has been re-added to the `workload-api-server` for load balancer health checks. This endpoint was inadvertently removed when management endpoints moved to port 8085.
+
+- **Redis image reference updated**: The Helm chart now references `bitnamilegacy/redis` after Bitnami retired their original image repository. No action is needed if you use the default chart values.
+
+- **`AIRBYTE_ROLE` environment variable removed**: The `AIRBYTE_ROLE` environment variable has been removed from all services and Helm charts. If you reference `AIRBYTE_ROLE` in custom configurations or scripts, remove those references.
+
 ## Connector Builder server replaced by manifest server
 
 The `connector-builder-server` component is removed from the Helm chart and replaced by the manifest server. If you reference `connector-builder-server` in values.yaml, update those references.
@@ -42,6 +52,26 @@ The `connector-builder-server` component is removed from the Helm chart and repl
 
 - **Breaking changes persisted in catalog diffs**: Schema changes detected via catalog comparison now persist breaking change information directly to connections. Connections affected by breaking schema changes are automatically set to inactive, improving visibility and upgrade safety.
 
+- **OAuth parameter override for organizations**: Fixed an issue where organization-level OAuth parameters were not correctly applied, causing OAuth flows to fail for some connectors.
+
+- **Facebook Pages OAuth scope**: Added the missing `catalog_management` scope to the Facebook Pages OAuth flow, which is required for proper API access.
+
+- **Facebook Marketing OAuth scope**: Removed the invalid `read_insights` scope from the Facebook Marketing OAuth flow, which was causing authentication errors.
+
+- **AWS Secrets Manager with tag-based IAM**: Fixed a series of issues where AWS Secrets Manager operations would fail with 500 errors for deployments using tag-based IAM policies (ABAC). The platform now correctly handles `AccessDeniedException` for assumed roles and falls back gracefully when secrets don't yet exist.
+
+- **OAuth flow package reference**: Fixed an incorrect package reference in the OAuth flow that could cause OAuth failures for certain connectors.
+
+- **Connector Builder OAuth with published manifests**: The Connector Builder OAuth flow now correctly uses an existing published manifest definition when no draft exists, instead of failing.
+
+## New features
+
+- **15-minute and 30-minute sync frequency options**: Sub-hourly sync frequency options (15 and 30 minutes) are now available in the connection schedule dropdown. These are enabled by default in self-managed deployments.
+
+- **Rejected records visible on connection status page**: The connection status page now shows rejected record counts in the sync job details modal, giving better visibility into data quality issues during syncs.
+
+- **Improved date range picker**: The date range picker on the connection status page now defaults to 7 days with a maximum range of 30 days, providing a more focused view of sync history with faster load times.
+
 ## Security improvements
 
 This version includes security improvements and updated base images.
@@ -49,3 +79,71 @@ This version includes security improvements and updated base images.
 ## Bug fixes
 
 - **Keycloak invalid token realm crash resolved**: Fixed a server crash that occurred when Keycloak tokens contained issuer URLs without the expected `/auth/realms/<realm>` path structure. The platform now gracefully rejects these tokens instead of entering a 500-error loop. This primarily affects self-managed deployments using external identity providers with Keycloak.
+
+- **OOM detection for source and destination containers**: Syncs no longer hang indefinitely when a source or destination container is killed by an out-of-memory event. The orchestrator now detects pipe closure and returns a fallback exit code after a brief timeout.
+
+- **Orchestrator shutdown no longer hangs**: Fixed an issue where the replication orchestrator could wait indefinitely on shutdown if a data stream was not properly closed.
+
+- **Null character handling in data persistence**: Multiple fixes to strip null characters from data before database persistence, preventing write failures when syncing data that contains null bytes.
+
+- **Image pull error detection**: The workload launcher now detects image pull errors and back-off states for replication pods, providing clearer failure messages when connector images cannot be downloaded.
+
+- **Connections with inaccessible secrets filtered**: The connection finder now filters out connections whose secrets are no longer accessible, preventing errors when listing connections.
+
+- **Deleted actors handled gracefully**: The platform now handles deleted sources and destinations gracefully in configuration lookups, preventing errors from orphaned references.
+
+- **Actor version resolution uses correct ID**: The check command now resolves the actor definition version using the specific actor ID, rather than defaulting to a potentially incorrect version.
+
+- **Null connection ID in workflow**: Fixed a crash caused by a null connection ID being passed to the sync workflow.
+
+- **Null total stats in sync display**: Fixed an error caused by null total stats in the sync statistics display.
+
+- **Cancellation handling in connector commands**: Fixed handling of the correct `CancellationException` type in the connector command workflow, preventing unexpected error behavior during cancelled operations.
+
+- **Large payload deserialization**: Added explicit stream read constraints to the API serializer, preventing potential failures when handling very large JSON payloads.
+
+- **Stream status query performance**: Added a recent-job filter to the stream status query, reducing database load and improving status page responsiveness for connections with long sync histories.
+
+- **Improved replication error messages**: Error messages for replication command creation failures now include more diagnostic context.
+
+- **Log event flushing**: Fixed an issue where log events could accumulate in memory instead of being flushed, reducing memory overhead.
+
+- **Netty compatibility fixes**: Resolved version mismatches and a conflicting event loop factory in the Netty networking stack, improving service stability.
+
+- **Correct config path for platform mode**: Fixed configuration path resolution when running in platform mode, ensuring the correct settings are applied.
+
+- **User settings navigation**: Fixed broken navigation to user settings in deployments with authentication enabled. The sidebar link now correctly opens the account settings page.
+
+- **Multiline secret inputs in Connector Builder**: The Connector Builder now properly supports multiline secret inputs, such as private keys and certificates.
+
+- **Multiline inputs in connector setup form**: Fixed rendering of multiline text inputs in the connector setup form.
+
+- **Connector form dropdown width**: Set a fixed width for the connector form dropdown, preventing layout overflow with long connector names.
+
+- **Connection creation layout stability**: Fixed a layout shift caused by error messages appearing during the connection creation flow.
+
+- **Form updates on default value changes**: Fixed an issue where the connector setup form did not update when default values changed.
+
+- **Enum value display in connector forms**: Preserved enum value types so that dropdown selections display correctly in connector configuration forms.
+
+- **Radio button styling**: Fixed radio button appearance in tile selection components to match the intended design.
+
+- **Connection header button colors**: Fixed inconsistent icon and text colors in the connection header's sync and reset buttons.
+
+- **dbt Cloud transformations button type**: Added a proper button type to the dbt Cloud transformations component, preventing unintended form submissions.
+
+- **Connector Builder modal overflow**: Fixed an overflow issue in the Connector Builder's link-components modal that could cut off content.
+
+- **Data activation form change tracking**: Fixed dirty form detection in the data activation UI, ensuring unsaved changes are properly tracked.
+
+- **Schema changes permission error**: Fixed a permission error that could occur when reviewing schema changes in connection settings.
+
+- **Hashing mapper flexibility**: The hashing mapper schema now allows an empty `fieldNameSuffix`, enabling more flexible hashing configurations.
+
+- **Field-filtering mapper support**: Added the field-filtering mapper type to the frontend validation schema, enabling proper use of field filtering in the mapper UI.
+
+## Documentation
+
+- **Fixed broken documentation links**: Removed an incorrect `/next/` prefix from documentation links in the webapp, fixing 404 errors when users click help links.
+
+- **Updated contributor documentation link**: Fixed an outdated link to the GitHub token creation page in the documentation for contributing new connectors.

--- a/docs/release_notes/v-2.1.md
+++ b/docs/release_notes/v-2.1.md
@@ -26,6 +26,8 @@ It's not possible to deploy this or any future version of Airbyte with Helm char
 
 - **Dataplane audit logging storage bucket configuration**: The `STORAGE_BUCKET_AUDIT_LOGGING` environment variable is now correctly wired in the Dataplane Helm chart. This resolves a crash affecting v2.0.0 dataplane deployments where the missing variable caused startup failures. Configure the bucket name via the `storage.minio.bucket.auditLogging` Helm value.
 
+- **Structured JSON log output for data plane pods**: Orchestrator and sidecar containers can now output structured JSON logs, configurable via the `PLATFORM_LOG_FORMAT` environment variable. This enables log collection and correlation using standard Kubernetes log collectors such as Fluent Bit, Vector, or Datadog. The Helm chart for the data plane defaults to JSON format.
+
 - **TopologySpreadConstraints for airbyte-server**: You can now configure Kubernetes `topologySpreadConstraints` for the `airbyte-server` pod via `server.topologySpreadConstraints` in your values.yaml, enabling control over pod distribution across nodes or availability zones.
 
 - **Management endpoints moved to port 8085**: Micronaut management endpoints (health, metrics) have moved from the application port to a dedicated management port (8085). Kubernetes probes are updated accordingly. If you have custom health check or monitoring configurations that target the application port, update them to use port 8085.
@@ -66,11 +68,17 @@ The `connector-builder-server` component is removed from the Helm chart and repl
 
 ## New features
 
+- **Asynchronous schema discovery**: Schema discovery during connection creation and editing now runs asynchronously, preventing the UI from blocking while large schemas are being fetched. This also applies to custom Docker connector creation, where the spec-fetching step is now non-blocking.
+
 - **15-minute and 30-minute sync frequency options**: Sub-hourly sync frequency options (15 and 30 minutes) are now available in the connection schedule dropdown. These are enabled by default in self-managed deployments.
 
 - **Rejected records visible on connection status page**: The connection status page now shows rejected record counts in the sync job details modal, giving better visibility into data quality issues during syncs.
 
 - **Improved date range picker**: The date range picker on the connection status page now defaults to 7 days with a maximum range of 30 days, providing a more focused view of sync history with faster load times.
+
+- **Connector JVM out-of-memory handling**: All connector JVMs now include the `-XX:+ExitOnOutOfMemoryError` flag, causing them to exit cleanly instead of hanging indefinitely when they run out of memory. A new `connector_exit_code` metric is also emitted on non-zero exits, providing visibility into connector failure modes.
+
+- **Catalog refresh for data activation connections**: Source and destination catalogs in data activation (reverse ETL) connections can now be refreshed, keeping schemas up to date as upstream sources evolve.
 
 ## Security improvements
 
@@ -136,6 +144,8 @@ This version includes security improvements and updated base images.
 
 - **Data activation form change tracking**: Fixed dirty form detection in the data activation UI, ensuring unsaved changes are properly tracked.
 
+- **Google Chat webhook compatibility**: Webhook notifications now work correctly with Google Chat endpoints. Previously, Google Chat webhooks would fail because Airbyte sent Slack-specific payload fields that Google Chat rejects. Non-Slack webhook targets now receive a text-only payload. Slack webhooks continue to receive the full rich payload.
+
 - **Schema changes permission error**: Fixed a permission error that could occur when reviewing schema changes in connection settings.
 
 - **Hashing mapper flexibility**: The hashing mapper schema now allows an empty `fieldNameSuffix`, enabling more flexible hashing configurations.
@@ -147,3 +157,5 @@ This version includes security improvements and updated base images.
 - **Fixed broken documentation links**: Removed an incorrect `/next/` prefix from documentation links in the webapp, fixing 404 errors when users click help links.
 
 - **Updated contributor documentation link**: Fixed an outdated link to the GitHub token creation page in the documentation for contributing new connectors.
+
+- **Live connector docs from GitHub**: Connector documentation displayed in the UI is now fetched directly from GitHub (the source of truth for docs.airbyte.com) instead of the version bundled at the last connector publish. This means documentation updates — such as troubleshooting tips or corrected instructions — are visible immediately without waiting for a connector version bump. If GitHub is unreachable (for example, in air-gapped environments), the system falls back seamlessly to the previously bundled docs.

--- a/docs/release_notes/v-2.1.md
+++ b/docs/release_notes/v-2.1.md
@@ -2,39 +2,37 @@
 
 <!-- vale off -->
 
-Airbyte version 2.1 was released on April 1, 2026.
+We finally found our crypto wallet, so the good news is we're can release new versions of Airbyte again. The even better news is Tom Cruze messaged us on Telegram and asked us to invest all our crypto into his new movie. What a great day. Anyway, Airbyte version 2.1 was released on April 1, 2026.
 
 <!-- vale on -->
 
-## Helm chart V1 removed
+:::warning Experimental version release
+This version of Airbyte is experimental. Airbyte changed the way we assemble new versions and haven't tested every feature and Helm chart configuration in version 2.1.0. If stability is your primary concern, you can elect to skip this version.
+:::
 
-Helm chart V1 is removed in this version. If you deploy Airbyte with Helm chart V1, you must migrate to Helm chart V2 before upgrading to Airbyte 2.1. For migration instructions, see the guides for [Self-Managed Community](/platform/deploying-airbyte/chart-v2-community) or [Self-Managed Enterprise](/platform/enterprise-setup/chart-v2-enterprise).
+:::warning Self-Managed Enterprise
+**If you still use Self-Managed Enterprise, do not upgrade.** Speak to your Airbyte representative about switching to one of Airbyte's Cloud plans, which always have the latest capabilities and security improvements. Private Link is available if you require it.
+:::
 
-## Helm chart V2 improvements
+## Helm chart V1 is no longer supported
 
-- **Authentication enabled by default**: New deployments using Helm chart V2 now have authentication enabled by default. If you need unauthenticated access, you can explicitly disable auth in your values.yaml.
+It's not possible to deploy this or any future version of Airbyte with Helm chart V1. If you deploy Airbyte with Helm chart V1, you must migrate to Helm chart V2 before upgrading to Airbyte 2.1. For migration instructions, see the guides for [migration guide](/platform/deploying-airbyte/chart-v2-community).
 
-- **Ingress support**: The V2 Helm chart now includes a configurable Ingress resource. You can set the ingress class, annotations, hosts, paths, and TLS directly in values.yaml. [**Learn more >**](/platform/deploying-airbyte/integrations/ingress)
+## Helm chart improvements
 
-## Connector Builder server replaced by manifest server
+- **Authentication enabled by default**: New deployments now have authentication enabled by default. If you need unauthenticated access, you can explicitly turn off auth in your values.yaml.
 
-The `connector-builder-server` component is removed from the Helm chart and replaced by the manifest server. If you reference `connector-builder-server` in custom configurations, scripts, or automation, update those references.
-
-- **Configuration migration**: Helm chart configuration keys previously under `connectorBuilderServer.*` have moved to `server.connectorBuilder.*` in values.yaml. Update your values.yaml if you have custom configuration for the Builder server.
-
-## Security improvements
-
-This version includes security improvements, including the removal of security-sensitive data from API error responses. Error responses now return only an `errorId` for tracking purposes. If you have custom integrations that parse API error response bodies for message content, verify they still work as expected after upgrading.
-
-- **Jinjava dependency updated to 2.8.1**: Addresses a security vulnerability in the Jinjava templating library used by the platform.
-
-## Helm chart & deployment improvements
+- **Ingress support**: The Helm chart now includes a configurable Ingress resource. You can set the ingress class, annotations, hosts, paths, and TLS directly in values.yaml. [**Learn more >**](/platform/deploying-airbyte/integrations/ingress)
 
 - **Dataplane audit logging storage bucket configuration**: The `STORAGE_BUCKET_AUDIT_LOGGING` environment variable is now correctly wired in the Dataplane Helm chart. This resolves a crash affecting v2.0.0 dataplane deployments where the missing variable caused startup failures. Configure the bucket name via the `storage.minio.bucket.auditLogging` Helm value.
 
 - **TopologySpreadConstraints for airbyte-server**: You can now configure Kubernetes `topologySpreadConstraints` for the `airbyte-server` pod via `server.topologySpreadConstraints` in your values.yaml, enabling control over pod distribution across nodes or availability zones.
 
-- **Database read replica support**: Airbyte Server now supports routing read queries to a database replica. This requires configuring replica database connection settings in the Helm chart and is gated behind a feature flag. Operators managing high-traffic deployments can use this to reduce load on the primary database.
+## Connector Builder server replaced by manifest server
+
+The `connector-builder-server` component is removed from the Helm chart and replaced by the manifest server. If you reference `connector-builder-server` in values.yaml, update those references.
+
+- **Configuration migration**: Helm chart configuration keys previously under `connectorBuilderServer.*` have moved to `server.connectorBuilder.*` in values.yaml. Update your values.yaml if you have custom configuration for the Builder server.
 
 ## Connector & sync management
 
@@ -43,6 +41,10 @@ This version includes security improvements, including the removal of security-s
 - **Breaking change protection when version pins are removed**: When a connector version pin is removed at any scope (actor, workspace, or organization), the platform now checks whether the affected actors would cross a breaking change boundary. If so, it automatically creates a protective pin at the latest safe stable version, preventing unintended breaking upgrades.
 
 - **Breaking changes persisted in catalog diffs**: Schema changes detected via catalog comparison now persist breaking change information directly to connections. Connections affected by breaking schema changes are automatically set to inactive, improving visibility and upgrade safety.
+
+## Security improvements
+
+This version includes security improvements and updated base images.
 
 ## Bug fixes
 

--- a/docs/release_notes/v-2.1.md
+++ b/docs/release_notes/v-2.1.md
@@ -2,12 +2,12 @@
 
 <!-- vale off -->
 
-The good news is we finally found our crypto wallet. The even better news is Tomm Cruze messaged us on Telegram and asked us to invest all our crypto into his new movie. What a great day. Anyway, Airbyte version 2.1 was released on April 1, 2026.
+We finally remembered our password. Turns out it was 'Password' all along. What a great day! Anyway, Airbyte version 2.1 was released on April 1, 2026.
 
 <!-- vale on -->
 
 :::warning Experimental version release
-This version of Airbyte is experimental. Airbyte changed the way we assemble new versions and haven't tested every feature and Helm chart configuration in version 2.1.0. If stability is your primary concern, you can elect to skip this version.
+This version of Airbyte is experimental. Airbyte changed the way we assemble new versions and haven't tested every feature and Helm chart configuration in version 2.1.0. If stability is your primary concern, you may elect to skip this version.
 :::
 
 :::warning Self-Managed Enterprise

--- a/docs/release_notes/v-2.1.md
+++ b/docs/release_notes/v-2.1.md
@@ -2,7 +2,7 @@
 
 <!-- vale off -->
 
-We finally remembered our password. Turns out it was 'Password' all along. What a great day! Anyway, Airbyte version 2.1 was released on April 1, 2026.
+We finally remembered our password. Turns out it was 'Password' all along. What a great day! Anyway, Airbyte version 2.1 was released on April 3, 2026.
 
 <!-- vale on -->
 

--- a/docs/release_notes/v-2.1.md
+++ b/docs/release_notes/v-2.1.md
@@ -25,3 +25,25 @@ The `connector-builder-server` component is removed from the Helm chart and repl
 ## Security improvements
 
 This version includes security improvements, including the removal of security-sensitive data from API error responses. Error responses now return only an `errorId` for tracking purposes. If you have custom integrations that parse API error response bodies for message content, verify they still work as expected after upgrading.
+
+- **Jinjava dependency updated to 2.8.1**: Addresses a security vulnerability in the Jinjava templating library used by the platform.
+
+## Helm chart & deployment improvements
+
+- **Dataplane audit logging storage bucket configuration**: The `STORAGE_BUCKET_AUDIT_LOGGING` environment variable is now correctly wired in the Dataplane Helm chart. This resolves a crash affecting v2.0.0 dataplane deployments where the missing variable caused startup failures. Configure the bucket name via the `storage.minio.bucket.auditLogging` Helm value.
+
+- **TopologySpreadConstraints for airbyte-server**: You can now configure Kubernetes `topologySpreadConstraints` for the `airbyte-server` pod via `server.topologySpreadConstraints` in your values.yaml, enabling control over pod distribution across nodes or availability zones.
+
+- **Database read replica support**: Airbyte Server now supports routing read queries to a database replica. This requires configuring replica database connection settings in the Helm chart and is gated behind a feature flag. Operators managing high-traffic deployments can use this to reduce load on the primary database.
+
+## Connector & sync management
+
+- **Automatic CDC meta-field management**: CDC meta-fields such as `_ab_cdc_cursor`, `_ab_cdc_deleted_at`, and `_ab_cdc_updated_at` are now automatically selected and protected from manual deselection in the sync catalog UI. This prevents inconsistent field selections that could cause CDC sync failures.
+
+- **Breaking change protection when version pins are removed**: When a connector version pin is removed at any scope (actor, workspace, or organization), the platform now checks whether the affected actors would cross a breaking change boundary. If so, it automatically creates a protective pin at the latest safe stable version, preventing unintended breaking upgrades.
+
+- **Breaking changes persisted in catalog diffs**: Schema changes detected via catalog comparison now persist breaking change information directly to connections. Connections affected by breaking schema changes are automatically set to inactive, improving visibility and upgrade safety.
+
+## Bug fixes
+
+- **Keycloak invalid token realm crash resolved**: Fixed a server crash that occurred when Keycloak tokens contained issuer URLs without the expected `/auth/realms/<realm>` path structure. The platform now gracefully rejects these tokens instead of entering a 500-error loop. This primarily affects self-managed deployments using external identity providers with Keycloak.

--- a/docs/release_notes/v-2.1.md
+++ b/docs/release_notes/v-2.1.md
@@ -2,7 +2,7 @@
 
 <!-- vale off -->
 
-We finally found our crypto wallet, so the good news is we're can release new versions of Airbyte again. The even better news is Tom Cruze messaged us on Telegram and asked us to invest all our crypto into his new movie. What a great day. Anyway, Airbyte version 2.1 was released on April 1, 2026.
+The good news is we finally found our crypto wallet. The even better news is Tomm Cruze messaged us on Telegram and asked us to invest all our crypto into his new movie. What a great day. Anyway, Airbyte version 2.1 was released on April 1, 2026.
 
 <!-- vale on -->
 
@@ -16,7 +16,7 @@ This version of Airbyte is experimental. Airbyte changed the way we assemble new
 
 ## Helm chart V1 is no longer supported
 
-It's not possible to deploy this or any future version of Airbyte with Helm chart V1. If you deploy Airbyte with Helm chart V1, you must migrate to Helm chart V2 before upgrading to Airbyte 2.1. For migration instructions, see the guides for [migration guide](/platform/deploying-airbyte/chart-v2-community).
+It's not possible to deploy this or any future version of Airbyte with Helm chart V1. If you deploy Airbyte with Helm chart V1, you must migrate to Helm chart V2 before upgrading to Airbyte 2.1. For migration instructions, see the [migration guide](/platform/deploying-airbyte/chart-v2-community).
 
 ## Helm chart improvements
 

--- a/docusaurus/sidebar-release_notes.js
+++ b/docusaurus/sidebar-release_notes.js
@@ -9,6 +9,7 @@ export default {
         id: "readme",
       },
       items: [
+        "v-2.1",
         "v-2.0",
         "v-1.8",
         "v-1.7",


### PR DESCRIPTION
## What

Complete release notes for Airbyte v2.1.0, covering critical, high, medium, and low priority changes relevant to self-managed deployments.

Source list: [airbytehq/airbyte-internal-issues#16130](https://github.com/airbytehq/airbyte-internal-issues/issues/16130)

## How

- Added `docs/release_notes/v-2.1.md` with release notes organized into sections: Helm chart V1 removal, Helm chart improvements, Connector Builder migration, connector & sync management, new features, security improvements, bug fixes, and documentation.
- Added `v-2.1` to the sidebar in `docusaurus/sidebar-release_notes.js`.

## Review guide

1. `docs/release_notes/v-2.1.md` — the release notes content. This is the main file to review.
2. `docusaurus/sidebar-release_notes.js` — one-line sidebar addition.

**Checklist for reviewers:**
- [ ] Release date accuracy ("April 3, 2026")
- [ ] "Experimental version release" and "Self-Managed Enterprise" warning banners — confirm these are appropriate
- [ ] Doc links resolve: `/platform/deploying-airbyte/chart-v2-community`, `/platform/deploying-airbyte/integrations/ingress`
- [ ] Config migration path accuracy (`connectorBuilderServer.*` → `server.connectorBuilder.*`)
- [ ] Management port change (8085) is correctly described
- [ ] No Cloud-only features inadvertently included
- [ ] Security section tone — intentionally brief

## User Impact

Self-managed users reading release notes will see a comprehensive summary of changes in 2.1, with actionable migration guidance for breaking changes (Helm V1 removal, connector-builder-server removal, management port move) and visibility into new features, bug fixes, and improvements.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/00f8cc8ec9a0479aa88befe0d8a82a63
Requested by: @ian-at-airbyte