### PR TITLE
ci(connectors): rename workflow to kebab-case and simplify matrix job names

### DIFF
--- a/.github/workflows/connectors-up-to-date.yml
+++ b/.github/workflows/connectors-up-to-date.yml
@@ -126,7 +126,7 @@ jobs:
 
   run_connectors_up_to_date:
     needs: generate_matrix
-    name: Connectors up-to-date
+    name: Connectors up-to-date (${{ matrix.connector }})
     runs-on: connector-up-to-date-medium
     continue-on-error: true
     strategy:


### PR DESCRIPTION
## What

Two cosmetic improvements to the `connectors_up_to_date` workflow:
1. Rename the file from `connectors_up_to_date.yml` to `connectors-up-to-date.yml` to match the repo's kebab-case convention for workflow files.
2. Simplify matrix job names to show only the connector name instead of the full matrix parameter set.

**Before:** `Connectors up-to-date (source-appfollow, source, manifest-only, 200, 1.1.42, airbyte-integrations...)`
**After:** `Connectors up-to-date (source-appfollow)`

## How

- `git mv` to rename the file
- Add `(${{ matrix.connector }})` to the matrix job's `name:` field so GitHub Actions uses only the connector name instead of dumping all matrix values

## Review guide

1. `.github/workflows/connectors-up-to-date.yml` — the only change inside the file is on line 129 (job name). The rest is the rename.

### Human review checklist
- [ ] **External references to old filename**: The file rename means any `workflow_dispatch` API calls or MCP tool invocations using `connectors_up_to_date.yml` must be updated to `connectors-up-to-date.yml`. Verify no other workflows or scripts reference the old filename.
- [ ] **Concurrency group**: Uses `${{ github.workflow }}` which resolves to the workflow `name:` (not the filename), so it should be unaffected. Worth confirming.
- [ ] **Cron schedule**: The cron trigger is defined inside the file and should carry over with the rename.

## User Impact

Cleaner job names in the GitHub Actions UI. No functional behavior change.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/b0b3701b43b54d81a0c98c66734fdbfe
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75987" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
