### PR TITLE
docs(agent-engine-mcp): add ChatGPT setup steps to MCP server docs

### DIFF
--- a/docs/ai-agents/mcp-server/readme.md
+++ b/docs/ai-agents/mcp-server/readme.md
@@ -35,7 +35,7 @@ Before you begin, make sure you have the following:
 
 - **An Agent Engine account.** Sign up at [app.airbyte.ai](https://app.airbyte.ai) if you don't have one.
 
-- **An AI agent that supports MCP.** For example, Claude Desktop, Claude Code, Cursor, or Codex.
+- **An AI agent that supports MCP.** For example, Claude Desktop, Claude Code, Cursor, Codex, or ChatGPT.
 
 - **Credentials for the connectors you want to use.** Each service requires its own authentication. For example, you need a Linear API key to connect Linear, or Salesforce OAuth credentials to connect Salesforce.
 
@@ -136,6 +136,43 @@ Add the MCP server to your Codex command line tool.
 4. Launch Codex with `codex`.
 
 5. Begin using the MCP server.
+
+</TabItem>
+<TabItem value="chatgpt" label="ChatGPT">
+
+ChatGPT supports remote MCP servers through its Developer Mode feature. Developer Mode is available on Pro, Plus, Business, Enterprise, and Education plans. It is not available on Free plans.
+
+:::note Business and Enterprise plans
+On Business plans, apps are enabled by default. Workspace owners can restrict them from **Workspace Settings** > **Apps**.
+
+On Enterprise and Education plans, apps are disabled by default. A workspace admin must go to **Workspace Settings** > **Apps** > **Directory**, find the app, and click **Enable** before workspace members can use it.
+:::
+
+1. Open [ChatGPT](https://chatgpt.com) on the web.
+
+2. Go to **Settings** > **Apps** > **Advanced settings**.
+
+3. Toggle **Developer mode** to **ON**.
+
+4. Click **Create app** next to "Advanced settings". This button only appears when Developer Mode is enabled.
+
+5. Enter the server details:
+
+    - **Name**: `Airbyte Agent Engine`
+    - **Server URL**: `https://mcp.airbyte.ai/mcp`
+    - **Authentication**: Select **OAuth**
+
+6. Click **Save**. The app appears under **Drafts** in your Apps settings.
+
+7. Open a new conversation. Click the **+** menu in the composer and select **Developer mode**.
+
+8. Select the Airbyte Agent Engine app from the list.
+
+9. ChatGPT discovers the available tools automatically. When ChatGPT connects, it triggers an OAuth flow. Log in with your [Agent Engine](https://app.airbyte.ai) account and grant access.
+
+10. Return to ChatGPT and begin using the MCP server.
+
+For more information, see the [OpenAI Developer Mode documentation](https://platform.openai.com/docs/guides/developer-mode).
 
 </TabItem>
 <TabItem value="other" label="Other clients">

--- a/docs/ai-agents/mcp-server/readme.md
+++ b/docs/ai-agents/mcp-server/readme.md
@@ -140,7 +140,7 @@ Add the MCP server to your Codex command line tool.
 </TabItem>
 <TabItem value="chatgpt" label="ChatGPT">
 
-ChatGPT supports remote MCP servers through its Developer Mode feature. Developer Mode is available on Pro, Plus, Business, Enterprise, and Education plans. It is not available on Free plans.
+ChatGPT supports remote MCP servers through its [Developer Mode](https://platform.openai.com/docs/guides/developer-mode) feature. Developer Mode is available on Pro, Plus, Business, Enterprise, and Education plans. It's not available on Free plans.
 
 :::note Business and Enterprise plans
 On Business plans, apps are enabled by default. Workspace owners can restrict them from **Workspace Settings** > **Apps**.
@@ -154,25 +154,21 @@ On Enterprise and Education plans, apps are disabled by default. A workspace adm
 
 3. Toggle **Developer mode** to **ON**.
 
-4. Click **Create app** next to "Advanced settings". This button only appears when Developer Mode is enabled.
+4. Go back to the apps screen.
 
-5. Enter the server details:
+5. Click **Create app** next to "Advanced settings." This button only appears when Developer Mode is enabled.
+
+6. Enter the server details:
 
     - **Name**: `Airbyte Agent Engine`
     - **Server URL**: `https://mcp.airbyte.ai/mcp`
     - **Authentication**: Select **OAuth**
 
-6. Click **Save**. The app appears under **Drafts** in your Apps settings.
+7. Accept ChatGPT's disclaimer and click **Create**. The app appears under **Drafts** in your Apps settings.
 
-7. Open a new conversation. Click the **+** menu in the composer and select **Developer mode**.
+8. When prompted, log into Agent Engine if necessary, then accept the access privileges.
 
-8. Select the Airbyte Agent Engine app from the list.
-
-9. ChatGPT discovers the available tools automatically. When ChatGPT connects, it triggers an OAuth flow. Log in with your [Agent Engine](https://app.airbyte.ai) account and grant access.
-
-10. Return to ChatGPT and begin using the MCP server.
-
-For more information, see the [OpenAI Developer Mode documentation](https://platform.openai.com/docs/guides/developer-mode).
+9. Open a new conversation to start using the MCP server.
 
 </TabItem>
 <TabItem value="other" label="Other clients">

--- a/docs/ai-agents/mcp-server/readme.md
+++ b/docs/ai-agents/mcp-server/readme.md
@@ -351,6 +351,10 @@ Once a connector is created, the agent uses it for all subsequent queries to tha
 - If the OAuth flow doesn't complete, try deleting the app in **Settings** > **Apps** and creating it again.
 - On Enterprise or Education plans, a workspace admin must enable the app before members can use it. Check with your admin if you see a permissions error.
 
+### ChatGPT doesn't use the MCP server tools
+
+ChatGPT may not realize it has access to data through the MCP server. If ChatGPT ignores the MCP or tries to answer without using your connected data, instruct it directly. For example: *"Use the Airbyte MCP to discover tools that can help you work with my Salesforce connector."*
+
 ### Queries return unexpected results
 
 - Ask the agent to describe the available entities before querying, so it picks the right one.

--- a/docs/ai-agents/mcp-server/readme.md
+++ b/docs/ai-agents/mcp-server/readme.md
@@ -339,6 +339,18 @@ Once a connector is created, the agent uses it for all subsequent queries to tha
 - Make sure you visited the credential URL the agent provided and completed the form in the browser.
 - If the flow timed out, ask the agent to start a new credential flow.
 
+### ChatGPT doesn't show the "Create app" button
+
+- Verify that Developer Mode is toggled on in **Settings** > **Apps** > **Advanced settings**.
+- Make sure your ChatGPT plan supports Developer Mode. It requires Pro, Plus, Business, Enterprise, or Education. Free plans don't have access.
+- After enabling Developer Mode, go back to the main **Apps** screen. The **Create app** button appears next to "Advanced settings."
+
+### ChatGPT can't connect to the MCP server
+
+- Confirm the server URL is exactly `https://mcp.airbyte.ai/mcp` with no trailing slash or extra path.
+- If the OAuth flow doesn't complete, try deleting the app in **Settings** > **Apps** and creating it again.
+- On Enterprise or Education plans, a workspace admin must enable the app before members can use it. Check with your admin if you see a permissions error.
+
 ### Queries return unexpected results
 
 - Ask the agent to describe the available entities before querying, so it picks the right one.


### PR DESCRIPTION
## What

Adds a ChatGPT tab to the "Add the MCP server to your agent" section and ChatGPT-specific troubleshooting entries, documenting how to connect the Airbyte Agent Engine MCP server from ChatGPT using Developer Mode.

## How

- Adds a new `<TabItem value="chatgpt" label="ChatGPT">` tab with step-by-step setup instructions
- Includes plan eligibility note (Pro, Plus, Business, Enterprise, Education — not Free)
- Includes an admonition with Business vs Enterprise/Education workspace admin differences
- Adds "ChatGPT" to the example clients list in the Requirements section
- Adds two ChatGPT-specific troubleshooting subsections ("Create app" button not visible, connection failures)
- Steps were cross-referenced against [OpenAI's Developer Mode documentation](https://platform.openai.com/docs/guides/developer-mode)

## Review guide

1. `docs/ai-agents/mcp-server/readme.md` — the only file changed.

Key items to verify:
- Menu paths: **Settings > Apps > Advanced settings** and the **Create app** button label
- Whether the OAuth flow in steps 7–8 accurately reflects what happens when ChatGPT connects to the Airbyte MCP server
- Plan eligibility and workspace admin behavior for Business vs Enterprise/Education
- Troubleshooting advice is actionable (especially the "delete and recreate app" suggestion for failed OAuth)

## User Impact

Users can now follow documented steps to connect the Airbyte Agent Engine MCP server from ChatGPT, and have ChatGPT-specific troubleshooting guidance when things go wrong.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/5f23a8c25147491d84f49a55523a3990
Requested by: @ian-at-airbyte
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/76056" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
