### PR TITLE
feat(source-snowflake): Add start/end date filtering with full_refresh_temporal_column support

### DIFF
--- a/airbyte-integrations/connectors/source-snowflake/metadata.yaml
+++ b/airbyte-integrations/connectors/source-snowflake/metadata.yaml
@@ -8,7 +8,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: e2d65910-8c8b-40a1-ae7d-ee2416b2bfa2
-  dockerImageTag: 1.0.10
+  dockerImageTag: 1.1.0
   dockerRepository: airbyte/source-snowflake
   documentationUrl: https://docs.airbyte.com/integrations/sources/snowflake
   githubIssueLabel: source-snowflake

--- a/airbyte-integrations/connectors/source-snowflake/src/main/kotlin/io/airbyte/integrations/source/snowflake/SnowflakeSourceConfiguration.kt
+++ b/airbyte-integrations/connectors/source-snowflake/src/main/kotlin/io/airbyte/integrations/source/snowflake/SnowflakeSourceConfiguration.kt
@@ -13,6 +13,8 @@ import jakarta.inject.Singleton
 import java.net.URLDecoder
 import java.nio.charset.StandardCharsets
 import java.time.Duration
+import java.time.LocalDate
+import java.time.format.DateTimeParseException
 
 private val log = KotlinLogging.logger {}
 
@@ -37,6 +39,9 @@ data class SnowflakeSourceConfiguration(
     override val resourceAcquisitionHeartbeat: Duration = Duration.ofMillis(100L),
     override val checkpointTargetInterval: Duration,
     override val checkPrivileges: Boolean,
+    val startDate: String? = null,
+    val endDate: String? = null,
+    val fullRefreshTemporalColumn: String? = null,
 ) : JdbcSourceConfiguration {
     override val global = false
     override val maxSnapshotReadDuration: Duration? =
@@ -125,6 +130,24 @@ class SnowflakeSourceConfigurationFactory :
         }
         val incrementalConfiguration: IncrementalConfiguration =
             UserDefinedCursorIncrementalConfiguration
+
+        // Validate and parse optional date range bounds
+        fun parseDate(field: String, value: String?): LocalDate? {
+            if (value == null) return null
+            return try {
+                LocalDate.parse(value)
+            } catch (e: DateTimeParseException) {
+                throw ConfigErrorException("$field must be in YYYY-MM-DD format, got: $value")
+            }
+        }
+        val parsedStartDate = parseDate("start_date", pojo.startDate)
+        val parsedEndDate = parseDate("end_date", pojo.endDate)
+        if (parsedStartDate != null && parsedEndDate != null && parsedStartDate > parsedEndDate) {
+            throw ConfigErrorException(
+                "start_date ($parsedStartDate) must not be after end_date ($parsedEndDate)"
+            )
+        }
+
         return SnowflakeSourceConfiguration(
             realHost = realHost,
             jdbcUrlFmt = jdbcUrlFmt,
@@ -135,6 +158,9 @@ class SnowflakeSourceConfigurationFactory :
             checkpointTargetInterval = checkpointTargetInterval,
             maxConcurrency = maxConcurrency,
             checkPrivileges = pojo.checkPrivileges ?: true,
+            startDate = pojo.startDate,
+            endDate = pojo.endDate,
+            fullRefreshTemporalColumn = pojo.fullRefreshTemporalColumn,
         )
     }
 

--- a/airbyte-integrations/connectors/source-snowflake/src/main/kotlin/io/airbyte/integrations/source/snowflake/SnowflakeSourceConfigurationSpecification.kt
+++ b/airbyte-integrations/connectors/source-snowflake/src/main/kotlin/io/airbyte/integrations/source/snowflake/SnowflakeSourceConfigurationSpecification.kt
@@ -148,6 +148,40 @@ class SnowflakeSourceConfigurationSpecification : ConfigurationSpecification() {
     )
     var checkPrivileges: Boolean? = true
 
+    @JsonProperty("start_date")
+    @JsonSchemaTitle("Start Date")
+    @JsonPropertyDescription(
+        "Only sync records where the cursor field (incremental) or the full_refresh_temporal_column " +
+            "(full-refresh) is on or after this date (YYYY-MM-DD).",
+    )
+    @JsonSchemaInject(
+        json =
+            """{"order":11,"pattern":"^[0-9]{4}-[0-9]{2}-[0-9]{2}${'$'}","examples":["2024-01-01"]}"""
+    )
+    var startDate: String? = null
+
+    @JsonProperty("end_date")
+    @JsonSchemaTitle("End Date")
+    @JsonPropertyDescription(
+        "Only sync records where the cursor field (incremental) or the full_refresh_temporal_column " +
+            "(full-refresh) is on or before this date (YYYY-MM-DD).",
+    )
+    @JsonSchemaInject(
+        json =
+            """{"order":12,"pattern":"^[0-9]{4}-[0-9]{2}-[0-9]{2}${'$'}","examples":["2024-12-31"]}"""
+    )
+    var endDate: String? = null
+
+    @JsonProperty("full_refresh_temporal_column")
+    @JsonSchemaTitle("Full Refresh Temporal Column")
+    @JsonPropertyDescription(
+        "Column used to filter full-refresh syncs by start_date and/or end_date. " +
+            "Must be a DATE or TIMESTAMP column present in every synced table. " +
+            "Has no effect when both start_date and end_date are unset.",
+    )
+    @JsonSchemaInject(json = """{"order":13}""")
+    var fullRefreshTemporalColumn: String? = null
+
     @JsonIgnore var additionalPropertiesMap = mutableMapOf<String, Any>()
 
     @JsonAnyGetter fun getAdditionalProperties(): Map<String, Any> = additionalPropertiesMap

--- a/airbyte-integrations/connectors/source-snowflake/src/main/kotlin/io/airbyte/integrations/source/snowflake/SnowflakeSourceOperations.kt
+++ b/airbyte-integrations/connectors/source-snowflake/src/main/kotlin/io/airbyte/integrations/source/snowflake/SnowflakeSourceOperations.kt
@@ -6,6 +6,8 @@ package io.airbyte.integrations.source.snowflake
 
 import com.fasterxml.jackson.databind.node.ObjectNode
 import io.airbyte.cdk.command.OpaqueStateValue
+import io.airbyte.cdk.command.SourceConfiguration
+import io.airbyte.cdk.data.LocalDateCodec
 import io.airbyte.cdk.discover.Field
 import io.airbyte.cdk.discover.FieldType
 import io.airbyte.cdk.discover.JdbcAirbyteStreamFactory
@@ -60,13 +62,43 @@ import io.airbyte.cdk.read.WhereNode
 import io.airbyte.cdk.util.Jsons
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.micronaut.context.annotation.Primary
+import io.micronaut.core.annotation.Nullable
+import jakarta.inject.Inject
 import jakarta.inject.Singleton
+import java.time.LocalDate
 import java.time.OffsetDateTime
 
 @Singleton
 @Primary
-class SnowflakeSourceOperations() :
-    JdbcMetadataQuerier.FieldTypeMapper, SelectQueryGenerator, JdbcAirbyteStreamFactory {
+class SnowflakeSourceOperations
+@Inject
+constructor(
+    @Nullable sourceConfig: SourceConfiguration? = null,
+) : JdbcMetadataQuerier.FieldTypeMapper, SelectQueryGenerator, JdbcAirbyteStreamFactory {
+    private val configuration: SnowflakeSourceConfiguration? =
+        when {
+            sourceConfig == null -> null
+            sourceConfig is SnowflakeSourceConfiguration -> sourceConfig
+            else ->
+                throw IllegalStateException(
+                    "Expected SnowflakeSourceConfiguration but got" +
+                        " ${sourceConfig::class.qualifiedName}"
+                )
+        }
+
+    /**
+     * Cache of cursor field per table (namespace to name), populated when a SELECT MAX(cursor)
+     * query is seen. Used to apply date bounds to unsplittable snapshot reads which have no ORDER
+     * BY and no SELECT MAX in their SelectQuerySpec.
+     *
+     * This cache is never cleared; it is scoped to a single sync run (one
+     * [SnowflakeSourceOperations] instance lifetime).
+     */
+    private val cursorFieldByTable =
+        java.util.concurrent.ConcurrentHashMap<Pair<String?, String>, Field>()
+
+    private val startDate: LocalDate? = configuration?.startDate?.let { LocalDate.parse(it) }
+    private val endDate: LocalDate? = configuration?.endDate?.let { LocalDate.parse(it) }
     private val log = KotlinLogging.logger {}
 
     override val globalCursor: MetaField? = null
@@ -127,8 +159,90 @@ class SnowflakeSourceOperations() :
         }
     }
 
-    override fun generate(ast: SelectQuerySpec): SelectQuery =
-        SelectQuery(ast.sql(), ast.select.columns, ast.bindings())
+    override fun generate(ast: SelectQuerySpec): SelectQuery {
+        val modifiedAst = applyDateBounds(ast)
+        return SelectQuery(modifiedAst.sql(), modifiedAst.select.columns, modifiedAst.bindings())
+    }
+
+    private fun tableKey(from: FromNode): Pair<String?, String>? =
+        when (from) {
+            is From -> from.namespace to from.name
+            is FromSample -> from.namespace to from.name
+            else -> null
+        }
+
+    private fun applyDateBounds(ast: SelectQuerySpec): SelectQuerySpec {
+        if (startDate == null && endDate == null) return ast
+
+        val key = tableKey(ast.from)
+        val fullRefreshColName = configuration?.fullRefreshTemporalColumn
+
+        // Detect the cursor field:
+        // 1. SELECT MAX — authoritative cursor; cache only when it is the temporal column or no
+        //    temporal column is configured. PK MAX queries (used for full-refresh splitting) must
+        //    NOT be cached, otherwise they pollute the cache for subsequent read queries.
+        // 2. Cached cursor — covers splittable reads where ORDER BY is the PK, not the cursor.
+        // 3. Full-refresh temporal column — look it up directly in the SELECT list (before the
+        //    ORDER BY fallback so PK columns in ORDER BY are not mistaken for the cursor).
+        // 4. ORDER BY fallback — for incremental without a cache entry yet (first partition).
+        val cursorField: Field? =
+            when {
+                ast.select is SelectColumnMaxValue -> {
+                    val field = (ast.select as SelectColumnMaxValue).column
+                    val isCursorMax = fullRefreshColName == null || field.id == fullRefreshColName
+                    if (isCursorMax) {
+                        key?.let { cursorFieldByTable[it] = field }
+                        field
+                    } else {
+                        null // PK MAX for full-refresh splitting — skip date filtering
+                    }
+                }
+                key != null && cursorFieldByTable.containsKey(key) -> cursorFieldByTable[key]
+                fullRefreshColName != null && ast.select is SelectColumns -> {
+                    val columns = (ast.select as SelectColumns).columns
+                    val byName = columns.find { it.id == fullRefreshColName }
+                    when {
+                        byName == null -> {
+                            // NullFieldType appears during LIMIT 0 discovery queries — skip those
+                            // silently. Only warn for real queries where types are resolved.
+                            if (columns.any { it.type is LosslessJdbcFieldType<*, *> }) {
+                                log.warn {
+                                    "fullRefreshTemporalColumn '$fullRefreshColName' not found in" +
+                                        " SELECT columns for $key — date filtering skipped"
+                                }
+                            }
+                            null
+                        }
+                        byName.type !is LosslessJdbcFieldType<*, *> -> null // discovery query
+                        else -> byName
+                    }
+                }
+                ast.orderBy is OrderBy -> (ast.orderBy as OrderBy).columns.firstOrNull()
+                else -> null
+            }
+        if (cursorField == null) return ast
+
+        // Build the extra date conditions using a LocalDate-typed binding
+        val extra = mutableListOf<WhereClauseNode>()
+        startDate?.let { extra += GreaterOrEqual(cursorField, LocalDateCodec.encode(it)) }
+        endDate?.let { extra += LesserOrEqual(cursorField, LocalDateCodec.encode(it)) }
+
+        fun addTo(w: WhereNode): WhereNode =
+            when {
+                extra.isEmpty() -> w
+                w is NoWhere -> Where(if (extra.size == 1) extra.first() else And(extra))
+                w is Where -> Where(And(listOf(w.clause) + extra))
+                else -> w
+            }
+
+        // For sampling queries, apply date conditions to the inner FromSample WHERE as well
+        val newFrom =
+            when (val f = ast.from) {
+                is FromSample -> f.copy(where = addTo(f.where ?: NoWhere))
+                else -> ast.from
+            }
+        return ast.copy(where = addTo(ast.where), from = newFrom)
+    }
 
     fun SelectQuerySpec.sql(): String {
         val components: List<String> = listOf(select.sql(), from.sql(), where.sql(), orderBy.sql())

--- a/airbyte-integrations/connectors/source-snowflake/src/test/kotlin/io/airbyte/integrations/source/snowflake/SnowflakeFullRefreshDateBoundsTest.kt
+++ b/airbyte-integrations/connectors/source-snowflake/src/test/kotlin/io/airbyte/integrations/source/snowflake/SnowflakeFullRefreshDateBoundsTest.kt
@@ -1,0 +1,549 @@
+/*
+ * Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.source.snowflake
+
+import io.airbyte.cdk.data.LocalDateCodec
+import io.airbyte.cdk.discover.Field
+import io.airbyte.cdk.jdbc.IntFieldType
+import io.airbyte.cdk.jdbc.LocalDateFieldType
+import io.airbyte.cdk.jdbc.NullFieldType
+import io.airbyte.cdk.jdbc.StringFieldType
+import io.airbyte.cdk.read.*
+import io.airbyte.cdk.util.Jsons
+import java.time.LocalDate
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests date bound filtering for full-refresh syncs via the `full_refresh_temporal_column` config.
+ *
+ * Key behaviours verified:
+ * - Temporal column found in SELECT → WHERE clause injected on that column
+ * - Temporal column not in SELECT → no filtering (skip gracefully)
+ * - NullFieldType during LIMIT 0 discovery → skip (guarded by LosslessJdbcFieldType check)
+ * - PK MAX query (full-refresh splitting) → NOT cached, no date bounds on PK
+ * - After PK MAX, read query → date bounds on temporal column, NOT on PK
+ * - Mixed catalog (incremental + full-refresh same table) → no cache interference
+ * - FromSample in full-refresh → bounds injected in both inner sample and outer WHERE
+ */
+class SnowflakeFullRefreshDateBoundsTest : SnowflakeOperationsBaseTest() {
+
+    @Test
+    fun testTemporalColumnInSelectAppliesDateBounds() {
+        val eventDateField = Field("event_date", LocalDateFieldType)
+        val gen =
+            SnowflakeSourceOperations(
+                configWith(
+                    startDate = "2024-01-01",
+                    endDate = "2024-12-31",
+                    fullRefreshTemporalColumn = "event_date"
+                )
+            )
+
+        val query =
+            gen.generate(
+                SelectQuerySpec(
+                    select = SelectColumns(eventDateField, Field("id", IntFieldType)),
+                    from = From("events", "public"),
+                    where = NoWhere,
+                    // No ORDER BY → full-refresh
+                    )
+            )
+
+        assertEquals(
+            """SELECT "event_date", "id" FROM "public"."events" WHERE ("event_date" >= ?) AND ("event_date" <= ?)""",
+            query.sql,
+        )
+        assertEquals(2, query.bindings.size)
+    }
+
+    // cas 14 & 15: only startDate / only endDate
+
+    @Test
+    fun testOnlyStartDateAppliedInFullRefreshMode() {
+        val dateField = Field("event_date", LocalDateFieldType)
+        val gen =
+            SnowflakeSourceOperations(
+                configWith(startDate = "2024-01-01", fullRefreshTemporalColumn = "event_date")
+            )
+
+        val query =
+            gen.generate(
+                SelectQuerySpec(
+                    select = SelectColumns(dateField, Field("id", IntFieldType)),
+                    from = From("events", "public"),
+                    where = NoWhere,
+                )
+            )
+
+        assertEquals(
+            """SELECT "event_date", "id" FROM "public"."events" WHERE "event_date" >= ?""",
+            query.sql,
+        )
+        assertEquals(1, query.bindings.size)
+    }
+
+    @Test
+    fun testOnlyEndDateAppliedInFullRefreshMode() {
+        val dateField = Field("event_date", LocalDateFieldType)
+        val gen =
+            SnowflakeSourceOperations(
+                configWith(endDate = "2024-12-31", fullRefreshTemporalColumn = "event_date")
+            )
+
+        val query =
+            gen.generate(
+                SelectQuerySpec(
+                    select = SelectColumns(dateField, Field("id", IntFieldType)),
+                    from = From("events", "public"),
+                    where = NoWhere,
+                )
+            )
+
+        assertEquals(
+            """SELECT "event_date", "id" FROM "public"."events" WHERE "event_date" <= ?""",
+            query.sql,
+        )
+        assertEquals(1, query.bindings.size)
+    }
+
+    @Test
+    fun testTemporalColumnNotInSelectSkipsDateBounds() {
+        val gen =
+            SnowflakeSourceOperations(
+                configWith(startDate = "2024-01-01", fullRefreshTemporalColumn = "missing_col")
+            )
+
+        val query =
+            gen.generate(
+                SelectQuerySpec(
+                    select =
+                        SelectColumns(Field("id", IntFieldType), Field("name", StringFieldType)),
+                    from = From("users", "public"),
+                    where = NoWhere,
+                )
+            )
+
+        assertEquals("""SELECT "id", "name" FROM "public"."users"""", query.sql)
+        assertEquals(0, query.bindings.size)
+    }
+
+    // cas 2: SELECT MAX on cursor = temporal col
+
+    /**
+     * SELECT MAX on the temporal column itself (cursor == temporal col, the realistic config):
+     * isCursorMax = true → the cursor is cached AND date bounds are applied to the MAX query. A
+     * subsequent snapshot read must also be filtered via the cache.
+     */
+    @Test
+    fun testTemporalColumnMaxQueryCachesAndAppliesBounds() {
+        val dateField = Field("DATE_COMMANDE", LocalDateFieldType)
+        val gen =
+            SnowflakeSourceOperations(
+                configWith(
+                    startDate = "2024-01-01",
+                    endDate = "2024-12-31",
+                    fullRefreshTemporalColumn = "DATE_COMMANDE",
+                )
+            )
+
+        val maxQuery =
+            gen.generate(
+                SelectQuerySpec(
+                    select = SelectColumnMaxValue(dateField),
+                    from = From("V1_COMMANDES", "OUT_ACTIONABLE"),
+                )
+            )
+
+        assertEquals(
+            """SELECT MAX("DATE_COMMANDE") FROM "OUT_ACTIONABLE"."V1_COMMANDES" WHERE ("DATE_COMMANDE" >= ?) AND ("DATE_COMMANDE" <= ?)""",
+            maxQuery.sql,
+        )
+        assertEquals(2, maxQuery.bindings.size)
+
+        // Cursor is now cached → a snapshot read (no ORDER BY) must also be filtered
+        val snapshotQuery =
+            gen.generate(
+                SelectQuerySpec(
+                    select = SelectColumns(dateField, Field("id", IntFieldType)),
+                    from = From("V1_COMMANDES", "OUT_ACTIONABLE"),
+                )
+            )
+        assert(snapshotQuery.sql.contains(""""DATE_COMMANDE" >= ?""")) { "startDate via cache" }
+        assert(snapshotQuery.sql.contains(""""DATE_COMMANDE" <= ?""")) { "endDate via cache" }
+    }
+
+    // cas 12: NullFieldType guard (LIMIT 0 discovery queries)
+
+    /**
+     * During schema discovery the CDK issues LIMIT 0 queries. At that point column types are
+     * NullFieldType — not yet resolved from JDBC metadata. The temporal column lookup must skip
+     * these columns (NullFieldType is not a LosslessJdbcFieldType) to avoid a ClassCastException.
+     */
+    @Test
+    fun testNullFieldTypeInSelectSkipsDateBoundsForFullRefresh() {
+        val nullTypedDateCol = Field("event_date", NullFieldType)
+        val gen =
+            SnowflakeSourceOperations(
+                configWith(
+                    startDate = "2024-01-01",
+                    endDate = "2024-12-31",
+                    fullRefreshTemporalColumn = "event_date",
+                )
+            )
+
+        val query =
+            gen.generate(
+                SelectQuerySpec(
+                    select = SelectColumns(nullTypedDateCol, Field("id", NullFieldType)),
+                    from = From("events", "public"),
+                    where = NoWhere,
+                    limit = Limit(0),
+                )
+            )
+
+        // NullFieldType guard → no WHERE injected, no ClassCastException
+        assertEquals("""SELECT "event_date", "id" FROM "public"."events" LIMIT 0""", query.sql)
+        assertEquals(0, query.bindings.size)
+    }
+
+    // cas 23 & 24: FromSample full-refresh with PK ORDER BY
+
+    /**
+     * Cas 23: FromSample, full-refresh, ORDER BY PK, cache empty (PK MAX was not cached). Step 3
+     * (temporal column lookup) must fire and inject bounds in both inner sample and outer WHERE.
+     */
+    @Test
+    fun testFullRefreshSamplingWithPkOrderAndEmptyCacheAppliesTemporalColumn() {
+        val dateField = Field("DATE_COMMANDE", LocalDateFieldType)
+        val pkField1 = Field("NUM_COMMANDE", StringFieldType)
+        val pkField2 = Field("NUM_LIGNE_COMMANDE", StringFieldType)
+        val gen =
+            SnowflakeSourceOperations(
+                configWith(
+                    startDate = "2024-01-01",
+                    endDate = "2024-12-31",
+                    fullRefreshTemporalColumn = "DATE_COMMANDE",
+                )
+            )
+
+        // PK MAX ran but was NOT cached (PK ≠ temporal col)
+        gen.generate(
+            SelectQuerySpec(
+                select = SelectColumnMaxValue(pkField1),
+                from = From("V1_COMMANDES", "OUT_ACTIONABLE"),
+            )
+        )
+
+        val query =
+            gen.generate(
+                SelectQuerySpec(
+                    select = SelectColumns(dateField, pkField1, pkField2),
+                    from =
+                        FromSample(
+                            name = "V1_COMMANDES",
+                            namespace = "OUT_ACTIONABLE",
+                            sampleRateInvPow2 = 8,
+                            sampleSize = 1024,
+                            where = NoWhere,
+                        ),
+                    where = NoWhere,
+                    orderBy = OrderBy(pkField1, pkField2),
+                )
+            )
+
+        assertEquals(
+            2,
+            query.sql.split(""""DATE_COMMANDE" >= ?""").size - 1,
+            "startDate in inner and outer"
+        )
+        assertEquals(
+            2,
+            query.sql.split(""""DATE_COMMANDE" <= ?""").size - 1,
+            "endDate in inner and outer"
+        )
+        assert(!query.sql.contains(""""NUM_COMMANDE" >= ?""")) { "No date bounds on PK" }
+        assertEquals(4, query.bindings.size)
+    }
+
+    /**
+     * Cas 24: FromSample, ORDER BY PK, cache populated with cursor (= temporal col). Step 2 (cache)
+     * fires before step 3, but produces the same result: bounds on temporal col.
+     */
+    @Test
+    fun testFullRefreshSamplingWithPkOrderAndCachedCursorAppliesTemporalColumn() {
+        val dateField = Field("DATE_COMMANDE", LocalDateFieldType)
+        val pkField1 = Field("NUM_COMMANDE", StringFieldType)
+        val pkField2 = Field("NUM_LIGNE_COMMANDE", StringFieldType)
+        val gen =
+            SnowflakeSourceOperations(
+                configWith(
+                    startDate = "2024-01-01",
+                    endDate = "2024-12-31",
+                    fullRefreshTemporalColumn = "DATE_COMMANDE",
+                )
+            )
+
+        // Cursor MAX populates the cache with DATE_COMMANDE
+        gen.generate(
+            SelectQuerySpec(
+                select = SelectColumnMaxValue(dateField),
+                from = From("V1_COMMANDES", "OUT_ACTIONABLE"),
+            )
+        )
+
+        val query =
+            gen.generate(
+                SelectQuerySpec(
+                    select = SelectColumns(dateField, pkField1, pkField2),
+                    from =
+                        FromSample(
+                            name = "V1_COMMANDES",
+                            namespace = "OUT_ACTIONABLE",
+                            sampleRateInvPow2 = 8,
+                            sampleSize = 1024,
+                            where = NoWhere,
+                        ),
+                    where = NoWhere,
+                    orderBy = OrderBy(pkField1, pkField2),
+                )
+            )
+
+        // Same expected output as cas 23 — cache vs step 3, same result
+        assertEquals(
+            2,
+            query.sql.split(""""DATE_COMMANDE" >= ?""").size - 1,
+            "startDate in inner and outer"
+        )
+        assertEquals(
+            2,
+            query.sql.split(""""DATE_COMMANDE" <= ?""").size - 1,
+            "endDate in inner and outer"
+        )
+        assert(!query.sql.contains(""""NUM_COMMANDE" >= ?""")) { "No date bounds on PK" }
+        assertEquals(4, query.bindings.size)
+    }
+
+    /**
+     * When fullRefreshTemporalColumn is configured, a SELECT MAX on a PK column (used by the CDK to
+     * determine partition boundaries) must NOT be cached and must NOT inject date bounds.
+     */
+    @Test
+    fun testPkMaxQuerySkipsDateBoundsAndDoesNotPolluteCursor() {
+        val pkField = Field("NUM_COMMANDE", StringFieldType)
+        val gen =
+            SnowflakeSourceOperations(
+                configWith(
+                    startDate = "2024-01-01",
+                    endDate = "2024-12-31",
+                    fullRefreshTemporalColumn = "DATE_COMMANDE"
+                )
+            )
+
+        val query =
+            gen.generate(
+                SelectQuerySpec(
+                    select = SelectColumnMaxValue(pkField),
+                    from = From("V1_COMMANDES", "OUT_ACTIONABLE"),
+                )
+            )
+
+        // NUM_COMMANDE != DATE_COMMANDE → PK MAX, no WHERE injected
+        assertEquals(
+            """SELECT MAX("NUM_COMMANDE") FROM "OUT_ACTIONABLE"."V1_COMMANDES"""",
+            query.sql
+        )
+        assertEquals(0, query.bindings.size)
+    }
+
+    /**
+     * After a PK MAX (not cached), a full-refresh read ordered by PK must apply date bounds using
+     * the temporal column found in the SELECT list — not the PK.
+     */
+    @Test
+    fun testFullRefreshReadAfterPkMaxUsesTemporalColumn() {
+        val dateField = Field("DATE_COMMANDE", LocalDateFieldType)
+        val pkField1 = Field("NUM_COMMANDE", StringFieldType)
+        val pkField2 = Field("NUM_LIGNE_COMMANDE", StringFieldType)
+        val gen =
+            SnowflakeSourceOperations(
+                configWith(
+                    startDate = "2024-01-01",
+                    endDate = "2024-12-31",
+                    fullRefreshTemporalColumn = "DATE_COMMANDE"
+                )
+            )
+
+        // PK MAX — must NOT cache NUM_COMMANDE
+        gen.generate(
+            SelectQuerySpec(
+                select = SelectColumnMaxValue(pkField1),
+                from = From("V1_COMMANDES", "OUT_ACTIONABLE"),
+            )
+        )
+
+        val pkBounds =
+            Where(
+                And(
+                    Greater(pkField1, Jsons.textNode("A000")),
+                    LesserOrEqual(pkField1, Jsons.textNode("Z999")),
+                )
+            )
+        val query =
+            gen.generate(
+                SelectQuerySpec(
+                    select = SelectColumns(dateField, pkField1, pkField2),
+                    from = From("V1_COMMANDES", "OUT_ACTIONABLE"),
+                    where = pkBounds,
+                    orderBy = OrderBy(pkField1, pkField2),
+                    limit = Limit(1000),
+                )
+            )
+
+        assert(query.sql.contains(""""DATE_COMMANDE" >= ?""")) {
+            "startDate must be on DATE_COMMANDE"
+        }
+        assert(query.sql.contains(""""DATE_COMMANDE" <= ?""")) {
+            "endDate must be on DATE_COMMANDE"
+        }
+        assert(!query.sql.contains(""""NUM_COMMANDE" >= ?""")) { "Date bounds must NOT be on PK" }
+        assert(query.sql.contains(""""NUM_COMMANDE" > ?""")) {
+            "PK lower bound must still be present"
+        }
+        assert(query.sql.contains("""ORDER BY "NUM_COMMANDE", "NUM_LIGNE_COMMANDE"""")) {
+            "ORDER BY must be on PK"
+        }
+    }
+
+    /**
+     * Mixed catalog: incremental and full-refresh streams share the same SnowflakeSourceOperations
+     * instance. The incremental MAX caches the cursor correctly. The full-refresh PK MAX must NOT
+     * overwrite that cache. Both subsequent read queries must filter on DATE_COMMANDE.
+     */
+    @Test
+    fun testMixedIncrementalAndFullRefreshDoNotInterfereWithCache() {
+        val dateField = Field("DATE_COMMANDE", LocalDateFieldType)
+        val pkField1 = Field("NUM_COMMANDE", StringFieldType)
+        val pkField2 = Field("NUM_LIGNE_COMMANDE", StringFieldType)
+        val gen =
+            SnowflakeSourceOperations(
+                configWith(
+                    startDate = "2024-01-01",
+                    endDate = "2024-12-31",
+                    fullRefreshTemporalColumn = "DATE_COMMANDE"
+                )
+            )
+
+        // Incremental MAX on cursor → caches DATE_COMMANDE
+        gen.generate(
+            SelectQuerySpec(
+                select = SelectColumnMaxValue(dateField),
+                from = From("V1_COMMANDES", "OUT_ACTIONABLE"),
+            )
+        )
+
+        // Full-refresh PK MAX → must NOT overwrite the cache with NUM_COMMANDE
+        gen.generate(
+            SelectQuerySpec(
+                select = SelectColumnMaxValue(pkField1),
+                from = From("V1_COMMANDES", "OUT_ACTIONABLE"),
+            )
+        )
+
+        // Incremental read (ORDER BY PK): cache must still have DATE_COMMANDE
+        val incrementalQuery =
+            gen.generate(
+                SelectQuerySpec(
+                    select = SelectColumns(dateField, pkField1, pkField2),
+                    from = From("V1_COMMANDES", "OUT_ACTIONABLE"),
+                    where =
+                        Where(
+                            And(
+                                Greater(
+                                    dateField,
+                                    LocalDateCodec.encode(LocalDate.parse("2024-06-01"))
+                                ),
+                                LesserOrEqual(
+                                    dateField,
+                                    LocalDateCodec.encode(LocalDate.parse("2024-09-01"))
+                                ),
+                            )
+                        ),
+                    orderBy = OrderBy(pkField1, pkField2),
+                    limit = Limit(1000),
+                )
+            )
+        assert(incrementalQuery.sql.contains(""""DATE_COMMANDE" >= ?""")) {
+            "Incremental: startDate on cursor"
+        }
+        assert(!incrementalQuery.sql.contains(""""NUM_COMMANDE" >= ?""")) {
+            "Incremental: date bound NOT on PK"
+        }
+
+        // Full-refresh read (ORDER BY PK, no cursor WHERE): temporal column must be used
+        val fullRefreshQuery =
+            gen.generate(
+                SelectQuerySpec(
+                    select = SelectColumns(dateField, pkField1, pkField2),
+                    from = From("V1_COMMANDES", "OUT_ACTIONABLE"),
+                    where = NoWhere,
+                    orderBy = OrderBy(pkField1, pkField2),
+                )
+            )
+        assert(fullRefreshQuery.sql.contains(""""DATE_COMMANDE" >= ?""")) {
+            "Full-refresh: startDate on temporal col"
+        }
+        assert(!fullRefreshQuery.sql.contains(""""NUM_COMMANDE" >= ?""")) {
+            "Full-refresh: date bound NOT on PK"
+        }
+    }
+
+    /**
+     * Full-refresh with a sampling query (FromSample): date bounds must be injected into both the
+     * inner sampling subquery and the outer WHERE clause.
+     */
+    @Test
+    fun testSamplingQueryAppliesDateBoundsInnerAndOuter() {
+        val dateField = Field("DATE_COMMANDE", LocalDateFieldType)
+        val pkField = Field("NUM_COMMANDE", StringFieldType)
+        val gen =
+            SnowflakeSourceOperations(
+                configWith(
+                    startDate = "2024-01-01",
+                    endDate = "2024-12-31",
+                    fullRefreshTemporalColumn = "DATE_COMMANDE"
+                )
+            )
+
+        val query =
+            gen.generate(
+                SelectQuerySpec(
+                    select = SelectColumns(dateField, pkField),
+                    from =
+                        FromSample(
+                            name = "V1_COMMANDES",
+                            namespace = "OUT_ACTIONABLE",
+                            sampleRateInvPow2 = 8,
+                            sampleSize = 1024,
+                            where = NoWhere,
+                        ),
+                    where = NoWhere,
+                    // No ORDER BY → full-refresh
+                    )
+            )
+
+        assertEquals(
+            2,
+            query.sql.split(""""DATE_COMMANDE" >= ?""").size - 1,
+            "startDate in inner and outer WHERE"
+        )
+        assertEquals(
+            2,
+            query.sql.split(""""DATE_COMMANDE" <= ?""").size - 1,
+            "endDate in inner and outer WHERE"
+        )
+        assertEquals(4, query.bindings.size)
+    }
+}

--- a/airbyte-integrations/connectors/source-snowflake/src/test/kotlin/io/airbyte/integrations/source/snowflake/SnowflakeIncrementalDateBoundsTest.kt
+++ b/airbyte-integrations/connectors/source-snowflake/src/test/kotlin/io/airbyte/integrations/source/snowflake/SnowflakeIncrementalDateBoundsTest.kt
@@ -1,0 +1,307 @@
+/*
+ * Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.source.snowflake
+
+import io.airbyte.cdk.data.LocalDateCodec
+import io.airbyte.cdk.discover.Field
+import io.airbyte.cdk.jdbc.IntFieldType
+import io.airbyte.cdk.jdbc.LocalDateFieldType
+import io.airbyte.cdk.jdbc.StringFieldType
+import io.airbyte.cdk.read.*
+import java.time.LocalDate
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests date bound filtering (start_date / end_date) for incremental syncs: cursor detected via
+ * ORDER BY or SELECT MAX, date conditions injected into regular and sampling queries.
+ */
+class SnowflakeIncrementalDateBoundsTest : SnowflakeOperationsBaseTest() {
+
+    @Test
+    fun testStartDateAddsGreaterOrEqualToRegularQuery() {
+        val cursorField = Field("updated_at", LocalDateFieldType)
+        val gen = SnowflakeSourceOperations(configWith(startDate = "2024-01-01"))
+
+        val query =
+            gen.generate(
+                SelectQuerySpec(
+                    select = SelectColumns(Field("id", IntFieldType), cursorField),
+                    from = From("orders", "sales"),
+                    where = NoWhere,
+                    orderBy = OrderBy(cursorField),
+                    limit = Limit(100),
+                )
+            )
+
+        assertEquals(
+            """SELECT "id", "updated_at" FROM "sales"."orders" WHERE "updated_at" >= ? ORDER BY "updated_at" LIMIT ?""",
+            query.sql,
+        )
+        assertEquals(2, query.bindings.size)
+    }
+
+    @Test
+    fun testEndDateAddsLesserOrEqualToRegularQuery() {
+        val cursorField = Field("updated_at", LocalDateFieldType)
+        val gen = SnowflakeSourceOperations(configWith(endDate = "2024-12-31"))
+
+        val query =
+            gen.generate(
+                SelectQuerySpec(
+                    select = SelectColumns(Field("id", IntFieldType), cursorField),
+                    from = From("orders", "sales"),
+                    where = NoWhere,
+                    orderBy = OrderBy(cursorField),
+                    limit = Limit(100),
+                )
+            )
+
+        assertEquals(
+            """SELECT "id", "updated_at" FROM "sales"."orders" WHERE "updated_at" <= ? ORDER BY "updated_at" LIMIT ?""",
+            query.sql,
+        )
+        assertEquals(2, query.bindings.size)
+    }
+
+    @Test
+    fun testBothDatesAddedToRegularQueryWithExistingCursorBounds() {
+        val cursorField = Field("created_at", LocalDateFieldType)
+        val gen =
+            SnowflakeSourceOperations(configWith(startDate = "2024-01-01", endDate = "2024-12-31"))
+
+        val existingWhere =
+            Where(
+                And(
+                    Greater(cursorField, LocalDateCodec.encode(LocalDate.parse("2024-06-01"))),
+                    LesserOrEqual(
+                        cursorField,
+                        LocalDateCodec.encode(LocalDate.parse("2024-09-01"))
+                    ),
+                )
+            )
+
+        val query =
+            gen.generate(
+                SelectQuerySpec(
+                    select = SelectColumns(cursorField),
+                    from = From("events", "public"),
+                    where = existingWhere,
+                    orderBy = OrderBy(cursorField),
+                    limit = Limit(500),
+                )
+            )
+
+        // Existing cursor bounds (> ?, <= ?) + startDate (>= ?) + endDate (<= ?) + LIMIT (?)
+        assertEquals(5, query.bindings.size)
+        assert(query.sql.contains(""""created_at" > ?""")) {
+            "Expected existing cursor lower bound"
+        }
+        assert(query.sql.contains(""""created_at" >= ?""")) { "Expected startDate condition" }
+        assertEquals(
+            2,
+            query.sql.split(""""created_at" <= ?""").size - 1,
+            "Expected two <= conditions"
+        )
+    }
+
+    @Test
+    fun testBothDatesAddedToSamplingQuery() {
+        val cursorField = Field("event_date", LocalDateFieldType)
+        val gen =
+            SnowflakeSourceOperations(configWith(startDate = "2024-01-01", endDate = "2024-12-31"))
+
+        val innerWhere =
+            Where(
+                And(
+                    Greater(cursorField, LocalDateCodec.encode(LocalDate.parse("2024-03-01"))),
+                    LesserOrEqual(
+                        cursorField,
+                        LocalDateCodec.encode(LocalDate.parse("2024-06-01"))
+                    ),
+                )
+            )
+
+        val query =
+            gen.generate(
+                SelectQuerySpec(
+                    select = SelectColumns(cursorField, Field("row_id", StringFieldType)),
+                    from =
+                        FromSample(
+                            name = "fact_events",
+                            namespace = "analytics",
+                            sampleRateInvPow2 = 16,
+                            sampleSize = 1024,
+                            where = innerWhere,
+                        ),
+                    where = innerWhere,
+                    orderBy = OrderBy(cursorField),
+                )
+            )
+
+        // 2 inner cursor + 2 inner date + 2 outer cursor + 2 outer date = 8
+        assertEquals(8, query.bindings.size)
+        assertEquals(
+            2,
+            query.sql.split(""""event_date" >= ?""").size - 1,
+            "startDate in both inner and outer WHERE"
+        )
+        assertEquals(
+            4,
+            query.sql.split(""""event_date" <= ?""").size - 1,
+            "endDate (<=) in cursor bounds + date bounds, inner and outer"
+        )
+    }
+
+    // ---- guard: full_refresh_temporal_column must not affect incremental queries ----
+
+    /**
+     * Configuring full_refresh_temporal_column must have zero effect on incremental queries. The
+     * cursor is always detected via ORDER BY or the SELECT MAX cache — the temporal column lookup
+     * (step 3 in applyDateBounds) must never be reached for incremental streams.
+     *
+     * This test would fail if the branch ordering in applyDateBounds were changed so that the
+     * temporal column check ran before ORDER BY or the cache.
+     */
+    @Test
+    fun testFullRefreshTemporalColumnDoesNotAffectIncrementalOrderByCursorQuery() {
+        val cursorField = Field("updated_at", LocalDateFieldType)
+        val gen =
+            SnowflakeSourceOperations(
+                configWith(
+                    startDate = "2024-01-01",
+                    endDate = "2024-12-31",
+                    fullRefreshTemporalColumn = "updated_at", // same column (realistic config)
+                )
+            )
+
+        val withTemporalCol =
+            gen.generate(
+                SelectQuerySpec(
+                    select = SelectColumns(Field("id", IntFieldType), cursorField),
+                    from = From("orders", "sales"),
+                    where = NoWhere,
+                    orderBy = OrderBy(cursorField),
+                    limit = Limit(100),
+                )
+            )
+
+        // Must be identical to the same query without fullRefreshTemporalColumn
+        val withoutTemporalCol =
+            SnowflakeSourceOperations(configWith(startDate = "2024-01-01", endDate = "2024-12-31"))
+                .generate(
+                    SelectQuerySpec(
+                        select = SelectColumns(Field("id", IntFieldType), cursorField),
+                        from = From("orders", "sales"),
+                        where = NoWhere,
+                        orderBy = OrderBy(cursorField),
+                        limit = Limit(100),
+                    )
+                )
+
+        assertEquals(withoutTemporalCol.sql, withTemporalCol.sql)
+        assertEquals(withoutTemporalCol.bindings.size, withTemporalCol.bindings.size)
+    }
+
+    /**
+     * Same guard for PK-ordered incremental reads (cursor cached via SELECT MAX). The cache (step
+     * 2) must take priority over the temporal column check (step 3).
+     */
+    @Test
+    fun testFullRefreshTemporalColumnDoesNotAffectIncrementalPkOrderedRead() {
+        val cursorField = Field("updated_at", LocalDateFieldType)
+        val pkField = Field("id", StringFieldType)
+        val gen =
+            SnowflakeSourceOperations(
+                configWith(
+                    startDate = "2024-01-01",
+                    endDate = "2024-12-31",
+                    fullRefreshTemporalColumn = "updated_at",
+                )
+            )
+
+        // Populate the cursor cache
+        gen.generate(
+            SelectQuerySpec(
+                select = SelectColumnMaxValue(cursorField),
+                from = From("orders", "sales"),
+            )
+        )
+
+        val withTemporalCol =
+            gen.generate(
+                SelectQuerySpec(
+                    select = SelectColumns(cursorField, pkField),
+                    from = From("orders", "sales"),
+                    where = NoWhere,
+                    orderBy = OrderBy(pkField),
+                    limit = Limit(500),
+                )
+            )
+
+        val genWithout =
+            SnowflakeSourceOperations(configWith(startDate = "2024-01-01", endDate = "2024-12-31"))
+        genWithout.generate(
+            SelectQuerySpec(
+                select = SelectColumnMaxValue(cursorField),
+                from = From("orders", "sales"),
+            )
+        )
+        val withoutTemporalCol =
+            genWithout.generate(
+                SelectQuerySpec(
+                    select = SelectColumns(cursorField, pkField),
+                    from = From("orders", "sales"),
+                    where = NoWhere,
+                    orderBy = OrderBy(pkField),
+                    limit = Limit(500),
+                )
+            )
+
+        assertEquals(withoutTemporalCol.sql, withTemporalCol.sql)
+        assertEquals(withoutTemporalCol.bindings.size, withTemporalCol.bindings.size)
+    }
+
+    @Test
+    fun testDateBoundsSkippedForFullRefreshQueryWithoutTemporalColumn() {
+        val gen =
+            SnowflakeSourceOperations(configWith(startDate = "2024-01-01", endDate = "2024-12-31"))
+
+        val query =
+            gen.generate(
+                SelectQuerySpec(
+                    select =
+                        SelectColumns(Field("id", IntFieldType), Field("name", StringFieldType)),
+                    from = From("users", "public"),
+                    where = NoWhere,
+                    // No ORDER BY and no fullRefreshTemporalColumn → skip
+                    )
+            )
+
+        assertEquals("""SELECT "id", "name" FROM "public"."users"""", query.sql)
+        assertEquals(0, query.bindings.size)
+    }
+
+    @Test
+    fun testDateBoundsAppliedToMaxValueQuery() {
+        val cursorField = Field("updated_at", LocalDateFieldType)
+        val gen =
+            SnowflakeSourceOperations(configWith(startDate = "2024-01-01", endDate = "2024-12-31"))
+
+        val query =
+            gen.generate(
+                SelectQuerySpec(
+                    select = SelectColumnMaxValue(cursorField),
+                    from = From("orders", "sales"),
+                )
+            )
+
+        assertEquals(
+            """SELECT MAX("updated_at") FROM "sales"."orders" WHERE ("updated_at" >= ?) AND ("updated_at" <= ?)""",
+            query.sql,
+        )
+        assertEquals(2, query.bindings.size)
+    }
+}

--- a/airbyte-integrations/connectors/source-snowflake/src/test/kotlin/io/airbyte/integrations/source/snowflake/SnowflakeOperationsBaseTest.kt
+++ b/airbyte-integrations/connectors/source-snowflake/src/test/kotlin/io/airbyte/integrations/source/snowflake/SnowflakeOperationsBaseTest.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.source.snowflake
+
+import java.time.Duration
+
+/** Shared helpers for SnowflakeSourceOperations unit tests. */
+abstract class SnowflakeOperationsBaseTest {
+
+    protected val queryGenerator = SnowflakeSourceOperations()
+
+    protected fun configWith(
+        startDate: String? = null,
+        endDate: String? = null,
+        fullRefreshTemporalColumn: String? = null,
+    ) =
+        SnowflakeSourceConfiguration(
+            realHost = "test.snowflakecomputing.com",
+            jdbcUrlFmt = "jdbc:snowflake://%s",
+            jdbcProperties = emptyMap(),
+            incremental = UserDefinedCursorIncrementalConfiguration,
+            maxConcurrency = 1,
+            checkpointTargetInterval = Duration.ofSeconds(300),
+            checkPrivileges = false,
+            startDate = startDate,
+            endDate = endDate,
+            fullRefreshTemporalColumn = fullRefreshTemporalColumn,
+        )
+}

--- a/airbyte-integrations/connectors/source-snowflake/src/test/kotlin/io/airbyte/integrations/source/snowflake/SnowflakePkCursorCacheTest.kt
+++ b/airbyte-integrations/connectors/source-snowflake/src/test/kotlin/io/airbyte/integrations/source/snowflake/SnowflakePkCursorCacheTest.kt
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.source.snowflake
+
+import io.airbyte.cdk.discover.Field
+import io.airbyte.cdk.jdbc.IntFieldType
+import io.airbyte.cdk.jdbc.LocalDateFieldType
+import io.airbyte.cdk.jdbc.StringFieldType
+import io.airbyte.cdk.read.*
+import io.airbyte.cdk.util.Jsons
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests the per-table cursor cache used for splittable (PK-ordered) partitions in incremental mode.
+ *
+ * When a table has a primary key, the CDK orders reads by PK columns, not by the cursor. The SELECT
+ * MAX(cursor) query populates the cache so that subsequent read queries — which only carry ORDER BY
+ * PK — can still apply date bounds on the correct cursor column.
+ */
+class SnowflakePkCursorCacheTest : SnowflakeOperationsBaseTest() {
+
+    @Test
+    fun testDateBoundsUsesCachedCursorNotPkWhenOrderByIsPk() {
+        val cursorField = Field("event_date", LocalDateFieldType)
+        val pkField1 = Field("order_id", StringFieldType)
+        val pkField2 = Field("line_id", StringFieldType)
+        val gen =
+            SnowflakeSourceOperations(configWith(startDate = "2026-01-01", endDate = "2026-02-02"))
+
+        // Step 1: MAX query caches the cursor for this table
+        gen.generate(
+            SelectQuerySpec(
+                select = SelectColumnMaxValue(cursorField),
+                from = From("fact_events", "analytics"),
+            )
+        )
+
+        // Step 2: Splittable read — ORDER BY is PK, not cursor
+        val pkBounds =
+            Where(
+                And(
+                    Greater(pkField1, Jsons.textNode("A000")),
+                    LesserOrEqual(pkField1, Jsons.textNode("Z999")),
+                )
+            )
+        val query =
+            gen.generate(
+                SelectQuerySpec(
+                    select = SelectColumns(cursorField, pkField1, pkField2),
+                    from = From("fact_events", "analytics"),
+                    where = pkBounds,
+                    orderBy = OrderBy(pkField1, pkField2),
+                    limit = Limit(1000),
+                )
+            )
+
+        assert(query.sql.contains(""""order_id" > ?""")) { "PK lower bound must be present" }
+        assert(query.sql.contains(""""order_id" <= ?""")) { "PK upper bound must be present" }
+        assert(query.sql.contains(""""event_date" >= ?""")) { "startDate must be on cursor" }
+        assert(query.sql.contains(""""event_date" <= ?""")) { "endDate must be on cursor" }
+        assert(!query.sql.contains(""""order_id" >= ?""")) { "Date bounds must NOT be on PK" }
+        assert(query.sql.contains("""ORDER BY "order_id", "line_id"""")) {
+            "ORDER BY must be on PK"
+        }
+    }
+
+    @Test
+    fun testDateBoundsUsesCachedCursorForUnsplittableSnapshot() {
+        val cursorField = Field("event_date", LocalDateFieldType)
+        val gen =
+            SnowflakeSourceOperations(configWith(startDate = "2026-01-01", endDate = "2026-02-02"))
+
+        // MAX query caches the cursor
+        gen.generate(
+            SelectQuerySpec(
+                select = SelectColumnMaxValue(cursorField),
+                from = From("fact_events", "analytics"),
+            )
+        )
+
+        // Unsplittable snapshot — no ORDER BY, no WHERE
+        val query =
+            gen.generate(
+                SelectQuerySpec(
+                    select = SelectColumns(cursorField, Field("user_id", IntFieldType)),
+                    from = From("fact_events", "analytics"),
+                )
+            )
+
+        assertEquals(
+            """SELECT "event_date", "user_id" FROM "analytics"."fact_events" WHERE ("event_date" >= ?) AND ("event_date" <= ?)""",
+            query.sql,
+        )
+        assertEquals(2, query.bindings.size)
+    }
+
+    /**
+     * Cas 8: ORDER BY PK, cache empty, no fullRefreshTemporalColumn, dates set. The ORDER BY
+     * fallback (step 4) fires and picks the first PK column as cursor. This documents the edge-case
+     * behavior — in normal operation SELECT MAX always runs first and populates the cache before
+     * any PK-ordered read.
+     */
+    @Test
+    fun testOrderByPkWithEmptyCacheAndNoDatesAppliesBoundsOnPkColumn() {
+        val pkField = Field("id", StringFieldType)
+        val dataField = Field("name", StringFieldType)
+        val gen =
+            SnowflakeSourceOperations(configWith(startDate = "2024-01-01", endDate = "2024-12-31"))
+
+        // No SELECT MAX → cache is empty
+        val query =
+            gen.generate(
+                SelectQuerySpec(
+                    select = SelectColumns(pkField, dataField),
+                    from = From("users", "public"),
+                    where = NoWhere,
+                    orderBy = OrderBy(pkField),
+                    limit = Limit(100),
+                )
+            )
+
+        // Fallback behavior: ORDER BY first column (PK) is used as cursor
+        assertEquals(
+            """SELECT "id", "name" FROM "public"."users" WHERE ("id" >= ?) AND ("id" <= ?) ORDER BY "id" LIMIT ?""",
+            query.sql,
+        )
+        assertEquals(3, query.bindings.size)
+    }
+
+    @Test
+    fun testNoDatesNoFilteringWithPk() {
+        val cursorField = Field("event_date", LocalDateFieldType)
+        val pkField = Field("order_id", StringFieldType)
+        val gen = SnowflakeSourceOperations(configWith()) // no dates
+
+        gen.generate(
+            SelectQuerySpec(
+                select = SelectColumnMaxValue(cursorField),
+                from = From("fact_events", "analytics"),
+            )
+        )
+
+        val query =
+            gen.generate(
+                SelectQuerySpec(
+                    select = SelectColumns(cursorField, pkField),
+                    from = From("fact_events", "analytics"),
+                    orderBy = OrderBy(pkField),
+                    limit = Limit(100),
+                )
+            )
+
+        assertEquals(
+            """SELECT "event_date", "order_id" FROM "analytics"."fact_events" ORDER BY "order_id" LIMIT ?""",
+            query.sql,
+        )
+    }
+
+    @Test
+    fun testSamplingQueryWithPkOrderByUsesCachedCursorForDateBounds() {
+        val cursorField = Field("event_date", LocalDateFieldType)
+        val pkField1 = Field("order_id", StringFieldType)
+        val pkField2 = Field("line_id", StringFieldType)
+        val gen =
+            SnowflakeSourceOperations(configWith(startDate = "2026-01-01", endDate = "2026-02-02"))
+
+        gen.generate(
+            SelectQuerySpec(
+                select = SelectColumnMaxValue(cursorField),
+                from = From("fact_events", "analytics"),
+            )
+        )
+
+        val pkPartitionWhere = Where(LesserOrEqual(pkField1, Jsons.textNode("Z999")))
+        val query =
+            gen.generate(
+                SelectQuerySpec(
+                    select = SelectColumns(cursorField, pkField1, pkField2),
+                    from =
+                        FromSample(
+                            name = "fact_events",
+                            namespace = "analytics",
+                            sampleRateInvPow2 = 16,
+                            sampleSize = 1024,
+                            where = pkPartitionWhere,
+                        ),
+                    where = NoWhere,
+                    orderBy = OrderBy(pkField1, pkField2),
+                )
+            )
+
+        assert(query.sql.contains(""""order_id" <= ?""")) { "PK upper bound must be in sample" }
+        assert(query.sql.contains(""""event_date" >= ?""")) {
+            "startDate must be on cursor in sample"
+        }
+        assert(query.sql.contains(""""event_date" <= ?""")) {
+            "endDate must be on cursor in sample"
+        }
+        assert(!query.sql.contains(""""order_id" >= ?""")) { "Date bounds must NOT be on PK" }
+    }
+}

--- a/airbyte-integrations/connectors/source-snowflake/src/test/kotlin/io/airbyte/integrations/source/snowflake/SnowflakeSamplingQueryTest.kt
+++ b/airbyte-integrations/connectors/source-snowflake/src/test/kotlin/io/airbyte/integrations/source/snowflake/SnowflakeSamplingQueryTest.kt
@@ -15,13 +15,14 @@ import java.time.LocalDate
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
-class SnowflakeSamplingQueryTest {
-
-    private val queryGenerator = SnowflakeSourceOperations()
+/**
+ * Tests SQL generation for sampling queries (FromSample) and basic SELECT queries, without date
+ * bound configuration.
+ */
+class SnowflakeSamplingQueryTest : SnowflakeOperationsBaseTest() {
 
     @Test
     fun testSamplingQueryWithoutWhereClause() {
-        // Test traditional sampling without a WHERE clause
         val querySpec =
             SelectQuerySpec(
                 select = SelectColumns(Field("id", IntFieldType), Field("name", StringFieldType)),
@@ -35,19 +36,14 @@ class SnowflakeSamplingQueryTest {
             )
 
         val query = queryGenerator.generate(querySpec)
-        val expectedSql =
-            """
-            SELECT "id", "name" FROM (SELECT * FROM (SELECT * FROM "public"."users" SAMPLE (0.39062500)  ORDER BY RANDOM()) LIMIT 1024)
-        """
-                .trimIndent()
-                .replace("\n", " ")
-
-        assertEquals(expectedSql, query.sql)
+        assertEquals(
+            """SELECT "id", "name" FROM (SELECT * FROM (SELECT * FROM "public"."users" SAMPLE (0.39062500)  ORDER BY RANDOM()) LIMIT 1024)""",
+            query.sql,
+        )
     }
 
     @Test
     fun testSamplingQueryWithWhereClause() {
-        // Test sampling with a WHERE clause (incremental sync scenario)
         val cursorField = Field("updated_at", LocalDateFieldType)
         val whereClause =
             Where(Greater(cursorField, LocalDateCodec.encode(LocalDate.parse("2025-01-01"))))
@@ -71,20 +67,15 @@ class SnowflakeSamplingQueryTest {
             )
 
         val query = queryGenerator.generate(querySpec)
-        val expectedSql =
-            """
-            SELECT "id", "name", "updated_at" FROM (SELECT * FROM (SELECT * FROM "sales"."orders" SAMPLE (0.0015258789062500) WHERE "updated_at" > ? ORDER BY RANDOM()) LIMIT 1024)
-        """
-                .trimIndent()
-                .replace("\n", " ")
-
-        assertEquals(expectedSql, query.sql)
+        assertEquals(
+            """SELECT "id", "name", "updated_at" FROM (SELECT * FROM (SELECT * FROM "sales"."orders" SAMPLE (0.0015258789062500) WHERE "updated_at" > ? ORDER BY RANDOM()) LIMIT 1024)""",
+            query.sql,
+        )
         assertEquals(1, query.bindings.size)
     }
 
     @Test
     fun testSamplingQueryWithComplexWhereClause() {
-        // Test sampling with a complex WHERE clause (multiple conditions)
         val idField = Field("id", IntFieldType)
         val statusField = Field("status", StringFieldType)
         val dateField = Field("created_date", LocalDateFieldType)
@@ -112,24 +103,18 @@ class SnowflakeSamplingQueryTest {
             )
 
         val query = queryGenerator.generate(querySpec)
-        val expectedSql =
-            """
-            SELECT "id", "status", "created_date" FROM (SELECT * FROM (SELECT * FROM "public"."users" SAMPLE (0.39062500) WHERE ("id" > ?) AND ("status" = ?) AND ("created_date" >= ?) ORDER BY RANDOM()) LIMIT 512)
-        """
-                .trimIndent()
-                .replace("\n", " ")
-
-        assertEquals(expectedSql, query.sql)
+        assertEquals(
+            """SELECT "id", "status", "created_date" FROM (SELECT * FROM (SELECT * FROM "public"."users" SAMPLE (0.39062500) WHERE ("id" > ?) AND ("status" = ?) AND ("created_date" >= ?) ORDER BY RANDOM()) LIMIT 512)""",
+            query.sql,
+        )
         assertEquals(3, query.bindings.size)
     }
 
     @Test
     fun testIncrementalPartitionSamplingQuery() {
-        // Test the exact scenario from the GitHub issue
-        val cursorField = Field("airdate", LocalDateFieldType)
-        val uuidField = Field("uuid", StringFieldType)
+        val cursorField = Field("event_date", LocalDateFieldType)
+        val idField = Field("row_id", StringFieldType)
 
-        // Simulate cursor bounds for incremental sync
         val lowerBound = LocalDate.parse("2025-08-07")
         val upperBound = LocalDate.parse("2025-08-08")
 
@@ -143,36 +128,29 @@ class SnowflakeSamplingQueryTest {
 
         val querySpec =
             SelectQuerySpec(
-                select = SelectColumns(cursorField, uuidField),
+                select = SelectColumns(cursorField, idField),
                 from =
                     FromSample(
-                        name = "VW_POLARIS_ADMO_AIRINGS",
-                        namespace = "POLARIS",
+                        name = "fact_events",
+                        namespace = "analytics",
                         sampleRateInvPow2 = 16,
                         sampleSize = 1024,
                         where = whereClause
                     ),
                 where = whereClause,
-                orderBy = OrderBy(uuidField)
+                orderBy = OrderBy(idField)
             )
 
         val query = queryGenerator.generate(querySpec)
-
-        // The WHERE clause should be inside the sampling subquery
-        val expectedSql =
-            """
-            SELECT "airdate", "uuid" FROM (SELECT * FROM (SELECT * FROM "POLARIS"."VW_POLARIS_ADMO_AIRINGS" SAMPLE (0.0015258789062500) WHERE ("airdate" > ?) AND ("airdate" <= ?) ORDER BY RANDOM()) LIMIT 1024) WHERE ("airdate" > ?) AND ("airdate" <= ?) ORDER BY "uuid"
-        """
-                .trimIndent()
-                .replace("\n", " ")
-
-        assertEquals(expectedSql, query.sql)
-        assertEquals(4, query.bindings.size) // Both inner and outer WHERE contribute bindings
+        assertEquals(
+            """SELECT "event_date", "row_id" FROM (SELECT * FROM (SELECT * FROM "analytics"."fact_events" SAMPLE (0.0015258789062500) WHERE ("event_date" > ?) AND ("event_date" <= ?) ORDER BY RANDOM()) LIMIT 1024) WHERE ("event_date" > ?) AND ("event_date" <= ?) ORDER BY "row_id"""",
+            query.sql,
+        )
+        assertEquals(4, query.bindings.size)
     }
 
     @Test
     fun testSamplingWithNoSampleRate() {
-        // Test when sample rate is 1 (no sampling)
         val whereClause = Where(Greater(Field("id", IntFieldType), Jsons.numberNode(100)))
 
         val querySpec =
@@ -182,28 +160,21 @@ class SnowflakeSamplingQueryTest {
                     FromSample(
                         name = "test_table",
                         namespace = "test_schema",
-                        sampleRateInvPow2 = 0, // 2^0 = 1, means no sampling
+                        sampleRateInvPow2 = 0,
                         sampleSize = 1024,
                         where = whereClause
                     )
             )
 
         val query = queryGenerator.generate(querySpec)
-
-        // When sampleRateInv is 1, no SAMPLE clause should be added
-        val expectedSql =
-            """
-            SELECT "id" FROM (SELECT * FROM (SELECT * FROM "test_schema"."test_table" WHERE "id" > ? ORDER BY RANDOM()) LIMIT 1024)
-        """
-                .trimIndent()
-                .replace("\n", " ")
-
-        assertEquals(expectedSql, query.sql)
+        assertEquals(
+            """SELECT "id" FROM (SELECT * FROM (SELECT * FROM "test_schema"."test_table" WHERE "id" > ? ORDER BY RANDOM()) LIMIT 1024)""",
+            query.sql,
+        )
     }
 
     @Test
     fun testSamplingQueryWithNullNamespace() {
-        // Test sampling query without namespace
         val whereClause = Where(Equal(Field("status", StringFieldType), Jsons.textNode("active")))
 
         val querySpec =
@@ -220,19 +191,14 @@ class SnowflakeSamplingQueryTest {
             )
 
         val query = queryGenerator.generate(querySpec)
-        val expectedSql =
-            """
-            SELECT "id" FROM (SELECT * FROM (SELECT * FROM "users" SAMPLE (6.2500) WHERE "status" = ? ORDER BY RANDOM()) LIMIT 256)
-        """
-                .trimIndent()
-                .replace("\n", " ")
-
-        assertEquals(expectedSql, query.sql)
+        assertEquals(
+            """SELECT "id" FROM (SELECT * FROM (SELECT * FROM "users" SAMPLE (6.2500) WHERE "status" = ? ORDER BY RANDOM()) LIMIT 256)""",
+            query.sql,
+        )
     }
 
     @Test
     fun testRegularQueryWithoutSampling() {
-        // Test that regular queries (non-sampling) still work correctly
         val querySpec =
             SelectQuerySpec(
                 select = SelectColumns(Field("id", IntFieldType), Field("name", StringFieldType)),
@@ -243,21 +209,15 @@ class SnowflakeSamplingQueryTest {
             )
 
         val query = queryGenerator.generate(querySpec)
-        val expectedSql =
-            """
-            SELECT "id", "name" FROM "public"."users" WHERE "id" > ? ORDER BY "id" LIMIT ?
-        """
-                .trimIndent()
-                .replace("\n", " ")
-
-        assertEquals(expectedSql, query.sql)
+        assertEquals(
+            """SELECT "id", "name" FROM "public"."users" WHERE "id" > ? ORDER BY "id" LIMIT ?""",
+            query.sql,
+        )
         assertEquals(2, query.bindings.size)
     }
 
     @Test
     fun testEmptyBoundsHandling() {
-        // Test that when there are no bounds, we get NoWhere instead of empty And/Or clauses
-        // This simulates a fresh snapshot with no lower/upper bounds
         val querySpec =
             SelectQuerySpec(
                 select = SelectColumns(Field("id", IntFieldType), Field("name", StringFieldType)),
@@ -274,19 +234,13 @@ class SnowflakeSamplingQueryTest {
             )
 
         val query = queryGenerator.generate(querySpec)
-
-        // Should generate SQL without any WHERE clause in the sampling subquery
-        val expectedSql =
-            """
-            SELECT "id", "name" FROM (SELECT * FROM (SELECT * FROM "test"."users" SAMPLE (0.0015258789062500)  ORDER BY RANDOM()) LIMIT 1024) ORDER BY "id"
-        """
-                .trimIndent()
-                .replace("\n", " ")
-
-        assertEquals(expectedSql, query.sql)
+        assertEquals(
+            """SELECT "id", "name" FROM (SELECT * FROM (SELECT * FROM "test"."users" SAMPLE (0.0015258789062500)  ORDER BY RANDOM()) LIMIT 1024) ORDER BY "id"""",
+            query.sql,
+        )
         assertEquals(
             listOf(Field("id", IntFieldType), Field("name", StringFieldType)),
-            query.columns
+            query.columns,
         )
     }
 }

--- a/airbyte-integrations/connectors/source-snowflake/src/test/kotlin/io/airbyte/integrations/source/snowflake/SnowflakeSourceConfigurationTest.kt
+++ b/airbyte-integrations/connectors/source-snowflake/src/test/kotlin/io/airbyte/integrations/source/snowflake/SnowflakeSourceConfigurationTest.kt
@@ -202,4 +202,79 @@ class SnowflakeSourceConfigurationTest {
             factory.makeWithoutExceptionHandling(spec)
         }
     }
+
+    private fun baseSpec() =
+        SnowflakeSourceConfigurationSpecification().apply {
+            host = "test.snowflakecomputing.com"
+            role = "TEST_ROLE"
+            warehouse = "TEST_WAREHOUSE"
+            database = "TEST_DATABASE"
+            credentials =
+                UsernamePasswordCredentialsSpecification(
+                    username = "testuser",
+                    password = "testpass"
+                )
+        }
+
+    @Test
+    fun testValidStartDate() {
+        val config =
+            factory.makeWithoutExceptionHandling(baseSpec().apply { startDate = "2024-01-01" })
+        assertEquals("2024-01-01", config.startDate)
+    }
+
+    @Test
+    fun testValidEndDate() {
+        val config =
+            factory.makeWithoutExceptionHandling(baseSpec().apply { endDate = "2024-12-31" })
+        assertEquals("2024-12-31", config.endDate)
+    }
+
+    @Test
+    fun testInvalidStartDateFormat() {
+        assertThrows(ConfigErrorException::class.java) {
+            factory.makeWithoutExceptionHandling(baseSpec().apply { startDate = "01-01-2024" })
+        }
+    }
+
+    @Test
+    fun testInvalidEndDateFormat() {
+        assertThrows(ConfigErrorException::class.java) {
+            factory.makeWithoutExceptionHandling(baseSpec().apply { endDate = "not-a-date" })
+        }
+    }
+
+    @Test
+    fun testStartDateAfterEndDateThrows() {
+        assertThrows(ConfigErrorException::class.java) {
+            factory.makeWithoutExceptionHandling(
+                baseSpec().apply {
+                    startDate = "2024-12-31"
+                    endDate = "2024-01-01"
+                }
+            )
+        }
+    }
+
+    @Test
+    fun testStartDateEqualsEndDateIsValid() {
+        val config =
+            factory.makeWithoutExceptionHandling(
+                baseSpec().apply {
+                    startDate = "2024-06-15"
+                    endDate = "2024-06-15"
+                }
+            )
+        assertEquals("2024-06-15", config.startDate)
+        assertEquals("2024-06-15", config.endDate)
+    }
+
+    @Test
+    fun testFullRefreshTemporalColumnPassThrough() {
+        val config =
+            factory.makeWithoutExceptionHandling(
+                baseSpec().apply { fullRefreshTemporalColumn = "updated_at" }
+            )
+        assertEquals("updated_at", config.fullRefreshTemporalColumn)
+    }
 }


### PR DESCRIPTION
## What
The Snowflake source connector previously had no way to limit the rows transferred — it always read the full table. This PR adds two optional date-bound parameters so users can transfer only the rows within a specific time window.

- start_date / end_date (YYYY-MM-DD): filter records where the cursor field (incremental) or the full_refresh_temporal_column (full-refresh) falls within the given range.
- full_refresh_temporal_column: a DATE or TIMESTAMP column present in every synced table, used to apply start_date/end_date filtering during full-refresh syncs.

## How
*Configuration* (SnowflakeSourceConfigurationSpecification, SnowflakeSourceConfiguration):

- Added start_date, end_date, and full_refresh_temporal_column as optional config fields with JSON schema annotations (order 11/12/13, date pattern validation).

*Query generation* (SnowflakeSourceOperations.applyDateBounds):
Reworked the cursor detection logic to support both sync modes:


1. SELECT MAX — cached only when the MAX column matches full_refresh_temporal_column (or no temporal column is set). PK MAX queries (used by the CDK for partition splitting in full-refresh) are intentionally not cached and receive no date bounds, preventing PK columns from polluting the cursor cache.
2. Cache hit — reuses the cached cursor for splittable partitions where ORDER BY is the PK, not the cursor.
3. Full-refresh temporal column — resolved from the SELECT column list. NullFieldType columns (LIMIT 0 discovery queries) are silently skipped.
4. ORDER BY fallback — used for incremental syncs before the first cursor cache entry.

NOTE : this PR was implemented with the help of Claude Code. I tested it extensively in my Airbyte cluster and everything seems to work correctly. I tried to add extensive unit test to avoid regressions.

## Review guide

1. [SnowflakeSourceConfigurationSpecification.kt](https://163lfd0ue8hv1usumi66a7sgnglcv4ejqao19jdqvkgkm48rvukd.assets.github.dev/stable/cfbea10c5ffb233ea9177d34726e6056e89913dc/out/vs/workbench/contrib/webview/browser/pre/airbyte-integrations/connectors/source-snowflake/src/main/kotlin/io/airbyte/integrations/source/snowflake/SnowflakeSourceConfigurationSpecification.kt) — new config fields and updated field descriptions.
2. [SnowflakeSourceConfiguration.kt](https://163lfd0ue8hv1usumi66a7sgnglcv4ejqao19jdqvkgkm48rvukd.assets.github.dev/stable/cfbea10c5ffb233ea9177d34726e6056e89913dc/out/vs/workbench/contrib/webview/browser/pre/airbyte-integrations/connectors/source-snowflake/src/main/kotlin/io/airbyte/integrations/source/snowflake/SnowflakeSourceConfiguration.kt) — propagation of fullRefreshTemporalColumn through the config factory.
3. [SnowflakeSourceOperations.kt](https://163lfd0ue8hv1usumi66a7sgnglcv4ejqao19jdqvkgkm48rvukd.assets.github.dev/stable/cfbea10c5ffb233ea9177d34726e6056e89913dc/out/vs/workbench/contrib/webview/browser/pre/airbyte-integrations/connectors/source-snowflake/src/main/kotlin/io/airbyte/integrations/source/snowflake/SnowflakeSourceOperations.kt) — core filtering logic in applyDateBounds.
4. [SnowflakeFullRefreshDateBoundsTest.kt](https://163lfd0ue8hv1usumi66a7sgnglcv4ejqao19jdqvkgkm48rvukd.assets.github.dev/stable/cfbea10c5ffb233ea9177d34726e6056e89913dc/out/vs/workbench/contrib/webview/browser/pre/airbyte-integrations/connectors/source-snowflake/src/test/kotlin/io/airbyte/integrations/source/snowflake/SnowflakeFullRefreshDateBoundsTest.kt) — full-refresh scenarios: temporal column found/missing, NullFieldType guard, PK MAX not cached, FromSample with PK ORDER BY.
6. [SnowflakeIncrementalDateBoundsTest.kt](https://163lfd0ue8hv1usumi66a7sgnglcv4ejqao19jdqvkgkm48rvukd.assets.github.dev/stable/cfbea10c5ffb233ea9177d34726e6056e89913dc/out/vs/workbench/contrib/webview/browser/pre/airbyte-integrations/connectors/source-snowflake/src/test/kotlin/io/airbyte/integrations/source/snowflake/SnowflakeIncrementalDateBoundsTest.kt) — incremental scenarios: cursor cache, splittable partitions, ORDER BY fallback.
7. [SnowflakePkCursorCacheTest.kt](https://163lfd0ue8hv1usumi66a7sgnglcv4ejqao19jdqvkgkm48rvukd.assets.github.dev/stable/cfbea10c5ffb233ea9177d34726e6056e89913dc/out/vs/workbench/contrib/webview/browser/pre/airbyte-integrations/connectors/source-snowflake/src/test/kotlin/io/airbyte/integrations/source/snowflake/SnowflakePkCursorCacheTest.kt) — cache isolation across tables.

## User Impact
Users can now configure start_date and/or end_date to transfer only a specific time window of data instead of the full table. For full-refresh syncs, they additionally set full_refresh_temporal_column to the name of the date/timestamp column to filter on. All three fields are optional and fully backwards-compatible — existing configurations without these fields behave exactly as before.

No negative side effects. If full_refresh_temporal_column is not present in a synced table, filtering is silently skipped for that table with a warning log.

## Can this PR be safely reverted and rolled back?
 YES 💚