### PR TITLE
fix(connectors): checkout with App token so git push triggers CI

### DIFF
--- a/.github/workflows/connectors-up-to-date.yml
+++ b/.github/workflows/connectors-up-to-date.yml
@@ -166,16 +166,18 @@ jobs:
           GH_TOKEN: ${{ steps.get-app-token.outputs.token }}
         run: echo "user-id=$(gh api "/users/${{ steps.get-app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
 
-      - name: Configure git author and push credentials
-        env:
-          APP_TOKEN: ${{ steps.get-app-token.outputs.token }}
+      # Re-checkout with the App token so git push authenticates as the
+      # GitHub App. Pushes made with GITHUB_TOKEN do not trigger
+      # pull_request workflows; pushes made with a GitHub App token do.
+      - name: Re-checkout with App token
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          token: ${{ steps.get-app-token.outputs.token }}
+
+      - name: Configure git author
         run: |
           git config --global user.name '${{ steps.get-app-token.outputs.app-slug }}[bot]'
           git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.get-app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
-          # Replace the default GITHUB_TOKEN remote credential with the App token.
-          # Pushes made with GITHUB_TOKEN do not trigger pull_request workflows;
-          # pushes made with a GitHub App token do.
-          git remote set-url origin "https://x-access-token:${APP_TOKEN}@github.com/${{ github.repository }}.git"
 
       - name: Docker login
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0

--- a/.github/workflows/connectors-up-to-date.yml
+++ b/.github/workflows/connectors-up-to-date.yml
@@ -142,15 +142,6 @@ jobs:
       - name: Set today's date
         run: echo "TODAY=$(date -u +%Y-%m-%d)" >> "$GITHUB_ENV"
 
-      - name: Checkout Airbyte
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
-
-      - name: Install airbyte-ops CLI
-        run: uv tool install airbyte-internal-ops
-
       - name: Authenticate as 'octavia-bot-hoard' GitHub App
         uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
         id: get-app-token
@@ -160,24 +151,30 @@ jobs:
           app-id: ${{ secrets.OCTAVIA_BOT_HOARD_APP_ID }}
           private-key: ${{ secrets.OCTAVIA_BOT_HOARD_PRIVATE_KEY }}
 
+      # Checkout with the App token so git push authenticates as the
+      # GitHub App. Pushes made with GITHUB_TOKEN do not trigger
+      # pull_request workflows; pushes made with a GitHub App token do.
+      - name: Checkout Airbyte
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          token: ${{ steps.get-app-token.outputs.token }}
+
       - name: Get GitHub App User ID
         id: get-user-id
         env:
           GH_TOKEN: ${{ steps.get-app-token.outputs.token }}
         run: echo "user-id=$(gh api "/users/${{ steps.get-app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
 
-      # Re-checkout with the App token so git push authenticates as the
-      # GitHub App. Pushes made with GITHUB_TOKEN do not trigger
-      # pull_request workflows; pushes made with a GitHub App token do.
-      - name: Re-checkout with App token
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
-        with:
-          token: ${{ steps.get-app-token.outputs.token }}
-
       - name: Configure git author
         run: |
           git config --global user.name '${{ steps.get-app-token.outputs.app-slug }}[bot]'
           git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.get-app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
+
+      - name: Install airbyte-ops CLI
+        run: uv tool install airbyte-internal-ops
 
       - name: Docker login
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0


### PR DESCRIPTION
## What

Step 9 (`git push` of the changelog commit) in the `connectors-up-to-date` workflow was not triggering `pull_request` CI workflows on the target PR. The previous fix (PR #75990) attempted to swap the remote URL credentials with `git remote set-url`, but `actions/checkout` persists credentials via `http.extraheader` in git config, which takes precedence over URL-embedded credentials — so the push still used `GITHUB_TOKEN`. GitHub does not trigger `pull_request` workflows for pushes made with `GITHUB_TOKEN` (anti-loop measure).

Supersedes PR #75992, which attempted to manually override the `extraheader` git config entry.

## How

Pass the App token directly to `actions/checkout` so git push credentials are set correctly from the start. This required reordering the steps so the App token is generated *before* checkout:

1. Generate App token (`actions/create-github-app-token`)
2. Checkout with `token: ${{ steps.get-app-token.outputs.token }}`
3. Get GitHub App user ID + configure git author
4. Install `uv` / `airbyte-ops` CLI (moved after checkout — no dependency on order)

Removed the `git remote set-url` workaround entirely.

## Review guide

1. `.github/workflows/connectors-up-to-date.yml` — the only file changed.
   - Verify `actions/create-github-app-token` does not require a checked-out repo (it shouldn't — it only uses secrets).
   - Verify the `uv`/`airbyte-ops` install steps still work after being moved below checkout (they have no dependency on the previous position).

**Note:** This fix still needs live verification — trigger `connectors_up_to_date` for `source-appfollow` after merge and confirm the changelog commit push produces full Connector CI checks (~39) instead of the previous ~6.

## User Impact

Connector dependency update PRs will have their full CI suite triggered on the final changelog commit, enabling auto-merge to work correctly.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/b0b3701b43b54d81a0c98c66734fdbfe
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75993" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
