### PR TITLE
chore(source-freshdesk): add concurrency_level for tuning (3.2.14-rc.1)

### DIFF
--- a/airbyte-integrations/connectors/source-freshdesk/manifest.yaml
+++ b/airbyte-integrations/connectors/source-freshdesk/manifest.yaml
@@ -1692,9 +1692,9 @@ spec:
           Number of concurrent threads for syncing. Higher values can speed up
           syncs but may increase API rate limit usage. Adjust based on your
           Freshdesk API plan.
-        default: 12
-        minimum: 1
-        maximum: 40
+        default: 4
+        minimum: 2
+        maximum: 16
         order: 5
     additionalProperties: true
 
@@ -3739,8 +3739,8 @@ schemas:
 
 concurrency_level:
   type: ConcurrencyLevel
-  default_concurrency: "{{ config.get('num_workers', 12) }}"
-  max_concurrency: 40
+  default_concurrency: "{{ config.get('num_workers', 4) }}"
+  max_concurrency: 16
 
 api_budget:
   type: HTTPAPIBudget

--- a/airbyte-integrations/connectors/source-freshdesk/manifest.yaml
+++ b/airbyte-integrations/connectors/source-freshdesk/manifest.yaml
@@ -1685,6 +1685,17 @@ spec:
         order: 4
         title: Lookback Window
         default: 14
+      num_workers:
+        type: integer
+        title: Number of Concurrent Workers
+        description: >-
+          Number of concurrent threads for syncing. Higher values can speed up
+          syncs but may increase API rate limit usage. Adjust based on your
+          Freshdesk API plan.
+        default: 12
+        minimum: 1
+        maximum: 40
+        order: 5
     additionalProperties: true
 
 metadata:
@@ -3725,6 +3736,11 @@ schemas:
           - string
           - "null"
     additionalProperties: true
+
+concurrency_level:
+  type: ConcurrencyLevel
+  default_concurrency: "{{ config.get('num_workers', 12) }}"
+  max_concurrency: 40
 
 api_budget:
   type: HTTPAPIBudget

--- a/airbyte-integrations/connectors/source-freshdesk/metadata.yaml
+++ b/airbyte-integrations/connectors/source-freshdesk/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: ec4b9503-13cb-48ab-a4ab-6ade4be46567
-  dockerImageTag: 3.2.13
+  dockerImageTag: 3.2.14-rc.1
   dockerRepository: airbyte/source-freshdesk
   documentationUrl: https://docs.airbyte.com/integrations/sources/freshdesk
   externalDocumentationUrls:
@@ -33,7 +33,7 @@ data:
       enabled: true
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
   releaseStage: generally_available
   suggestedStreams:
     streams:

--- a/airbyte-integrations/connectors/source-harvest/metadata.yaml
+++ b/airbyte-integrations/connectors/source-harvest/metadata.yaml
@@ -41,7 +41,22 @@ data:
         upgradeDeadline: "2024-04-29"
         scopedImpact:
           - scopeType: stream
-            impactedScopes: ["expenses_clients", "expenses_categories", "expenses_projects", "expenses_team", "time_clients", "time_projects", "time_tasks", "time_team", "uninvoiced", "estimate_messages", "invoice_payments", "invoice_messages", "project_assignments"]
+            impactedScopes:
+              [
+                "expenses_clients",
+                "expenses_categories",
+                "expenses_projects",
+                "expenses_team",
+                "time_clients",
+                "time_projects",
+                "time_tasks",
+                "time_team",
+                "uninvoiced",
+                "estimate_messages",
+                "invoice_payments",
+                "invoice_messages",
+                "project_assignments",
+              ]
   releaseStage: generally_available
   suggestedStreams:
     streams:

--- a/airbyte-integrations/connectors/source-harvest/metadata.yaml
+++ b/airbyte-integrations/connectors/source-harvest/metadata.yaml
@@ -41,22 +41,7 @@ data:
         upgradeDeadline: "2024-04-29"
         scopedImpact:
           - scopeType: stream
-            impactedScopes:
-              [
-                "expenses_clients",
-                "expenses_categories",
-                "expenses_projects",
-                "expenses_team",
-                "time_clients",
-                "time_projects",
-                "time_tasks",
-                "time_team",
-                "uninvoiced",
-                "estimate_messages",
-                "invoice_payments",
-                "invoice_messages",
-                "project_assignments",
-              ]
+            impactedScopes: ["expenses_clients", "expenses_categories", "expenses_projects", "expenses_team", "time_clients", "time_projects", "time_tasks", "time_team", "uninvoiced", "estimate_messages", "invoice_payments", "invoice_messages", "project_assignments"]
   releaseStage: generally_available
   suggestedStreams:
     streams:

--- a/docs/integrations/sources/freshdesk.md
+++ b/docs/integrations/sources/freshdesk.md
@@ -72,6 +72,7 @@ If you don't use the start date Freshdesk will retrieve only the last 30 days. M
 
 | Version | Date       | Pull Request                                             | Subject                                                                               |
 | :------ | :--------- | :------------------------------------------------------- | :------------------------------------------------------------------------------------ |
+| 3.2.14-rc.1 | 2026-04-10 | [76202](https://github.com/airbytehq/airbyte/pull/76202) | Add concurrency_level and num_workers for concurrency tuning |
 | 3.2.13 | 2026-03-31 | [75719](https://github.com/airbytehq/airbyte/pull/75719) | Update dependencies |
 | 3.2.12 | 2026-03-24 | [74647](https://github.com/airbytehq/airbyte/pull/74647) | Update dependencies |
 | 3.2.11 | 2026-03-03 | [74188](https://github.com/airbytehq/airbyte/pull/74188) | Update dependencies |


### PR DESCRIPTION
## What

Adds concurrency support to `source-freshdesk` as part of the concurrency tuning epic ([internal issue](https://github.com/airbytehq/airbyte-internal-issues/issues/15331)). This is the initial RC version to begin progressive rollout and performance tuning.

## How

**manifest.yaml:**
- Added `concurrency_level` top-level block (`ConcurrencyLevel` type) with `default_concurrency` of 4 (configurable via `num_workers`) and `max_concurrency` of 16.
- Added `num_workers` user-facing config parameter to the spec (integer, default: 4, range: 2–16) so users can tune concurrency for their Freshdesk plan.
- The existing `HTTPAPIBudget` (50 calls/min, hardcoded for free/trial plan) is **unchanged** and will act as the rate-limiting safety net.

**metadata.yaml:**
- Bumped version to `3.2.14-rc.1`.
- Enabled `enableProgressiveRollout: true` so this version can be selectively rolled out to a subset of connections.

**docs/integrations/sources/freshdesk.md:**
- Added changelog entry for `3.2.14-rc.1`.

**Concurrency calculation:** Freshdesk's highest plan rate limit is 700 req/min (Enterprise) = ~11.67 req/s. Using `floor(11.67 / 4) = 2`, the special-case rule applies: `starting_concurrency = 4`, `step = 1`. The `max_concurrency: 16` provides headroom for tuning upward.

## Review guide

1. `manifest.yaml` — `concurrency_level` block (lines ~3740–3743): verify the Jinja interpolation `{{ config.get('num_workers', 4) }}` and that it sits correctly as a top-level key alongside `api_budget`.
2. `manifest.yaml` — `num_workers` spec property (lines ~1688–1698): verify defaults/min/max are reasonable given the existing 50 calls/min budget and highest plan limit of 700 req/min.
3. `metadata.yaml` — version bump and rollout flag.
4. `docs/integrations/sources/freshdesk.md` — changelog entry for `3.2.14-rc.1`.

**Key consideration:** The default concurrency of 4 with the existing budget of 50 calls/min means workers will be throttled by the budget on lower plans. This is intentional — the budget acts as a safety net. The `max_concurrency: 16` accommodates users on higher Freshdesk plans (up to 700 req/min for Enterprise) who may override `num_workers`.

### Human review checklist
- [ ] Verify the Jinja expression `{{ config.get('num_workers', 4) }}` is valid for `ConcurrencyLevel.default_concurrency`
- [ ] Confirm `minimum: 2` for `num_workers` is appropriate (concurrency floor)
- [ ] Confirm the existing `HTTPAPIBudget` (50 calls/min) will properly throttle concurrent workers

## User Impact

- No impact on existing users during RC phase — progressive rollout is enabled and the RC will only be deployed to a selected subset of Tier 2 connections.
- Once GA, users gain a `num_workers` config option to tune sync parallelism. Default behavior (4 workers) should improve sync speed for most users while the existing rate limit budget prevents 429 errors.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/f5e7f185cbaf4e49b5d1ff5af45e3749
Requested by: @sophiecuiy
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/76202" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
