### PR TITLE
feat(source-airtable): add oauth_connector_input_specification with granular scopes

### DIFF
--- a/airbyte-integrations/connectors/source-airtable/manifest.yaml
+++ b/airbyte-integrations/connectors/source-airtable/manifest.yaml
@@ -677,6 +677,17 @@ spec:
       - auth_method
     predicate_value: oauth2.0
     oauth_config_specification:
+      oauth_connector_input_specification:
+        scopes:
+          - scope: "data.records:read"
+          - scope: "schema.bases:read"
+        consent_url: "https://airtable.com/oauth2/v1/authorize?{{client_id_param}}&{{redirect_uri_param}}&response_type=code&{{scopes_param}}&{{state_param}}"
+        access_token_url: "https://airtable.com/oauth2/v1/token"
+        access_token_headers:
+          Content-Type: "application/x-www-form-urlencoded"
+        extract_output:
+          - access_token
+          - refresh_token
       complete_oauth_output_specification:
         type: object
         properties:

--- a/airbyte-integrations/connectors/source-airtable/metadata.yaml
+++ b/airbyte-integrations/connectors/source-airtable/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 14c6e7ea-97ed-4f5e-a7b5-25e9a80b8212
-  dockerImageTag: 4.6.24
+  dockerImageTag: 4.6.25
   dockerRepository: airbyte/source-airtable
   documentationUrl: https://docs.airbyte.com/integrations/sources/airtable
   externalDocumentationUrls:

--- a/docs/integrations/sources/airtable.md
+++ b/docs/integrations/sources/airtable.md
@@ -144,6 +144,7 @@ See information about rate limits [here](https://airtable.com/developers/web/api
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                 |
 |:-----------|:-----------|:---------------------------------------------------------|:----------------------------------------------------------------------------------------|
+| 4.6.25 | 2026-04-03 | [76068](https://github.com/airbytehq/airbyte/pull/76068) | Add `oauth_connector_input_specification` with granular scopes |
 | 4.6.24 | 2026-03-10 | [74540](https://github.com/airbytehq/airbyte/pull/74540) | Update dependencies |
 | 4.6.23 | 2026-02-24 | [73755](https://github.com/airbytehq/airbyte/pull/73755) | Update dependencies |
 | 4.6.22 | 2026-02-17 | [73390](https://github.com/airbytehq/airbyte/pull/73390) | Update dependencies |


### PR DESCRIPTION
## Summary

- Adds `oauth_connector_input_specification` to the existing `advanced_auth` block
- Specifies granular OAuth scopes: `data.records:read` and `schema.bases:read`
- Includes Airtable OAuth consent URL and token endpoint

References https://github.com/airbytehq/airbyte-internal-issues/issues/16023

## Test plan

- [ ] Verify OAuth flow still works for existing connections
- [ ] Verify granular scopes are requested during OAuth consent