### PR TITLE
fix(source-zendesk-talk): add token_expiry_date to complete_oauth_output_specification

### DIFF
--- a/airbyte-integrations/connectors/source-zendesk-talk/manifest.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-talk/manifest.yaml
@@ -712,6 +712,12 @@ spec:
             path_in_connector_config:
               - credentials
               - refresh_token
+          token_expiry_date:
+            type: string
+            format: date-time
+            path_in_connector_config:
+              - credentials
+              - token_expiry_date
       complete_oauth_server_input_specification:
         type: object
         additionalProperties: false

--- a/airbyte-integrations/connectors/source-zendesk-talk/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-talk/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: c8630570-086d-4a40-99ae-ea5b18673071
-  dockerImageTag: 2.0.9
+  dockerImageTag: 2.0.10
   dockerRepository: airbyte/source-zendesk-talk
   documentationUrl: https://docs.airbyte.com/integrations/sources/zendesk-talk
   externalDocumentationUrls:

--- a/docs/integrations/sources/zendesk-talk.md
+++ b/docs/integrations/sources/zendesk-talk.md
@@ -79,6 +79,7 @@ The Zendesk connector should not run into Zendesk API limitations under normal u
 
 | Version | Date       | Pull Request                                             | Subject                                                                     |
 |:--------|:-----------|:---------------------------------------------------------|:----------------------------------------------------------------------------|
+| 2.0.10 | 2026-04-06 | [](https://github.com/airbytehq/airbyte/pull/) | Add `token_expiry_date` to `complete_oauth_output_specification` so it is hidden from the UI as an OAuth-managed field |
 | 2.0.9 | 2026-03-31 | [75808](https://github.com/airbytehq/airbyte/pull/75808) | Update dependencies |
 | 2.0.8 | 2026-03-11 | [74395](https://github.com/airbytehq/airbyte/pull/74395) | Migrate to scopes object array format |
 | 2.0.7 | 2026-03-10 | [74446](https://github.com/airbytehq/airbyte/pull/74446) | Update dependencies |


### PR DESCRIPTION
## What

The `token_expiry_date` field is visible in the connector setup UI as a user-editable "Optional" field under the OAuth2.0 authentication option. This field is auto-managed by the CDK's `SingleUseRefreshTokenOauth2Authenticator` during token refresh and should never be user-facing.

This is the same bug as in `source-zendesk-support` (sister PR: #76105). The field was omitted from `complete_oauth_output_specification` when OAuth2.0 refresh token support was added in #71857. `source-zendesk-sunshine` already lists this field correctly and does not exhibit the bug.

Related: [AGENTIC-566](https://linear.app/airbyteio/issue/AGENTIC-566)

## How

Added `token_expiry_date` to `complete_oauth_output_specification` in the connector's `advanced_auth` config, matching the pattern used by `source-zendesk-sunshine`. The `path_in_connector_config` (`credentials.token_expiry_date`) is consistent with the existing `token_expiry_date_config_path` in the manifest's `refresh_token_updater`.

Bumps connector version 2.0.9 → 2.0.10.

## Review guide

1. `manifest.yaml` — 6-line addition under `complete_oauth_output_specification.properties`
2. `metadata.yaml` — version bump
3. `docs/integrations/sources/zendesk-talk.md` — changelog entry (⚠️ PR number placeholder needs backfill after merge)

## User Impact

The "Token Expiry Date" optional field will no longer appear in the OAuth2.0 authentication form. No functional change to connector sync behavior — the CDK continues to manage this field automatically during token refresh.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/c0ecee4421a84b14bfe7cb2038fa06df
Requested by: @aldogonzalez8