### PR TITLE
feat(source-gitlab): Revert concurrency to 8 with HTTPAPIBudget (4.4.23-rc.5)

### DIFF
--- a/airbyte-integrations/connectors/source-gitlab/manifest.yaml
+++ b/airbyte-integrations/connectors/source-gitlab/manifest.yaml
@@ -946,7 +946,7 @@ api_budget:
 
 concurrency_level:
   type: ConcurrencyLevel
-  default_concurrency: "{{ config.get('num_workers', 10) }}"
+  default_concurrency: "{{ config.get('num_workers', 8) }}"
   max_concurrency: 25
 
 streams:

--- a/airbyte-integrations/connectors/source-gitlab/metadata.yaml
+++ b/airbyte-integrations/connectors/source-gitlab/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 5e6175e5-68e1-4c17-bff9-56103bbb0d80
-  dockerImageTag: 4.4.23-rc.4
+  dockerImageTag: 4.4.23-rc.5
   dockerRepository: airbyte/source-gitlab
   documentationUrl: https://docs.airbyte.com/integrations/sources/gitlab
   externalDocumentationUrls:

--- a/docs/integrations/sources/gitlab.md
+++ b/docs/integrations/sources/gitlab.md
@@ -136,7 +136,7 @@ The connector silently skips any group, project, or resource that returns an HTT
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                                                            |
 | :------ | :--------- | :------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 4.4.23-rc.5 | 2026-04-01 | [TBD](https://github.com/airbytehq/airbyte/pull/TBD) | Revert concurrency to 8 with HTTPAPIBudget for progressive rollout tuning |
+| 4.4.23-rc.5 | 2026-04-01 | [75994](https://github.com/airbytehq/airbyte/pull/75994) | Revert concurrency to 8 with HTTPAPIBudget for progressive rollout tuning |
 | 4.4.23-rc.4 | 2026-03-31 | [75915](https://github.com/airbytehq/airbyte/pull/75915) | Re-enable HTTPAPIBudget with concurrency 10 for rate limit protection during progressive rollout |
 | 4.4.23-rc.3 | 2026-03-27 | [75537](https://github.com/airbytehq/airbyte/pull/75537) | Increase default concurrency from 8 to 10 for progressive rollout tuning |
 | 4.4.23-rc.2 | 2026-03-25 | [75480](https://github.com/airbytehq/airbyte/pull/75480) | Comment out HTTPAPIBudget to isolate concurrency tuning during progressive rollout |

--- a/docs/integrations/sources/gitlab.md
+++ b/docs/integrations/sources/gitlab.md
@@ -50,7 +50,7 @@ Log into [GitLab](https://gitlab.com) and then generate a [personal access token
 7. **Start date** (Optional) - The date from which you'd like to replicate data for streams, in the format `YYYY-MM-DDT00:00:00Z`.
 8. **Groups** (Optional) - List of GitLab group IDs, e.g. `airbytehq` for a single group.
 9. **Projects** (Optional) - List of GitLab projects to pull data for, e.g. `airbytehq/airbyte`.
-10. **Number of Concurrent Workers** (Optional) - The number of concurrent threads used for syncing. Higher values can speed up syncs but may hit rate limits. Defaults to 10. Adjust based on your GitLab instance's rate limits.
+10. **Number of Concurrent Workers** (Optional) - The number of concurrent threads used for syncing. Higher values can speed up syncs but may hit rate limits. Defaults to 8. Adjust based on your GitLab instance's rate limits.
 11. Click **Set up source**.
 
 **Note:** You can specify either Group IDs or Project IDs in the source configuration. If both fields are blank, the connector retrieves a list of all groups accessible to the configured token and ingests as normal.
@@ -136,6 +136,7 @@ The connector silently skips any group, project, or resource that returns an HTT
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                                                            |
 | :------ | :--------- | :------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 4.4.23-rc.5 | 2026-04-01 | [TBD](https://github.com/airbytehq/airbyte/pull/TBD) | Revert concurrency to 8 with HTTPAPIBudget for progressive rollout tuning |
 | 4.4.23-rc.4 | 2026-03-31 | [75915](https://github.com/airbytehq/airbyte/pull/75915) | Re-enable HTTPAPIBudget with concurrency 10 for rate limit protection during progressive rollout |
 | 4.4.23-rc.3 | 2026-03-27 | [75537](https://github.com/airbytehq/airbyte/pull/75537) | Increase default concurrency from 8 to 10 for progressive rollout tuning |
 | 4.4.23-rc.2 | 2026-03-25 | [75480](https://github.com/airbytehq/airbyte/pull/75480) | Comment out HTTPAPIBudget to isolate concurrency tuning during progressive rollout |


### PR DESCRIPTION
## What

Reverts default concurrency from 10 to 8 while keeping HTTPAPIBudget enabled, matching the rc.1 configuration which showed the best performance profile during progressive rollout tuning.

**Context:** Across rc.1–rc.4, the rc.1 config (budget + concurrency=8) had the lowest full mean sync duration (388s) among the 6 connections with data across all versions. Increasing concurrency to 10 (rc.3, rc.4) caused regressions for connections hitting rate-limited endpoints (e.g. group-based configs triggering 429s).

## How

- `manifest.yaml`: Change `default_concurrency` from `10` to `8`
- `metadata.yaml`: Bump version to `4.4.23-rc.5`
- `docs/.../gitlab.md`: Update default workers documentation and add changelog entry

## Review guide

1. `airbyte-integrations/connectors/source-gitlab/manifest.yaml` — single-line concurrency change
2. `airbyte-integrations/connectors/source-gitlab/metadata.yaml` — version bump
3. `docs/integrations/sources/gitlab.md` — docs + changelog

**Note:** The changelog entry contains a `[TBD]` placeholder for the PR link that should be updated post-merge.

## User Impact

Connectors pinned to this RC will use concurrency=8 (down from 10) with HTTPAPIBudget rate limiting. This should reduce 429 errors for connections with group-based configurations while maintaining the ~1.5x speedup over the stable version (4.4.22).

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/4462c8953c3c483084a62a7240f6973f
Requested by: @sophiecuiy