### PR TITLE
ci(deps): add github-actions ecosystem to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,7 +28,7 @@ updates:
       prefix: "chore(deps): "
     open-pull-requests-limit: 10
 
-  # GitHub Actions - keep action versions up to date (e.g. Node.js runtime deprecations)
+  # GitHub Actions - keep action versions up to date
   - package-ecosystem: github-actions
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,3 +27,12 @@ updates:
     commit-message:
       prefix: "chore(deps): "
     open-pull-requests-limit: 10
+
+  # GitHub Actions - keep action versions up to date (e.g. Node.js runtime deprecations)
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "ci(deps): "
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## What

The Dependabot configuration does not currently monitor GitHub Actions for version updates. This means the repo won't get automated PRs when actions like `actions/checkout` or `astral-sh/setup-uv` release new versions — which is relevant now that [Node.js 20 is being deprecated on GitHub Actions runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) (forced Node.js 24 starting June 2, 2026).

## How

Adds a `github-actions` package ecosystem entry to `.github/dependabot.yml`, following the same structure as the existing `pip`, `gradle`, and `docker` entries.

Uses `ci(deps): ` as the commit message prefix (instead of `chore(deps): ` used by the other ecosystems) since these are CI infrastructure updates.

## Review guide

1. `.github/dependabot.yml` — the only file changed

**Things to verify:**
- Is `ci(deps): ` the right commit prefix, or should it match the others with `chore(deps): `?
- Is `open-pull-requests-limit: 10` appropriate? Depending on how many workflow files reference pinned actions, Dependabot could open many PRs at once.

## User Impact

Once merged, Dependabot will begin creating weekly PRs to update GitHub Actions used in `.github/workflows/`. This will help the repo stay ahead of the Node.js 20 deprecation deadline.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

Link to Devin session: https://app.devin.ai/sessions/89acaba40e82452a8b091595a382e31c
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75997" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
