### PR TITLE
docs: move "How authentication works" above Troubleshooting in MCP server docs

### DIFF
--- a/docs/ai-agents/mcp-server/readme.md
+++ b/docs/ai-agents/mcp-server/readme.md
@@ -29,77 +29,6 @@ When you connect a service through the MCP server, the Agent Engine can copy key
 
 For the complete list of connectors and their supported entities, see [Agent connectors](../connectors).
 
-## How authentication works
-
-The MCP server uses a two-layer authentication model: one layer to authenticate you with the Airbyte Agent Engine, and a second layer to authenticate with each third-party service you connect.
-
-### Layer 1: Authenticating with the MCP server
-
-When your AI client first connects to the MCP server, it initiates an [OAuth 2.0](https://oauth.net/2/) authorization flow with Airbyte:
-
-```mermaid
-sequenceDiagram
-    participant Client as AI Client
-    participant Browser as Browser
-    participant Airbyte as Airbyte Agent Engine
-
-    Client->>Airbyte: Connect to MCP server
-    Airbyte-->>Client: Authentication required
-    Client->>Browser: Open Airbyte login page
-    Browser->>Airbyte: User logs in and grants access
-    Airbyte-->>Browser: Redirect with OAuth token
-    Browser-->>Client: OAuth token delivered
-    Client->>Airbyte: Authenticated MCP requests
-```
-
-1. Your client detects that the MCP server at `https://mcp.airbyte.ai/mcp` requires authentication.
-2. Your client opens a browser window to the Airbyte login page.
-3. You log in with your [Agent Engine](https://app.airbyte.ai) account (or create one).
-4. You grant the MCP server access to your Airbyte account.
-5. The browser redirects back to your client with an OAuth token.
-6. Your client stores the token and uses it for all subsequent MCP requests.
-
-This token authorizes the MCP server to act on your behalf within the Agent Engine. The token is scoped to your Airbyte account and organization, so the MCP server can only access connectors and data that belong to you. If the token expires, your client automatically triggers a new OAuth flow.
-
-### Layer 2: Authenticating with third-party services
-
-After you authenticate with the MCP server, you still need to connect each third-party service individually. When you ask your agent to connect a service (for example, "Connect my Salesforce account"), a second credential flow begins:
-
-```mermaid
-sequenceDiagram
-    participant User as You
-    participant Agent as AI Agent
-    participant MCP as MCP Server
-    participant Browser as Browser
-    participant Service as Third-Party Service
-
-    User->>Agent: "Connect my Salesforce account"
-    Agent->>MCP: Initiate credential flow
-    MCP-->>Agent: Credential URL
-    Agent-->>User: Visit this URL
-    User->>Browser: Open credential URL
-    Browser->>Service: OAuth consent or credential form
-    Note over Service: User authorizes access
-    Service-->>MCP: Credentials delivered
-    Note over MCP: Connector created
-    MCP-->>Agent: Connector ready
-    Agent-->>User: "Salesforce is connected"
-```
-
-1. The agent calls the MCP server to initiate a credential flow for the requested service.
-2. The MCP server returns a secure URL for you to visit in your browser.
-3. You open the URL and authenticate directly with the third-party service. Depending on the connector, this is either:
-   - An **OAuth consent screen** where you authorize Airbyte to access your account (used by services like Salesforce, HubSpot, GitHub, Google, and Slack), or
-   - A **credential form** where you enter an API key or access token (used by services like Stripe, Gong, and Linear).
-4. After you complete the flow, Airbyte securely stores your credentials and creates a connector.
-5. The agent confirms the connector is ready and you can begin querying data.
-
-:::note
-Your third-party credentials are always entered in the browser, never in the agent chat. Airbyte stores credentials securely on the server side and the MCP server never exposes them to the AI agent.
-:::
-
-Once a connector is created, the agent uses it for all subsequent queries to that service. You don't need to re-authenticate unless your credentials expire or are revoked by the third-party service.
-
 ## Requirements
 
 Before you begin, make sure you have the following:
@@ -285,6 +214,77 @@ How many Zendesk tickets are in "open" status?
 ```
 
 The agent uses field selection to return only the data you need, which reduces token usage and improves response quality.
+
+## How authentication works
+
+The MCP server uses a two-layer authentication model: one layer to authenticate you with the Airbyte Agent Engine, and a second layer to authenticate with each third-party service you connect.
+
+### Layer 1: Authenticating with the MCP server
+
+When your AI client first connects to the MCP server, it initiates an [OAuth 2.0](https://oauth.net/2/) authorization flow with Airbyte:
+
+```mermaid
+sequenceDiagram
+    participant Client as AI Client
+    participant Browser as Browser
+    participant Airbyte as Airbyte Agent Engine
+
+    Client->>Airbyte: Connect to MCP server
+    Airbyte-->>Client: Authentication required
+    Client->>Browser: Open Airbyte login page
+    Browser->>Airbyte: User logs in and grants access
+    Airbyte-->>Browser: Redirect with OAuth token
+    Browser-->>Client: OAuth token delivered
+    Client->>Airbyte: Authenticated MCP requests
+```
+
+1. Your client detects that the MCP server at `https://mcp.airbyte.ai/mcp` requires authentication.
+2. Your client opens a browser window to the Airbyte login page.
+3. You log in with your [Agent Engine](https://app.airbyte.ai) account (or create one).
+4. You grant the MCP server access to your Airbyte account.
+5. The browser redirects back to your client with an OAuth token.
+6. Your client stores the token and uses it for all subsequent MCP requests.
+
+This token authorizes the MCP server to act on your behalf within the Agent Engine. The token is scoped to your Airbyte account and organization, so the MCP server can only access connectors and data that belong to you. If the token expires, your client automatically triggers a new OAuth flow.
+
+### Layer 2: Authenticating with third-party services
+
+After you authenticate with the MCP server, you still need to connect each third-party service individually. When you ask your agent to connect a service (for example, "Connect my Salesforce account"), a second credential flow begins:
+
+```mermaid
+sequenceDiagram
+    participant User as You
+    participant Agent as AI Agent
+    participant MCP as MCP Server
+    participant Browser as Browser
+    participant Service as Third-Party Service
+
+    User->>Agent: "Connect my Salesforce account"
+    Agent->>MCP: Initiate credential flow
+    MCP-->>Agent: Credential URL
+    Agent-->>User: Visit this URL
+    User->>Browser: Open credential URL
+    Browser->>Service: OAuth consent or credential form
+    Note over Service: User authorizes access
+    Service-->>MCP: Credentials delivered
+    Note over MCP: Connector created
+    MCP-->>Agent: Connector ready
+    Agent-->>User: "Salesforce is connected"
+```
+
+1. The agent calls the MCP server to initiate a credential flow for the requested service.
+2. The MCP server returns a secure URL for you to visit in your browser.
+3. You open the URL and authenticate directly with the third-party service. Depending on the connector, this is either:
+   - An **OAuth consent screen** where you authorize Airbyte to access your account (used by services like Salesforce, HubSpot, GitHub, Google, and Slack), or
+   - A **credential form** where you enter an API key or access token (used by services like Stripe, Gong, and Linear).
+4. After you complete the flow, Airbyte securely stores your credentials and creates a connector.
+5. The agent confirms the connector is ready and you can begin querying data.
+
+:::note
+Your third-party credentials are always entered in the browser, never in the agent chat. Airbyte stores credentials securely on the server side and the MCP server never exposes them to the AI agent.
+:::
+
+Once a connector is created, the agent uses it for all subsequent queries to that service. You don't need to re-authenticate unless your credentials expire or are revoked by the third-party service.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## What

Reorders the "How authentication works" section on the [MCP server docs page](https://docs.airbyte.com/ai-agents/mcp-server/) so it sits just above "Troubleshooting" instead of near the top of the page.

## How

Moved the entire "How authentication works" section (including both subsections, mermaid diagrams, and the admonition) from its original position after "What connectors do" to just before "Troubleshooting". No content was added, removed, or modified.

New section order:
1. What connectors do
2. Requirements
3. Add the MCP server to your agent
4. Example usage
5. **How authentication works** ← moved here
6. Troubleshooting

## Review guide

1. `docs/ai-agents/mcp-server/readme.md` — only file changed. Confirm the 71 removed lines match the 71 added lines exactly (pure move, no edits).

## User Impact

Readers of the MCP server docs page will now encounter setup and usage instructions before the authentication deep-dive, with authentication details still available above troubleshooting. The anchor `#how-authentication-works` is unchanged, so existing links remain valid.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/2fb16770ea4d47e096f39140f5d1ad0d
Requested by: @ian-at-airbyte