### PR TITLE
chore(source-hubspot): Remove registry version overrides, bump to 6.4.2

### DIFF
--- a/airbyte-integrations/connectors/source-hubspot/metadata.yaml
+++ b/airbyte-integrations/connectors/source-hubspot/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 36c891d9-4bd9-43ac-bad2-10e12756272c
-  dockerImageTag: 6.4.0
+  dockerImageTag: 6.4.1
   dockerRepository: airbyte/source-hubspot
   documentationUrl: https://docs.airbyte.com/integrations/sources/hubspot
   resourceRequirements:

--- a/airbyte-integrations/connectors/source-hubspot/metadata.yaml
+++ b/airbyte-integrations/connectors/source-hubspot/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 36c891d9-4bd9-43ac-bad2-10e12756272c
-  dockerImageTag: 6.4.1
+  dockerImageTag: 6.4.2
   dockerRepository: airbyte/source-hubspot
   documentationUrl: https://docs.airbyte.com/integrations/sources/hubspot
   resourceRequirements:

--- a/airbyte-integrations/connectors/source-hubspot/metadata.yaml
+++ b/airbyte-integrations/connectors/source-hubspot/metadata.yaml
@@ -36,10 +36,8 @@ data:
   registryOverrides:
     cloud:
       enabled: true
-      dockerImageTag: 6.3.1
     oss:
       enabled: true
-      dockerImageTag: 6.3.1
   releaseStage: generally_available
   releases:
     rolloutConfiguration:

--- a/airbyte-integrations/connectors/source-hubspot/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-hubspot/unit_tests/test_source.py
@@ -85,7 +85,7 @@ def test_streams(requests_mock, config):
     requests_mock.get("https://api.hubapi.com/crm/v3/schemas", json={}, status_code=200)
     streams = get_source(config).streams(config)
 
-    assert len(streams) == 34
+    assert len(streams) == 35
 
 
 def test_streams_forbidden_returns_default_streams(requests_mock, config):
@@ -96,7 +96,7 @@ def test_streams_forbidden_returns_default_streams(requests_mock, config):
         status_code=403,
     )
     streams = get_source(config).streams(config)
-    assert len(streams) == 34
+    assert len(streams) == 35
 
 
 def test_check_credential_title_exception(config):
@@ -115,7 +115,7 @@ def test_streams_ok_with_one_custom_stream(requests_mock, config, mock_dynamic_s
     )
     streams = discover(get_source(config), config).catalog.catalog.streams
     assert adapter.called
-    assert len(streams) == 35
+    assert len(streams) == 36
 
 
 def test_check_connection_backoff_on_limit_reached(requests_mock, config):

--- a/docs/integrations/sources/hubspot.md
+++ b/docs/integrations/sources/hubspot.md
@@ -345,6 +345,7 @@ If you use [custom properties](https://knowledge.hubspot.com/properties/create-a
 | Version     | Date       | Pull Request                                             | Subject                                                                                                                                                                                                                      |
 |:------------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | 6.4.2 | 2026-04-06 | [76096](https://github.com/airbytehq/airbyte/pull/76096) | Remove registry version overrides pinning to 6.3.1, fix stream count test assertions |
+| 6.4.1 | 2026-04-03 | [75574](https://github.com/airbytehq/airbyte/pull/75574) | Add `oauth_connector_input_specification` with granular scopes and optional_scopes |
 | 6.4.0 | 2026-04-01 | [70920](https://github.com/airbytehq/airbyte/pull/70920) | Add new stream Users |
 | 6.3.5 | 2026-03-31 | [75665](https://github.com/airbytehq/airbyte/pull/75665) | Update dependencies |
 | 6.3.4 | 2026-03-30 | [75595](https://github.com/airbytehq/airbyte/pull/75595) | Fixed HTTP 429 responses mapped to RETRY instead of RATE_LIMITED, enabling correct rate-limit handling |

--- a/docs/integrations/sources/hubspot.md
+++ b/docs/integrations/sources/hubspot.md
@@ -344,6 +344,7 @@ If you use [custom properties](https://knowledge.hubspot.com/properties/create-a
 
 | Version     | Date       | Pull Request                                             | Subject                                                                                                                                                                                                                      |
 |:------------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 6.4.1 | 2026-04-06 | [76096](https://github.com/airbytehq/airbyte/pull/76096) | Remove registry version overrides pinning to 6.3.1, fix stream count test assertions |
 | 6.4.0 | 2026-04-01 | [70920](https://github.com/airbytehq/airbyte/pull/70920) | Add new stream Users |
 | 6.3.5 | 2026-03-31 | [75665](https://github.com/airbytehq/airbyte/pull/75665) | Update dependencies |
 | 6.3.4 | 2026-03-30 | [75595](https://github.com/airbytehq/airbyte/pull/75595) | Fixed HTTP 429 responses mapped to RETRY instead of RATE_LIMITED, enabling correct rate-limit handling |

--- a/docs/integrations/sources/hubspot.md
+++ b/docs/integrations/sources/hubspot.md
@@ -344,7 +344,7 @@ If you use [custom properties](https://knowledge.hubspot.com/properties/create-a
 
 | Version     | Date       | Pull Request                                             | Subject                                                                                                                                                                                                                      |
 |:------------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 6.4.1 | 2026-04-06 | [76096](https://github.com/airbytehq/airbyte/pull/76096) | Remove registry version overrides pinning to 6.3.1, fix stream count test assertions |
+| 6.4.2 | 2026-04-06 | [76096](https://github.com/airbytehq/airbyte/pull/76096) | Remove registry version overrides pinning to 6.3.1, fix stream count test assertions |
 | 6.4.0 | 2026-04-01 | [70920](https://github.com/airbytehq/airbyte/pull/70920) | Add new stream Users |
 | 6.3.5 | 2026-03-31 | [75665](https://github.com/airbytehq/airbyte/pull/75665) | Update dependencies |
 | 6.3.4 | 2026-03-30 | [75595](https://github.com/airbytehq/airbyte/pull/75595) | Fixed HTTP 429 responses mapped to RETRY instead of RATE_LIMITED, enabling correct rate-limit handling |


### PR DESCRIPTION
## What

Removes the `dockerImageTag: 6.3.1` registry overrides that were pinning source-hubspot to version 6.3.1 in both cloud and OSS environments. These overrides were added in #75223 as a rollback to address an OAuth scope mismatch during authentication (tracked in [oncall#11688](https://github.com/airbytehq/oncall/issues/11688)). Customers have confirmed the OAuth issue is now resolved, so the pins are no longer needed.

Also fixes pre-existing unit test failures where hardcoded stream count assertions were out of date (34 → 35 built-in streams).

Closes https://github.com/airbytehq/oncall/issues/11688

## How

- Removed the two `dockerImageTag: 6.3.1` lines from the `registryOverrides.cloud` and `registryOverrides.oss` sections in `metadata.yaml`.
- Bumped `dockerImageTag` from `6.4.0` to `6.4.2` and added a changelog entry. (6.4.1 was already taken, so bumped to 6.4.2 to avoid conflict.)
- Updated stream count assertions in `test_source.py` to reflect the current number of built-in streams (35 instead of 34; 36 instead of 35 when a custom stream is added).

## Review guide

1. `airbyte-integrations/connectors/source-hubspot/metadata.yaml` — confirm the override removal and version bump look correct.
2. `airbyte-integrations/connectors/source-hubspot/unit_tests/test_source.py` — three assertions updated (`34→35`, `34→35`, `35→36`).
3. `docs/integrations/sources/hubspot.md` — new changelog entry for 6.4.2.

### Human review checklist
- [ ] Verify that 35 is the correct current built-in stream count (a stream was recently added but the test assertions were not updated at the time — the new count is inferred from CI runtime failures, not independently verified).
- [ ] Confirm that 6.4.2 is the appropriate next version (6.4.1 already exists, so this PR skips to 6.4.2).

## User Impact

HubSpot source connector users on cloud and OSS will now receive version 6.4.2 instead of being held back on 6.3.1. This restores access to fixes and improvements shipped in versions after 6.3.1.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/45c7d5ab54ed421896ed1a3b9f2c98d7
Requested by: @agarctfi