### PR TITLE
fix(source-google-analytics-data-api): fix dynamic stream name to use custom_ prefix and correct field path

### DIFF
--- a/airbyte-integrations/connectors/source-google-analytics-data-api/manifest.yaml
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/manifest.yaml
@@ -922,13 +922,11 @@ dynamic_streams:
         - type: ComponentMappingDefinition
           field_path: ["schema_loader", "retriever", "requester", "path"]
           value: "properties/{{ components_values['source_config_1'][1] }}/metadata"
-        # NOTE: Yes, this is weird, but it exists solely for backward-compatibility.
-        # When the config contains multiple property IDs, it keeps the
-        # first stream as <report_name>, and names each additional stream
-        # <report_name>Property<property_id>.
+        # This mapping sets the stream name with a "custom_" prefix to differentiate
+        # dynamic streams from built-in ones and avoid name collisions with parent streams.
         - type: ComponentMappingDefinition
-          field_path: ["**", "name"]
-          value: "{{ components_values['name'] + 'Property' + components_values['source_config_1'][1] if components_values['source_config_1'][0] > 0 else components_values['name'] }}"
+          field_path: ["name"]
+          value: "custom_{{components_values['name']}}"
         # This mapping add transformation that add property_id and date slice value to record.
         # Note: We need {% raw %} as we don't want to attempt interpolation on stream_slice since
         # it doesn't exist in this context yet as we populate the template


### PR DESCRIPTION
## What

Fixes [airbytehq/oncall#11900](https://github.com/airbytehq/oncall/issues/11900).

The `ComponentMappingDefinition` for the stream `name` field used `field_path: ["**", "name"]`, a recursive glob that overwrites **all** `name` fields in the stream template — including parent stream names. This caused `_collect_all_parent_stream_names` in the CDK to see every parent stream with the same name as the dynamic stream, triggering infinite recursion.

## How

In `manifest.yaml`, the name mapping is changed from:

```yaml
field_path: ["**", "name"]
value: "{{ components_values['name'] + 'Property' + ... }}"
```

to:

```yaml
field_path: ["name"]
value: "custom_{{components_values['name']}}"
```

- `field_path` narrowed to `["name"]` so only the top-level stream name is set, leaving parent/sub-component names untouched.
- Value prefixed with `custom_` to differentiate dynamic streams from built-in ones.

## Review guide

1. `airbyte-integrations/connectors/source-google-analytics-data-api/manifest.yaml` — the only file changed.

**⚠️ Key items for reviewer attention:**

- **Multi-property-ID backward-compat removed**: The old value expression appended `Property<property_id>` for the 2nd+ property IDs. That logic is now gone — all dynamic streams get the same `custom_<name>` regardless of property index. Confirm this is acceptable or if multi-property naming needs to be preserved.
- **`custom_` prefix applies to default streams too**: The default streams defined in `default_values` (e.g., `daily_active_users`, `devices`, `pages`) will now be named `custom_daily_active_users`, etc. Verify this is the intended behavior and assess whether this constitutes a breaking change for existing syncs.

## User Impact

- Dynamic stream names are now prefixed with `custom_` (e.g., `custom_daily_active_users` instead of `daily_active_users`).
- Resolves recursion / crash caused by parent stream name collisions.
- **Potential breakage**: Existing connections may see stream name changes, which could reset incremental state or require catalog reconfiguration.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/79e7213d1d7b4e75bc12b2a6b3908840
Requested by: @darynaishchenko