### PR TITLE
fix(connectors): override extraheader credential so git push triggers CI

### DIFF
--- a/.github/workflows/connectors-up-to-date.yml
+++ b/.github/workflows/connectors-up-to-date.yml
@@ -172,10 +172,14 @@ jobs:
         run: |
           git config --global user.name '${{ steps.get-app-token.outputs.app-slug }}[bot]'
           git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.get-app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
-          # Replace the default GITHUB_TOKEN remote credential with the App token.
-          # Pushes made with GITHUB_TOKEN do not trigger pull_request workflows;
-          # pushes made with a GitHub App token do.
-          git remote set-url origin "https://x-access-token:${APP_TOKEN}@github.com/${{ github.repository }}.git"
+          # Replace the GITHUB_TOKEN push credential with the App token.
+          # actions/checkout persists credentials via http.extraheader in the
+          # local git config, which takes precedence over the remote URL.
+          # We must override that header so `git push` authenticates as the
+          # App — pushes made with GITHUB_TOKEN do not trigger pull_request
+          # workflows, but pushes made with a GitHub App token do.
+          AUTH=$(echo -n "x-access-token:${APP_TOKEN}" | base64)
+          git config --local http.https://github.com/.extraheader "AUTHORIZATION: basic ${AUTH}"
 
       - name: Docker login
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0


### PR DESCRIPTION
## What

The changelog push in Step 9 of the `connectors-up-to-date` pipeline does not trigger `pull_request` CI workflows (Connector CI, Format Check, Lint, Test, etc.). PR #75990 attempted to fix this by setting the remote URL with the App token, but that approach failed because `actions/checkout` persists credentials via `http.extraheader` in the local git config, which **takes precedence over URL-embedded credentials**.

**Evidence from PR #75882 (source-appfollow):**
- First commit (pushed by `peter-evans/create-pull-request` using its own token handling) → 16 workflow runs including full Connector CI
- Second commit (our `git push` in Step 9) → only 2 `dynamic` events, zero `pull_request` workflows — even after PR #75990

## How

Replace the `git remote set-url` approach with an override of the `http.extraheader` git config entry. This is the same mechanism `actions/checkout` uses internally to persist credentials. By overwriting the header with the App token's base64-encoded credentials, `git push` now authenticates as the GitHub App instead of using `GITHUB_TOKEN`.

## Review guide

1. `.github/workflows/connectors-up-to-date.yml` — the only change
   - Verify the `base64` encoding pattern is correct (`echo -n "x-access-token:${TOKEN}" | base64`)
   - Verify `--local` scope is appropriate (should only affect this checkout, not global)
   - **Note:** `base64` without `-w 0` could theoretically insert line breaks for very long inputs — the token + prefix should be well under 76 chars, but worth confirming
   - The `APP_TOKEN` env var is auto-masked by GitHub Actions, so it won't leak in logs

## User Impact

Up-to-date PRs will get full CI coverage on the changelog commit, matching the legacy Python pipeline behavior. Without this fix, the final commit on every up-to-date PR gets no connector CI checks.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Reverting restores the `git remote set-url` approach from PR #75990 (which is non-functional but harmless — it just means CI won't trigger on the changelog push).

Link to Devin session: https://app.devin.ai/sessions/b0b3701b43b54d81a0c98c66734fdbfe
Requested by: @aaronsteers