### PR TITLE
docs: update PrivateLink badge to indicate Pro availability

### DIFF
--- a/docs/platform/operating-airbyte/privatelink.md
+++ b/docs/platform/operating-airbyte/privatelink.md
@@ -1,5 +1,5 @@
 ---
-products: enterprise-flex
+products: cloud-teams
 ---
 
 # PrivateLink


### PR DESCRIPTION
## What

Updates the PrivateLink documentation page to indicate that PrivateLink is available to Pro subscribers, not only Enterprise Flex.

## How

Changes the `products` frontmatter key from `enterprise-flex` to `cloud-teams`. Per the [contribution docs](https://docs.airbyte.com/community/contributing-to-airbyte/writing-docs), `cloud-teams` enables both the **Pro** and **Enterprise Flex** badges (Enterprise Flex is automatically enabled via Cloud tier inheritance). Previously, only the Enterprise Flex badge was highlighted.

## Review guide

1. `docs/platform/operating-airbyte/privatelink.md` — single frontmatter change

**Key review question:** Confirm that PrivateLink is indeed available at the Pro tier (not only Enterprise Flex). The `cloud-teams` key will show Pro and Enterprise Flex as enabled, with Core, Standard, Plus, and Self-Managed Enterprise grayed out.

## User Impact

The PrivateLink docs page will display the Pro badge as available (highlighted) alongside Enterprise Flex, making it clear to Pro subscribers that PrivateLink is available to them. Previously, only Enterprise Flex appeared highlighted, which could mislead Pro users into thinking the feature was unavailable to them.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/0cea86804dc54baf8b782e9bb8248c2f
Requested by: @ian-at-airbyte