### PR TITLE
ci: pass --progressive-rollout-enabled=false on preview bump-version

### DIFF
--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -376,7 +376,8 @@ jobs:
             --name "${{ matrix.connector }}" \
             --repo-path "$GITHUB_WORKSPACE" \
             --new-version "${{ steps.resolve-docker-image-tag.outputs.docker-image-tag }}" \
-            --no-changelog
+            --no-changelog \
+            --progressive-rollout-enabled=false
 
       # --- Registry artifact generation and publishing ---
       - name: Generate Registry Artifacts


### PR DESCRIPTION
## What

Fixes prerelease workflow failures where connectors with `enableProgressiveRollout: true` in their metadata (set during active progressive rollouts) fail the "Generate Registry Artifacts" step with:

> `GA progressive rollout is not yet enabled. The enableProgressiveRollout flag requires an RC version suffix.`

Preview builds use a non-RC version suffix (`-preview.{sha}`), so the registry validator rejects the flag.

## How

Passes `--progressive-rollout-enabled=false` to the existing `airbyte-ops local connector bump-version` call in the ephemeral preview bump step. This tells the CLI to set `enableProgressiveRollout: false` in metadata.yaml before artifact generation, avoiding the validator rejection.

This flag is added in [airbytehq/airbyte-ops-mcp#681](https://github.com/airbytehq/airbyte-ops-mcp/pull/681).

## Review guide

1. `.github/workflows/publish_connectors.yml` — single-line addition to the bump-version invocation

Key things to verify:
- **Merge order**: airbytehq/airbyte-ops-mcp#681 must be merged and the new CLI version published **before** this PR merges, otherwise `--progressive-rollout-enabled` will be an unrecognized flag and break all preview builds.
- **Flag syntax**: `--progressive-rollout-enabled=false` must be correctly parsed as boolean `False` by cyclopts (the CLI framework). Confirm this works with the published CLI version.

## User Impact

Preview/prerelease connector publishes will stop failing for connectors that have an active progressive rollout. No impact on RC or GA builds.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/492a3fd6ed4741368c5f035d606c9324
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/76104" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
