### PR TITLE
fix(auto-merge): fix dry-run echo quoting (em dash → ASCII)

### DIFF
--- a/.github/workflows/auto_merge.yml
+++ b/.github/workflows/auto_merge.yml
@@ -224,7 +224,7 @@ jobs:
 
       # ---------- Approve and merge ----------
       - name: Authenticate as 'octavia-bot-admin' GitHub App
-        if: steps.eligible.outputs.result == 'true'
+        if: steps.eligible.outputs.result == 'true' && vars.ENABLE_CONNECTOR_AUTO_MERGE == 'true'
         uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
         id: get-admin-token
         with:
@@ -234,7 +234,7 @@ jobs:
           private-key: ${{ secrets.OCTAVIA_BOT_ADMIN_PRIVATE_KEY }}
 
       - name: Approve PR with admin bot
-        if: steps.eligible.outputs.result == 'true'
+        if: steps.eligible.outputs.result == 'true' && vars.ENABLE_CONNECTOR_AUTO_MERGE == 'true'
         env:
           GH_TOKEN: ${{ steps.get-admin-token.outputs.token }}
         run: >
@@ -261,7 +261,7 @@ jobs:
 
       - name: Dry-run notice
         if: steps.eligible.outputs.result == 'true' && vars.ENABLE_CONNECTOR_AUTO_MERGE != 'true'
-        run: echo "::notice::DRY RUN — would merge PR #$PR_NUMBER"
+        run: echo "::notice::DRY RUN -- would merge PR #$PR_NUMBER"
 
   # ---------- Job 3: Force merge (bypass CI checks) ----------
   force-merge:
@@ -345,7 +345,7 @@ jobs:
 
       # ---------- Approve and merge ----------
       - name: Authenticate as 'octavia-bot-admin' GitHub App
-        if: steps.eligible.outputs.result == 'true'
+        if: steps.eligible.outputs.result == 'true' && vars.ENABLE_CONNECTOR_AUTO_MERGE == 'true'
         uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
         id: get-admin-token
         with:
@@ -355,7 +355,7 @@ jobs:
           private-key: ${{ secrets.OCTAVIA_BOT_ADMIN_PRIVATE_KEY }}
 
       - name: Approve PR with admin bot
-        if: steps.eligible.outputs.result == 'true'
+        if: steps.eligible.outputs.result == 'true' && vars.ENABLE_CONNECTOR_AUTO_MERGE == 'true'
         env:
           GH_TOKEN: ${{ steps.get-admin-token.outputs.token }}
         run: >
@@ -382,4 +382,4 @@ jobs:
 
       - name: Dry-run notice
         if: steps.eligible.outputs.result == 'true' && vars.ENABLE_CONNECTOR_AUTO_MERGE != 'true'
-        run: echo "::notice::DRY RUN — would force-merge PR #$PR_NUMBER"
+        run: echo "::notice::DRY RUN -- would force-merge PR #$PR_NUMBER"

--- a/.github/workflows/auto_merge.yml
+++ b/.github/workflows/auto_merge.yml
@@ -1,6 +1,7 @@
 name: Auto merge connector PRs Cron
 # Dry-run mode is controlled by the org-level variable ENABLE_CONNECTOR_AUTO_MERGE.
 # Set to "true" to enable real merges; any other value (or unset) runs in dry-run mode.
+# In dry-run mode, PRs are still approved and promoted from draft, but merges are skipped.
 # Manage at: https://github.com/organizations/airbytehq/settings/variables/actions
 
 on:
@@ -224,7 +225,7 @@ jobs:
 
       # ---------- Approve and merge ----------
       - name: Authenticate as 'octavia-bot-admin' GitHub App
-        if: steps.eligible.outputs.result == 'true' && vars.ENABLE_CONNECTOR_AUTO_MERGE == 'true'
+        if: steps.eligible.outputs.result == 'true'
         uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
         id: get-admin-token
         with:
@@ -234,7 +235,7 @@ jobs:
           private-key: ${{ secrets.OCTAVIA_BOT_ADMIN_PRIVATE_KEY }}
 
       - name: Approve PR with admin bot
-        if: steps.eligible.outputs.result == 'true' && vars.ENABLE_CONNECTOR_AUTO_MERGE == 'true'
+        if: steps.eligible.outputs.result == 'true'
         env:
           GH_TOKEN: ${{ steps.get-admin-token.outputs.token }}
         run: >
@@ -345,7 +346,7 @@ jobs:
 
       # ---------- Approve and merge ----------
       - name: Authenticate as 'octavia-bot-admin' GitHub App
-        if: steps.eligible.outputs.result == 'true' && vars.ENABLE_CONNECTOR_AUTO_MERGE == 'true'
+        if: steps.eligible.outputs.result == 'true'
         uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
         id: get-admin-token
         with:
@@ -355,7 +356,7 @@ jobs:
           private-key: ${{ secrets.OCTAVIA_BOT_ADMIN_PRIVATE_KEY }}
 
       - name: Approve PR with admin bot
-        if: steps.eligible.outputs.result == 'true' && vars.ENABLE_CONNECTOR_AUTO_MERGE == 'true'
+        if: steps.eligible.outputs.result == 'true'
         env:
           GH_TOKEN: ${{ steps.get-admin-token.outputs.token }}
         run: >


### PR DESCRIPTION
## What

Fixes a bug discovered by monitoring cron runs after merging #75929. Every cron run since the first has been failing.

**Shell quoting error on dry-run notice step** — the em dash character (`—`, U+2014) in the echo string causes bash to fail with `unexpected EOF while looking for matching "` when GitHub Actions writes the inline script to a temp file.

Also clarifies the dry-run behavior in the header comment: approvals and draft-to-ready promotion still run in dry-run mode; only actual merges are skipped. This matches the intended design per discussion with @aaronsteers — letting PRs merge on their own merit via CI is fine.

## How

1. Replace em dash (`—`) with ASCII `--` in both dry-run echo lines (normal-merge and force-merge jobs).
2. Add a clarifying comment at the top of the workflow file about what dry-run mode does and doesn't gate.

## Review guide

All changes are in `.github/workflows/auto_merge.yml`:

1. **Line 4** — new comment clarifying dry-run scope
2. **Line 265** — normal-merge dry-run echo: em dash → ASCII `--`
3. **Line 386** — force-merge dry-run echo: em dash → ASCII `--`

### Human review checklist

- [ ] Confirm the ASCII `--` replacement doesn't change the user-visible notice meaning
- [ ] Confirm dry-run behavior description in comment is accurate (approvals + draft promotion run; only merges are skipped)

## User Impact

- Cron runs will stop failing on the dry-run notice step.
- No change to merge behavior — this is a fix for the dry-run logging path only.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/b0b3701b43b54d81a0c98c66734fdbfe
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75977" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
