### PR TITLE
chore: scope `CODEOWNERS` move-destinations to certified + JDK-based destinations

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -38,9 +38,46 @@
 /airbyte-integrations/connectors/source-*/ @airbytehq/dbsources
 
 # -----------------------------------------------------------------------------
-# DESTINATION CONNECTORS
+# DESTINATION CONNECTORS (certified and/or JDK-based only)
 # -----------------------------------------------------------------------------
-/airbyte-integrations/connectors/destination-*/ @airbytehq/move-destinations
+# Only certified or JDK-based destination connectors are owned by
+# @airbytehq/move-destinations. Community/non-JDK connectors are excluded
+# to avoid unnecessary review requests (e.g. dependabot bumps).
+/airbyte-integrations/connectors/destination-azure-blob-storage/ @airbytehq/move-destinations
+/airbyte-integrations/connectors/destination-bigquery/ @airbytehq/move-destinations
+/airbyte-integrations/connectors/destination-clickhouse/ @airbytehq/move-destinations
+/airbyte-integrations/connectors/destination-csv/ @airbytehq/move-destinations
+/airbyte-integrations/connectors/destination-customer-io/ @airbytehq/move-destinations
+/airbyte-integrations/connectors/destination-databricks/ @airbytehq/move-destinations
+/airbyte-integrations/connectors/destination-dev-null/ @airbytehq/move-destinations
+/airbyte-integrations/connectors/destination-dynamodb/ @airbytehq/move-destinations
+/airbyte-integrations/connectors/destination-elasticsearch/ @airbytehq/move-destinations
+/airbyte-integrations/connectors/destination-elasticsearch-strict-encrypt/ @airbytehq/move-destinations
+/airbyte-integrations/connectors/destination-gcs/ @airbytehq/move-destinations
+/airbyte-integrations/connectors/destination-gcs-data-lake/ @airbytehq/move-destinations
+/airbyte-integrations/connectors/destination-hubspot/ @airbytehq/move-destinations
+/airbyte-integrations/connectors/destination-kafka/ @airbytehq/move-destinations
+/airbyte-integrations/connectors/destination-local-json/ @airbytehq/move-destinations
+/airbyte-integrations/connectors/destination-mongodb/ @airbytehq/move-destinations
+/airbyte-integrations/connectors/destination-mongodb-strict-encrypt/ @airbytehq/move-destinations
+/airbyte-integrations/connectors/destination-motherduck/ @airbytehq/move-destinations
+/airbyte-integrations/connectors/destination-mssql/ @airbytehq/move-destinations
+/airbyte-integrations/connectors/destination-mysql/ @airbytehq/move-destinations
+/airbyte-integrations/connectors/destination-mysql-strict-encrypt/ @airbytehq/move-destinations
+/airbyte-integrations/connectors/destination-oracle/ @airbytehq/move-destinations
+/airbyte-integrations/connectors/destination-oracle-strict-encrypt/ @airbytehq/move-destinations
+/airbyte-integrations/connectors/destination-pinecone/ @airbytehq/move-destinations
+/airbyte-integrations/connectors/destination-postgres/ @airbytehq/move-destinations
+/airbyte-integrations/connectors/destination-pubsub/ @airbytehq/move-destinations
+/airbyte-integrations/connectors/destination-redis/ @airbytehq/move-destinations
+/airbyte-integrations/connectors/destination-redshift/ @airbytehq/move-destinations
+/airbyte-integrations/connectors/destination-s3/ @airbytehq/move-destinations
+/airbyte-integrations/connectors/destination-s3-data-lake/ @airbytehq/move-destinations
+/airbyte-integrations/connectors/destination-singlestore/ @airbytehq/move-destinations
+/airbyte-integrations/connectors/destination-snowflake/ @airbytehq/move-destinations
+/airbyte-integrations/connectors/destination-starburst-galaxy/ @airbytehq/move-destinations
+/airbyte-integrations/connectors/destination-teradata/ @airbytehq/move-destinations
+/airbyte-integrations/connectors/destination-yellowbrick/ @airbytehq/move-destinations
 
 # Destination documentation
 /docs/integrations/destinations/ @airbytehq/move-destinations

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -38,46 +38,24 @@
 /airbyte-integrations/connectors/source-*/ @airbytehq/dbsources
 
 # -----------------------------------------------------------------------------
-# DESTINATION CONNECTORS (certified and/or JDK-based only)
+# DESTINATION CONNECTORS (certified + JDK-based only)
 # -----------------------------------------------------------------------------
-# Only certified or JDK-based destination connectors are owned by
-# @airbytehq/move-destinations. Community/non-JDK connectors are excluded
-# to avoid unnecessary review requests (e.g. dependabot bumps).
+# Only destination connectors that are both certified AND JDK-based are owned
+# by @airbytehq/move-destinations. This avoids unnecessary review requests on
+# community or non-JDK connectors (e.g. dependabot bumps).
 /airbyte-integrations/connectors/destination-azure-blob-storage/ @airbytehq/move-destinations
 /airbyte-integrations/connectors/destination-bigquery/ @airbytehq/move-destinations
 /airbyte-integrations/connectors/destination-clickhouse/ @airbytehq/move-destinations
-/airbyte-integrations/connectors/destination-csv/ @airbytehq/move-destinations
 /airbyte-integrations/connectors/destination-customer-io/ @airbytehq/move-destinations
 /airbyte-integrations/connectors/destination-databricks/ @airbytehq/move-destinations
-/airbyte-integrations/connectors/destination-dev-null/ @airbytehq/move-destinations
-/airbyte-integrations/connectors/destination-dynamodb/ @airbytehq/move-destinations
-/airbyte-integrations/connectors/destination-elasticsearch/ @airbytehq/move-destinations
-/airbyte-integrations/connectors/destination-elasticsearch-strict-encrypt/ @airbytehq/move-destinations
-/airbyte-integrations/connectors/destination-gcs/ @airbytehq/move-destinations
 /airbyte-integrations/connectors/destination-gcs-data-lake/ @airbytehq/move-destinations
 /airbyte-integrations/connectors/destination-hubspot/ @airbytehq/move-destinations
-/airbyte-integrations/connectors/destination-kafka/ @airbytehq/move-destinations
-/airbyte-integrations/connectors/destination-local-json/ @airbytehq/move-destinations
-/airbyte-integrations/connectors/destination-mongodb/ @airbytehq/move-destinations
-/airbyte-integrations/connectors/destination-mongodb-strict-encrypt/ @airbytehq/move-destinations
-/airbyte-integrations/connectors/destination-motherduck/ @airbytehq/move-destinations
 /airbyte-integrations/connectors/destination-mssql/ @airbytehq/move-destinations
-/airbyte-integrations/connectors/destination-mysql/ @airbytehq/move-destinations
-/airbyte-integrations/connectors/destination-mysql-strict-encrypt/ @airbytehq/move-destinations
-/airbyte-integrations/connectors/destination-oracle/ @airbytehq/move-destinations
-/airbyte-integrations/connectors/destination-oracle-strict-encrypt/ @airbytehq/move-destinations
-/airbyte-integrations/connectors/destination-pinecone/ @airbytehq/move-destinations
 /airbyte-integrations/connectors/destination-postgres/ @airbytehq/move-destinations
-/airbyte-integrations/connectors/destination-pubsub/ @airbytehq/move-destinations
-/airbyte-integrations/connectors/destination-redis/ @airbytehq/move-destinations
 /airbyte-integrations/connectors/destination-redshift/ @airbytehq/move-destinations
 /airbyte-integrations/connectors/destination-s3/ @airbytehq/move-destinations
 /airbyte-integrations/connectors/destination-s3-data-lake/ @airbytehq/move-destinations
-/airbyte-integrations/connectors/destination-singlestore/ @airbytehq/move-destinations
 /airbyte-integrations/connectors/destination-snowflake/ @airbytehq/move-destinations
-/airbyte-integrations/connectors/destination-starburst-galaxy/ @airbytehq/move-destinations
-/airbyte-integrations/connectors/destination-teradata/ @airbytehq/move-destinations
-/airbyte-integrations/connectors/destination-yellowbrick/ @airbytehq/move-destinations
 
 # Destination documentation
 /docs/integrations/destinations/ @airbytehq/move-destinations


### PR DESCRIPTION
## What

The `@airbytehq/move-destinations` team was being assigned as reviewers on PRs to **all** destination connectors due to the wildcard CODEOWNERS rule `/airbyte-integrations/connectors/destination-*/`. This caused unnecessary review requests on community/Python-based connectors the team doesn't own — e.g. [#76017](https://github.com/airbytehq/airbyte/pull/76017) (a dependabot bump on `destination-weaviate`).

## How

Replaced the single wildcard rule with 13 explicit entries covering only destination connectors that are both **certified** AND **JDK-based** (have a `build.gradle` / `build.gradle.kts` and `supportLevel: certified` in `metadata.yaml`).

The 13 connectors are: `destination-azure-blob-storage`, `destination-bigquery`, `destination-clickhouse`, `destination-customer-io`, `destination-databricks`, `destination-gcs-data-lake`, `destination-hubspot`, `destination-mssql`, `destination-postgres`, `destination-redshift`, `destination-s3`, `destination-s3-data-lake`, `destination-snowflake`.

Notable exclusions (certified-only, not JDK): `destination-motherduck`, `destination-pinecone`.
Notable exclusions (JDK-only, not certified): 20 connectors including `destination-csv`, `destination-mongodb`, `destination-mysql`, `destination-oracle`, etc.

The `/docs/integrations/destinations/` docs rule and the `source-*` wildcard for `@airbytehq/dbsources` are left unchanged.

## Review guide

1. `.github/CODEOWNERS` — the only file changed.

**Key things to verify:**
- [ ] Is the set of 13 connectors correct? Confirm the move-destinations team does not actively maintain any of the excluded JDK-only or certified-only destinations.
- [ ] **Maintenance trade-off**: The wildcard was self-maintaining; this explicit list requires a manual update when a new certified JDK destination is added. Consider whether a CI check or comment reminder is warranted.
- [ ] Should the same scoping be applied to `source-*` / `@airbytehq/dbsources`? (Not changed here since the request was specifically about the move team.)

## User Impact

No user-facing impact. This only affects which GitHub team is auto-requested for review on destination connector PRs.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/0ab07112bbbd4bee9c5426fec2c41d22
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/76018" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
