### PR TITLE
ci(connectors): use legacy branch pattern for up-to-date PR reuse

### DIFF
--- a/.github/workflows/connectors_up_to_date.yml
+++ b/.github/workflows/connectors_up_to_date.yml
@@ -245,7 +245,7 @@ jobs:
         with:
           token: ${{ steps.get-app-token.outputs.token }}
           commit-message: "chore(${{ env.CONNECTOR_NAME }}): update dependencies"
-          branch: "connectors-up-to-date/${{ env.CONNECTOR_NAME }}"
+          branch: "up-to-date/${{ env.CONNECTOR_NAME }}"
           delete-branch: true
           title: "chore(${{ env.CONNECTOR_NAME }}): update dependencies"
           body: |


### PR DESCRIPTION
## What

The new `connectors_up_to_date` workflow (migrated from `airbyte-ci` to `airbyte-ops`) uses a different branch naming pattern (`connectors-up-to-date/{connector}`) than the legacy workflow (`up-to-date/{connector}`). This means the next cron run would create **duplicate PRs** for all ~225 connectors that still have open legacy PRs, instead of reusing them.

## How

Single-line change: update the `branch` parameter in the `peter-evans/create-pull-request` step from `connectors-up-to-date/${{ env.CONNECTOR_NAME }}` to `up-to-date/${{ env.CONNECTOR_NAME }}`.

`peter-evans/create-pull-request` uses the branch name to decide whether to create a new PR or update an existing one, so matching the legacy pattern ensures the new pipeline adopts and updates the 225 existing open PRs rather than creating duplicates.

## Review guide

1. `.github/workflows/connectors_up_to_date.yml` — line 248, one string change

**Things to verify:**
- `peter-evans/create-pull-request` should handle pre-existing branches created by the legacy `airbyte-ci` tool (it force-pushes to the branch, so prior commit history doesn't matter).
- The one existing PR on the *new* pattern (`connectors-up-to-date/source-github`, PR #75930) will become orphaned — it should be manually closed.

## User Impact

None — this is an internal CI workflow change. Existing open dependency-update PRs will be updated in-place instead of duplicated.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/b0b3701b43b54d81a0c98c66734fdbfe
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75983" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
