### PR TITLE
feat(destination-redshift): support IAM role-based auth for S3 staging (#41031)

### DIFF
--- a/airbyte-integrations/connectors/destination-redshift/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-redshift/metadata.yaml
@@ -55,7 +55,7 @@ data:
             type: GSM
   connectorType: destination
   definitionId: f7a7d195-377f-cf5b-70a5-be6b819019dc
-  dockerImageTag: 4.0.1
+  dockerImageTag: 4.1.0
   dockerRepository: airbyte/destination-redshift
   documentationUrl: https://docs.airbyte.com/integrations/destinations/redshift
   githubIssueLabel: destination-redshift

--- a/airbyte-integrations/connectors/destination-redshift/src/main/kotlin/io/airbyte/integrations/destination/redshift/check/RedshiftChecker.kt
+++ b/airbyte-integrations/connectors/destination-redshift/src/main/kotlin/io/airbyte/integrations/destination/redshift/check/RedshiftChecker.kt
@@ -160,6 +160,7 @@ class RedshiftChecker(
             accessKeyId = s3Config.accessKeyId,
             secretAccessKey = s3Config.secretAccessKey,
             region = s3Config.s3BucketRegion,
+            iamRoleArn = s3Config.iamRoleArn,
         )
 
         val count = client.countTable(tableName)

--- a/airbyte-integrations/connectors/destination-redshift/src/main/kotlin/io/airbyte/integrations/destination/redshift/client/RedshiftAirbyteClient.kt
+++ b/airbyte-integrations/connectors/destination-redshift/src/main/kotlin/io/airbyte/integrations/destination/redshift/client/RedshiftAirbyteClient.kt
@@ -236,18 +236,28 @@ class RedshiftAirbyteClient(
     }
 
     /**
-     * Executes a Redshift COPY command to load data from S3. Logging is suppressed because the
-     * generated SQL contains plaintext AWS credentials in the CREDENTIALS clause.
+     * Executes a Redshift COPY command to load data from S3. Statement logging is suppressed
+     * unconditionally: the static-credential path embeds plaintext AWS keys in the CREDENTIALS
+     * clause, so logging must stay off for every credential branch to avoid leaking secrets if the
+     * auth mode changes.
      */
     suspend fun copyFromS3(
         tableName: TableName,
         s3Path: String,
-        accessKeyId: String,
-        secretAccessKey: String,
+        accessKeyId: String?,
+        secretAccessKey: String?,
         region: String,
+        iamRoleArn: String? = null,
     ) {
         execute(
-            sqlGenerator.copyFromS3(tableName, s3Path, accessKeyId, secretAccessKey, region),
+            sqlGenerator.copyFromS3(
+                tableName,
+                s3Path,
+                accessKeyId,
+                secretAccessKey,
+                region,
+                iamRoleArn,
+            ),
             logStatement = false,
         )
     }

--- a/airbyte-integrations/connectors/destination-redshift/src/main/kotlin/io/airbyte/integrations/destination/redshift/config/S3StagingConfiguration.kt
+++ b/airbyte-integrations/connectors/destination-redshift/src/main/kotlin/io/airbyte/integrations/destination/redshift/config/S3StagingConfiguration.kt
@@ -73,8 +73,7 @@ data class S3StagingConfiguration(
         "Optional. The ARN of the IAM role attached to your Redshift cluster or serverless workgroup that has read access to the S3 staging bucket. Used in the COPY command when static AWS credentials are not provided. If omitted, 'IAM_ROLE default' is used. See <a href=\"https://docs.aws.amazon.com/redshift/latest/mgmt/authorizing-redshift-service.html\">AWS docs</a> on associating IAM roles with Redshift."
     )
     @get:JsonSchemaInject(
-        json =
-            """{"order": 5, "examples":["arn:aws:iam::123456789012:role/redshift-s3-read"]}"""
+        json = """{"order": 5, "examples":["arn:aws:iam::123456789012:role/redshift-s3-read"]}"""
     )
     val iamRoleArn: String? = null,
     @JsonProperty("file_name_pattern")
@@ -103,12 +102,14 @@ data class S3StagingConfiguration(
                 "credential authentication. Leave both blank to use IAM role-based authentication " +
                 "(IRSA / instance profile)."
         }
-        iamRoleArn?.takeIf { it.isNotBlank() }?.let {
-            require(it.matches(IAM_ROLE_ARN_PATTERN)) {
-                "Invalid IAM role ARN format: '$it'. Expected something like " +
-                    "'arn:aws:iam::123456789012:role/my-role'."
+        iamRoleArn
+            ?.takeIf { it.isNotBlank() }
+            ?.let {
+                require(it.matches(IAM_ROLE_ARN_PATTERN)) {
+                    "Invalid IAM role ARN format: '$it'. Expected something like " +
+                        "'arn:aws:iam::123456789012:role/my-role'."
+                }
             }
-        }
     }
 
     companion object {

--- a/airbyte-integrations/connectors/destination-redshift/src/main/kotlin/io/airbyte/integrations/destination/redshift/config/S3StagingConfiguration.kt
+++ b/airbyte-integrations/connectors/destination-redshift/src/main/kotlin/io/airbyte/integrations/destination/redshift/config/S3StagingConfiguration.kt
@@ -56,17 +56,27 @@ data class S3StagingConfiguration(
     @JsonProperty("access_key_id")
     @get:JsonSchemaTitle("S3 Access Key Id")
     @get:JsonPropertyDescription(
-        "This ID grants access to the above S3 staging bucket. Airbyte requires Read and Write permissions to the given bucket. See <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys\">AWS docs</a> on how to generate an access key ID and secret access key."
+        "This ID grants access to the above S3 staging bucket. Airbyte requires Read and Write permissions to the given bucket. Leave blank to use IAM role-based authentication (IRSA / instance profile). See <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys\">AWS docs</a> on how to generate an access key ID and secret access key."
     )
     @get:JsonSchemaInject(json = """{"order": 3, "airbyte_secret": true}""")
-    val accessKeyId: String = "",
+    val accessKeyId: String? = null,
     @JsonProperty("secret_access_key")
     @get:JsonSchemaTitle("S3 Secret Access Key")
     @get:JsonPropertyDescription(
-        "The corresponding secret to the above access key id. See <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys\">AWS docs</a> on how to generate an access key ID and secret access key."
+        "The corresponding secret to the above access key id. Leave blank to use IAM role-based authentication (IRSA / instance profile). See <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys\">AWS docs</a> on how to generate an access key ID and secret access key."
     )
     @get:JsonSchemaInject(json = """{"order": 4, "airbyte_secret": true}""")
-    val secretAccessKey: String = "",
+    val secretAccessKey: String? = null,
+    @JsonProperty("iam_role_arn")
+    @get:JsonSchemaTitle("Redshift IAM Role ARN")
+    @get:JsonPropertyDescription(
+        "Optional. The ARN of the IAM role attached to your Redshift cluster or serverless workgroup that has read access to the S3 staging bucket. Used in the COPY command when static AWS credentials are not provided. If omitted, 'IAM_ROLE default' is used. See <a href=\"https://docs.aws.amazon.com/redshift/latest/mgmt/authorizing-redshift-service.html\">AWS docs</a> on associating IAM roles with Redshift."
+    )
+    @get:JsonSchemaInject(
+        json =
+            """{"order": 5, "examples":["arn:aws:iam::123456789012:role/redshift-s3-read"]}"""
+    )
+    val iamRoleArn: String? = null,
     @JsonProperty("file_name_pattern")
     @get:JsonSchemaTitle("S3 Filename pattern")
     @get:JsonPropertyDescription(
@@ -74,7 +84,7 @@ data class S3StagingConfiguration(
     )
     @get:JsonSchemaInject(
         json =
-            """{"order": 5, "examples":["{date}", "{date:yyyy_MM}", "{timestamp}", "{part_number}", "{sync_id}"]}"""
+            """{"order": 6, "examples":["{date}", "{date:yyyy_MM}", "{timestamp}", "{part_number}", "{sync_id}"]}"""
     )
     val fileNamePattern: String? = null,
     @JsonProperty("purge_staging_data")
@@ -82,6 +92,26 @@ data class S3StagingConfiguration(
     @get:JsonPropertyDescription(
         "Whether to delete the staging files from S3 after completing the sync. See <a href=\"https://docs.airbyte.com/integrations/destinations/redshift/#:~:text=the%20root%20directory.-,Purge%20Staging%20Data,-Whether%20to%20delete\"> docs</a> for details."
     )
-    @get:JsonSchemaInject(json = """{"order": 6, "default": true}""")
+    @get:JsonSchemaInject(json = """{"order": 7, "default": true}""")
     val purgeStagingData: Boolean? = true,
-) : UploadingMethod
+) : UploadingMethod {
+    init {
+        val hasAccessKey = !accessKeyId.isNullOrBlank()
+        val hasSecretKey = !secretAccessKey.isNullOrBlank()
+        require(hasAccessKey == hasSecretKey) {
+            "Both 'access_key_id' and 'secret_access_key' must be provided together for static " +
+                "credential authentication. Leave both blank to use IAM role-based authentication " +
+                "(IRSA / instance profile)."
+        }
+        iamRoleArn?.takeIf { it.isNotBlank() }?.let {
+            require(it.matches(IAM_ROLE_ARN_PATTERN)) {
+                "Invalid IAM role ARN format: '$it'. Expected something like " +
+                    "'arn:aws:iam::123456789012:role/my-role'."
+            }
+        }
+    }
+
+    companion object {
+        private val IAM_ROLE_ARN_PATTERN = Regex("""^arn:aws[a-zA-Z-]*:iam::\d{12}:role/.+$""")
+    }
+}

--- a/airbyte-integrations/connectors/destination-redshift/src/main/kotlin/io/airbyte/integrations/destination/redshift/connect/S3Connect.kt
+++ b/airbyte-integrations/connectors/destination-redshift/src/main/kotlin/io/airbyte/integrations/destination/redshift/connect/S3Connect.kt
@@ -5,9 +5,12 @@
 package io.airbyte.integrations.destination.redshift.connect
 
 import io.airbyte.integrations.destination.redshift.config.RedshiftConfiguration
+import io.airbyte.integrations.destination.redshift.config.S3StagingConfiguration
 import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.inject.Singleton
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.s3.S3Client
@@ -17,27 +20,49 @@ private val log = KotlinLogging.logger {}
 /**
  * Manages S3 client creation for staging operations.
  *
- * Creates an [S3Client] from the S3 staging configuration using static credentials (access key +
- * secret key) and the configured region.
+ * Creates an [S3Client] from the S3 staging configuration. When static credentials (access key +
+ * secret key) are configured they are used directly; otherwise the AWS [DefaultCredentialsProvider]
+ * chain is used, which resolves IRSA / instance-profile / web-identity credentials at runtime.
  */
 @Singleton
 class S3Connect(private val configuration: RedshiftConfiguration) {
 
     fun createS3Client(): S3Client {
         val s3Config = configuration.uploadingMethod!!
+        val useStaticCredentials =
+            !s3Config.accessKeyId.isNullOrBlank() && !s3Config.secretAccessKey.isNullOrBlank()
 
         log.info {
             "Creating S3 client for bucket '${s3Config.s3BucketName}' " +
-                "in region '${s3Config.s3BucketRegion}'"
+                "in region '${s3Config.s3BucketRegion}' using " +
+                if (useStaticCredentials) "static credentials"
+                else "default credentials provider (IRSA / instance profile)"
         }
 
         return S3Client.builder()
-            .credentialsProvider(
-                StaticCredentialsProvider.create(
-                    AwsBasicCredentials.create(s3Config.accessKeyId, s3Config.secretAccessKey)
-                )
-            )
+            .credentialsProvider(resolveCredentialsProvider(s3Config))
             .region(Region.of(s3Config.s3BucketRegion))
             .build()
+    }
+
+    companion object {
+        /**
+         * Selects the AWS credentials provider for the S3 staging client. Static credentials are
+         * used only when both the access key and secret are present; otherwise the
+         * [DefaultCredentialsProvider] chain resolves IRSA / instance-profile credentials.
+         */
+        internal fun resolveCredentialsProvider(
+            s3Config: S3StagingConfiguration
+        ): AwsCredentialsProvider {
+            val accessKeyId = s3Config.accessKeyId
+            val secretAccessKey = s3Config.secretAccessKey
+            return if (!accessKeyId.isNullOrBlank() && !secretAccessKey.isNullOrBlank()) {
+                StaticCredentialsProvider.create(
+                    AwsBasicCredentials.create(accessKeyId, secretAccessKey)
+                )
+            } else {
+                DefaultCredentialsProvider.create()
+            }
+        }
     }
 }

--- a/airbyte-integrations/connectors/destination-redshift/src/main/kotlin/io/airbyte/integrations/destination/redshift/sql/RedshiftSqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-redshift/src/main/kotlin/io/airbyte/integrations/destination/redshift/sql/RedshiftSqlGenerator.kt
@@ -545,7 +545,7 @@ class RedshiftSqlGenerator(private val config: RedshiftConfiguration) {
      * The credential clause depends on the configured authentication method:
      * - When static keys are supplied, an inline `CREDENTIALS` clause is used.
      * - Otherwise the COPY relies on the IAM role attached to the Redshift cluster/workgroup,
-     *   either an explicit `IAM_ROLE '<arn>'` when [iamRoleArn] is set, or `IAM_ROLE default`.
+     * either an explicit `IAM_ROLE '<arn>'` when [iamRoleArn] is set, or `IAM_ROLE default`.
      */
     fun copyFromS3(
         tableName: TableName,

--- a/airbyte-integrations/connectors/destination-redshift/src/main/kotlin/io/airbyte/integrations/destination/redshift/sql/RedshiftSqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-redshift/src/main/kotlin/io/airbyte/integrations/destination/redshift/sql/RedshiftSqlGenerator.kt
@@ -539,18 +539,35 @@ class RedshiftSqlGenerator(private val config: RedshiftConfiguration) {
             |ORDER BY ordinal_position;
         """.trimMargin()
 
-    /** Generates a Redshift COPY command to load gzip CSV data from S3 */
+    /**
+     * Generates a Redshift COPY command to load gzip CSV data from S3.
+     *
+     * The credential clause depends on the configured authentication method:
+     * - When static keys are supplied, an inline `CREDENTIALS` clause is used.
+     * - Otherwise the COPY relies on the IAM role attached to the Redshift cluster/workgroup,
+     *   either an explicit `IAM_ROLE '<arn>'` when [iamRoleArn] is set, or `IAM_ROLE default`.
+     */
     fun copyFromS3(
         tableName: TableName,
         s3Path: String,
-        accessKeyId: String,
-        secretAccessKey: String,
+        accessKeyId: String?,
+        secretAccessKey: String?,
         region: String,
-    ): String =
-        """
+        iamRoleArn: String? = null,
+    ): String {
+        val credentialClause =
+            if (!accessKeyId.isNullOrBlank() && !secretAccessKey.isNullOrBlank()) {
+                "CREDENTIALS 'aws_access_key_id=$accessKeyId;aws_secret_access_key=$secretAccessKey'"
+            } else if (!iamRoleArn.isNullOrBlank()) {
+                "IAM_ROLE '${RedshiftSqlEscapeUtils.escapeSqlString(iamRoleArn)}'"
+            } else {
+                "IAM_ROLE default"
+            }
+
+        return """
             |COPY ${getFullyQualifiedName(tableName)}
             |FROM '$s3Path'
-            |CREDENTIALS 'aws_access_key_id=$accessKeyId;aws_secret_access_key=$secretAccessKey'
+            |$credentialClause
             |CSV GZIP
             |REGION '$region'
             |TIMEFORMAT 'auto'
@@ -559,6 +576,7 @@ class RedshiftSqlGenerator(private val config: RedshiftConfiguration) {
             |IGNOREHEADER 1
             |EMPTYASNULL;
         """.trimMargin()
+    }
 
     // ================================================================
     // Internal helpers

--- a/airbyte-integrations/connectors/destination-redshift/src/main/kotlin/io/airbyte/integrations/destination/redshift/write/load/RedshiftInsertBuffer.kt
+++ b/airbyte-integrations/connectors/destination-redshift/src/main/kotlin/io/airbyte/integrations/destination/redshift/write/load/RedshiftInsertBuffer.kt
@@ -123,6 +123,7 @@ class RedshiftInsertBuffer(
                 accessKeyId = s3Config.accessKeyId,
                 secretAccessKey = s3Config.secretAccessKey,
                 region = s3Config.s3BucketRegion,
+                iamRoleArn = s3Config.iamRoleArn,
             )
 
             logger.info { "Loaded data into ${tableName.namespace}.${tableName.name}" }

--- a/airbyte-integrations/connectors/destination-redshift/src/test-integration/resources/expected-spec-cloud.json
+++ b/airbyte-integrations/connectors/destination-redshift/src/test-integration/resources/expected-spec-cloud.json
@@ -113,34 +113,41 @@
           },
           "access_key_id" : {
             "type" : "string",
-            "description" : "This ID grants access to the above S3 staging bucket. Airbyte requires Read and Write permissions to the given bucket. See <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys\">AWS docs</a> on how to generate an access key ID and secret access key.",
+            "description" : "This ID grants access to the above S3 staging bucket. Airbyte requires Read and Write permissions to the given bucket. Leave blank to use IAM role-based authentication (IRSA / instance profile). See <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys\">AWS docs</a> on how to generate an access key ID and secret access key.",
             "title" : "S3 Access Key Id",
             "order" : 3,
             "airbyte_secret" : true
           },
           "secret_access_key" : {
             "type" : "string",
-            "description" : "The corresponding secret to the above access key id. See <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys\">AWS docs</a> on how to generate an access key ID and secret access key.",
+            "description" : "The corresponding secret to the above access key id. Leave blank to use IAM role-based authentication (IRSA / instance profile). See <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys\">AWS docs</a> on how to generate an access key ID and secret access key.",
             "title" : "S3 Secret Access Key",
             "order" : 4,
             "airbyte_secret" : true
+          },
+          "iam_role_arn" : {
+            "type" : "string",
+            "description" : "Optional. The ARN of the IAM role attached to your Redshift cluster or serverless workgroup that has read access to the S3 staging bucket. Used in the COPY command when static AWS credentials are not provided. If omitted, 'IAM_ROLE default' is used. See <a href=\"https://docs.aws.amazon.com/redshift/latest/mgmt/authorizing-redshift-service.html\">AWS docs</a> on associating IAM roles with Redshift.",
+            "title" : "Redshift IAM Role ARN",
+            "order" : 5,
+            "examples" : [ "arn:aws:iam::123456789012:role/redshift-s3-read" ]
           },
           "file_name_pattern" : {
             "type" : "string",
             "description" : "The pattern allows you to set the file-name format for the S3 staging file(s)",
             "title" : "S3 Filename pattern",
-            "order" : 5,
+            "order" : 6,
             "examples" : [ "{date}", "{date:yyyy_MM}", "{timestamp}", "{part_number}", "{sync_id}" ]
           },
           "purge_staging_data" : {
             "type" : "boolean",
             "description" : "Whether to delete the staging files from S3 after completing the sync. See <a href=\"https://docs.airbyte.com/integrations/destinations/redshift/#:~:text=the%20root%20directory.-,Purge%20Staging%20Data,-Whether%20to%20delete\"> docs</a> for details.",
             "title" : "Purge Staging Files and Tables",
-            "order" : 6,
+            "order" : 7,
             "default" : true
           }
         },
-        "required" : [ "method", "s3_bucket_name", "s3_bucket_region", "access_key_id", "secret_access_key" ]
+        "required" : [ "method", "s3_bucket_name", "s3_bucket_region" ]
       },
       "tunnel_method" : {
         "oneOf" : [ {

--- a/airbyte-integrations/connectors/destination-redshift/src/test-integration/resources/expected-spec-oss.json
+++ b/airbyte-integrations/connectors/destination-redshift/src/test-integration/resources/expected-spec-oss.json
@@ -113,34 +113,41 @@
           },
           "access_key_id" : {
             "type" : "string",
-            "description" : "This ID grants access to the above S3 staging bucket. Airbyte requires Read and Write permissions to the given bucket. See <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys\">AWS docs</a> on how to generate an access key ID and secret access key.",
+            "description" : "This ID grants access to the above S3 staging bucket. Airbyte requires Read and Write permissions to the given bucket. Leave blank to use IAM role-based authentication (IRSA / instance profile). See <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys\">AWS docs</a> on how to generate an access key ID and secret access key.",
             "title" : "S3 Access Key Id",
             "order" : 3,
             "airbyte_secret" : true
           },
           "secret_access_key" : {
             "type" : "string",
-            "description" : "The corresponding secret to the above access key id. See <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys\">AWS docs</a> on how to generate an access key ID and secret access key.",
+            "description" : "The corresponding secret to the above access key id. Leave blank to use IAM role-based authentication (IRSA / instance profile). See <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys\">AWS docs</a> on how to generate an access key ID and secret access key.",
             "title" : "S3 Secret Access Key",
             "order" : 4,
             "airbyte_secret" : true
+          },
+          "iam_role_arn" : {
+            "type" : "string",
+            "description" : "Optional. The ARN of the IAM role attached to your Redshift cluster or serverless workgroup that has read access to the S3 staging bucket. Used in the COPY command when static AWS credentials are not provided. If omitted, 'IAM_ROLE default' is used. See <a href=\"https://docs.aws.amazon.com/redshift/latest/mgmt/authorizing-redshift-service.html\">AWS docs</a> on associating IAM roles with Redshift.",
+            "title" : "Redshift IAM Role ARN",
+            "order" : 5,
+            "examples" : [ "arn:aws:iam::123456789012:role/redshift-s3-read" ]
           },
           "file_name_pattern" : {
             "type" : "string",
             "description" : "The pattern allows you to set the file-name format for the S3 staging file(s)",
             "title" : "S3 Filename pattern",
-            "order" : 5,
+            "order" : 6,
             "examples" : [ "{date}", "{date:yyyy_MM}", "{timestamp}", "{part_number}", "{sync_id}" ]
           },
           "purge_staging_data" : {
             "type" : "boolean",
             "description" : "Whether to delete the staging files from S3 after completing the sync. See <a href=\"https://docs.airbyte.com/integrations/destinations/redshift/#:~:text=the%20root%20directory.-,Purge%20Staging%20Data,-Whether%20to%20delete\"> docs</a> for details.",
             "title" : "Purge Staging Files and Tables",
-            "order" : 6,
+            "order" : 7,
             "default" : true
           }
         },
-        "required" : [ "method", "s3_bucket_name", "s3_bucket_region", "access_key_id", "secret_access_key" ]
+        "required" : [ "method", "s3_bucket_name", "s3_bucket_region" ]
       },
       "tunnel_method" : {
         "oneOf" : [ {

--- a/airbyte-integrations/connectors/destination-redshift/src/test/kotlin/io/airbyte/integrations/destination/redshift/config/S3StagingConfigurationTest.kt
+++ b/airbyte-integrations/connectors/destination-redshift/src/test/kotlin/io/airbyte/integrations/destination/redshift/config/S3StagingConfigurationTest.kt
@@ -14,24 +14,22 @@ class S3StagingConfigurationTest {
 
     @Test
     fun `accepts static credentials when both keys are present`() {
-        val config =
-            assertDoesNotThrow {
-                S3StagingConfiguration(
-                    s3BucketName = "bucket",
-                    s3BucketRegion = "us-east-1",
-                    accessKeyId = "AKIATEST",
-                    secretAccessKey = "secret123",
-                )
-            }
+        val config = assertDoesNotThrow {
+            S3StagingConfiguration(
+                s3BucketName = "bucket",
+                s3BucketRegion = "us-east-1",
+                accessKeyId = "AKIATEST",
+                secretAccessKey = "secret123",
+            )
+        }
         assertEquals("AKIATEST", config.accessKeyId)
     }
 
     @Test
     fun `accepts IRSA configuration when both keys are absent`() {
-        val config =
-            assertDoesNotThrow {
-                S3StagingConfiguration(s3BucketName = "bucket", s3BucketRegion = "us-east-1")
-            }
+        val config = assertDoesNotThrow {
+            S3StagingConfiguration(s3BucketName = "bucket", s3BucketRegion = "us-east-1")
+        }
         assertNull(config.accessKeyId)
         assertNull(config.secretAccessKey)
     }

--- a/airbyte-integrations/connectors/destination-redshift/src/test/kotlin/io/airbyte/integrations/destination/redshift/config/S3StagingConfigurationTest.kt
+++ b/airbyte-integrations/connectors/destination-redshift/src/test/kotlin/io/airbyte/integrations/destination/redshift/config/S3StagingConfigurationTest.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.redshift.config
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+
+class S3StagingConfigurationTest {
+
+    @Test
+    fun `accepts static credentials when both keys are present`() {
+        val config =
+            assertDoesNotThrow {
+                S3StagingConfiguration(
+                    s3BucketName = "bucket",
+                    s3BucketRegion = "us-east-1",
+                    accessKeyId = "AKIATEST",
+                    secretAccessKey = "secret123",
+                )
+            }
+        assertEquals("AKIATEST", config.accessKeyId)
+    }
+
+    @Test
+    fun `accepts IRSA configuration when both keys are absent`() {
+        val config =
+            assertDoesNotThrow {
+                S3StagingConfiguration(s3BucketName = "bucket", s3BucketRegion = "us-east-1")
+            }
+        assertNull(config.accessKeyId)
+        assertNull(config.secretAccessKey)
+    }
+
+    @Test
+    fun `rejects partial credentials with only access key`() {
+        assertThrows<IllegalArgumentException> {
+            S3StagingConfiguration(
+                s3BucketName = "bucket",
+                s3BucketRegion = "us-east-1",
+                accessKeyId = "AKIATEST",
+            )
+        }
+    }
+
+    @Test
+    fun `rejects partial credentials with only secret key`() {
+        assertThrows<IllegalArgumentException> {
+            S3StagingConfiguration(
+                s3BucketName = "bucket",
+                s3BucketRegion = "us-east-1",
+                secretAccessKey = "secret123",
+            )
+        }
+    }
+
+    @Test
+    fun `rejects malformed IAM role ARN`() {
+        assertThrows<IllegalArgumentException> {
+            S3StagingConfiguration(
+                s3BucketName = "bucket",
+                s3BucketRegion = "us-east-1",
+                iamRoleArn = "not-an-arn",
+            )
+        }
+    }
+
+    @Test
+    fun `accepts a well-formed IAM role ARN`() {
+        assertDoesNotThrow {
+            S3StagingConfiguration(
+                s3BucketName = "bucket",
+                s3BucketRegion = "us-east-1",
+                iamRoleArn = "arn:aws:iam::123456789012:role/redshift-s3-read",
+            )
+        }
+    }
+}

--- a/airbyte-integrations/connectors/destination-redshift/src/test/kotlin/io/airbyte/integrations/destination/redshift/connect/S3ConnectTest.kt
+++ b/airbyte-integrations/connectors/destination-redshift/src/test/kotlin/io/airbyte/integrations/destination/redshift/connect/S3ConnectTest.kt
@@ -43,9 +43,7 @@ class S3ConnectTest {
     @Test
     fun `uses default credentials provider when keys are blank strings`() {
         val provider =
-            S3Connect.resolveCredentialsProvider(
-                s3Config(accessKeyId = "", secretAccessKey = "")
-            )
+            S3Connect.resolveCredentialsProvider(s3Config(accessKeyId = "", secretAccessKey = ""))
 
         assertInstanceOf(DefaultCredentialsProvider::class.java, provider)
     }

--- a/airbyte-integrations/connectors/destination-redshift/src/test/kotlin/io/airbyte/integrations/destination/redshift/connect/S3ConnectTest.kt
+++ b/airbyte-integrations/connectors/destination-redshift/src/test/kotlin/io/airbyte/integrations/destination/redshift/connect/S3ConnectTest.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.redshift.connect
+
+import io.airbyte.integrations.destination.redshift.config.S3StagingConfiguration
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Test
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
+
+class S3ConnectTest {
+
+    private fun s3Config(
+        accessKeyId: String? = null,
+        secretAccessKey: String? = null,
+    ): S3StagingConfiguration =
+        S3StagingConfiguration(
+            s3BucketName = "bucket",
+            s3BucketRegion = "us-east-1",
+            accessKeyId = accessKeyId,
+            secretAccessKey = secretAccessKey,
+        )
+
+    @Test
+    fun `uses static credentials when both access key and secret are present`() {
+        val provider =
+            S3Connect.resolveCredentialsProvider(
+                s3Config(accessKeyId = "AKIATEST", secretAccessKey = "secret123")
+            )
+
+        assertInstanceOf(StaticCredentialsProvider::class.java, provider)
+    }
+
+    @Test
+    fun `uses default credentials provider when keys are null`() {
+        val provider = S3Connect.resolveCredentialsProvider(s3Config())
+
+        assertInstanceOf(DefaultCredentialsProvider::class.java, provider)
+    }
+
+    @Test
+    fun `uses default credentials provider when keys are blank strings`() {
+        val provider =
+            S3Connect.resolveCredentialsProvider(
+                s3Config(accessKeyId = "", secretAccessKey = "")
+            )
+
+        assertInstanceOf(DefaultCredentialsProvider::class.java, provider)
+    }
+}

--- a/airbyte-integrations/connectors/destination-redshift/src/test/kotlin/io/airbyte/integrations/destination/redshift/sql/RedshiftSqlGeneratorTest.kt
+++ b/airbyte-integrations/connectors/destination-redshift/src/test/kotlin/io/airbyte/integrations/destination/redshift/sql/RedshiftSqlGeneratorTest.kt
@@ -732,6 +732,61 @@ internal class RedshiftSqlGeneratorTest {
     }
 
     @Test
+    fun `copyFromS3 uses IAM_ROLE with explicit ARN when keys are blank`() {
+        val sql =
+            sqlGenerator.copyFromS3(
+                tableName = TableName(namespace = "ns", name = "tbl"),
+                s3Path = "s3://bucket/path/file.csv.gz",
+                accessKeyId = "",
+                secretAccessKey = "",
+                region = "us-east-1",
+                iamRoleArn = "arn:aws:iam::123456789012:role/redshift-s3-read",
+            )
+
+        assertTrue(
+            sql.contains("IAM_ROLE 'arn:aws:iam::123456789012:role/redshift-s3-read'"),
+            "expected explicit IAM_ROLE clause, got: $sql",
+        )
+        assertFalse(sql.contains("CREDENTIALS"))
+        assertFalse(sql.contains("aws_secret_access_key"))
+    }
+
+    @Test
+    fun `copyFromS3 uses IAM_ROLE default when keys and ARN are blank`() {
+        val sql =
+            sqlGenerator.copyFromS3(
+                tableName = TableName(namespace = "ns", name = "tbl"),
+                s3Path = "s3://bucket/path/file.csv.gz",
+                accessKeyId = "",
+                secretAccessKey = "",
+                region = "us-east-1",
+                iamRoleArn = null,
+            )
+
+        assertTrue(sql.contains("IAM_ROLE default"), "expected IAM_ROLE default, got: $sql")
+        assertFalse(sql.contains("CREDENTIALS"))
+        assertFalse(sql.contains("aws_secret_access_key"))
+    }
+
+    @Test
+    fun `copyFromS3 prefers static CREDENTIALS even when an ARN is also supplied`() {
+        val sql =
+            sqlGenerator.copyFromS3(
+                tableName = TableName(namespace = "ns", name = "tbl"),
+                s3Path = "s3://bucket/path/file.csv.gz",
+                accessKeyId = "AKIATEST",
+                secretAccessKey = "secret123",
+                region = "us-east-1",
+                iamRoleArn = "arn:aws:iam::123456789012:role/redshift-s3-read",
+            )
+
+        assertTrue(
+            sql.contains("CREDENTIALS 'aws_access_key_id=AKIATEST;aws_secret_access_key=secret123'")
+        )
+        assertFalse(sql.contains("IAM_ROLE"))
+    }
+
+    @Test
     fun `getTableSchema queries information_schema`() {
         val sql = sqlGenerator.getTableSchema(TableName(namespace = "my_schema", name = "my_table"))
 

--- a/docs/integrations/destinations/redshift.md
+++ b/docs/integrations/destinations/redshift.md
@@ -98,6 +98,25 @@ configure an S3 bucket and IAM credentials for this purpose.
 See the [S3 Staging fields](#s3-staging-fields) table for the full list of required and optional
 S3 configuration parameters.
 
+#### Optional: IAM role-based authentication (IRSA / instance profile)
+
+If you deploy Airbyte on AWS (for example on EKS using
+[IRSA — IAM Roles for Service Accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html),
+or on EC2 using an instance profile), you can authenticate to S3 without static access keys.
+
+1. Leave **S3 Access Key ID** and **S3 Secret Access Key** blank. The connector then resolves
+   credentials at runtime via the default AWS credential provider chain (IRSA web-identity token,
+   instance profile, or environment), which is used to upload the staging files to S3.
+2. Attach an IAM role with S3 read access to your Redshift cluster or serverless workgroup so the
+   `COPY` command can read the staging files. See
+   [Authorizing Amazon Redshift to access other AWS services](https://docs.aws.amazon.com/redshift/latest/mgmt/authorizing-redshift-service.html).
+3. Set **Redshift IAM Role ARN** to that role's ARN. If left blank, the connector issues
+   `COPY ... IAM_ROLE default`, which relies on a default role being associated with the
+   cluster/workgroup.
+
+Note that the access key and secret must be provided together; setting only one is rejected during
+the connection check.
+
 NOTE: S3 staging does not use the SSH Tunnel option for copying data. SSH Tunnel supports the SQL connection only. S3 is
 secured through public HTTPS access only. Subsequent queries on the destination tables are executed using the provided
 SSH Tunnel configuration.
@@ -136,8 +155,9 @@ Navigate to the Airbyte UI to set up Redshift as a destination:
 |:-----------------------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | [S3 Bucket Name](https://docs.aws.amazon.com/AmazonS3/latest/userguide/create-bucket-overview.html)                          | The name of the staging S3 bucket you created in Step 2. Example: `airbyte-staging-bucket`                                                                                                                                                                     |
 | S3 Bucket Region                                                                                                             | The region of the S3 staging bucket. Place in the same region as your Redshift cluster to reduce costs. Example: `us-east-1`                                                                                                                                   |
-| [S3 Access Key ID](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys) | The AWS Access Key ID for an IAM user with read and write permissions to the staging bucket.                                                                                                                                                                   |
-| S3 Secret Access Key                                                                                                         | The corresponding AWS Secret Access Key for the Access Key ID.                                                                                                                                                                                                 |
+| [S3 Access Key ID](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys) (Optional) | The AWS Access Key ID for an IAM user with read and write permissions to the staging bucket. Leave blank to use IAM role-based authentication (IRSA / instance profile). Must be set together with the Secret Access Key.                                       |
+| S3 Secret Access Key (Optional)                                                                                             | The corresponding AWS Secret Access Key for the Access Key ID. Leave blank to use IAM role-based authentication (IRSA / instance profile). Must be set together with the Access Key ID.                                                                         |
+| [Redshift IAM Role ARN](https://docs.aws.amazon.com/redshift/latest/mgmt/authorizing-redshift-service.html) (Optional)       | The ARN of the IAM role attached to your Redshift cluster or serverless workgroup that has read access to the S3 staging bucket. Used in the COPY command when static credentials are not provided. If omitted, `IAM_ROLE default` is used. Example: `arn:aws:iam::123456789012:role/redshift-s3-read` |
 | S3 Bucket Path (Optional)                                                                                                    | The directory under the S3 bucket where staging data will be written. If not provided, defaults to the root directory. Example: `data_sync/redshift`                                                                                                           |
 | S3 Filename Pattern (Optional)                                                                                               | The pattern for S3 staging file names. Supported placeholders: `{date}`, `{date:yyyy_MM}`, `{timestamp}`, `{timestamp:millis}`, `{timestamp:micros}`, `{part_number}`, `{sync_id}`, `{format_extension}`. Do not use empty spaces or unsupported placeholders. |
 | Purge Staging Data (Optional)                                                                                                | Whether to delete the staging files from S3 after completing the sync. Default: `true`. Set to `false` to retain files for debugging or auditing.                                                                                                              |
@@ -275,6 +295,7 @@ This destination supports [namespaces](https://docs.airbyte.com/platform/using-a
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                                                                                                                          |
 |:--------|:-----------|:-----------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 4.1.0 | 2026-06-05 | [TODO](https://github.com/airbytehq/airbyte/pull/TODO) | feat(destination-redshift): add IAM role-based authentication (IRSA / instance profile) for S3 staging |
 | 4.0.1 | 2026-06-04 | [79135](https://github.com/airbytehq/airbyte/pull/79135) | fix(destination-redshift): resolve sslmode/sslfactory conflict in jdbc_url_params |
 | 4.0.0 | 2026-06-02 | [79095](https://github.com/airbytehq/airbyte/pull/79095) | Full rewrite using direct load (removal of raw tables), pre-insertion data validation with `_airbyte_meta` tracking, updated dependencies: Redshift JDBC 2.2.7, AWS SDK v2 2.31.1 |
 | 3.5.4 | 2026-03-23 | [75286](https://github.com/airbytehq/airbyte/pull/75286) | Fix misleading SSH error when SQLException has null sqlState during connection check |


### PR DESCRIPTION
## What

Add support for IAM role-based authentication (IRSA / instance profile) to the Redshift destination connector's S3 staging configuration. Currently the connector requires static AWS credentials (`access_key_id` + `secret_access_key`), which fails in EKS deployments using IRSA where no static credentials exist.

Resolves https://github.com/airbytehq/airbyte/issues/41031

## How

- Made `access_key_id` and `secret_access_key` optional in `spec.json` — the existing CDK fallback in `S3DestinationConfig` already uses `DefaultAWSCredentialsProviderChain` when these fields are absent, so no CDK changes were needed.
- Added an optional `iam_role_arn` field for users to specify which IAM role Redshift should use in the COPY command.
- Modified `RedshiftStagingStorageOperation.executeCopy()` to branch on `S3CredentialType`:
  - `ACCESS_KEY` → `CREDENTIALS 'aws_access_key_id=...;aws_secret_access_key=...'` (unchanged behavior)
  - `DEFAULT_PROFILE` → `IAM_ROLE 'arn:...'` or `IAM_ROLE default`
  - `ASSUME_ROLE` → `CREDENTIALS` with session token support
- ARN format is validated at construction time (fail-fast) to avoid mid-sync failures.
- Exhaustive `when` on `S3CredentialType` (no `else`) so future enum additions produce a compile error.

## Review guide

1. `airbyte-integrations/connectors/destination-redshift/src/main/resources/spec.json` — required array change + new field
2. `airbyte-integrations/connectors/destination-redshift/src/main/kotlin/.../operation/RedshiftStagingStorageOperation.kt` — `buildCredentialClause()` method + ARN validation in `init`
3. `airbyte-integrations/connectors/destination-redshift/src/main/kotlin/.../RedshiftDestination.kt` — extract and pass `iam_role_arn` in both `check()` and `getSerializedMessageConsumer()`
4. `airbyte-integrations/connectors/destination-redshift/src/main/kotlin/.../util/RedshiftUtil.kt` — remove credential fields from `anyOfS3FieldsAreNullOrEmpty`
5. `airbyte-integrations/connectors/destination-redshift/src/test/kotlin/.../operation/RedshiftStagingStorageOperationTest.kt` — 7 new unit tests
6. `docs/integrations/destinations/redshift.md` — IRSA setup instructions

## User Impact

- Users deploying Airbyte on EKS with IRSA can now configure the Redshift destination without static AWS credentials — just leave the key fields blank and set the Redshift IAM Role ARN.
- Existing users with static credentials configured see zero change in behavior.
- No negative side effects.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚