### PR TITLE
ci(deps): bump actions/checkout from v4/v5 to v6.0.2 (Node.js 24)

### DIFF
--- a/.github/workflows/ai-canary-prerelease-command.yml
+++ b/.github/workflows/ai-canary-prerelease-command.yml
@@ -35,7 +35,7 @@ jobs:
           echo "run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> $GITHUB_OUTPUT
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Authenticate as GitHub App
         uses: actions/create-github-app-token@v3.0.0

--- a/.github/workflows/ai-create-docs-pr-command.yml
+++ b/.github/workflows/ai-create-docs-pr-command.yml
@@ -36,7 +36,7 @@ jobs:
           echo "run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> $GITHUB_OUTPUT
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Authenticate as GitHub App
         uses: actions/create-github-app-token@v3.0.0

--- a/.github/workflows/ai-dev-command.yml
+++ b/.github/workflows/ai-dev-command.yml
@@ -57,7 +57,7 @@ jobs:
           echo "run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> $GITHUB_OUTPUT
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Authenticate as GitHub App
         uses: actions/create-github-app-token@v3.0.0

--- a/.github/workflows/ai-docs-review-command.yml
+++ b/.github/workflows/ai-docs-review-command.yml
@@ -110,7 +110,7 @@ jobs:
 
       - name: Checkout PR code
         if: steps.validate.outputs.valid == 'true'
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           # Use refs/pull/N/head which works for both fork and non-fork PRs

--- a/.github/workflows/ai-prove-fix-command.yml
+++ b/.github/workflows/ai-prove-fix-command.yml
@@ -35,7 +35,7 @@ jobs:
           echo "run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> $GITHUB_OUTPUT
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Authenticate as GitHub App
         uses: actions/create-github-app-token@v3.0.0

--- a/.github/workflows/ai-release-watch-command.yml
+++ b/.github/workflows/ai-release-watch-command.yml
@@ -35,7 +35,7 @@ jobs:
           echo "run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> $GITHUB_OUTPUT
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Authenticate as GitHub App
         uses: actions/create-github-app-token@v3.0.0

--- a/.github/workflows/ai-review-command.yml
+++ b/.github/workflows/ai-review-command.yml
@@ -43,7 +43,7 @@ jobs:
           echo "run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> $GITHUB_OUTPUT
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Authenticate as GitHub App
         uses: actions/create-github-app-token@v3.0.0

--- a/.github/workflows/auto-upgrade-certified-connectors-cdk.yml
+++ b/.github/workflows/auto-upgrade-certified-connectors-cdk.yml
@@ -20,7 +20,7 @@ jobs:
       connectors: ${{ steps.list-connectors.outputs.connectors }}
     steps:
       - name: Checkout Airbyte
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # Needed for when airbyte-enterprise calls this workflow
           submodules: true
@@ -63,7 +63,7 @@ jobs:
           git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
 
       - name: Checkout Airbyte
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ steps.app-token.outputs.token }}
           # Needed for when airbyte-enterprise calls this workflow

--- a/.github/workflows/autodoc.yml
+++ b/.github/workflows/autodoc.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       # Step 1: Get the pushed code
       - name: Checkout pushed code
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0 # Full history needed for comprehensive analysis
 

--- a/.github/workflows/build-connector-images-command.yml
+++ b/.github/workflows/build-connector-images-command.yml
@@ -58,7 +58,7 @@ jobs:
             > [Check job output.](${{ steps.job-vars.outputs.run-url }})
 
       - name: Repo Checkout
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ inputs.repo || github.repository }}
           ref: ${{ inputs.gitref || '' }}

--- a/.github/workflows/bump-version-command.yml
+++ b/.github/workflows/bump-version-command.yml
@@ -90,7 +90,7 @@ jobs:
       # forks if the user installs the app into their fork. Until we document this as a clear
       # path, we will have to keep using the PAT.
       - name: Checkout Airbyte
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ steps.job-vars.outputs.repo }}
           ref: ${{ steps.job-vars.outputs.branch }}

--- a/.github/workflows/cdk-destination-connector-compatibility-test.yml
+++ b/.github/workflows/cdk-destination-connector-compatibility-test.yml
@@ -17,7 +17,7 @@ jobs:
       connectors-matrix: ${{ steps.generate-matrix.outputs.connectors_matrix }}
     steps:
       - name: Checkout Airbyte
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true # Needed for when airbyte-enterprise calls this workflow
 
@@ -47,7 +47,7 @@ jobs:
     steps:
       - name: Checkout Airbyte
         if: matrix.connector
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true # Needed for airbyte-enterprise connectors (no-op otherwise)
 

--- a/.github/workflows/cdk-source-connector-compatibility-test.yml
+++ b/.github/workflows/cdk-source-connector-compatibility-test.yml
@@ -17,7 +17,7 @@ jobs:
       connectors-matrix: ${{ steps.generate-matrix.outputs.connectors_matrix }}
     steps:
       - name: Checkout Airbyte
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true # Needed for when airbyte-enterprise calls this workflow
 
@@ -47,7 +47,7 @@ jobs:
     steps:
       - name: Checkout Airbyte
         if: matrix.connector
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true # Needed for airbyte-enterprise connectors (no-op otherwise)
 

--- a/.github/workflows/community-pr-permissions-check.yml
+++ b/.github/workflows/community-pr-permissions-check.yml
@@ -21,7 +21,7 @@ jobs:
     if: github.event.pull_request.head.repo.fork == true
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: master
           repository: airbytehq/airbyte

--- a/.github/workflows/connector-ci-checks.yml
+++ b/.github/workflows/connector-ci-checks.yml
@@ -50,7 +50,7 @@ jobs:
     steps:
       - name: Checkout Current Branch
         id: checkout
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ inputs.repo || github.event.pull_request.head.repo.full_name }}
           ref: ${{ inputs.gitref || github.head_ref || github.ref_name }}
@@ -139,7 +139,7 @@ jobs:
       - name: Checkout Airbyte
         if: matrix.connector
         id: checkout
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ inputs.repo || github.event.pull_request.head.repo.full_name }}
           ref: ${{ inputs.gitref || github.head_ref || github.ref_name }}
@@ -230,7 +230,7 @@ jobs:
       - name: Checkout Airbyte
         if: matrix.connector
         id: checkout
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ inputs.repo || github.event.pull_request.head.repo.full_name }}
           ref: ${{ inputs.gitref || github.head_ref || github.ref_name }}
@@ -331,7 +331,7 @@ jobs:
     steps:
       - name: Checkout Airbyte
         if: matrix.connector
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ inputs.repo || github.event.pull_request.head.repo.full_name }}
           ref: ${{ inputs.gitref || github.head_ref || github.ref_name }}
@@ -422,7 +422,7 @@ jobs:
     steps:
       - name: Checkout Airbyte
         if: matrix.connector
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ inputs.repo || github.event.pull_request.head.repo.full_name }}
           ref: ${{ inputs.gitref || github.head_ref || github.ref_name }}
@@ -479,7 +479,7 @@ jobs:
     steps:
       - name: Checkout Airbyte
         if: matrix.connector
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ inputs.repo || github.event.pull_request.head.repo.full_name }}
           ref: ${{ inputs.gitref || github.head_ref || github.ref_name }}

--- a/.github/workflows/connector-image-build.yml
+++ b/.github/workflows/connector-image-build.yml
@@ -42,7 +42,7 @@ jobs:
       url: https://ghcr.io/airbytehq/${{ inputs.connector }}
     steps:
       - name: Checkout Current Branch
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ inputs.repo || github.event.pull_request.head.repo.full_name }}
           ref: ${{ inputs.gitref || github.head_ref }}

--- a/.github/workflows/connectors-cdk-version-check.yml
+++ b/.github/workflows/connectors-cdk-version-check.yml
@@ -27,7 +27,7 @@ jobs:
     if: needs.detect-changes.outputs.changed == 'true'
     steps:
       - name: Checkout Airbyte
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true # Needed for airbyte-enterprise connectors (no-op otherwise)
 

--- a/.github/workflows/connectors-up-to-date.yml
+++ b/.github/workflows/connectors-up-to-date.yml
@@ -25,7 +25,7 @@ jobs:
       generated_matrix: ${{ steps.generate_matrix.outputs.generated_matrix }}
     steps:
       - name: Checkout Airbyte
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install uv
         uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
@@ -155,7 +155,7 @@ jobs:
       # GitHub App. Pushes made with GITHUB_TOKEN do not trigger
       # pull_request workflows; pushes made with a GitHub App token do.
       - name: Checkout Airbyte
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ steps.get-app-token.outputs.token }}
 

--- a/.github/workflows/docker-connector-base-image-tests.yml
+++ b/.github/workflows/docker-connector-base-image-tests.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - id: changes
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
@@ -57,7 +57,7 @@ jobs:
     if: needs.detect-changes.outputs.java-images == 'true'
     steps:
       - name: Checkout code
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 
@@ -104,7 +104,7 @@ jobs:
     if: needs.detect-changes.outputs.python-images == 'true'
     steps:
       - name: Checkout code
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 
@@ -159,7 +159,7 @@ jobs:
       url: https://ghcr.io/airbytehq/${{ matrix.connector }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 
@@ -264,7 +264,7 @@ jobs:
       url: https://ghcr.io/airbytehq/${{ matrix.connector }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Log in to GHCR
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
@@ -344,7 +344,7 @@ jobs:
       url: https://ghcr.io/airbytehq/${{ matrix.connector }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 

--- a/.github/workflows/docker-connector-image-publishing.yml
+++ b/.github/workflows/docker-connector-image-publishing.yml
@@ -50,7 +50,7 @@ jobs:
       url: https://${{ github.event.inputs.repository-root == 'docker.io/airbyte' && 'hub.docker.com/r/airbyte' || github.event.inputs.repository-root }}/${{ github.event.inputs.connector-type }}-connector-base
     steps:
       - name: Checkout code
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -34,7 +34,7 @@ jobs:
     if: needs.detect-changes.outputs.changed == 'true'
     steps:
       - name: Checkout Current Branch
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -95,7 +95,7 @@ jobs:
 
     steps:
       - name: Checkout Current Branch
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 

--- a/.github/workflows/finalize_rollout.yml
+++ b/.github/workflows/finalize_rollout.yml
@@ -47,7 +47,7 @@ jobs:
       # The cleanup CLI reads metadata.yaml from the local repo to
       # resolve the connector's dockerRepository.
       - name: Checkout Airbyte repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 
@@ -136,7 +136,7 @@ jobs:
           git config --global user.email "octavia-squidington-iii@users.noreply.github.com"
 
       - name: Checkout Airbyte repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ steps.get-app-token.outputs.token }}
           fetch-depth: 1

--- a/.github/workflows/format-fix-command.yml
+++ b/.github/workflows/format-fix-command.yml
@@ -48,7 +48,7 @@ jobs:
       # forks if the user installs the app into their fork. Until we document this as a clear
       # path, we will have to keep using the PAT.
       - name: Checkout Airbyte
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ steps.job-vars.outputs.repo }}
           ref: ${{ steps.job-vars.outputs.branch }}

--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -14,7 +14,7 @@ jobs:
     name: "Format Check"
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Java
         uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3.14.1
         with:

--- a/.github/workflows/generate-connector-registries.yml
+++ b/.github/workflows/generate-connector-registries.yml
@@ -47,7 +47,7 @@ jobs:
 
     steps:
       - name: Checkout Airbyte
-        uses: actions/checkout@8edcb1bdb4e267140fa742c62e395cd74f332709 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.inputs.gitref || github.ref }}
           submodules: true

--- a/.github/workflows/gradle-dependency-diff.yml
+++ b/.github/workflows/gradle-dependency-diff.yml
@@ -10,7 +10,7 @@ jobs:
     if: github.event.pull_request.head.repo.fork == false
     steps:
       - name: Checkout Code
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Java
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:

--- a/.github/workflows/java-bulk-cdk-base-publish.yml
+++ b/.github/workflows/java-bulk-cdk-base-publish.yml
@@ -27,7 +27,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout Airbyte
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Java
         uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3.14.1

--- a/.github/workflows/java-bulk-cdk-extract-publish.yml
+++ b/.github/workflows/java-bulk-cdk-extract-publish.yml
@@ -30,7 +30,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout Airbyte
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Java
         uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3.14.1

--- a/.github/workflows/java-bulk-cdk-load-publish.yml
+++ b/.github/workflows/java-bulk-cdk-load-publish.yml
@@ -29,7 +29,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout Airbyte
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Java
         uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3.14.1

--- a/.github/workflows/java-cdk-tests.yml
+++ b/.github/workflows/java-cdk-tests.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: Checkout Airbyte
         if: github.event_name != 'pull_request'
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - id: changes
         uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
         with:
@@ -52,7 +52,7 @@ jobs:
     steps:
       - name: Checkout Airbyte
         if: github.event_name != 'pull_request'
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - id: changes
         uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
         with:
@@ -80,7 +80,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout Airbyte
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Java Setup
         uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3.14.1
         with:
@@ -130,7 +130,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout Airbyte
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Java Setup
         uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3.14.1
         with:

--- a/.github/workflows/kotlin-bulk-cdk-dokka-publish.yml
+++ b/.github/workflows/kotlin-bulk-cdk-dokka-publish.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Checkout Repository [Push Trigger]
         if: github.event_name == 'push'
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 2
 
@@ -56,7 +56,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
@@ -111,7 +111,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 

--- a/.github/workflows/notify-on-replication-version-change.yml
+++ b/.github/workflows/notify-on-replication-version-change.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 2

--- a/.github/workflows/publish-connectors-prerelease-command.yml
+++ b/.github/workflows/publish-connectors-prerelease-command.yml
@@ -57,7 +57,7 @@ jobs:
       connector-version: ${{ steps.connector-version.outputs.connector-version }}
     steps:
       - name: Checkout to get commit SHA
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ inputs.repo || github.repository }}
           ref: refs/pull/${{ inputs.pr }}/head

--- a/.github/workflows/publish-java-cdk-command.yml
+++ b/.github/workflows/publish-java-cdk-command.yml
@@ -89,7 +89,7 @@ jobs:
             > :clock2: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
 
       - name: Checkout Airbyte
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ env.GITREF }}
 

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -80,7 +80,7 @@ jobs:
     steps:
       - name: Checkout Airbyte
         # v4
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.gitref || '' }}
           fetch-depth: 2 # Required so we can conduct a diff from the previous commit to understand what connectors have changed.
@@ -162,7 +162,7 @@ jobs:
 
       - name: Checkout Airbyte
         # v4
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.gitref || '' }}
           fetch-depth: 2 # Required so we can conduct a diff from the previous commit to understand what connectors have changed.
@@ -531,7 +531,7 @@ jobs:
 
       - name: Checkout Airbyte
         # v4
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.gitref || '' }}
           submodules: true # Required for the enterprise repo since it uses a submodule that needs to exist for this workflow to run successfully.

--- a/.github/workflows/pyairbyte-docs-generate.yml
+++ b/.github/workflows/pyairbyte-docs-generate.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout Airbyte Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/regenerate-agent-engine-api-spec.yml
+++ b/.github/workflows/regenerate-agent-engine-api-spec.yml
@@ -35,7 +35,7 @@ jobs:
           git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
 
       - name: Checkout Airbyte
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ steps.app-token.outputs.token }}
 

--- a/.github/workflows/resolve-stale-metadata.yml
+++ b/.github/workflows/resolve-stale-metadata.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout Airbyte
-        uses: actions/checkout@8edcb1bdb4e267140fa742c62e395cd74f332709 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.inputs.gitref || github.ref }}
 

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -15,7 +15,7 @@ jobs:
     name: Docs / MarkDownLint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: markdownlint
         uses: reviewdog/action-markdownlint@3667398db9118d7e78f7a63d10e26ce454ba5f58 # v0.26.2
         with:
@@ -28,7 +28,7 @@ jobs:
     name: Docs / Vale
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # V5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - uses: errata-ai/vale-action@d89dee975228ae261d22c15adcd03578634d429c # Pinned to V2.1.1

--- a/.github/workflows/sync-ai-connector-docs.yml
+++ b/.github/workflows/sync-ai-connector-docs.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout airbyte repo
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Checkout airbyte-agent-connectors
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: airbytehq/airbyte-agent-connectors
           path: agent-connectors-source

--- a/.github/workflows/tk-todo-check.yml
+++ b/.github/workflows/tk-todo-check.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Check for TK-TODO markers # IGNORE:TK
         uses: aaronsteers/tk-todo-check-action@v1.0.0 # IGNORE:TK

--- a/.github/workflows/update-connector-cdk-version-command.yml
+++ b/.github/workflows/update-connector-cdk-version-command.yml
@@ -44,7 +44,7 @@ jobs:
             > Update CDK version job started for `${{ github.event.inputs.connector }}`. Check the [job logs](${{ steps.resolve-job-vars.outputs.run-url }}) for details.
 
       - name: Checkout Airbyte
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true # Needed for airbyte-enterprise connectors (no-op otherwise)
 

--- a/.github/workflows/welcome-message.yml
+++ b/.github/workflows/welcome-message.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Render template
         id: template


### PR DESCRIPTION
## What

Bumps `actions/checkout` to v6.0.2 (`de0fac2e4500dabe0009e67214ff5f5447ce83dd`) across all 43 workflow files. This eliminates the Node.js 20 deprecation warnings that clutter workflow annotations and obscure real warnings.

Dependabot did not create this PR because its `open-pull-requests-limit: 10` for `github-actions` was already saturated with other bumps.

## How

Mechanical find-and-replace of every `actions/checkout@<old-ref>` with the pinned v6.0.2 commit hash. Old versions replaced: `v3.6.0`, `v4`, `v4.2.2`, `v4.3.0`, `v5.0.0`, and bare `@v4`.

## Review guide

This is a 68-line, 43-file mechanical replacement — every hunk is identical in shape. Key things to verify:

1. **Hash correctness** — `de0fac2e4500dabe0009e67214ff5f5447ce83dd` is the commit for [`actions/checkout@v6.0.2`](https://github.com/actions/checkout/releases/tag/v6.0.2).
2. **Runner compatibility** — v6 requires Actions Runner ≥ v2.329.0. GitHub-hosted runners satisfy this; verify any **self-hosted runners** (e.g. `connector-up-to-date-medium`) are up to date.
3. **Credential persistence change** — v5+ stores credentials in `$RUNNER_TEMP` instead of `.git/config`. Workflows that do `git push` after checkout (e.g. `connectors-up-to-date.yml`, `bump-version-command.yml`, `auto-upgrade-certified-connectors-cdk.yml`) should still work since git picks up the new credential location automatically, but these are worth watching on the first run.
4. **`publish-java-cdk-command.yml`** — this jumped from v3.6.0 → v6.0.2 (largest gap). No special checkout options used beyond `ref:`, so this should be fine.

## User Impact

No user-facing impact. Eliminates dozens of deprecation warning annotations per workflow run, making real warnings visible again.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/b0b3701b43b54d81a0c98c66734fdbfe
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/76019" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
