### PR TITLE
ci(deps): bump actions/setup-java, gradle/actions/setup-gradle, LouisBrunner/checks-action to Node 24

### DIFF
--- a/.github/actions/install-java-environment/action.yml
+++ b/.github/actions/install-java-environment/action.yml
@@ -19,11 +19,11 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
+    - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
       with:
         distribution: corretto
         java-version: ${{ inputs.java_version }}
-    - uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
+    - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
       with:
         cache-read-only: ${{ inputs.gradle_cache_read_only }}
         cache-write-only: ${{ inputs.gradle_cache_write_only }}

--- a/.github/actions/runner-prepare-for-build/action.yml
+++ b/.github/actions/runner-prepare-for-build/action.yml
@@ -17,7 +17,7 @@ runs:
   using: "composite"
   steps:
     - if: inputs.install_java == 'true'
-      uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3.14.1
+      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
       with:
         distribution: "zulu"
         java-version: "21"

--- a/.github/workflows/auto-upgrade-certified-connectors-cdk.yml
+++ b/.github/workflows/auto-upgrade-certified-connectors-cdk.yml
@@ -73,13 +73,13 @@ jobs:
         run: sudo snap install yq
 
       - name: Setup Java
-        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: "zulu"
           java-version: "21"
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@80e941e61874822d2a89974089c4915748e8f4b7 # v4
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
 
       - name: Run upgradeCdk for ${{ matrix.connector }}
         id: upgrade-cdk

--- a/.github/workflows/cdk-destination-connector-compatibility-test.yml
+++ b/.github/workflows/cdk-destination-connector-compatibility-test.yml
@@ -51,14 +51,14 @@ jobs:
         with:
           submodules: true # Needed for airbyte-enterprise connectors (no-op otherwise)
 
-      - uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         if: matrix.connector
         with:
           distribution: zulu
           java-version: 21
           cache: gradle
 
-      - uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1 # v4.4.4
+      - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
         if: matrix.connector
         with:
           gradle-version: "8.14"

--- a/.github/workflows/cdk-source-connector-compatibility-test.yml
+++ b/.github/workflows/cdk-source-connector-compatibility-test.yml
@@ -51,14 +51,14 @@ jobs:
         with:
           submodules: true # Needed for airbyte-enterprise connectors (no-op otherwise)
 
-      - uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         if: matrix.connector
         with:
           distribution: zulu
           java-version: 21
           cache: gradle
 
-      - uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1 # v4.4.4
+      - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
         if: matrix.connector
         with:
           gradle-version: "8.14"

--- a/.github/workflows/connector-ci-checks.yml
+++ b/.github/workflows/connector-ci-checks.yml
@@ -147,7 +147,7 @@ jobs:
           fetch-depth: 1
 
       # Java deps
-      - uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         if: matrix.connector
         with:
           distribution: zulu
@@ -156,7 +156,7 @@ jobs:
 
       # The default behaviour is read-only on PR branches and read/write on master.
       # See https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#using-the-cache-read-only.
-      - uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1 # v4.4.4
+      - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
         if: matrix.connector
         with:
           gradle-version: "8.14"
@@ -339,14 +339,14 @@ jobs:
           fetch-depth: 1
 
       # Java deps
-      - uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         if: matrix.connector
         with:
           distribution: zulu
           java-version: 21
           cache: gradle
 
-      - uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1 # v4.4.4
+      - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
         if: matrix.connector
         with:
           cache-read-only: false
@@ -492,14 +492,14 @@ jobs:
 
       # Java deps (needed for JVM connector Docker image builds via Gradle)
       # TODO: Consider making this conditional on connector language to skip for non-JVM connectors.
-      - uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         if: matrix.connector
         with:
           distribution: zulu
           java-version: 21
           cache: gradle
 
-      - uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1 # v4.4.4
+      - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
         if: matrix.connector
         with:
           gradle-version: "8.14"
@@ -598,7 +598,7 @@ jobs:
         if: >
           always() && !cancelled() &&
           steps.get-app-token.outcome == 'success'
-        uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
+        uses: LouisBrunner/checks-action@dfcbcf801bff1ea7f1414824fc28f2cd697b35da # v3.0.0
         with:
           name: "Connector CI Checks Summary" # << Name of the 'Required' check
           sha: ${{ needs.generate-matrix.outputs.commit-sha }}

--- a/.github/workflows/connector-image-build.yml
+++ b/.github/workflows/connector-image-build.yml
@@ -74,14 +74,14 @@ jobs:
           echo "image-build-num-tag=${IMAGE_PR_NUM_TAG}-build${{ github.run_number }}" | tee -a $GITHUB_OUTPUT
 
       # Java deps
-      - uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         if: ${{ steps.vars.outputs.connector-language == 'java' }}
         with:
           distribution: zulu
           java-version: 21
           cache: gradle
 
-      - uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1 # v4.4.4
+      - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
         if: ${{ steps.vars.outputs.connector-language == 'java' }}
         with:
           cache-read-only: false

--- a/.github/workflows/connectors-cdk-version-check.yml
+++ b/.github/workflows/connectors-cdk-version-check.yml
@@ -32,13 +32,13 @@ jobs:
           submodules: true # Needed for airbyte-enterprise connectors (no-op otherwise)
 
       - name: Setup Java
-        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 #v5.0.0
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: "zulu"
           java-version: "21"
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1 #v4.4.4
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
         with:
           gradle-version: "8.14"
 

--- a/.github/workflows/docker-connector-base-image-tests.yml
+++ b/.github/workflows/docker-connector-base-image-tests.yml
@@ -165,13 +165,13 @@ jobs:
 
       # Java deps
       - name: Set up Java
-        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: zulu
           java-version: 21
           cache: gradle
 
-      - uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1 # v4.4.4
+      - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
         with:
           cache-read-only: false
           cache-write-only: false

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -120,7 +120,7 @@ jobs:
 
       # If successful, post a check status with the Preview URL as its "details" link
       - name: Post Custom Check with Preview URL (${{ steps.deploy-vercel.outputs.preview-url }})
-        uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
+        uses: LouisBrunner/checks-action@dfcbcf801bff1ea7f1414824fc28f2cd697b35da # v3.0.0
         with:
           name: "Vercel Preview Deployed" # << Name of the check
           status: completed

--- a/.github/workflows/format-fix-command.yml
+++ b/.github/workflows/format-fix-command.yml
@@ -73,7 +73,7 @@ jobs:
 
       # Compare the below to the `format_check.yml` workflow
       - name: Setup Java
-        uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3.14.1
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: "zulu"
           java-version: "21"

--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Java
-        uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3.14.1
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: "zulu"
           java-version: "21"

--- a/.github/workflows/gradle-dependency-diff.yml
+++ b/.github/workflows/gradle-dependency-diff.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Java
-        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: temurin
           java-version: 21

--- a/.github/workflows/java-bulk-cdk-base-publish.yml
+++ b/.github/workflows/java-bulk-cdk-base-publish.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Java
-        uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3.14.1
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: "zulu"
           java-version: "21"

--- a/.github/workflows/java-bulk-cdk-extract-publish.yml
+++ b/.github/workflows/java-bulk-cdk-extract-publish.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Java
-        uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3.14.1
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: "zulu"
           java-version: "21"

--- a/.github/workflows/java-bulk-cdk-load-publish.yml
+++ b/.github/workflows/java-bulk-cdk-load-publish.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Java
-        uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3.14.1
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: "zulu"
           java-version: "21"

--- a/.github/workflows/java-cdk-tests.yml
+++ b/.github/workflows/java-cdk-tests.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Checkout Airbyte
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Java Setup
-        uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3.14.1
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: "zulu"
           java-version: "21"
@@ -132,7 +132,7 @@ jobs:
       - name: Checkout Airbyte
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Java Setup
-        uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3.14.1
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: "zulu"
           java-version: "21"

--- a/.github/workflows/kotlin-bulk-cdk-dokka-publish.yml
+++ b/.github/workflows/kotlin-bulk-cdk-dokka-publish.yml
@@ -63,7 +63,7 @@ jobs:
           ref: ${{ github.head_ref || github.ref }}
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: "zulu"
           java-version: "21"
@@ -162,7 +162,7 @@ jobs:
 
       - name: Post Custom Check with Preview URL
         if: github.event_name == 'pull_request'
-        uses: LouisBrunner/checks-action@v2.0.0
+        uses: LouisBrunner/checks-action@dfcbcf801bff1ea7f1414824fc28f2cd697b35da # v3.0.0
         with:
           name: "Kotlin Bulk CDK Docs Preview"
           status: completed

--- a/.github/workflows/publish-java-cdk-command.yml
+++ b/.github/workflows/publish-java-cdk-command.yml
@@ -107,7 +107,7 @@ jobs:
           echo "CDK_VERSION=${cdk_version}" >> $GITHUB_ENV
 
       - name: Setup Java
-        uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3.14.1
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: "zulu"
           java-version: "21"

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -173,7 +173,7 @@ jobs:
         shell: bash
         run: docker buildx create --use --driver=docker-container --name builder --platform linux/amd64,linux/arm64
 
-      - uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: zulu
           java-version: 21

--- a/.github/workflows/update-connector-cdk-version-command.yml
+++ b/.github/workflows/update-connector-cdk-version-command.yml
@@ -71,13 +71,13 @@ jobs:
           fi
 
       - name: Setup Java
-        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: "zulu"
           java-version: "21"
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1 # v4.4.4
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
 
       - name: Run CDK upgrade
         run: ./gradlew ":airbyte-integrations:connectors:${{ github.event.inputs.connector }}:upgradeCdk"


### PR DESCRIPTION
## What

Bumps three remaining GitHub Actions that were triggering Node.js 20 deprecation warnings to Node 24-compatible versions, ahead of the [June 2, 2026 forced migration deadline](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).

- `actions/setup-java` → v5.2.0 (from v3.14.1 / v4.7.1 / v5.0.0)
- `gradle/actions/setup-gradle` → v5.0.2 (from v3.5.0 / v4.4.4)
- `LouisBrunner/checks-action` → v3.0.0 (from v2.0.0)

## How

Pure SHA pin updates across 21 workflow/action files. No workflow logic, inputs, or parameters were changed.

**`gradle/actions` is deliberately pinned to v5.0.2, not v6.x.** The v6 release [changed the license](https://blog.gradle.org/github-actions-for-gradle-v6) for the caching component from MIT to proprietary (Gradle Terms of Use). v5.0.2 provides Node 24 support while remaining fully MIT-licensed.

Also normalizes a few previously unpinned tag refs (`@v4`, `@v2.0.0`) to full commit SHA pins.

## Review guide

**Please verify the SHAs match the tagged releases:**

| Action | Version | SHA | Release page |
|--------|---------|-----|-------------|
| `actions/setup-java` | v5.2.0 | `be666c2fcd27ec809703dec50e508c2fdc7f6654` | https://github.com/actions/setup-java/releases/tag/v5.2.0 |
| `gradle/actions/setup-gradle` | v5.0.2 | `0723195856401067f7a2779048b490ace7a47d7c` | https://github.com/gradle/actions/releases/tag/v5.0.2 |
| `LouisBrunner/checks-action` | v3.0.0 | `dfcbcf801bff1ea7f1414824fc28f2cd697b35da` | https://github.com/LouisBrunner/checks-action/releases/tag/v3.0.0 |

All three are lightweight (non-annotated) tags pointing directly at commits, so the tag SHA = commit SHA.

### Breaking change assessment

- **`actions/setup-java` v5**: Only breaking change is Node 24 runtime. Requires Actions Runner v2.327.1+ (GitHub-hosted runners already satisfy this). No input/output API changes.
- **`gradle/actions` v5**: Only breaking change is Node 24 runtime. Same runner requirement. `cache-read-only`, `cache-write-only`, `gradle-version` inputs are unchanged. No `configuration-cache` usage exists in this repo (which was removed in v6).
- **`LouisBrunner/checks-action` v3**: Only change is Node 24 runtime migration (to Bun internally). No input/output API changes.

## User Impact

Eliminates Node.js 20 deprecation warnings from CI runs for `actions/setup-java`, `gradle/actions/setup-gradle`, and `LouisBrunner/checks-action`.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/89acaba40e82452a8b091595a382e31c
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/76023" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
