### PR TITLE
ci(connectors): add [skip ci] to first commit in up-to-date workflow

### DIFF
--- a/.github/workflows/connectors-up-to-date.yml
+++ b/.github/workflows/connectors-up-to-date.yml
@@ -252,7 +252,7 @@ jobs:
         uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         with:
           token: ${{ steps.get-app-token.outputs.token }}
-          commit-message: "deps(${{ env.CONNECTOR_NAME }}): update dependencies"
+          commit-message: "deps(${{ env.CONNECTOR_NAME }}): update dependencies [skip ci]"
           branch: "up-to-date/${{ env.CONNECTOR_NAME }}"
           delete-branch: true
           title: "deps(${{ env.CONNECTOR_NAME }}): 🐙 update dependencies [${{ env.TODAY }}]"


### PR DESCRIPTION
## What

Prevents wasted CI runs on the intermediate first commit in the `connectors-up-to-date` pipeline.

The workflow creates two commits per connector PR:
1. **Deps update** (via `peter-evans/create-pull-request`) — intermediate, always followed by commit 2
2. **Version bump + changelog** (manual `git push`) — the final commit that should trigger CI

Without `[skip ci]`, both commits trigger CI, doubling the load for no benefit since the first commit is immediately superseded.

## How

Appends `[skip ci]` to the `commit-message` parameter of `peter-evans/create-pull-request` (line 255). The second commit message (line 318) is unchanged and continues to trigger CI normally.

## Review guide

1. `.github/workflows/connectors-up-to-date.yml` — single-line change to `commit-message`
2. Verify the second commit at line 318 (`deps($CONNECTOR_NAME): bump version and update changelog`) does **not** have `[skip ci]` — it should be the one that triggers CI.

## User Impact

Reduces unnecessary CI runs on connector update PRs. No change to PR content or merge behavior.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/b0b3701b43b54d81a0c98c66734fdbfe
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/76022" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
