### PR TITLE
ci: add release-block.yaml marker file convention for connectors

### DIFF
--- a/.github/workflows/connector-ci-checks.yml
+++ b/.github/workflows/connector-ci-checks.yml
@@ -443,6 +443,19 @@ jobs:
         run: |
           uv tool install airbyte-internal-ops
 
+      - name: Check for release-block marker
+        if: matrix.connector
+        shell: bash
+        run: |
+          BLOCK_FILE="airbyte-integrations/connectors/${{ matrix.connector }}/release-block.yaml"
+          if [[ -f "$BLOCK_FILE" ]]; then
+            echo "::warning::Release blocked for ${{ matrix.connector }}. Publishing will be skipped while release-block.yaml exists."
+            echo ""
+            echo "--- release-block.yaml contents ---"
+            cat "$BLOCK_FILE"
+            echo "---"
+          fi
+
       - name: Run QA Checks
         if: matrix.connector
         # remove "-strict-encrypt" suffix, if present, for parity with the previous version of this workflow

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -168,6 +168,25 @@ jobs:
           fetch-depth: 2 # Required so we can conduct a diff from the previous commit to understand what connectors have changed.
           submodules: true # Required for the enterprise repo since it uses a submodule that needs to exist for this workflow to run successfully.
 
+      - name: Check for release-block marker
+        id: check-release-block
+        shell: bash
+        run: |
+          BLOCK_FILE="airbyte-integrations/connectors/${{ matrix.connector }}/release-block.yaml"
+          if [[ -f "$BLOCK_FILE" ]]; then
+            echo "::error::Release blocked for ${{ matrix.connector }}."
+            echo ""
+            echo "A release-block.yaml marker file exists at: $BLOCK_FILE"
+            echo "Publishing is blocked while this file is present."
+            echo ""
+            echo "--- release-block.yaml contents ---"
+            cat "$BLOCK_FILE"
+            echo "---"
+            echo ""
+            echo "To unblock, remove the release-block.yaml file and merge to master."
+            exit 1
+          fi
+
       - name: Create docker buildx builder
         id: create-buildx-builder
         shell: bash

--- a/.github/workflows/release-block-command.yml
+++ b/.github/workflows/release-block-command.yml
@@ -1,0 +1,182 @@
+name: Add or remove a release-block marker for a connector
+
+on:
+  workflow_dispatch:
+    inputs:
+      connector:
+        description: "Connector name (e.g. source-pokeapi)"
+        required: true
+        type: string
+      reason:
+        description: "Reason for blocking the release"
+        required: false
+        default: ""
+        type: string
+      action:
+        description: "Action to perform: 'add' to block, 'remove' to unblock"
+        required: false
+        default: "add"
+        type: choice
+        options:
+          - add
+          - remove
+      comment-id:
+        description: "Optional. The comment-id of the slash command. Used to update the comment with the status."
+        required: false
+
+      # These must be declared, but they are unused and ignored.
+      # TODO: Infer 'repo' and 'gitref' from PR number on other workflows, so we can remove these.
+      repo:
+        description: "Repo (Ignored)"
+        required: false
+        default: "airbytehq/airbyte"
+      gitref:
+        description: "Ref (Ignored)"
+        required: false
+      pr:
+        description: "PR number (Ignored)"
+        required: false
+
+run-name: "Release block: ${{ inputs.action }} for ${{ inputs.connector }}"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-block:
+    name: "${{ inputs.action == 'remove' && 'Remove' || 'Add' }} release-block for ${{ inputs.connector }}"
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Validate connector name
+        shell: bash
+        run: |
+          CONNECTOR="${{ inputs.connector }}"
+          if [[ -z "$CONNECTOR" ]]; then
+            echo "::error::Connector name is required."
+            exit 1
+          fi
+          # Basic validation: connector name should match expected pattern
+          if [[ ! "$CONNECTOR" =~ ^(source|destination)-[a-z0-9-]+$ ]]; then
+            echo "::error::Invalid connector name: '$CONNECTOR'. Expected format: source-<name> or destination-<name>."
+            exit 1
+          fi
+
+      - name: Authenticate as GitHub App
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        id: get-app-token
+        with:
+          owner: "airbytehq"
+          repositories: "airbyte"
+          app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
+          private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
+
+      - name: Configure git identity
+        run: |
+          git config --global user.name "Octavia Squidington III"
+          git config --global user.email "octavia-squidington-iii@users.noreply.github.com"
+
+      - name: Checkout Airbyte repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          token: ${{ steps.get-app-token.outputs.token }}
+          fetch-depth: 1
+
+      - name: Verify connector directory exists
+        shell: bash
+        run: |
+          CONNECTOR_DIR="airbyte-integrations/connectors/${{ inputs.connector }}"
+          if [[ ! -d "$CONNECTOR_DIR" ]]; then
+            echo "::error::Connector directory not found: $CONNECTOR_DIR"
+            exit 1
+          fi
+
+      - name: Add release-block marker
+        if: inputs.action == 'add'
+        shell: bash
+        run: |
+          BLOCK_FILE="airbyte-integrations/connectors/${{ inputs.connector }}/release-block.yaml"
+          REASON="${{ inputs.reason }}"
+
+          if [[ -f "$BLOCK_FILE" ]]; then
+            echo "::warning::release-block.yaml already exists for ${{ inputs.connector }}. Overwriting."
+          fi
+
+          cat > "$BLOCK_FILE" << EOF
+          # This file blocks publishing for ${{ inputs.connector }}.
+          # Remove this file to unblock publishing.
+          reason: "${REASON:-No reason provided}"
+          created_by: "${{ github.actor }}"
+          created_at: "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          EOF
+
+          # Remove leading whitespace from heredoc
+          sed -i 's/^          //' "$BLOCK_FILE"
+
+          echo "Created release-block.yaml:"
+          cat "$BLOCK_FILE"
+
+      - name: Remove release-block marker
+        if: inputs.action == 'remove'
+        shell: bash
+        run: |
+          BLOCK_FILE="airbyte-integrations/connectors/${{ inputs.connector }}/release-block.yaml"
+          if [[ ! -f "$BLOCK_FILE" ]]; then
+            echo "::warning::No release-block.yaml found for ${{ inputs.connector }}. Nothing to remove."
+            exit 0
+          fi
+
+          echo "Removing release-block.yaml:"
+          cat "$BLOCK_FILE"
+          rm "$BLOCK_FILE"
+
+      - name: Check for changes
+        id: git-diff
+        shell: bash
+        run: |
+          git diff --quiet && echo "No changes to commit" || echo "changes=true" >> $GITHUB_OUTPUT
+
+      - name: Create PR with release-block change
+        if: steps.git-diff.outputs.changes == 'true'
+        id: create-pr
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
+        with:
+          token: ${{ steps.get-app-token.outputs.token }}
+          commit-message: "ci: ${{ inputs.action }} release-block for ${{ inputs.connector }}"
+          branch: "release-block/${{ inputs.action }}/${{ inputs.connector }}"
+          base: ${{ github.event.repository.default_branch }}
+          delete-branch: true
+          title: "ci: ${{ inputs.action }} release-block for ${{ inputs.connector }}"
+          body: |
+            ${{ inputs.action == 'add' && format('Adds a `release-block.yaml` marker to block publishing for `{0}`.', inputs.connector) || format('Removes the `release-block.yaml` marker to unblock publishing for `{0}`.', inputs.connector) }}
+
+            ${{ inputs.reason != '' && format('**Reason:** {0}', inputs.reason) || '' }}
+
+            Triggered by @${{ github.actor }} via [`release-block` workflow](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).
+          labels: |
+            area/connectors
+
+      - name: Append comment with PR link
+        if: inputs.comment-id && steps.create-pr.outputs.pull-request-number
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        with:
+          comment-id: ${{ inputs.comment-id }}
+          body: |
+            > Release-block PR created: #${{ steps.create-pr.outputs.pull-request-number }}
+
+      - name: Summary
+        if: steps.create-pr.outputs.pull-request-number
+        run: |
+          echo "### Release Block PR Created" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Connector:** ${{ inputs.connector }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Action:** ${{ inputs.action }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **PR:** #${{ steps.create-pr.outputs.pull-request-number }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Reason:** ${{ inputs.reason || 'No reason provided' }}" >> $GITHUB_STEP_SUMMARY
+
+      - name: Summary (no changes)
+        if: steps.git-diff.outputs.changes != 'true'
+        run: |
+          echo "### No Changes Needed" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "No changes were needed for ${{ inputs.connector }} (action: ${{ inputs.action }})." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release-block-command.yml
+++ b/.github/workflows/release-block-command.yml
@@ -94,9 +94,10 @@ jobs:
       - name: Add release-block marker
         if: inputs.action == 'add'
         shell: bash
+        env:
+          REASON: ${{ inputs.reason }}
         run: |
           BLOCK_FILE="airbyte-integrations/connectors/${{ inputs.connector }}/release-block.yaml"
-          REASON="${{ inputs.reason }}"
 
           if [[ -f "$BLOCK_FILE" ]]; then
             echo "::warning::release-block.yaml already exists for ${{ inputs.connector }}. Overwriting."
@@ -134,7 +135,7 @@ jobs:
         id: git-diff
         shell: bash
         run: |
-          git diff --quiet && echo "No changes to commit" || echo "changes=true" >> $GITHUB_OUTPUT
+          if [[ -n "$(git status --porcelain)" ]]; then echo "changes=true" >> $GITHUB_OUTPUT; else echo "No changes to commit"; fi
 
       - name: Create PR with release-block change
         if: steps.git-diff.outputs.changes == 'true'
@@ -166,13 +167,15 @@ jobs:
 
       - name: Summary
         if: steps.create-pr.outputs.pull-request-number
+        env:
+          BLOCK_REASON: ${{ inputs.reason }}
         run: |
           echo "### Release Block PR Created" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "- **Connector:** ${{ inputs.connector }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Action:** ${{ inputs.action }}" >> $GITHUB_STEP_SUMMARY
           echo "- **PR:** #${{ steps.create-pr.outputs.pull-request-number }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Reason:** ${{ inputs.reason || 'No reason provided' }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Reason:** ${BLOCK_REASON:-No reason provided}" >> $GITHUB_STEP_SUMMARY
 
       - name: Summary (no changes)
         if: steps.git-diff.outputs.changes != 'true'

--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -73,6 +73,7 @@ jobs:
             poe
             publish-connectors-prerelease
             publish-java-cdk
+            release-block
             run-cat-tests
             run-connector-tests
             run-regression-tests


### PR DESCRIPTION
## What

Introduces a `release-block.yaml` marker file convention that prevents a connector from being published while the file is present in the connector's directory. Also adds a `/release-block` slash command to create/remove the marker via workflow dispatch.

## How

1. **Publish gate** (`publish_connectors.yml`): A new step runs immediately after checkout in the `publish_connectors` matrix job. If `airbyte-integrations/connectors/<name>/release-block.yaml` exists, the job fails with a clear error before any build/push work begins.

2. **PR warning** (`connector-ci-checks.yml`): A non-blocking `::warning` annotation is emitted during pre-release checks so PR authors see the block status before merge.

3. **Slash command workflow** (`release-block-command.yml`): A `workflow_dispatch` workflow that validates the connector name, creates or removes a `release-block.yaml` file, and opens a PR via `peter-evans/create-pull-request`. Supports both `add` and `remove` actions. Usage: `/release-block connector=source-foo reason="investigating regression"`

4. **Slash command registration** (`slash-commands.yml`): `release-block` added to the dispatch command list.

## Review guide

1. `.github/workflows/release-block-command.yml` — New workflow; highest review priority. Pay attention to:
   - The heredoc + `sed` whitespace cleanup approach for generating the YAML file (lines 107-119) — fragile if indentation shifts.
   - `inputs.reason` is passed via `env:` blocks (not direct `${{ }}` interpolation) to prevent script injection. The reason value still ends up in the generated YAML file, so YAML special characters could produce a malformed marker file. Impact is low since the file is only `cat`'d by CI.
   - `inputs.connector` is validated by regex (`^(source|destination)-[a-z0-9-]+$`) before use in shell commands.
   - Change detection uses `git status --porcelain` (not `git diff --quiet`) so newly created untracked files are detected.
2. `.github/workflows/publish_connectors.yml` — The publish-blocking check. Verify placement (after checkout, before any build steps) is correct and that `exit 1` properly fails the matrix job.
3. `.github/workflows/connector-ci-checks.yml` — Warning-only check in pre-release-checks. Confirm this should remain non-blocking.
4. `.github/workflows/slash-commands.yml` — Trivial one-line addition.

### Reviewer checklist

- [ ] Confirm publish gate placement in `publish_connectors.yml` is after checkout but before any build/push steps
- [ ] Confirm `::warning` (non-blocking) is the right severity for CI checks — or should it also block?
- [ ] Verify heredoc indentation approach won't break if workflow formatting changes

## User Impact

- If a `release-block.yaml` file exists in a connector directory on master, the publish workflow will fail for that connector, preventing accidental releases.
- PR authors modifying a release-blocked connector will see a CI warning annotation.
- Engineers can use `/release-block connector=<name> reason="..."` in issues/PRs (or trigger the workflow manually) to create a PR that adds the block marker.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/15082e4f50e34afca73e901bee88d0d7
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/76126" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
