### PR TITLE
feat(extract-cdc): filter schema history to captured tables only

### DIFF
--- a/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/DebeziumPropertiesBuilder.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/DebeziumPropertiesBuilder.kt
@@ -85,6 +85,7 @@ class DebeziumPropertiesBuilder(private val props: Properties = Properties()) {
     fun withSchemaHistory(): DebeziumPropertiesBuilder = apply {
         with("schema.history.internal", FileSchemaHistory::class.java.canonicalName)
         with("schema.history.internal.store.only.captured.databases.ddl", "true")
+        with("schema.history.internal.store.only.captured.tables.ddl", "true")
     }
 
     val expectsSchemaHistoryFile: Boolean


### PR DESCRIPTION
## Summary

Adds `schema.history.internal.store.only.captured.tables.ddl=true` to the Debezium properties builder.

## Problem

Currently, Debezium stores DDL history for all tables in the captured database, even those not being synced. This increases schema history file size and slows down snapshot/recovery, especially in databases with hundreds or thousands of tables.

## Solution

By setting `store.only.captured.tables.ddl=true`, Debezium only records DDL changes for the tables that are actually being captured. This complements the existing `store.only.captured.databases.ddl=true` property, which already filters at the database level.

## Impact

- Reduces schema history file size
- Faster Debezium startup and recovery
- No functional change — only non-captured table DDL is skipped
