### PR TITLE
feat(destination-redshift): support IAM role-based auth for S3 staging (#41031)

### DIFF
--- a/airbyte-integrations/connectors/destination-redshift/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-redshift/metadata.yaml
@@ -41,7 +41,7 @@ data:
             type: GSM
   connectorType: destination
   definitionId: f7a7d195-377f-cf5b-70a5-be6b819019dc
-  dockerImageTag: 3.5.4
+  dockerImageTag: 3.6.0
   dockerRepository: airbyte/destination-redshift
   documentationUrl: https://docs.airbyte.com/integrations/destinations/redshift
   githubIssueLabel: destination-redshift

--- a/airbyte-integrations/connectors/destination-redshift/src/main/kotlin/io/airbyte/integrations/destination/redshift/RedshiftDestination.kt
+++ b/airbyte-integrations/connectors/destination-redshift/src/main/kotlin/io/airbyte/integrations/destination/redshift/RedshiftDestination.kt
@@ -107,8 +107,7 @@ class RedshiftDestination : BaseConnector(), Destination {
 
     override fun check(config: JsonNode): AirbyteConnectionStatus? {
         val s3Options = RedshiftUtil.findS3Options(config)
-        val s3Config: S3DestinationConfig =
-            S3DestinationConfig.getS3DestinationConfig(s3Options)
+        val s3Config: S3DestinationConfig = S3DestinationConfig.getS3DestinationConfig(s3Options)
         val iamRoleArn = s3Options.get("iam_role_arn")?.asText()
         val encryptionConfig =
             if (config.has(RedshiftDestinationConstants.UPLOADING_METHOD))

--- a/airbyte-integrations/connectors/destination-redshift/src/main/kotlin/io/airbyte/integrations/destination/redshift/RedshiftDestination.kt
+++ b/airbyte-integrations/connectors/destination-redshift/src/main/kotlin/io/airbyte/integrations/destination/redshift/RedshiftDestination.kt
@@ -106,8 +106,10 @@ class RedshiftDestination : BaseConnector(), Destination {
     }
 
     override fun check(config: JsonNode): AirbyteConnectionStatus? {
+        val s3Options = RedshiftUtil.findS3Options(config)
         val s3Config: S3DestinationConfig =
-            S3DestinationConfig.getS3DestinationConfig(RedshiftUtil.findS3Options(config))
+            S3DestinationConfig.getS3DestinationConfig(s3Options)
+        val iamRoleArn = s3Options.get("iam_role_arn")?.asText()
         val encryptionConfig =
             if (config.has(RedshiftDestinationConstants.UPLOADING_METHOD))
                 fromJson(
@@ -165,6 +167,7 @@ class RedshiftDestination : BaseConnector(), Destination {
                     sqlGenerator,
                     destinationHandler,
                     RedshiftSqlGenerator.isDropCascade(config),
+                    iamRoleArn,
                 )
 
             // We simulate a mini-sync to see the raw table code path is exercised. and disable T+D
@@ -378,6 +381,7 @@ class RedshiftDestination : BaseConnector(), Destination {
         else NoEncryption()
         val s3Options = RedshiftUtil.findS3Options(config)
         val s3Config: S3DestinationConfig = S3DestinationConfig.getS3DestinationConfig(s3Options)
+        val iamRoleArn = s3Options.get("iam_role_arn")?.asText()
         val defaultNamespace = config["schema"].asText()
 
         val sqlGenerator = RedshiftSqlGenerator(namingResolver, config)
@@ -411,6 +415,7 @@ class RedshiftDestination : BaseConnector(), Destination {
                 sqlGenerator,
                 redshiftDestinationHandler,
                 RedshiftSqlGenerator.isDropCascade(config),
+                iamRoleArn,
             )
         val syncOperation =
             DefaultSyncOperation(

--- a/airbyte-integrations/connectors/destination-redshift/src/main/kotlin/io/airbyte/integrations/destination/redshift/operation/RedshiftStagingStorageOperation.kt
+++ b/airbyte-integrations/connectors/destination-redshift/src/main/kotlin/io/airbyte/integrations/destination/redshift/operation/RedshiftStagingStorageOperation.kt
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import io.airbyte.cdk.integrations.base.JavaBaseConstants
 import io.airbyte.cdk.integrations.destination.record_buffer.SerializableBuffer
 import io.airbyte.cdk.integrations.destination.s3.S3DestinationConfig
+import io.airbyte.cdk.integrations.destination.s3.credential.S3CredentialType
 import io.airbyte.cdk.integrations.destination.s3.S3StorageOperations
 import io.airbyte.integrations.base.destination.operation.StorageOperation
 import io.airbyte.integrations.base.destination.typing_deduping.Sql
@@ -36,6 +37,7 @@ class RedshiftStagingStorageOperation(
     private val sqlGenerator: RedshiftSqlGenerator,
     private val destinationHandler: RedshiftDestinationHandler,
     private val dropCascade: Boolean,
+    private val iamRoleArn: String? = null,
 ) : StorageOperation<SerializableBuffer> {
     private val connectionId: UUID = UUID.randomUUID()
     private val writeDatetime: ZonedDateTime = Instant.now().atZone(ZoneOffset.UTC)
@@ -241,23 +243,55 @@ class RedshiftStagingStorageOperation(
         tableName: String,
         suffix: String,
     ) {
-        val accessKeyId =
-            s3Config.s3CredentialConfig!!.s3CredentialsProvider.credentials.awsAccessKeyId
-        val secretAccessKey =
-            s3Config.s3CredentialConfig!!.s3CredentialsProvider.credentials.awsSecretKey
+        val credentialClause = buildCredentialClause()
 
         val copyQuery =
             """
             COPY $schemaName.$tableName$suffix FROM '${getFullS3Path(s3Config.bucketName!!, manifestPath)}'
-            CREDENTIALS 'aws_access_key_id=$accessKeyId;aws_secret_access_key=$secretAccessKey'
+            $credentialClause
             CSV GZIP
             REGION '${s3Config.bucketRegion}' TIMEFORMAT 'auto'
             STATUPDATE OFF
             MANIFEST;
             """.trimIndent()
 
-        // Disable statement logging. The statement contains a plaintext S3 secret+access key.
+        // Disable statement logging. The statement may contain plaintext credentials.
         destinationHandler.execute(Sql.of(copyQuery), logStatements = false)
+    }
+
+    internal fun buildCredentialClause(): String {
+        val credentialType = s3Config.s3CredentialConfig!!.credentialType
+        return when (credentialType) {
+            S3CredentialType.ACCESS_KEY -> {
+                val accessKeyId =
+                    s3Config.s3CredentialConfig!!.s3CredentialsProvider.credentials.awsAccessKeyId
+                val secretAccessKey =
+                    s3Config.s3CredentialConfig!!.s3CredentialsProvider.credentials.awsSecretKey
+                "CREDENTIALS 'aws_access_key_id=$accessKeyId;aws_secret_access_key=$secretAccessKey'"
+            }
+            S3CredentialType.ASSUME_ROLE -> {
+                val creds = s3Config.s3CredentialConfig!!.s3CredentialsProvider.credentials
+                val accessKeyId = creds.awsAccessKeyId
+                val secretAccessKey = creds.awsSecretKey
+                val sessionToken =
+                    (creds as? com.amazonaws.auth.BasicSessionCredentials)?.sessionToken
+                if (sessionToken != null) {
+                    "CREDENTIALS 'aws_access_key_id=$accessKeyId;aws_secret_access_key=$secretAccessKey;token=$sessionToken'"
+                } else {
+                    "CREDENTIALS 'aws_access_key_id=$accessKeyId;aws_secret_access_key=$secretAccessKey'"
+                }
+            }
+            S3CredentialType.DEFAULT_PROFILE -> {
+                if (iamRoleArn != null) {
+                    require(iamRoleArn.matches(Regex("arn:aws[a-zA-Z-]*:iam::\\d{12}:role/.+"))) {
+                        "Invalid IAM role ARN format: $iamRoleArn"
+                    }
+                    "IAM_ROLE '$iamRoleArn'"
+                } else {
+                    "IAM_ROLE default"
+                }
+            }
+        }
     }
 
     companion object {

--- a/airbyte-integrations/connectors/destination-redshift/src/main/kotlin/io/airbyte/integrations/destination/redshift/operation/RedshiftStagingStorageOperation.kt
+++ b/airbyte-integrations/connectors/destination-redshift/src/main/kotlin/io/airbyte/integrations/destination/redshift/operation/RedshiftStagingStorageOperation.kt
@@ -7,9 +7,10 @@ package io.airbyte.integrations.destination.redshift.operation
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.airbyte.cdk.integrations.base.JavaBaseConstants
 import io.airbyte.cdk.integrations.destination.record_buffer.SerializableBuffer
+import com.amazonaws.auth.BasicSessionCredentials
 import io.airbyte.cdk.integrations.destination.s3.S3DestinationConfig
-import io.airbyte.cdk.integrations.destination.s3.credential.S3CredentialType
 import io.airbyte.cdk.integrations.destination.s3.S3StorageOperations
+import io.airbyte.cdk.integrations.destination.s3.credential.S3CredentialType
 import io.airbyte.integrations.base.destination.operation.StorageOperation
 import io.airbyte.integrations.base.destination.typing_deduping.Sql
 import io.airbyte.integrations.base.destination.typing_deduping.StreamConfig
@@ -39,6 +40,14 @@ class RedshiftStagingStorageOperation(
     private val dropCascade: Boolean,
     private val iamRoleArn: String? = null,
 ) : StorageOperation<SerializableBuffer> {
+    init {
+        if (iamRoleArn != null) {
+            require(iamRoleArn.matches(IAM_ROLE_ARN_PATTERN)) {
+                "Invalid IAM role ARN format: $iamRoleArn"
+            }
+        }
+    }
+
     private val connectionId: UUID = UUID.randomUUID()
     private val writeDatetime: ZonedDateTime = Instant.now().atZone(ZoneOffset.UTC)
     private val objectMapper = ObjectMapper()
@@ -274,7 +283,7 @@ class RedshiftStagingStorageOperation(
                 val accessKeyId = creds.awsAccessKeyId
                 val secretAccessKey = creds.awsSecretKey
                 val sessionToken =
-                    (creds as? com.amazonaws.auth.BasicSessionCredentials)?.sessionToken
+                    (creds as? BasicSessionCredentials)?.sessionToken
                 if (sessionToken != null) {
                     "CREDENTIALS 'aws_access_key_id=$accessKeyId;aws_secret_access_key=$secretAccessKey;token=$sessionToken'"
                 } else {
@@ -283,9 +292,6 @@ class RedshiftStagingStorageOperation(
             }
             S3CredentialType.DEFAULT_PROFILE -> {
                 if (iamRoleArn != null) {
-                    require(iamRoleArn.matches(Regex("arn:aws[a-zA-Z-]*:iam::\\d{12}:role/.+"))) {
-                        "Invalid IAM role ARN format: $iamRoleArn"
-                    }
                     "IAM_ROLE '$iamRoleArn'"
                 } else {
                     "IAM_ROLE default"
@@ -295,6 +301,7 @@ class RedshiftStagingStorageOperation(
     }
 
     companion object {
+        private val IAM_ROLE_ARN_PATTERN = Regex("arn:aws[a-zA-Z-]*:iam::\\d{12}:role/.+")
         private val nameTransformer = RedshiftSQLNameTransformer()
 
         private fun createRawTableQuery(streamId: StreamId, suffix: String): String {

--- a/airbyte-integrations/connectors/destination-redshift/src/main/kotlin/io/airbyte/integrations/destination/redshift/operation/RedshiftStagingStorageOperation.kt
+++ b/airbyte-integrations/connectors/destination-redshift/src/main/kotlin/io/airbyte/integrations/destination/redshift/operation/RedshiftStagingStorageOperation.kt
@@ -4,10 +4,10 @@
 
 package io.airbyte.integrations.destination.redshift.operation
 
+import com.amazonaws.auth.BasicSessionCredentials
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.airbyte.cdk.integrations.base.JavaBaseConstants
 import io.airbyte.cdk.integrations.destination.record_buffer.SerializableBuffer
-import com.amazonaws.auth.BasicSessionCredentials
 import io.airbyte.cdk.integrations.destination.s3.S3DestinationConfig
 import io.airbyte.cdk.integrations.destination.s3.S3StorageOperations
 import io.airbyte.cdk.integrations.destination.s3.credential.S3CredentialType
@@ -282,8 +282,7 @@ class RedshiftStagingStorageOperation(
                 val creds = s3Config.s3CredentialConfig!!.s3CredentialsProvider.credentials
                 val accessKeyId = creds.awsAccessKeyId
                 val secretAccessKey = creds.awsSecretKey
-                val sessionToken =
-                    (creds as? BasicSessionCredentials)?.sessionToken
+                val sessionToken = (creds as? BasicSessionCredentials)?.sessionToken
                 if (sessionToken != null) {
                     "CREDENTIALS 'aws_access_key_id=$accessKeyId;aws_secret_access_key=$secretAccessKey;token=$sessionToken'"
                 } else {

--- a/airbyte-integrations/connectors/destination-redshift/src/main/kotlin/io/airbyte/integrations/destination/redshift/util/RedshiftUtil.kt
+++ b/airbyte-integrations/connectors/destination-redshift/src/main/kotlin/io/airbyte/integrations/destination/redshift/util/RedshiftUtil.kt
@@ -28,9 +28,7 @@ object RedshiftUtil {
     @JvmStatic
     fun anyOfS3FieldsAreNullOrEmpty(jsonNode: JsonNode): Boolean {
         return (isNullOrEmpty(jsonNode["s3_bucket_name"]) &&
-            isNullOrEmpty(jsonNode["s3_bucket_region"]) &&
-            isNullOrEmpty(jsonNode["access_key_id"]) &&
-            isNullOrEmpty(jsonNode["secret_access_key"]))
+            isNullOrEmpty(jsonNode["s3_bucket_region"]))
     }
 
     private fun isNullOrEmpty(jsonNode: JsonNode?): Boolean {

--- a/airbyte-integrations/connectors/destination-redshift/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/destination-redshift/src/main/resources/spec.json
@@ -78,11 +78,7 @@
           {
             "title": "AWS S3 Staging",
             "description": "<i>(recommended)</i> Uploads data to S3 and then uses a COPY to insert the data into Redshift. COPY is recommended for production workloads for better speed and scalability. See <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/creating-bucket.html\">AWS docs</a> for more details.",
-            "required": [
-              "method",
-              "s3_bucket_name",
-              "s3_bucket_region"
-            ],
+            "required": ["method", "s3_bucket_name", "s3_bucket_region"],
             "properties": {
               "method": {
                 "type": "string",

--- a/airbyte-integrations/connectors/destination-redshift/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/destination-redshift/src/main/resources/spec.json
@@ -81,9 +81,7 @@
             "required": [
               "method",
               "s3_bucket_name",
-              "s3_bucket_region",
-              "access_key_id",
-              "secret_access_key"
+              "s3_bucket_region"
             ],
             "properties": {
               "method": {
@@ -149,17 +147,24 @@
               },
               "access_key_id": {
                 "type": "string",
-                "description": "This ID grants access to the above S3 staging bucket. Airbyte requires Read and Write permissions to the given bucket. See <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys\">AWS docs</a> on how to generate an access key ID and secret access key.",
+                "description": "This ID grants access to the above S3 staging bucket. Airbyte requires Read and Write permissions to the given bucket. Not required if using IAM role-based authentication (IRSA / instance profile). See <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys\">AWS docs</a> on how to generate an access key ID and secret access key.",
                 "title": "S3 Access Key Id",
                 "airbyte_secret": true,
                 "order": 3
               },
               "secret_access_key": {
                 "type": "string",
-                "description": "The corresponding secret to the above access key id. See <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys\">AWS docs</a> on how to generate an access key ID and secret access key.",
+                "description": "The corresponding secret to the above access key id. Not required if using IAM role-based authentication (IRSA / instance profile). See <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys\">AWS docs</a> on how to generate an access key ID and secret access key.",
                 "title": "S3 Secret Access Key",
                 "airbyte_secret": true,
                 "order": 4
+              },
+              "iam_role_arn": {
+                "type": "string",
+                "description": "The ARN of the IAM role attached to your Redshift cluster or serverless workgroup that has read access to the S3 staging bucket. Required when not using static AWS credentials. If omitted, 'IAM_ROLE default' is used in the COPY command. See <a href=\"https://docs.aws.amazon.com/redshift/latest/mgmt/authorizing-redshift-service.html\">AWS docs</a> on associating IAM roles with Redshift.",
+                "title": "Redshift IAM Role ARN",
+                "examples": ["arn:aws:iam::123456789012:role/redshift-s3-read"],
+                "order": 5
               },
               "file_name_pattern": {
                 "type": "string",
@@ -172,14 +177,14 @@
                   "{part_number}",
                   "{sync_id}"
                 ],
-                "order": 5
+                "order": 6
               },
               "purge_staging_data": {
                 "title": "Purge Staging Files and Tables",
                 "type": "boolean",
                 "description": "Whether to delete the staging files from S3 after completing the sync. See <a href=\"https://docs.airbyte.com/integrations/destinations/redshift/#:~:text=the%20root%20directory.-,Purge%20Staging%20Data,-Whether%20to%20delete\"> docs</a> for details.",
                 "default": true,
-                "order": 6
+                "order": 7
               }
             }
           }

--- a/airbyte-integrations/connectors/destination-redshift/src/test-integration/kotlin/io/airbyte/integrations/destination/redshift/RedshiftS3StagingStorageOperationTest.kt
+++ b/airbyte-integrations/connectors/destination-redshift/src/test-integration/kotlin/io/airbyte/integrations/destination/redshift/RedshiftS3StagingStorageOperationTest.kt
@@ -243,6 +243,7 @@ class RedshiftS3StagingStorageOperationTest {
             RedshiftSqlGenerator(RedshiftSQLNameTransformer(), config),
             RedshiftDestinationHandler(databaseName, jdbcDatabase, streamId.rawNamespace),
             dropCascade,
+            iamRoleArn = null,
         )
     }
 

--- a/airbyte-integrations/connectors/destination-redshift/src/test/kotlin/io/airbyte/integrations/destination/redshift/RedshiftSpecTest.kt
+++ b/airbyte-integrations/connectors/destination-redshift/src/test/kotlin/io/airbyte/integrations/destination/redshift/RedshiftSpecTest.kt
@@ -81,6 +81,44 @@ class RedshiftSpecTest {
         Assertions.assertNotNull(spec.connectionSpecification["properties"]["jdbc_url_params"])
     }
 
+    @Test
+    fun testS3CredentialsMissing() {
+        // Credentials are now optional for IRSA / instance profile auth
+        val configWithS3 = deserialize("""{
+            "host": "localhost",
+            "port": 5439,
+            "username": "redshift",
+            "password": "password",
+            "database": "db",
+            "schema": "public",
+            "uploading_method": {
+                "method": "S3 Staging",
+                "s3_bucket_name": "test-bucket",
+                "s3_bucket_region": "us-east-1"
+            }
+        }""")
+        Assertions.assertTrue(validator!!.test(schema!!, configWithS3))
+    }
+
+    @Test
+    fun testS3WithIamRoleArn() {
+        val configWithIamRole = deserialize("""{
+            "host": "localhost",
+            "port": 5439,
+            "username": "redshift",
+            "password": "password",
+            "database": "db",
+            "schema": "public",
+            "uploading_method": {
+                "method": "S3 Staging",
+                "s3_bucket_name": "test-bucket",
+                "s3_bucket_region": "us-east-1",
+                "iam_role_arn": "arn:aws:iam::123456789012:role/redshift-s3-read"
+            }
+        }""")
+        Assertions.assertTrue(validator!!.test(schema!!, configWithIamRole))
+    }
+
     companion object {
         private var schema: JsonNode? = null
         private var config: JsonNode? = null

--- a/airbyte-integrations/connectors/destination-redshift/src/test/kotlin/io/airbyte/integrations/destination/redshift/RedshiftSpecTest.kt
+++ b/airbyte-integrations/connectors/destination-redshift/src/test/kotlin/io/airbyte/integrations/destination/redshift/RedshiftSpecTest.kt
@@ -84,38 +84,44 @@ class RedshiftSpecTest {
     @Test
     fun testS3CredentialsMissing() {
         // Credentials are now optional for IRSA / instance profile auth
-        val configWithS3 = deserialize("""{
-            "host": "localhost",
-            "port": 5439,
-            "username": "redshift",
-            "password": "password",
-            "database": "db",
-            "schema": "public",
-            "uploading_method": {
-                "method": "S3 Staging",
-                "s3_bucket_name": "test-bucket",
-                "s3_bucket_region": "us-east-1"
-            }
-        }""")
+        val configWithS3 =
+            deserialize(
+                """{
+                "host": "localhost",
+                "port": 5439,
+                "username": "redshift",
+                "password": "password",
+                "database": "db",
+                "schema": "public",
+                "uploading_method": {
+                    "method": "S3 Staging",
+                    "s3_bucket_name": "test-bucket",
+                    "s3_bucket_region": "us-east-1"
+                }
+            }"""
+            )
         Assertions.assertTrue(validator!!.test(schema!!, configWithS3))
     }
 
     @Test
     fun testS3WithIamRoleArn() {
-        val configWithIamRole = deserialize("""{
-            "host": "localhost",
-            "port": 5439,
-            "username": "redshift",
-            "password": "password",
-            "database": "db",
-            "schema": "public",
-            "uploading_method": {
-                "method": "S3 Staging",
-                "s3_bucket_name": "test-bucket",
-                "s3_bucket_region": "us-east-1",
-                "iam_role_arn": "arn:aws:iam::123456789012:role/redshift-s3-read"
-            }
-        }""")
+        val configWithIamRole =
+            deserialize(
+                """{
+                "host": "localhost",
+                "port": 5439,
+                "username": "redshift",
+                "password": "password",
+                "database": "db",
+                "schema": "public",
+                "uploading_method": {
+                    "method": "S3 Staging",
+                    "s3_bucket_name": "test-bucket",
+                    "s3_bucket_region": "us-east-1",
+                    "iam_role_arn": "arn:aws:iam::123456789012:role/redshift-s3-read"
+                }
+            }"""
+            )
         Assertions.assertTrue(validator!!.test(schema!!, configWithIamRole))
     }
 

--- a/airbyte-integrations/connectors/destination-redshift/src/test/kotlin/io/airbyte/integrations/destination/redshift/operation/RedshiftStagingStorageOperationTest.kt
+++ b/airbyte-integrations/connectors/destination-redshift/src/test/kotlin/io/airbyte/integrations/destination/redshift/operation/RedshiftStagingStorageOperationTest.kt
@@ -85,17 +85,15 @@ class RedshiftStagingStorageOperationTest {
     }
 
     @Test
-    fun testBuildCredentialClauseRejectsInvalidArn() {
+    fun testRejectsInvalidArnAtConstructionTime() {
         val credentialConfig = mock(S3CredentialConfig::class.java)
         `when`(credentialConfig.credentialType).thenReturn(S3CredentialType.DEFAULT_PROFILE)
 
-        val operation = createOperation(
-            credentialConfig,
-            iamRoleArn = "not-a-valid-arn"
-        )
-
         assertThrows(IllegalArgumentException::class.java) {
-            operation.buildCredentialClause()
+            createOperation(
+                credentialConfig,
+                iamRoleArn = "not-a-valid-arn"
+            )
         }
     }
 

--- a/airbyte-integrations/connectors/destination-redshift/src/test/kotlin/io/airbyte/integrations/destination/redshift/operation/RedshiftStagingStorageOperationTest.kt
+++ b/airbyte-integrations/connectors/destination-redshift/src/test/kotlin/io/airbyte/integrations/destination/redshift/operation/RedshiftStagingStorageOperationTest.kt
@@ -43,10 +43,11 @@ class RedshiftStagingStorageOperationTest {
 
     @Test
     fun testBuildCredentialClauseWithAccessKey() {
-        val credentialConfig = S3AccessKeyCredentialConfig(
-            "AKIAIOSFODNN7EXAMPLE",
-            "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
-        )
+        val credentialConfig =
+            S3AccessKeyCredentialConfig(
+                "AKIAIOSFODNN7EXAMPLE",
+                "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+            )
         val operation = createOperation(credentialConfig)
 
         val clause = operation.buildCredentialClause()
@@ -74,10 +75,11 @@ class RedshiftStagingStorageOperationTest {
         val credentialConfig = mock(S3CredentialConfig::class.java)
         `when`(credentialConfig.credentialType).thenReturn(S3CredentialType.DEFAULT_PROFILE)
 
-        val operation = createOperation(
-            credentialConfig,
-            iamRoleArn = "arn:aws:iam::123456789012:role/redshift-s3-read"
-        )
+        val operation =
+            createOperation(
+                credentialConfig,
+                iamRoleArn = "arn:aws:iam::123456789012:role/redshift-s3-read"
+            )
 
         val clause = operation.buildCredentialClause()
 
@@ -90,18 +92,13 @@ class RedshiftStagingStorageOperationTest {
         `when`(credentialConfig.credentialType).thenReturn(S3CredentialType.DEFAULT_PROFILE)
 
         assertThrows(IllegalArgumentException::class.java) {
-            createOperation(
-                credentialConfig,
-                iamRoleArn = "not-a-valid-arn"
-            )
+            createOperation(credentialConfig, iamRoleArn = "not-a-valid-arn")
         }
     }
 
     @Test
     fun testBuildCredentialClauseWithAssumeRoleAndSessionToken() {
-        val sessionCreds = BasicSessionCredentials(
-            "ASIATEMP", "tempSecret", "sessionToken123"
-        )
+        val sessionCreds = BasicSessionCredentials("ASIATEMP", "tempSecret", "sessionToken123")
         val provider: AWSCredentialsProvider = AWSStaticCredentialsProvider(sessionCreds)
 
         val credentialConfig = mock(S3CredentialConfig::class.java)
@@ -137,14 +134,16 @@ class RedshiftStagingStorageOperationTest {
 
     @Test
     fun testBuildCredentialClauseAccessKeyTakesPrecedenceOverIamRoleArn() {
-        val credentialConfig = S3AccessKeyCredentialConfig(
-            "AKIAIOSFODNN7EXAMPLE",
-            "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
-        )
-        val operation = createOperation(
-            credentialConfig,
-            iamRoleArn = "arn:aws:iam::123456789012:role/should-be-ignored"
-        )
+        val credentialConfig =
+            S3AccessKeyCredentialConfig(
+                "AKIAIOSFODNN7EXAMPLE",
+                "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+            )
+        val operation =
+            createOperation(
+                credentialConfig,
+                iamRoleArn = "arn:aws:iam::123456789012:role/should-be-ignored"
+            )
 
         val clause = operation.buildCredentialClause()
 

--- a/airbyte-integrations/connectors/destination-redshift/src/test/kotlin/io/airbyte/integrations/destination/redshift/operation/RedshiftStagingStorageOperationTest.kt
+++ b/airbyte-integrations/connectors/destination-redshift/src/test/kotlin/io/airbyte/integrations/destination/redshift/operation/RedshiftStagingStorageOperationTest.kt
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+ */
+package io.airbyte.integrations.destination.redshift.operation
+
+import com.amazonaws.auth.AWSCredentialsProvider
+import com.amazonaws.auth.AWSStaticCredentialsProvider
+import com.amazonaws.auth.BasicAWSCredentials
+import com.amazonaws.auth.BasicSessionCredentials
+import io.airbyte.cdk.integrations.destination.s3.S3DestinationConfig
+import io.airbyte.cdk.integrations.destination.s3.S3StorageOperations
+import io.airbyte.cdk.integrations.destination.s3.credential.S3AccessKeyCredentialConfig
+import io.airbyte.cdk.integrations.destination.s3.credential.S3CredentialConfig
+import io.airbyte.cdk.integrations.destination.s3.credential.S3CredentialType
+import io.airbyte.integrations.destination.redshift.typing_deduping.RedshiftDestinationHandler
+import io.airbyte.integrations.destination.redshift.typing_deduping.RedshiftSqlGenerator
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+
+class RedshiftStagingStorageOperationTest {
+
+    private fun createOperation(
+        credentialConfig: S3CredentialConfig,
+        iamRoleArn: String? = null,
+    ): RedshiftStagingStorageOperation {
+        val s3Config = mock(S3DestinationConfig::class.java)
+        `when`(s3Config.s3CredentialConfig).thenReturn(credentialConfig)
+
+        return RedshiftStagingStorageOperation(
+            s3Config,
+            keepStagingFiles = false,
+            mock(S3StorageOperations::class.java),
+            mock(RedshiftSqlGenerator::class.java),
+            mock(RedshiftDestinationHandler::class.java),
+            dropCascade = false,
+            iamRoleArn = iamRoleArn,
+        )
+    }
+
+    @Test
+    fun testBuildCredentialClauseWithAccessKey() {
+        val credentialConfig = S3AccessKeyCredentialConfig(
+            "AKIAIOSFODNN7EXAMPLE",
+            "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+        )
+        val operation = createOperation(credentialConfig)
+
+        val clause = operation.buildCredentialClause()
+
+        assertEquals(
+            "CREDENTIALS 'aws_access_key_id=AKIAIOSFODNN7EXAMPLE;aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'",
+            clause
+        )
+    }
+
+    @Test
+    fun testBuildCredentialClauseWithIamRoleDefault() {
+        val credentialConfig = mock(S3CredentialConfig::class.java)
+        `when`(credentialConfig.credentialType).thenReturn(S3CredentialType.DEFAULT_PROFILE)
+
+        val operation = createOperation(credentialConfig, iamRoleArn = null)
+
+        val clause = operation.buildCredentialClause()
+
+        assertEquals("IAM_ROLE default", clause)
+    }
+
+    @Test
+    fun testBuildCredentialClauseWithExplicitIamRoleArn() {
+        val credentialConfig = mock(S3CredentialConfig::class.java)
+        `when`(credentialConfig.credentialType).thenReturn(S3CredentialType.DEFAULT_PROFILE)
+
+        val operation = createOperation(
+            credentialConfig,
+            iamRoleArn = "arn:aws:iam::123456789012:role/redshift-s3-read"
+        )
+
+        val clause = operation.buildCredentialClause()
+
+        assertEquals("IAM_ROLE 'arn:aws:iam::123456789012:role/redshift-s3-read'", clause)
+    }
+
+    @Test
+    fun testBuildCredentialClauseRejectsInvalidArn() {
+        val credentialConfig = mock(S3CredentialConfig::class.java)
+        `when`(credentialConfig.credentialType).thenReturn(S3CredentialType.DEFAULT_PROFILE)
+
+        val operation = createOperation(
+            credentialConfig,
+            iamRoleArn = "not-a-valid-arn"
+        )
+
+        assertThrows(IllegalArgumentException::class.java) {
+            operation.buildCredentialClause()
+        }
+    }
+
+    @Test
+    fun testBuildCredentialClauseWithAssumeRoleAndSessionToken() {
+        val sessionCreds = BasicSessionCredentials(
+            "ASIATEMP", "tempSecret", "sessionToken123"
+        )
+        val provider: AWSCredentialsProvider = AWSStaticCredentialsProvider(sessionCreds)
+
+        val credentialConfig = mock(S3CredentialConfig::class.java)
+        `when`(credentialConfig.credentialType).thenReturn(S3CredentialType.ASSUME_ROLE)
+        `when`(credentialConfig.s3CredentialsProvider).thenReturn(provider)
+
+        val operation = createOperation(credentialConfig)
+
+        val clause = operation.buildCredentialClause()
+
+        assertTrue(clause.contains("token=sessionToken123"))
+        assertTrue(clause.contains("aws_access_key_id=ASIATEMP"))
+    }
+
+    @Test
+    fun testBuildCredentialClauseWithAssumeRoleWithoutSessionToken() {
+        val basicCreds = BasicAWSCredentials("ASIANONSESSION", "nonSessionSecret")
+        val provider: AWSCredentialsProvider = AWSStaticCredentialsProvider(basicCreds)
+
+        val credentialConfig = mock(S3CredentialConfig::class.java)
+        `when`(credentialConfig.credentialType).thenReturn(S3CredentialType.ASSUME_ROLE)
+        `when`(credentialConfig.s3CredentialsProvider).thenReturn(provider)
+
+        val operation = createOperation(credentialConfig)
+
+        val clause = operation.buildCredentialClause()
+
+        assertEquals(
+            "CREDENTIALS 'aws_access_key_id=ASIANONSESSION;aws_secret_access_key=nonSessionSecret'",
+            clause
+        )
+    }
+
+    @Test
+    fun testBuildCredentialClauseAccessKeyTakesPrecedenceOverIamRoleArn() {
+        val credentialConfig = S3AccessKeyCredentialConfig(
+            "AKIAIOSFODNN7EXAMPLE",
+            "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+        )
+        val operation = createOperation(
+            credentialConfig,
+            iamRoleArn = "arn:aws:iam::123456789012:role/should-be-ignored"
+        )
+
+        val clause = operation.buildCredentialClause()
+
+        assertTrue(clause.startsWith("CREDENTIALS '"))
+        assertTrue(clause.contains("aws_access_key_id=AKIAIOSFODNN7EXAMPLE"))
+    }
+}

--- a/airbyte-integrations/connectors/destination-redshift/src/test/kotlin/io/airbyte/integrations/destination/redshift/util/RedshiftUtilTest.kt
+++ b/airbyte-integrations/connectors/destination-redshift/src/test/kotlin/io/airbyte/integrations/destination/redshift/util/RedshiftUtilTest.kt
@@ -43,8 +43,6 @@ class RedshiftUtilTest {
         val jsonNode = Mockito.mock(JsonNode::class.java)
         Mockito.`when`(jsonNode["s3_bucket_name"]).thenReturn(null)
         Mockito.`when`(jsonNode["s3_bucket_region"]).thenReturn(null)
-        Mockito.`when`(jsonNode["access_key_id"]).thenReturn(null)
-        Mockito.`when`(jsonNode["secret_access_key"]).thenReturn(null)
 
         Assertions.assertTrue(anyOfS3FieldsAreNullOrEmpty(jsonNode))
     }
@@ -57,10 +55,6 @@ class RedshiftUtilTest {
         Mockito.`when`(jsonNode["s3_bucket_name"].asText()).thenReturn("test")
         Mockito.`when`(jsonNode["s3_bucket_region"]).thenReturn(Mockito.mock(JsonNode::class.java))
         Mockito.`when`(jsonNode["s3_bucket_region"].asText()).thenReturn("test")
-        Mockito.`when`(jsonNode["access_key_id"]).thenReturn(Mockito.mock(JsonNode::class.java))
-        Mockito.`when`(jsonNode["access_key_id"].asText()).thenReturn("test")
-        Mockito.`when`(jsonNode["secret_access_key"]).thenReturn(Mockito.mock(JsonNode::class.java))
-        Mockito.`when`(jsonNode["secret_access_key"].asText()).thenReturn("test")
 
         Assertions.assertFalse(anyOfS3FieldsAreNullOrEmpty(jsonNode))
     }

--- a/airbyte-integrations/connectors/destination-redshift/src/test/resources/config-test.json
+++ b/airbyte-integrations/connectors/destination-redshift/src/test/resources/config-test.json
@@ -5,5 +5,12 @@
   "password": "password",
   "database": "db",
   "schema": "public",
-  "jdbc_url_params": "property1=pValue1&property2=pValue2"
+  "jdbc_url_params": "property1=pValue1&property2=pValue2",
+  "uploading_method": {
+    "method": "S3 Staging",
+    "s3_bucket_name": "test-bucket",
+    "s3_bucket_region": "us-east-1",
+    "access_key_id": "test-access-key",
+    "secret_access_key": "test-secret-key"
+  }
 }

--- a/docs/integrations/destinations/redshift.md
+++ b/docs/integrations/destinations/redshift.md
@@ -20,15 +20,17 @@ The Airbyte Redshift destination allows you to sync data to Redshift. Airbyte re
     create an S3 bucket.
 - **S3 Bucket Region**
   - Place the S3 bucket and the Redshift cluster in the same region to save on networking costs.
-- **Access Key Id**
+- **Access Key Id** _(optional when using IAM role auth)_
   - See
     [this](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys)
     on how to generate an access key.
   - We recommend creating an Airbyte-specific user. This user will require
     [read and write permissions](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_examples_s3_rw-bucket.html)
     to objects in the staging bucket.
-- **Secret Access Key**
+  - Not required if using IAM role-based authentication (IRSA / instance profile).
+- **Secret Access Key** _(optional when using IAM role auth)_
   - Corresponding key to the above key id.
+  - Not required if using IAM role-based authentication (IRSA / instance profile).
 
 Optional parameters:
 
@@ -40,6 +42,12 @@ Optional parameters:
   - The pattern allows you to set the file-name format for the S3 staging file(s), next placeholders combinations are currently supported: `{date}`, `{date:yyyy_MM}`, `{timestamp}`,
     `{timestamp:millis}`, `{timestamp:micros}`, `{part_number}`, `{sync_id}`, `{format_extension}`.
     The pattern you supply will apply to anything under the Bucket Path. If this field is left blank, everything syncs under the Bucket Path. Please, don't use empty space and not supportable placeholders, as they won't recognized.
+- **Redshift IAM Role ARN**
+  - The ARN of the IAM role attached to your Redshift cluster or serverless workgroup that has read
+    access to the S3 staging bucket. Required when not using static AWS credentials. If omitted,
+    `IAM_ROLE default` is used in the COPY command. See
+    [AWS docs](https://docs.aws.amazon.com/redshift/latest/mgmt/authorizing-redshift-service.html) on
+    associating IAM roles with Redshift.
 - **Purge Staging Data**
   - Whether to delete the staging files from S3 after completing the sync. Specifically, the
     connector will create CSV files named
@@ -95,6 +103,27 @@ This connector supports the use of a Bastion host as a gateway to a private Reds
 Tunneling. Setup of the host is beyond the scope of this document but several tutorials are
 available online to facilitate this task. Enter the bastion host, port and credentials in the
 destination configuration.
+
+### Using IAM Role-Based Authentication (IRSA / Instance Profile)
+
+If you're running Airbyte on AWS (EKS, EC2, or ECS), you can use IAM role-based authentication
+instead of static access keys. This eliminates the need to manage and rotate long-lived credentials.
+
+**Prerequisites:**
+
+1. The Airbyte pod or instance must have an IAM role with read/write access to the S3 staging bucket.
+   On EKS, this is typically configured via
+   [IRSA (IAM Roles for Service Accounts)](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html).
+2. Your Redshift cluster or serverless workgroup must have an
+   [associated IAM role](https://docs.aws.amazon.com/redshift/latest/mgmt/authorizing-redshift-service.html)
+   with read access to the same S3 staging bucket.
+
+**Configuration:**
+
+- Leave **Access Key Id** and **Secret Access Key** blank.
+- Set **Redshift IAM Role ARN** to the ARN of the IAM role attached to your Redshift cluster
+  (e.g., `arn:aws:iam::123456789012:role/redshift-s3-read`). If your cluster has a single default
+  role, you can leave this blank and the connector will use `IAM_ROLE default`.
 
 ## Step 2: Set up the destination connector in Airbyte
 

--- a/docs/integrations/destinations/redshift.md
+++ b/docs/integrations/destinations/redshift.md
@@ -262,6 +262,7 @@ This destination supports [namespaces](https://docs.airbyte.com/platform/using-a
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                                                                                                                          |
 | :------ | :--------- | :--------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 3.6.0 | 2026-04-09 | [TBD](https://github.com/airbytehq/airbyte/pull/TBD) | Add support for IAM role-based authentication (IRSA / instance profile) for S3 staging |
 | 3.5.4 | 2026-03-23 | [75286](https://github.com/airbytehq/airbyte/pull/75286) | Fix misleading SSH error when SQLException has null sqlState during connection check |
 | 3.5.3 | 2025-03-24 | [56355](https://github.com/airbytehq/airbyte/pull/56355) | Upgrade to airbyte/java-connector-base:2.0.1 to be M4 compatible. |
 | 3.5.2 | 2025-01-14 | [51500](https://github.com/airbytehq/airbyte/pull/51500) | Use a non root base image |


### PR DESCRIPTION
## What

Add support for IAM role-based authentication (IRSA / instance profile) to the Redshift destination connector's S3 staging configuration. Currently the connector requires static AWS credentials (`access_key_id` + `secret_access_key`), which fails in EKS deployments using IRSA where no static credentials exist.

Resolves https://github.com/airbytehq/airbyte/issues/41031

## How

- Made `access_key_id` and `secret_access_key` optional in `spec.json` — the existing CDK fallback in `S3DestinationConfig` already uses `DefaultAWSCredentialsProviderChain` when these fields are absent, so no CDK changes were needed.
- Added an optional `iam_role_arn` field for users to specify which IAM role Redshift should use in the COPY command.
- Modified `RedshiftStagingStorageOperation.executeCopy()` to branch on `S3CredentialType`:
  - `ACCESS_KEY` → `CREDENTIALS 'aws_access_key_id=...;aws_secret_access_key=...'` (unchanged behavior)
  - `DEFAULT_PROFILE` → `IAM_ROLE 'arn:...'` or `IAM_ROLE default`
  - `ASSUME_ROLE` → `CREDENTIALS` with session token support
- ARN format is validated at construction time (fail-fast) to avoid mid-sync failures.
- Exhaustive `when` on `S3CredentialType` (no `else`) so future enum additions produce a compile error.

## Review guide

1. `airbyte-integrations/connectors/destination-redshift/src/main/resources/spec.json` — required array change + new field
2. `airbyte-integrations/connectors/destination-redshift/src/main/kotlin/.../operation/RedshiftStagingStorageOperation.kt` — `buildCredentialClause()` method + ARN validation in `init`
3. `airbyte-integrations/connectors/destination-redshift/src/main/kotlin/.../RedshiftDestination.kt` — extract and pass `iam_role_arn` in both `check()` and `getSerializedMessageConsumer()`
4. `airbyte-integrations/connectors/destination-redshift/src/main/kotlin/.../util/RedshiftUtil.kt` — remove credential fields from `anyOfS3FieldsAreNullOrEmpty`
5. `airbyte-integrations/connectors/destination-redshift/src/test/kotlin/.../operation/RedshiftStagingStorageOperationTest.kt` — 7 new unit tests
6. `docs/integrations/destinations/redshift.md` — IRSA setup instructions

## User Impact

- Users deploying Airbyte on EKS with IRSA can now configure the Redshift destination without static AWS credentials — just leave the key fields blank and set the Redshift IAM Role ARN.
- Existing users with static credentials configured see zero change in behavior.
- No negative side effects.

## Can this PR be safely reverted and rolled back?

- [x] YES 