### PR TITLE
fix(connectors): reorder steps to fix dirty working tree crash in up-to-date workflow

### DIFF
--- a/.github/workflows/connectors_up_to_date.yml
+++ b/.github/workflows/connectors_up_to_date.yml
@@ -281,9 +281,10 @@ jobs:
           PR_BRANCH: ${{ steps.create-pr.outputs.pull-request-branch }}
           GH_TOKEN: ${{ steps.get-app-token.outputs.token }}
         run: |
-          git checkout -- .
+          git stash --include-untracked
           git fetch --depth=1 origin "$PR_BRANCH"
           git checkout "$PR_BRANCH"
+          git stash pop
           git add "$CONNECTOR_DIR"
           git commit -m "chore($CONNECTOR_NAME): bump version and update changelog"
           git push origin "$PR_BRANCH"

--- a/.github/workflows/connectors_up_to_date.yml
+++ b/.github/workflows/connectors_up_to_date.yml
@@ -281,6 +281,7 @@ jobs:
           PR_BRANCH: ${{ steps.create-pr.outputs.pull-request-branch }}
           GH_TOKEN: ${{ steps.get-app-token.outputs.token }}
         run: |
+          git checkout -- .
           git fetch --depth=1 origin "$PR_BRANCH"
           git checkout "$PR_BRANCH"
           git add "$CONNECTOR_DIR"

--- a/.github/workflows/connectors_up_to_date.yml
+++ b/.github/workflows/connectors_up_to_date.yml
@@ -259,9 +259,21 @@ jobs:
             auto-merge
           draft: true
 
-      # --- Step 6: Bump version + changelog (needs PR number) ---
+      # --- Step 6: Check out PR branch ---
+      # peter-evans/create-pull-request commits dependency changes to the PR branch
+      # but leaves the working tree dirty on master. We must reset and switch to the
+      # PR branch before running the version bump (which needs the PR number).
+      - name: Check out PR branch
+        if: steps.check-changes.outputs.has_changes == 'true'
+        env:
+          PR_BRANCH: ${{ steps.create-pr.outputs.pull-request-branch }}
+        run: |
+          git checkout -- .
+          git fetch --depth=1 origin "$PR_BRANCH"
+          git checkout "$PR_BRANCH"
+
+      # --- Step 7: Bump version + changelog (needs PR number) ---
       # This runs after PR creation so we can reference the PR number in the changelog.
-      # The changes are pushed as a follow-up commit to the PR branch.
       - name: Bump connector version (patch) with changelog
         if: steps.check-changes.outputs.has_changes == 'true'
         env:
@@ -274,22 +286,18 @@ jobs:
             --changelog-message "Update dependencies" \
             --pr-number "$PR_NUMBER"
 
-      # --- Step 7: Push changelog commit to the PR branch ---
+      # --- Step 8: Push changelog commit to the PR branch ---
       - name: Push changelog commit to PR branch
         if: steps.check-changes.outputs.has_changes == 'true'
         env:
           PR_BRANCH: ${{ steps.create-pr.outputs.pull-request-branch }}
           GH_TOKEN: ${{ steps.get-app-token.outputs.token }}
         run: |
-          git stash --include-untracked
-          git fetch --depth=1 origin "$PR_BRANCH"
-          git checkout "$PR_BRANCH"
-          git stash pop
           git add "$CONNECTOR_DIR"
           git commit -m "chore($CONNECTOR_NAME): bump version and update changelog"
           git push origin "$PR_BRANCH"
 
-      # --- Step 8: Mark PR ready for review ---
+      # --- Step 9: Mark PR ready for review ---
       - name: Mark PR as ready for review
         if: steps.check-changes.outputs.has_changes == 'true'
         env:
@@ -297,7 +305,7 @@ jobs:
           PR_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
         run: gh pr ready "$PR_NUMBER"
 
-      # --- Step 9: Enable auto-merge ---
+      # --- Step 10: Enable auto-merge ---
       - name: Enable auto-merge on PR
         if: steps.check-changes.outputs.has_changes == 'true'
         env:
@@ -305,7 +313,7 @@ jobs:
           PR_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
         run: gh pr merge "$PR_NUMBER" --squash --auto
 
-      # --- Step 10: Apply bot approval ---
+      # --- Step 11: Apply bot approval ---
       # Use a different bot identity (admin) to approve, because the hoard bot
       # that created the PR cannot approve its own PRs.
       - name: Authenticate as 'octavia-bot-admin' GitHub App
@@ -326,7 +334,7 @@ jobs:
           PR_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
         run: gh pr review "$PR_NUMBER" --approve --body "Auto-approved by connectors up-to-date workflow."
 
-      # --- Step 11: Write job summary ---
+      # --- Step 12: Write job summary ---
       - name: Write step summary
         if: always()
         env:


### PR DESCRIPTION
## What

Fixes a failure in the `connectors_up_to_date` workflow where Step 7 ("Push changelog commit to PR branch") crashes with:

```
error: Your local changes to the following files would be overwritten by checkout:
    airbyte-integrations/connectors/source-square/metadata.yaml
Please commit your changes or stash them before you switch branches.
```

This was discovered during a test run of the pipeline with `--connectors-filter=source-appfollow,source-square`: [run #23863805039](https://github.com/airbytehq/airbyte/actions/runs/23863805039). Both matrix jobs failed at the same step.

## How

Reorders the workflow steps so that the branch switch happens **before** the version bump, avoiding dirty-tree conflicts entirely.

**Root cause:** `peter-evans/create-pull-request` (Step 5) commits and pushes dependency changes to the PR branch but leaves the working directory dirty on `master`. The old flow then ran `bump-version` (adding more local changes), then tried `git checkout "$PR_BRANCH"` — which failed because of the dirty tree.

**New step order:**

| Step | Old flow | New flow |
|------|----------|----------|
| 5 | Create/update PR (peter-evans) | *(unchanged)* |
| 6 | Bump version on dirty master | **Check out PR branch** (`git checkout -- .` to reset, then switch) |
| 7 | Checkout PR branch + push ❌ | Bump version (now runs directly on PR branch) |
| 8 | Mark ready | Push changelog commit |
| 9+ | Enable auto-merge, approve, summary | *(shifted by one, unchanged)* |

`git checkout -- .` is safe here because peter-evans already committed those changes to the PR branch — the local copies are redundant.

### Updates since last revision

Replaced the initial `git stash`/`git stash pop` approach with this step-reorder. The stash approach risked merge conflicts on pop when the same files were already committed on the PR branch by peter-evans. The reorder avoids stash entirely.

## Review guide

1. `.github/workflows/connectors_up_to_date.yml` — new "Check out PR branch" step inserted after peter-evans; bump-version and push steps simplified since we're already on the correct branch.

### Human review checklist
- [ ] **`bump-version` on PR branch**: The version bump now runs on the PR branch (which already contains the dependency changes) instead of on `master`. Verify that `airbyte-ops local connector bump-version --repo-path "$GITHUB_WORKSPACE"` produces correct results in this context — it should, since it only modifies `metadata.yaml` and changelog files based on `--name` and `--pr-number`.
- [ ] **`git checkout -- .` scope**: This discards _all_ working-tree modifications. If any step before peter-evans created files outside the connector directory that weren't committed, those would be lost. In the current flow (bump-deps + bump-base-image both target `$CONNECTOR_DIR`), this should be safe.

## User Impact

Without this fix, the up-to-date pipeline fails for every connector — PRs get created (Step 5 succeeds) but never receive the version bump + changelog commit, and downstream steps (mark ready, enable auto-merge, approve) are skipped.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/b0b3701b43b54d81a0c98c66734fdbfe
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75985" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
