### PR TITLE
fix(source-linkedin-ads): fix dynamic stream name field_path to avoid parent stream name collision

### DIFF
--- a/airbyte-integrations/connectors/source-linkedin-ads/manifest.yaml
+++ b/airbyte-integrations/connectors/source-linkedin-ads/manifest.yaml
@@ -1634,7 +1634,7 @@ dynamic_streams:
           - ad_analytics_reports
       components_mapping:
         - type: ComponentMappingDefinition
-          field_path: ["**", "name"]
+          field_path: ["name"]
           value: "custom_{{components_values['name']}}"
         - type: ComponentMappingDefinition
           field_path: ["retriever", "requester", "request_parameters", "pivot"]

--- a/airbyte-integrations/connectors/source-linkedin-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-linkedin-ads/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 137ece28-5434-455c-8f34-69dc3782f451
-  dockerImageTag: 5.6.7
+  dockerImageTag: 5.6.8
   dockerRepository: airbyte/source-linkedin-ads
   documentationUrl: https://docs.airbyte.com/integrations/sources/linkedin-ads
   externalDocumentationUrls:

--- a/docs/integrations/sources/linkedin-ads.md
+++ b/docs/integrations/sources/linkedin-ads.md
@@ -212,7 +212,7 @@ No workaround has been identified to manage this issue as of 2025, February.
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:-----------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 5.6.8 | 2026-04-07 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Fix dynamic stream name field_path to avoid parent stream name collision |
+| 5.6.8 | 2026-04-07 | [76120](https://github.com/airbytehq/airbyte/pull/76120) | Fix dynamic stream name field_path to avoid parent stream name collision |
 | 5.6.7 | 2026-04-02 | [76040](https://github.com/airbytehq/airbyte/pull/76040) | Replace deprecated MessageRepresentationAirbyteTracedErrors with AirbyteTracedException in tests |
 | 5.6.6 | 2026-04-01 | [75583](https://github.com/airbytehq/airbyte/pull/75583) | Add `oauth_connector_input_specification` with granular scopes |
 | 5.6.5 | 2026-03-30 | [75597](https://github.com/airbytehq/airbyte/pull/75597) | Map HTTP 429 responses to RATE_LIMITED instead of RETRY for proper indefinite backoff on rate-limited requests |

--- a/docs/integrations/sources/linkedin-ads.md
+++ b/docs/integrations/sources/linkedin-ads.md
@@ -212,6 +212,7 @@ No workaround has been identified to manage this issue as of 2025, February.
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:-----------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 5.6.8 | 2026-04-07 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Fix dynamic stream name field_path to avoid parent stream name collision |
 | 5.6.7 | 2026-04-02 | [76040](https://github.com/airbytehq/airbyte/pull/76040) | Replace deprecated MessageRepresentationAirbyteTracedErrors with AirbyteTracedException in tests |
 | 5.6.6 | 2026-04-01 | [75583](https://github.com/airbytehq/airbyte/pull/75583) | Add `oauth_connector_input_specification` with granular scopes |
 | 5.6.5 | 2026-03-30 | [75597](https://github.com/airbytehq/airbyte/pull/75597) | Map HTTP 429 responses to RATE_LIMITED instead of RETRY for proper indefinite backoff on rate-limited requests |


### PR DESCRIPTION
## What

Fixes [airbytehq/oncall#11900](https://github.com/airbytehq/oncall/issues/11900).

The `ComponentMappingDefinition` for the dynamic stream `name` field used `field_path: ["**", "name"]`, a recursive glob that overwrites **all** `name` fields in the stream template — including nested ones like `$parameters.name` in the retriever. This caused `_collect_all_parent_stream_names` in the CDK to see parent streams with the same name as the custom report stream, triggering infinite recursion.

## How

Changed `field_path` from `["**", "name"]` to `["name"]` so only the top-level stream name is set, leaving nested `name` fields (e.g., in `$parameters`) untouched.

Version bumped `5.6.7` → `5.6.8` with changelog entry.

## Review guide

1. `airbyte-integrations/connectors/source-linkedin-ads/manifest.yaml` — single-line change at line 1637.
2. `airbyte-integrations/connectors/source-linkedin-ads/metadata.yaml` — version bump.
3. `docs/integrations/sources/linkedin-ads.md` — changelog entry.

**⚠️ Key items for reviewer attention:**

- The old glob also set `$parameters.name` (line ~1396 in the template) to the custom stream name. With `["name"]`, the retriever's `$parameters.name` will remain as the template default (`custom_analytics_report`). Verify this doesn't break request routing or logging that depends on `$parameters.name` matching the actual stream name.

## User Impact

Resolves a crash (infinite recursion) when using custom analytics reports with `source-linkedin-ads`.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/79e7213d1d7b4e75bc12b2a6b3908840
Requested by: @darynaishchenko