### PR TITLE
ci: disable enableProgressiveRollout for preview builds in publish workflow

### DIFF
--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -362,6 +362,21 @@ jobs:
           grep -n "enableProgressiveRollout" metadata.yaml
           echo "Progressive rollout enabled in metadata.yaml"
 
+      - name: Disable progressive rollout for preview builds
+        if: needs.publish_options.outputs.with-semver-suffix == 'preview'
+        working-directory: airbyte-integrations/connectors/${{ matrix.connector }}
+        run: |
+          echo "Disabling progressive rollout for preview build..."
+          echo "=== enableProgressiveRollout BEFORE update ==="
+          grep -n "enableProgressiveRollout" metadata.yaml || echo "(not found)"
+          # Ephemerally disable progressive rollout in metadata.yaml (not committed back).
+          # Preview versions are not RC versions and the validator rejects
+          # enableProgressiveRollout=true on non-RC versions.
+          yq -i '.data.releases.rolloutConfiguration.enableProgressiveRollout = false' metadata.yaml
+          echo "=== enableProgressiveRollout AFTER update ==="
+          grep -n "enableProgressiveRollout" metadata.yaml
+          echo "Progressive rollout disabled in metadata.yaml"
+
       # --- Ephemeral version bump for pre-release builds ---
       # For preview builds, the metadata.yaml still contains the base version (e.g. 3.2.3)
       # but the actual published tag is the preview version (e.g. 3.2.3-preview.820ce48).


### PR DESCRIPTION
## What

Fixes prerelease connector publishing failures caused by `enableProgressiveRollout: true` in connector metadata being rejected by the registry validator for non-RC versions.

Many connectors now have `enableProgressiveRollout: true` committed in their `metadata.yaml` (set during progressive rollout flows). The `airbyte-ops` registry validator rejects this flag on non-RC versions (when `ALLOW_GA_PROGRESSIVE_ROLLOUT` is `False`). Preview builds like `2.1.23-preview.27f1df2` are not RC versions, so the "Generate Registry Artifacts" step fails with:

> `GA progressive rollout is not yet enabled. The enableProgressiveRollout flag requires an RC version suffix.`

Recent failures: [workflow runs](https://github.com/airbytehq/airbyte/actions/workflows/publish-connectors-prerelease-command.yml)

## How

Adds a new workflow step that ephemerally sets `enableProgressiveRollout: false` in `metadata.yaml` for preview builds, mirroring the existing step that enables it for RC builds. The change is ephemeral — it modifies the in-memory working copy only and is never committed back to the repo.

## Review guide

1. `.github/workflows/publish_connectors.yml` — single new step at line 365

Key things to verify:
- The `yq` path `.data.releases.rolloutConfiguration.enableProgressiveRollout` matches the existing RC step
- The condition `== 'preview'` correctly targets prerelease builds
- Note: `yq -i` will create the `rolloutConfiguration` path on connectors that don't have it — this is harmless since `false` is the safe/default value

## User Impact

Prerelease connector publishing via `/publish-connectors-prerelease` will stop failing for connectors that have `enableProgressiveRollout: true` in their metadata.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/492a3fd6ed4741368c5f035d606c9324
Requested by: @aaronsteers