### PR TITLE
docs(source-appfollow): add missing changelog entry for v1.1.43

### DIFF
--- a/docs/integrations/sources/appfollow.md
+++ b/docs/integrations/sources/appfollow.md
@@ -40,6 +40,7 @@ The Appfollow connector ideally should gracefully handle Appfollow API limitatio
 
 | Version | Date       | Pull Request                                             | Subject                                 |
 | :------ | :--------- | :------------------------------------------------------- | :-------------------------------------- |
+| 1.1.43 | 2026-04-01 | [75882](https://github.com/airbytehq/airbyte/pull/75882) | Update dependencies |
 | 1.1.42 | 2026-03-24 | [75020](https://github.com/airbytehq/airbyte/pull/75020) | Update dependencies |
 | 1.1.41 | 2026-03-10 | [74488](https://github.com/airbytehq/airbyte/pull/74488) | Update dependencies |
 | 1.1.40 | 2026-02-24 | [73802](https://github.com/airbytehq/airbyte/pull/73802) | Update dependencies |


### PR DESCRIPTION
## What

Adds the missing changelog entry for `source-appfollow` v1.1.43, which was omitted when PR #75882 merged.

The `connectors-up-to-date` workflow has a bug where Step 9 runs `git add "$CONNECTOR_DIR"` (which only stages files under `airbyte-integrations/connectors/source-appfollow/`), but the changelog lives in `docs/integrations/sources/appfollow.md`. The version bump in `metadata.yaml` was committed and merged, but the corresponding changelog update was silently dropped. A separate PR will fix the workflow bug.

## How

Single-line addition to the changelog table in `docs/integrations/sources/appfollow.md`, matching the existing format.

## Review guide

1. `docs/integrations/sources/appfollow.md` — verify the version (1.1.43), date (2026-04-01), and PR number (75882) match the merged commit.

## User Impact

Docs-only change. Restores changelog accuracy for `source-appfollow`.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/b0b3701b43b54d81a0c98c66734fdbfe
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/75998" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
