### PR TITLE
fix(connectors): stage docs changelog in up-to-date push step

### DIFF
--- a/.github/workflows/connectors-up-to-date.yml
+++ b/.github/workflows/connectors-up-to-date.yml
@@ -305,13 +305,16 @@ jobs:
         run: gh pr ready "$PR_NUMBER"
 
       # --- Step 9: Push changelog commit to the PR branch ---
+      # bump-version modifies files in both the connector dir and the
+      # docs changelog (docs/integrations/…), so we stage everything.
       - name: Push changelog commit to PR branch
         if: steps.check-changes.outputs.has_changes == 'true'
         env:
           PR_BRANCH: ${{ steps.create-pr.outputs.pull-request-branch }}
           GH_TOKEN: ${{ steps.get-app-token.outputs.token }}
         run: |
-          git add "$CONNECTOR_DIR"
+          git add "$CONNECTOR_DIR" docs/
+          git diff --cached --stat
           git commit -m "deps($CONNECTOR_NAME): bump version and update changelog"
           git push origin "$PR_BRANCH"
 


### PR DESCRIPTION
## What

The `connectors-up-to-date` workflow's Step 9 was only staging files under `$CONNECTOR_DIR`, but the `bump-version` CLI (Step 7) also writes a changelog entry to `docs/integrations/sources/<connector>.md`. The docs change was silently dropped on every run, causing PRs to merge without changelog entries.

This was discovered when PR #75882 (`source-appfollow` v1.1.43) merged with the version bump in `metadata.yaml` but no corresponding changelog entry. A separate docs-only PR (#75998) backfills that missing entry.

## How

Changed `git add "$CONNECTOR_DIR"` → `git add "$CONNECTOR_DIR" docs/` so both the connector directory and the docs changelog are staged before the commit. Added `git diff --cached --stat` for visibility in the workflow logs.

## Review guide

1. `.github/workflows/connectors-up-to-date.yml` — the only change, 3 lines modified in the Step 9 `run` block.

**Worth checking:** Is `docs/` too broad a staging path? In a clean runner environment, only `bump-version` should have modified anything under `docs/`, so this should be safe. A more targeted path (e.g., deriving the exact doc file from the connector name) would be more defensive but adds complexity.

## User Impact

Connector dependency update PRs will now include the changelog entry that `bump-version` generates, matching legacy behavior.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/b0b3701b43b54d81a0c98c66734fdbfe
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/76004" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
