### PR TITLE
docs: remove Airbyte Embedded mention from API documentation

### DIFF
--- a/docs/developers/api-documentation.md
+++ b/docs/developers/api-documentation.md
@@ -7,10 +7,7 @@ import TabItem from "@theme/TabItem";
 
 # API documentation
 
-Use the Airbyte API to programmatically interact with Airbyte. You can extend it to:
-
-- Control Airbyte in conjunction with orchestration tools like Airflow
-- Use [Airbyte Embedded](https://airbyte.com/ai)
+Use the Airbyte API to programmatically interact with Airbyte. For example, you can control Airbyte in conjunction with orchestration tools like Airflow.
 
 This article shows you how to get an access token and make your first request, and it provides strategies to manage token expiry.
 


### PR DESCRIPTION
## What

Removes the reference to Airbyte Embedded from the [API documentation page](https://docs.airbyte.com/developers/api-documentation).

## How

Removed the bullet list that included the Airbyte Embedded link and converted the remaining bullet point into inline prose, since a single-item list is unnecessary.

## Review guide

1. `docs/developers/api-documentation.md` — the only change. Verify the intro paragraph reads naturally.

## User Impact

The API documentation page no longer references Airbyte Embedded. No functional impact.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/7ae3ae7fac554817bc12bc7925aa1e0f
Requested by: @ian-at-airbyte