### PR TITLE
ci: fix stale cron, bump to v10.2.0, add summaries and manual dispatch

### DIFF
--- a/.github/workflows/stale-community-issues.yaml
+++ b/.github/workflows/stale-community-issues.yaml
@@ -18,6 +18,7 @@ jobs:
           app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
           private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
       - uses: actions/stale@b5d41d4d0e39afb4e3d58060a07f6fb1ce2caa77 # v10.2.0
+        id: stale
         with:
           any-of-labels: "community"
           exempt-issue-labels: "frozen"
@@ -33,3 +34,13 @@ jobs:
             To keep it open, please comment to let us know why it is important to you and if it is still reproducible on recent versions of Airbyte.
           close-issue-message: "This issue was closed because it has been inactive for 20 days since being marked as stale."
           repo-token: ${{ steps.get-app-token.outputs.token }}
+      - name: Write job summary
+        if: always()
+        run: |
+          echo "## Stale Community Issues Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Staled Issues" >> $GITHUB_STEP_SUMMARY
+          echo "${{ steps.stale.outputs.staled-issues-prs }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Closed Issues" >> $GITHUB_STEP_SUMMARY
+          echo "${{ steps.stale.outputs.closed-issues-prs }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/stale-community-issues.yaml
+++ b/.github/workflows/stale-community-issues.yaml
@@ -1,7 +1,9 @@
 name: Stale Issue action
 on:
+  workflow_dispatch:
   schedule:
-    - cron: "0 9 * * *"
+    - cron: "0 1 * * *"
+      timezone: "America/Los_Angeles"
 
 jobs:
   close-issues:

--- a/.github/workflows/stale-community-issues.yaml
+++ b/.github/workflows/stale-community-issues.yaml
@@ -17,7 +17,7 @@ jobs:
           repositories: "airbyte"
           app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
           private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
-      - uses: actions/stale@f7176fd3007623b69d27091f9b9d4ab7995f0a06 # v5.2.1
+      - uses: actions/stale@b5d41d4d0e39afb4e3d58060a07f6fb1ce2caa77 # v10.2.0
         with:
           any-of-labels: "community"
           exempt-issue-labels: "frozen"

--- a/.github/workflows/stale-routed-issues.yaml
+++ b/.github/workflows/stale-routed-issues.yaml
@@ -19,6 +19,7 @@ jobs:
           app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
           private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
       - uses: actions/stale@b5d41d4d0e39afb4e3d58060a07f6fb1ce2caa77 # v10.2.0
+        id: stale
         with:
           any-of-labels: "frozen"
           days-before-issue-stale: 365
@@ -31,3 +32,13 @@ jobs:
             To keep it open, please comment to let us know why it is important to you and if it is still reproducible on recent versions of Airbyte.
           close-issue-message: "This issue was closed because it has been inactive for 20 days since being marked as stale."
           repo-token: ${{ steps.get-app-token.outputs.token }}
+      - name: Write job summary
+        if: always()
+        run: |
+          echo "## Stale Routed Issues Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Staled Issues" >> $GITHUB_STEP_SUMMARY
+          echo "${{ steps.stale.outputs.staled-issues-prs }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Closed Issues" >> $GITHUB_STEP_SUMMARY
+          echo "${{ steps.stale.outputs.closed-issues-prs }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/stale-routed-issues.yaml
+++ b/.github/workflows/stale-routed-issues.yaml
@@ -1,7 +1,7 @@
 name: Stale issue action
 on:
   schedule:
-    - cron: "* 8 * * *"
+    - cron: "0 8 * * *"
 
 jobs:
   close-issues:

--- a/.github/workflows/stale-routed-issues.yaml
+++ b/.github/workflows/stale-routed-issues.yaml
@@ -1,7 +1,9 @@
 name: Stale issue action
 on:
+  workflow_dispatch:
   schedule:
-    - cron: "0 8 * * *"
+    - cron: "0 2 * * *"
+      timezone: "America/Los_Angeles"
 
 jobs:
   close-issues:

--- a/.github/workflows/stale-routed-issues.yaml
+++ b/.github/workflows/stale-routed-issues.yaml
@@ -18,7 +18,7 @@ jobs:
           repositories: "airbyte"
           app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
           private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
-      - uses: actions/stale@f7176fd3007623b69d27091f9b9d4ab7995f0a06 # v5.2.1
+      - uses: actions/stale@b5d41d4d0e39afb4e3d58060a07f6fb1ce2caa77 # v10.2.0
         with:
           any-of-labels: "frozen"
           days-before-issue-stale: 365


### PR DESCRIPTION
## What

1. **Cron fix**: The `stale-routed-issues` workflow had a cron expression `* 8 * * *` which triggers every minute during the 8 AM UTC hour. GitHub was running this 2-3 times per day instead of the intended single daily run.
2. **Version bump**: Bumps `actions/stale` from v5.2.1 to v10.2.0 (SHA-pinned) in both stale workflows.
3. **Timezone**: Switches both cron schedules to use the new GitHub Actions `timezone` support (`America/Los_Angeles`). Community issues run at 1 AM Pacific, routed issues at 2 AM Pacific — staggered to minimize rate-limit contention.
4. **Job summary**: Adds a `$GITHUB_STEP_SUMMARY` step to both workflows that surfaces the list of staled and closed issues/PRs on the workflow run page.
5. **Manual dispatch**: Adds `workflow_dispatch` trigger to both workflows so they can be triggered manually for testing.

## How

- **stale-routed-issues.yaml**: Fixed cron (`* 8 * * *` → `0 2 * * *`), added `timezone: "America/Los_Angeles"`, bumped SHA from `f7176fd` (v5.2.1) to `b5d41d4` (v10.2.0), added `id: stale` to reference outputs, added job summary step, added `workflow_dispatch`.
- **stale-community-issues.yaml**: Changed cron from `0 9 * * *` (UTC) to `0 1 * * *` with `timezone: "America/Los_Angeles"`, same version bump, `id: stale`, job summary step, and `workflow_dispatch`.

## Review guide

1. `.github/workflows/stale-community-issues.yaml` — `workflow_dispatch` + timezone on lines 3–6, version bump on line 22, job summary on lines 38–48.
2. `.github/workflows/stale-routed-issues.yaml` — `workflow_dispatch` + timezone + cron fix on lines 3–6, version bump on line 23, job summary on lines 36–46.

### Reviewer checklist

- [ ] Verify SHA `b5d41d4` corresponds to [actions/stale v10.2.0](https://github.com/actions/stale/releases/tag/v10.2.0).
- [ ] Note that v9+ introduced **statefulness** — if a run hits `operations-per-run`, the next run resumes where it left off instead of restarting. This is relevant for `stale-community-issues.yaml` which sets `operations-per-run: 100`. Behavior should be net-positive but is a change from v5.
- [ ] v10 requires runner ≥ v2.327.1 (Node 24). Both workflows use `ubuntu-24.04`, which satisfies this.
- [ ] The `timezone` key in `on.schedule` is a [new GitHub Actions feature (March 2026)](https://github.blog/changelog/2026-03-19-github-actions-late-march-2026-updates/). Confirm it is working as expected after merging by triggering a manual run.
- [ ] The job summary step references `steps.stale.outputs.staled-issues-prs` and `steps.stale.outputs.closed-issues-prs` — verify these output names match the [v10 docs](https://github.com/actions/stale#outputs).

## User Impact

- The stale-routed-issues workflow will run exactly once per day instead of 2-3 times.
- Both workflows now run at stable Pacific times (1 AM / 2 AM) with automatic DST handling.
- Each workflow run will show a summary of staled and closed issues on the Actions run page.
- Both workflows can be manually triggered from the Actions tab for testing.
- No change to stale issue behavior or labeling logic.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/8cb982ff0dc4471eb089a4ec39eda7cc
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/76024" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
