### PR TITLE
fix(extract-jdbc): Handle FromSample.where in H2 test fixture

### DIFF
--- a/airbyte-cdk/bulk/toolkits/extract-jdbc/src/testFixtures/kotlin/io/airbyte/cdk/h2source/H2SourceOperations.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-jdbc/src/testFixtures/kotlin/io/airbyte/cdk/h2source/H2SourceOperations.kt
@@ -177,7 +177,13 @@ class H2SourceOperations :
             is From -> if (namespace == null) "FROM $name" else "FROM $namespace.$name"
             is FromSample -> {
                 val innerFrom: String = From(name, namespace).sql()
-                val innerWhere = "WHERE MOD(ROWNUM(), $sampleRateInv) = 0 "
+                val samplingCondition = "MOD(ROWNUM(), $sampleRateInv) = 0"
+                val innerWhere =
+                    if (where is Where) {
+                        "WHERE ${(where as Where).clause.sql()} AND $samplingCondition"
+                    } else {
+                        "WHERE $samplingCondition"
+                    }
                 val innerLimit = "LIMIT $sampleSize"
                 "FROM (SELECT * $innerFrom $innerWhere $innerLimit)"
             }
@@ -212,7 +218,14 @@ class H2SourceOperations :
             is Limit -> "LIMIT $n"
         }
 
-    fun SelectQuerySpec.bindings(): List<SelectQuery.Binding> = where.bindings()
+    fun SelectQuerySpec.bindings(): List<SelectQuery.Binding> =
+        from.bindings() + where.bindings()
+
+    fun FromNode.bindings(): List<SelectQuery.Binding> =
+        when (this) {
+            is FromSample -> where?.bindings() ?: emptyList()
+            else -> emptyList()
+        }
 
     fun WhereNode.bindings(): List<SelectQuery.Binding> =
         when (this) {


### PR DESCRIPTION
## What
The H2 test fixture (`H2SourceOperations`) was silently dropping the `where` clause from `FromSample`, meaning CDK integration tests were not exercising the sampling-with-bounds code path.

## How
Three changes to `H2SourceOperations.kt`:
- `FromNode.sql()`: Include `FromSample.where` in the H2 sampling inner SELECT, combined with AND alongside `MOD(ROWNUM(), ...)` sampling condition
- `SelectQuerySpec.bindings()`: Include `from.bindings()` for WHERE clause parameter values
- New `FromNode.bindings()`: Extracts bindings from `FromSample.where`

This ensures the H2 test fixture correctly models real database behavior where sampling respects WHERE clause bounds.

Companion enterprise PR for Oracle source fix: airbytehq/airbyte-enterprise (fix/oracle-snapshot-sampling-where)

## Test plan
- [x] All existing CDK tests pass (DefaultJdbcPartitionFactoryTest, JdbcPartitionsCreatorTest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)