### PR TITLE
ci(deps): bump peter-evans/create-pull-request to v8.1.0 and docker/login-action to v4.0.0

### DIFF
--- a/.github/workflows/auto-upgrade-certified-connectors-cdk.yml
+++ b/.github/workflows/auto-upgrade-certified-connectors-cdk.yml
@@ -114,7 +114,7 @@ jobs:
       - name: Create Pull Request
         id: create-pr
         if: steps.check-changes.outputs.has_changes == 'true'
-        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         with:
           token: ${{ steps.app-token.outputs.token }}
           commit-message: "chore: upgrade bulk CDK for ${{ matrix.connector }}"

--- a/.github/workflows/connector-image-build.yml
+++ b/.github/workflows/connector-image-build.yml
@@ -95,7 +95,7 @@ jobs:
           ./gradlew :airbyte-integrations:connectors:${{ inputs.connector }}:distTar
 
       - name: Log in to GHCR
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/.github/workflows/connectors-up-to-date.yml
+++ b/.github/workflows/connectors-up-to-date.yml
@@ -177,7 +177,7 @@ jobs:
         run: uv tool install airbyte-internal-ops
 
       - name: Docker login
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
@@ -249,7 +249,7 @@ jobs:
       - name: Create or update PR
         id: create-pr
         if: steps.check-changes.outputs.has_changes == 'true'
-        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         with:
           token: ${{ steps.get-app-token.outputs.token }}
           commit-message: "deps(${{ env.CONNECTOR_NAME }}): update dependencies"

--- a/.github/workflows/docker-connector-base-image-tests.yml
+++ b/.github/workflows/docker-connector-base-image-tests.yml
@@ -62,7 +62,7 @@ jobs:
           fetch-depth: 1
 
       - name: Log in to GHCR
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -109,7 +109,7 @@ jobs:
           fetch-depth: 1
 
       - name: Log in to GHCR
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -183,7 +183,7 @@ jobs:
           ./gradlew :airbyte-integrations:connectors:${{ matrix.connector }}:distTar
 
       - name: Log in to GHCR
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -267,7 +267,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Log in to GHCR
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -349,7 +349,7 @@ jobs:
           fetch-depth: 1
 
       - name: Log in to GHCR
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/.github/workflows/docker-connector-image-publishing.yml
+++ b/.github/workflows/docker-connector-image-publishing.yml
@@ -55,14 +55,14 @@ jobs:
           fetch-depth: 1
 
       - name: Log in to DockerHub
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         if: ${{ github.event.inputs.repository-root == 'docker.io/airbyte' }}
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
 
       - name: Log in to GHCR
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         if: ${{ github.event.inputs.repository-root == 'ghcr.io/airbytehq' }}
         with:
           registry: ghcr.io/airbytehq

--- a/.github/workflows/finalize_rollout.yml
+++ b/.github/workflows/finalize_rollout.yml
@@ -164,7 +164,7 @@ jobs:
       # number for the changelog entry.
       - name: Create cleanup PR
         id: create-pr
-        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         with:
           token: ${{ steps.get-app-token.outputs.token }}
           commit-message: "chore: finalize promote for ${{ env.CONNECTOR_NAME }}"

--- a/.github/workflows/java-bulk-cdk-base-publish.yml
+++ b/.github/workflows/java-bulk-cdk-base-publish.yml
@@ -36,7 +36,7 @@ jobs:
           java-version: "21"
 
       - name: Docker login
-        uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7 # v1.14.1
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}

--- a/.github/workflows/java-bulk-cdk-extract-publish.yml
+++ b/.github/workflows/java-bulk-cdk-extract-publish.yml
@@ -39,7 +39,7 @@ jobs:
           java-version: "21"
 
       - name: Docker login
-        uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7 # v1.14.1
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}

--- a/.github/workflows/java-bulk-cdk-load-publish.yml
+++ b/.github/workflows/java-bulk-cdk-load-publish.yml
@@ -38,7 +38,7 @@ jobs:
           java-version: "21"
 
       - name: Docker login
-        uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7 # v1.14.1
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}

--- a/.github/workflows/publish-java-cdk-command.yml
+++ b/.github/workflows/publish-java-cdk-command.yml
@@ -114,7 +114,7 @@ jobs:
 
       - name: Docker login
         # Some tests use testcontainers which pull images from DockerHub.
-        uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7 # v1.14.1
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -180,7 +180,7 @@ jobs:
           cache: gradle
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}

--- a/.github/workflows/pyairbyte-docs-generate.yml
+++ b/.github/workflows/pyairbyte-docs-generate.yml
@@ -269,7 +269,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.changes.outputs.has_changes == 'true'
-        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         with:
           token: ${{ steps.get-app-token.outputs.token }}
           commit-message: "docs: Update PyAirbyte API reference documentation for v${{ steps.version.outputs.version }}"

--- a/.github/workflows/regenerate-agent-engine-api-spec.yml
+++ b/.github/workflows/regenerate-agent-engine-api-spec.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Create Pull Request
         id: create-pr
         if: steps.check-changes.outputs.has_changes == 'true'
-        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         with:
           token: ${{ steps.app-token.outputs.token }}
           commit-message: "chore(docs): regenerate cached Agent Engine API spec"

--- a/.github/workflows/sync-ai-connector-docs.yml
+++ b/.github/workflows/sync-ai-connector-docs.yml
@@ -57,7 +57,7 @@ jobs:
           private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
 
       - name: Create PR if changes
-        uses: peter-evans/create-pull-request@0979079bc20c05bbbb590a56c21c4e2b1d1f1bbe # v6
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         with:
           token: ${{ steps.get-app-token.outputs.token }}
           commit-message: "docs: sync agent connector docs from airbyte-agent-connectors repo"


### PR DESCRIPTION
## What

Fixes `Duplicate header: "Authorization"` error that broke the `connectors-up-to-date` workflow after `actions/checkout` was bumped to v6 in #76019.

`actions/checkout@v6` changed how git credentials are persisted, which conflicts with `peter-evans/create-pull-request@v6`'s own credential setup. The result is two AUTHORIZATION headers on git remote operations, causing HTTP 400 errors. Known issue: https://github.com/peter-evans/create-pull-request/issues/4228

Also bumps `docker/login-action` from v1.14.1/v3.6.0 to v4.0.0 (Node.js 24 compatible), eliminating remaining Node.js 20 deprecation warnings.

## How

Mechanical find-and-replace across 14 workflow files:

- `peter-evans/create-pull-request`: v6 / v7.0.8 → `v8.1.0` (`c0f553fe549906ede9cf27b5156039d195d2ece0`)
- `docker/login-action`: v1.14.1 / v3.6.0 → `v4.0.0` (`b45d80f862d83dbcd57f89517bcf500b2ab88fb2`)

No workflow configuration changes — only version pins updated.

## Review guide

1. **Verify hashes match releases** — [`peter-evans/create-pull-request@v8.1.0`](https://github.com/peter-evans/create-pull-request/releases/tag/v8.1.0), [`docker/login-action@v4.0.0`](https://github.com/docker/login-action/releases/tag/v4.0.0)
2. **Check for breaking changes in major version jumps:**
   - `peter-evans/create-pull-request` v6→v8: [v7 changelog](https://github.com/peter-evans/create-pull-request/releases/tag/v7.0.0), [v8 changelog](https://github.com/peter-evans/create-pull-request/releases/tag/v8.0.0). Key concern: default author/committer changes in v7 — but our workflows pass explicit values or rely on `token`-based defaults, so this should be safe.
   - `docker/login-action` v1→v4 (for `java-bulk-cdk-*` and `publish-java-cdk-command`): interface is stable, primarily a Node.js runtime bump.
3. **Highest-risk workflows** — `connectors-up-to-date.yml` and `finalize_rollout.yml` (both use peter-evans heavily and are cron/automated).

## User Impact

No user-facing impact. Fixes a broken automated workflow (`connectors-up-to-date`) and eliminates remaining Node.js 20 deprecation warning annotations.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Reverting would re-break `connectors-up-to-date` (duplicate auth header) but all other workflows would continue working on older pins.

Link to Devin session: https://app.devin.ai/sessions/b0b3701b43b54d81a0c98c66734fdbfe
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/76021" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
