### PR TITLE
fix(connectors): use App token for git push so CI workflows trigger

### DIFF
--- a/.github/workflows/connectors-up-to-date.yml
+++ b/.github/workflows/connectors-up-to-date.yml
@@ -166,10 +166,16 @@ jobs:
           GH_TOKEN: ${{ steps.get-app-token.outputs.token }}
         run: echo "user-id=$(gh api "/users/${{ steps.get-app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
 
-      - name: Configure git author
+      - name: Configure git author and push credentials
+        env:
+          APP_TOKEN: ${{ steps.get-app-token.outputs.token }}
         run: |
           git config --global user.name '${{ steps.get-app-token.outputs.app-slug }}[bot]'
           git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.get-app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
+          # Replace the default GITHUB_TOKEN remote credential with the App token.
+          # Pushes made with GITHUB_TOKEN do not trigger pull_request workflows;
+          # pushes made with a GitHub App token do.
+          git remote set-url origin "https://x-access-token:${APP_TOKEN}@github.com/${{ github.repository }}.git"
 
       - name: Docker login
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0


### PR DESCRIPTION
## What

The changelog push in Step 9 of the `connectors-up-to-date` pipeline does not trigger `pull_request` CI workflows (Connector CI, Format Check, Lint, Test, etc.). This means the final commit on up-to-date PRs gets no CI coverage.

**Evidence:** On PR #75882 (source-appfollow), the first commit (pushed by `peter-evans/create-pull-request` using the App token) triggered 16 workflow runs including full Connector CI. The second commit (our manual `git push` in Step 9) triggered only 2 `dynamic` events — zero `pull_request` workflows.

## How

`actions/checkout` configures the git remote with `GITHUB_TOKEN` by default. [GitHub does not trigger workflow runs for pushes made with `GITHUB_TOKEN`](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow) (to prevent infinite loops). After generating the hoard App token, we now reconfigure the remote URL to use it instead, so subsequent `git push` commands trigger `pull_request` workflows as expected.

The token is passed via `env` (masked in logs by GitHub Actions) rather than inline in the workflow expression.

## Review guide

1. `.github/workflows/connectors-up-to-date.yml` — the only change. Verify:
   - The `git remote set-url` pattern won't leak the token in logs (GitHub Actions auto-masks env secrets)
   - This doesn't interfere with the `peter-evans/create-pull-request` step above (it configures its own credentials internally via its `token` parameter)

## User Impact

Up-to-date PRs will now get full CI coverage (Connector CI, Format Check, Lint, Test, etc.) on the changelog commit, matching the behavior of the legacy Python pipeline.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/b0b3701b43b54d81a0c98c66734fdbfe
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75990" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
