### PR TITLE
fix(cdk): preserve original ConfigErrorException message through wrapping chain

### DIFF
--- a/airbyte-cdk/bulk/core/base/changelog.md
+++ b/airbyte-cdk/bulk/core/base/changelog.md
@@ -1,3 +1,7 @@
+## Version 1.0.3
+
+Preserve original ConnectorErrorException message through wrapping chain instead of replacing it with generic text. Users now see the actual root cause (e.g., "Connection from Airbyte Cloud requires SSL encryption or an SSH tunnel.") instead of "Failed to initialize connector operation."
+
 ## Version 1.0.2
 
 Improved null handling for array types.

--- a/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/AirbyteConnectorRunnable.kt
+++ b/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/AirbyteConnectorRunnable.kt
@@ -30,7 +30,8 @@ class AirbyteConnectorRunnable : Runnable {
             try {
                 operation = operationProvider.get()!!
             } catch (e: Throwable) {
-                throw ConfigErrorException("Failed to initialize connector operation", e)
+                throw unwrapConnectorError(e)
+                    ?: ConfigErrorException("Failed to initialize connector operation.", e)
             }
             log.info { "Executing ${operation::class} operation." }
             operation.execute()
@@ -54,15 +55,31 @@ class AirbyteConnectorRunnable : Runnable {
         if (operationName == "check") {
             // During check, we don't fail the command on uncaught error. We assume the check as
             // failed and return a trace + a connection status message.
-            val exception: Throwable? =
-                if (e.message == "Failed to initialize connector operation") e.cause else e
             val (errorTraceMessage, connectionStatusMessage) =
-                exceptionHandler.handleCheckFailure(exception ?: e)
+                exceptionHandler.handleCheckFailure(e)
             outputConsumer.accept(errorTraceMessage)
             outputConsumer.accept(connectionStatusMessage)
         } else {
             outputConsumer.accept(exceptionHandler.handle(e))
             throw e
+        }
+    }
+
+    companion object {
+        /**
+         * Walks the cause chain of [e] looking for a [ConnectorErrorException]. Returns the
+         * deepest one found so the most specific message is preserved, or null if none exists.
+         */
+        fun unwrapConnectorError(e: Throwable): ConnectorErrorException? {
+            var result: ConnectorErrorException? = null
+            var current: Throwable? = e
+            while (current != null) {
+                if (current is ConnectorErrorException) {
+                    result = current
+                }
+                current = current.cause
+            }
+            return result
         }
     }
 }

--- a/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/AirbyteConnectorRunnable.kt
+++ b/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/AirbyteConnectorRunnable.kt
@@ -67,8 +67,8 @@ class AirbyteConnectorRunnable : Runnable {
 
     companion object {
         /**
-         * Walks the cause chain of [e] looking for a [ConnectorErrorException]. Returns the
-         * deepest one found so the most specific message is preserved, or null if none exists.
+         * Walks the cause chain of [e] looking for a [ConnectorErrorException]. Returns the deepest
+         * one found so the most specific message is preserved, or null if none exists.
          */
         fun unwrapConnectorError(e: Throwable): ConnectorErrorException? {
             var result: ConnectorErrorException? = null

--- a/airbyte-cdk/bulk/core/base/src/test/kotlin/io/airbyte/cdk/AirbyteConnectorRunnableTest.kt
+++ b/airbyte-cdk/bulk/core/base/src/test/kotlin/io/airbyte/cdk/AirbyteConnectorRunnableTest.kt
@@ -14,6 +14,7 @@ import io.mockk.every
 import io.mockk.mockk
 import jakarta.inject.Inject
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -59,5 +60,28 @@ class AirbyteConnectorRunnableTest {
         assertEquals(AirbyteTraceMessage.Type.ERROR, outputConsumer.traces()[0].type)
         assertEquals(1, outputConsumer.statuses().size)
         assertEquals(AirbyteConnectionStatus.Status.FAILED, outputConsumer.statuses()[0].status)
+    }
+
+    @Test
+    fun `unwrapConnectorError returns deepest ConnectorErrorException`() {
+        val root = ConfigErrorException("SSL required.")
+        val mid = ConfigErrorException("Failed to build ConnectorConfiguration.", root)
+        val outer = RuntimeException("bean instantiation failed", mid)
+
+        val result = AirbyteConnectorRunnable.unwrapConnectorError(outer)
+        assertEquals("SSL required.", result?.message)
+    }
+
+    @Test
+    fun `unwrapConnectorError returns null when no ConnectorErrorException in chain`() {
+        val e = RuntimeException("generic", IllegalStateException("inner"))
+        assertNull(AirbyteConnectorRunnable.unwrapConnectorError(e))
+    }
+
+    @Test
+    fun `unwrapConnectorError returns single ConnectorErrorException`() {
+        val e = ConfigErrorException("direct error")
+        val result = AirbyteConnectorRunnable.unwrapConnectorError(e)
+        assertEquals("direct error", result?.message)
     }
 }

--- a/airbyte-cdk/bulk/core/base/version.properties
+++ b/airbyte-cdk/bulk/core/base/version.properties
@@ -1,1 +1,1 @@
-version=1.0.2
+version=1.0.3

--- a/airbyte-cdk/bulk/core/extract/changelog.md
+++ b/airbyte-cdk/bulk/core/extract/changelog.md
@@ -9,6 +9,7 @@ The Extract CDK provides functionality for source connectors including schema di
 
 | Version | Date       | Pull Request                                              | Subject                                                                                                                                              |
 |---------|------------|-----------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1.1.3   | 2026-04-09 | [76175](https://github.com/airbytehq/airbyte/pull/76175)  | Preserve original ConnectorErrorException in SourceConfigurationFactory instead of wrapping with generic message.                                    |
 | 1.1.2   | 2026-03-31 | [74124](https://github.com/airbytehq/airbyte/pull/74124)  | Change the default implementation of JDBC incremental partition to non splittable                                                                    |
 | 1.1.1   | 2026-04-02 | [76054](https://github.com/airbytehq/airbyte/pull/76054)  | Clarified CDC termination condition. Ensure querySingleValue returns one result or throws.                                                           |
 | 1.1.0   | 2026-03-30 | [75636](https://github.com/airbytehq/airbyte/pull/75636)  | CDC positions are partially ordered. Added optional CDC startup hook. Field is now EmittedField.                                                     |

--- a/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/command/SourceConfigurationFactory.kt
+++ b/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/command/SourceConfigurationFactory.kt
@@ -2,6 +2,7 @@
 package io.airbyte.cdk.command
 
 import io.airbyte.cdk.ConfigErrorException
+import io.airbyte.cdk.ConnectorErrorException
 
 /**
  * Each connector contains an implementation of this interface in a stateless class which maps the
@@ -15,6 +16,8 @@ interface SourceConfigurationFactory<I : ConfigurationSpecification, O : SourceC
     fun make(spec: I): O =
         try {
             makeWithoutExceptionHandling(spec)
+        } catch (e: ConnectorErrorException) {
+            throw e
         } catch (e: Exception) {
             // Wrap NPEs (mostly) in ConfigErrorException.
             throw ConfigErrorException("Failed to build ConnectorConfiguration.", e)

--- a/airbyte-cdk/bulk/core/extract/version.properties
+++ b/airbyte-cdk/bulk/core/extract/version.properties
@@ -1,1 +1,1 @@
-version=1.1.2
+version=1.1.3


### PR DESCRIPTION
## What

When a `ConfigErrorException` is thrown during source connector configuration (e.g., `"Connection from Airbyte Cloud requires SSL encryption or an SSH tunnel."`), the message gets buried under multiple layers of generic wrappers. The user sees `"Failure in source: Failed to initialize connector operation"` instead of the actionable root cause.

The wrapping chain is:
1. Connector throws `ConfigErrorException("Connection from Airbyte Cloud requires SSL encryption...")` 
2. `SourceConfigurationFactory.make()` catches and wraps → `ConfigErrorException("Failed to build ConnectorConfiguration.")`
3. Micronaut wraps in `BeanInstantiationException`
4. `AirbyteConnectorRunnable.run()` catches and wraps → `ConfigErrorException("Failed to initialize connector operation")`
5. `DefaultExceptionClassifier.unwind()` finds the **outermost** `ConfigErrorException` first → user sees the generic message

## How

**1. `SourceConfigurationFactory.kt`** — Added a `catch (e: ConnectorErrorException)` clause that re-throws directly, preventing the generic wrapping. This matches the pattern already in `DestinationConfigurationFactory.kt`.

**2. `AirbyteConnectorRunnable.kt`** — Instead of blindly wrapping all exceptions:
- Added `unwrapConnectorError(e)` which walks the full cause chain and returns the **deepest** `ConnectorErrorException` (the most specific one).
- Falls back to the original generic wrapping only when no `ConnectorErrorException` exists in the chain.
- Removed the fragile string-matching workaround in `handleOperationException` (`if (e.message == "Failed to initialize connector operation") e.cause else e`) since it's no longer needed.

**Version bumps:** `bulk-cdk-core-base` 1.0.2 → 1.0.3 and `bulk-cdk-core-extract` 1.1.2 → 1.1.3, with corresponding changelog entries (required by CI).

## Review guide

1. `SourceConfigurationFactory.kt` — Small change, mirrors existing `DestinationConfigurationFactory` pattern
2. `AirbyteConnectorRunnable.kt` — Core logic change:
   - **Line 33**: New unwrap-or-wrap behavior  
   - **Lines 55-59**: Removal of string-matching workaround in check path — verify this is safe given the unwrap now happens upstream
   - **Lines 68-83**: `unwrapConnectorError` helper — note it returns the **deepest** match, not the first. Verify this is the right strategy (deepest = most specific message like "SSL required", vs outermost = potentially overridden message)
3. `AirbyteConnectorRunnableTest.kt` — Unit tests for the helper

### ⚠️ Items for human review
- **Deepest-wins strategy**: `unwrapConnectorError` returns the innermost `ConnectorErrorException`. If any intermediate wrapper intentionally overrides the message with better context, that would be lost. In the known failure scenario the deepest message is the most useful, but confirm this holds generally.
- **Catch ordering in `SourceConfigurationFactory`**: The new `catch (e: ConnectorErrorException)` precedes `catch (e: Exception)`. Since `ConnectorErrorException` is a subtype of `Exception`, Kotlin evaluates catches top-down so this is correct — but worth a glance.
- **`handleOperationException` simplification**: The old code stripped the generic wrapper via string matching before passing to `handleCheckFailure`. Now the exception reaching this method should already carry the real message. Verify no other caller relies on the old wrapper-stripping behavior.

## User Impact

Users will now see the actual root cause error message (e.g., `"Connection from Airbyte Cloud requires SSL encryption or an SSH tunnel."`) instead of the generic `"Failed to initialize connector operation"`. This applies to all source connectors using the bulk CDK.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/650f055417ef40459bbf3cd2ba6d9f47
Requested by: @mwbayley