### PR TITLE
fix(connectors): add [skip ci] to first commit and fix author identity

### DIFF
--- a/.github/workflows/connectors-up-to-date.yml
+++ b/.github/workflows/connectors-up-to-date.yml
@@ -248,7 +248,7 @@ jobs:
         with:
           token: ${{ steps.get-app-token.outputs.token }}
           author: "${{ steps.get-app-token.outputs.app-slug }}[bot] <${{ steps.get-user-id.outputs.user-id }}+${{ steps.get-app-token.outputs.app-slug }}[bot]@users.noreply.github.com>"
-          commit-message: "deps(${{ env.CONNECTOR_NAME }}): update dependencies [skip ci]"
+          commit-message: "deps(${{ env.CONNECTOR_NAME }}): update dependencies"
           branch: "up-to-date/${{ env.CONNECTOR_NAME }}"
           delete-branch: true
           title: "deps(${{ env.CONNECTOR_NAME }}): 🐙 update dependencies [${{ env.TODAY }}]"

--- a/.github/workflows/connectors-up-to-date.yml
+++ b/.github/workflows/connectors-up-to-date.yml
@@ -247,7 +247,8 @@ jobs:
         uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
         with:
           token: ${{ steps.get-app-token.outputs.token }}
-          commit-message: "deps(${{ env.CONNECTOR_NAME }}): update dependencies"
+          author: "${{ steps.get-app-token.outputs.app-slug }}[bot] <${{ steps.get-user-id.outputs.user-id }}+${{ steps.get-app-token.outputs.app-slug }}[bot]@users.noreply.github.com>"
+          commit-message: "deps(${{ env.CONNECTOR_NAME }}): update dependencies [skip ci]"
           branch: "up-to-date/${{ env.CONNECTOR_NAME }}"
           delete-branch: true
           title: "deps(${{ env.CONNECTOR_NAME }}): 🐙 update dependencies [${{ env.TODAY }}]"


### PR DESCRIPTION
## What

Two issues discovered during readiness testing of the `connectors-up-to-date` pipeline:

1. **CLA check failures on dependency PRs.** The `peter-evans/create-pull-request` action defaults its `author` field to `${{ github.actor }}` — the human who triggered the workflow. This caused the CLA bot to flag the commit as unsigned by a human (e.g. `aaronsteers`) instead of recognizing it as a bot commit. The legacy Python pipeline authored commits as `octavia-bot-hoard[bot]`.

2. **Unnecessary CI triggered on the draft push.** The first commit (dependency bump) is pushed to a draft PR branch. CI workflows that respond to `pull_request` events will fire on this push even though the PR is still in draft and a second commit (changelog + version bump) is about to follow. This wastes CI resources.

## How

Single-file change to `.github/workflows/connectors-up-to-date.yml`, two additions to the `peter-evans/create-pull-request` step:

- **`author`**: Explicitly set to the hoard bot's GitHub identity (`octavia-bot-hoard[bot] <ID+octavia-bot-hoard[bot]@users.noreply.github.com>`) using the same `app-slug` and `user-id` outputs already computed for `git config`.
- **`commit-message`**: Append `[skip ci]` so the initial force-push to the PR branch does not trigger CI. The subsequent changelog push (Step 9, after "mark ready") does **not** have `[skip ci]` and will be the commit that triggers the full CI suite.

## Review guide

1. `.github/workflows/connectors-up-to-date.yml` — only the `peter-evans/create-pull-request` step (around line 248-251) is changed.

### Human review checklist
- [ ] Confirm the `author` format string matches the bot identity pattern used in the `Configure git author` step (lines 170-172). A mismatch could cause the CLA bot to still flag commits.
- [ ] Verify that `[skip ci]` in the peter-evans commit message is sufficient to suppress CI on the draft push. GitHub honors `[skip ci]` in commit messages for `push` and `pull_request` triggers regardless of auth method.
- [ ] Confirm Step 9's changelog push (line 310) does **not** contain `[skip ci]` — that's the commit that should trigger CI after the PR is marked ready in Step 8.

## User Impact

- Connector dependency PRs will no longer trigger CLA failures from bot-authored commits.
- CI will only run once per pipeline execution (on the final changelog commit) instead of twice.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/b0b3701b43b54d81a0c98c66734fdbfe
Requested by: @aaronsteers