### PR TITLE
docs: add Airbyte 2.1.0 release notes (high-priority changes)

### DIFF
--- a/docs/release_notes/v-2.1.md
+++ b/docs/release_notes/v-2.1.md
@@ -25,3 +25,25 @@ The `connector-builder-server` component is removed from the Helm chart and repl
 ## Security improvements
 
 This version includes security improvements, including the removal of security-sensitive data from API error responses. Error responses now return only an `errorId` for tracking purposes. If you have custom integrations that parse API error response bodies for message content, verify they still work as expected after upgrading.
+
+- **Jinjava dependency updated to 2.8.1**: Addresses a security vulnerability in the Jinjava templating library used by the platform.
+
+## Helm chart & deployment improvements
+
+- **Dataplane audit logging storage bucket configuration**: The `STORAGE_BUCKET_AUDIT_LOGGING` environment variable is now correctly wired in the Dataplane Helm chart. This resolves a crash affecting v2.0.0 dataplane deployments where the missing variable caused startup failures. Configure the bucket name via the `storage.minio.bucket.auditLogging` Helm value.
+
+- **TopologySpreadConstraints for airbyte-server**: You can now configure Kubernetes `topologySpreadConstraints` for the `airbyte-server` pod via `server.topologySpreadConstraints` in your values.yaml, enabling control over pod distribution across nodes or availability zones.
+
+- **Database read replica support**: Airbyte Server now supports routing read queries to a database replica. This requires configuring replica database connection settings in the Helm chart and is gated behind a feature flag. Operators managing high-traffic deployments can use this to reduce load on the primary database.
+
+## Connector & sync management
+
+- **Automatic CDC meta-field management**: CDC meta-fields such as `_ab_cdc_cursor`, `_ab_cdc_deleted_at`, and `_ab_cdc_updated_at` are now automatically selected and protected from manual deselection in the sync catalog UI. This prevents inconsistent field selections that could cause CDC sync failures.
+
+- **Breaking change protection when version pins are removed**: When a connector version pin is removed at any scope (actor, workspace, or organization), the platform now checks whether the affected actors would cross a breaking change boundary. If so, it automatically creates a protective pin at the latest safe stable version, preventing unintended breaking upgrades.
+
+- **Breaking changes persisted in catalog diffs**: Schema changes detected via catalog comparison now persist breaking change information directly to connections. Connections affected by breaking schema changes are automatically set to inactive, improving visibility and upgrade safety.
+
+## Bug fixes
+
+- **Keycloak invalid token realm crash resolved**: Fixed a server crash that occurred when Keycloak tokens contained issuer URLs without the expected `/auth/realms/<realm>` path structure. The platform now gracefully rejects these tokens instead of entering a 500-error loop. This primarily affects self-managed deployments using external identity providers with Keycloak.


### PR DESCRIPTION
This PR targets the following PR:
- #75961

---

## What

Adds the **high-priority** release notes to the Airbyte v2.1.0 release notes page, stacking on top of #75961 (which covers critical changes).

Source list: [airbytehq/airbyte-internal-issues#16130](https://github.com/airbytehq/airbyte-internal-issues/issues/16130)

The 10 high-priority PRs covered:
- [airbytehq/airbyte-platform-internal#17967](https://github.com/airbytehq/airbyte-platform-internal/pull/17967) — Dataplane `STORAGE_BUCKET_AUDIT_LOGGING` fix
- [airbytehq/airbyte-platform-internal#18412](https://github.com/airbytehq/airbyte-platform-internal/pull/18412) — TopologySpreadConstraints for airbyte-server
- [airbytehq/airbyte-platform-internal#18563](https://github.com/airbytehq/airbyte-platform-internal/pull/18563) — Database read replica support
- [airbytehq/airbyte-platform-internal#17874](https://github.com/airbytehq/airbyte-platform-internal/pull/17874) — Jinjava security bump to 2.8.1
- [airbytehq/airbyte-platform-internal#18383](https://github.com/airbytehq/airbyte-platform-internal/pull/18383) — Automatic CDC meta-field management
- [airbytehq/airbyte-platform-internal#18793](https://github.com/airbytehq/airbyte-platform-internal/pull/18793) — Breaking change protection for scope deletion
- [airbytehq/airbyte-platform-internal#18812](https://github.com/airbytehq/airbyte-platform-internal/pull/18812) — Exclude preview versions from breaking change pins
- [airbytehq/airbyte-platform-internal#18341](https://github.com/airbytehq/airbyte-platform-internal/pull/18341) — Persist breaking changes in catalog diffs
- [airbytehq/airbyte-platform-internal#18485](https://github.com/airbytehq/airbyte-platform-internal/pull/18485) — Keycloak invalid token realm crash fix
- [airbytehq/airbyte-platform-internal#17759](https://github.com/airbytehq/airbyte-platform-internal/pull/17759) — Remove connector-builder-server calls (folded into critical section context)

## How

Appended four new sections to `docs/release_notes/v-2.1.md`:
1. A Jinjava bullet under the existing **Security improvements** heading
2. **Helm chart & deployment improvements** — dataplane fix, topology constraints, read replicas
3. **Connector & sync management** — CDC meta-fields, breaking change protection, catalog diffs
4. **Bug fixes** — Keycloak token crash

## Review guide

1. `docs/release_notes/v-2.1.md` — the only file changed

**Key items for reviewers:**
- [ ] Technical accuracy of each bullet — do the descriptions match what the referenced PRs actually do?
- [ ] There are now two Helm-related sections: "Helm chart V2 improvements" (from #75961) and "Helm chart & deployment improvements" (this PR). Consider whether these should be consolidated when the stack is merged.
- [ ] Heading casing: the base PR uses title case ("Helm chart V2 improvements") while this PR uses sentence case ("Helm chart & deployment improvements"). Decide on a consistent style.
- [ ] The Jinjava bullet is appended under the existing "Security improvements" section — verify this reads naturally as a continuation.

## User Impact

Self-managed users reading release notes will see a more complete summary of v2.1 changes, covering deployment improvements, sync management features, and bug fixes beyond the critical items.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/8ec7e2d8cc784439b8523d9803956ddb
Requested by: @ian-at-airbyte