### PR TITLE
chore(source-zendesk-talk): add concurrency and HTTP API budget support

### DIFF
--- a/airbyte-integrations/connectors/source-zendesk-talk/manifest.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-talk/manifest.yaml
@@ -555,16 +555,16 @@ streams:
 # Zendesk Talk API rate limits:
 # - Support API base limits vary by plan: Team (200 req/min), Growth (400), Professional (400),
 #   Enterprise (700), Enterprise Plus (2500)
-# - Talk API additional limits: All endpoints (15,000 reqs/5 min),
-#   Current Queue Activity (2,500 reqs/5 min)
-# - Incremental Exports (calls, call_legs): 10 requests per minute (bottleneck)
+# - Talk API additional limits: All endpoints (15,000 reqs/5 min = 50 req/sec),
+#   Current Queue Activity (2,500 reqs/5 min), Incremental Exports (10 req/min)
 #
-# Starting concurrency is set to 4 based on the special-case rule:
-# floor(10 / 4) = 2, which is <= 2, so we override to starting_concurrency = 4, step = 1.
+# Concurrency calculated using highest rate limit across all endpoints:
+# highest = 50 req/sec (Talk API all endpoints), concurrency = floor(50 / 4) = 12
+# Ref: https://developer.zendesk.com/api-reference/voice/talk-api/rate_limits/
 concurrency_level:
   type: ConcurrencyLevel
-  default_concurrency: 4
-  max_concurrency: 40
+  default_concurrency: 12
+  max_concurrency: 48
 
 spec:
   type: Spec

--- a/airbyte-integrations/connectors/source-zendesk-talk/manifest.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-talk/manifest.yaml
@@ -566,6 +566,33 @@ concurrency_level:
   default_concurrency: 12
   max_concurrency: 48
 
+# HTTP API Budget: throttle requests per Zendesk Talk API rate limits
+# Ref: https://developer.zendesk.com/api-reference/voice/talk-api/rate_limits/
+api_budget:
+  type: HTTPAPIBudget
+  policies:
+    # Incremental Exports (calls, call_legs): 10 requests per minute
+    - type: FixedWindowCallRatePolicy
+      period: "PT1M"
+      call_limit: 10
+      matchers:
+        - method: GET
+          url_path_pattern: "/stats/incremental/"
+    # Current Queue Activity: 2,500 requests per 5 minutes
+    - type: FixedWindowCallRatePolicy
+      period: "PT5M"
+      call_limit: 2500
+      matchers:
+        - method: GET
+          url_path_pattern: "/stats/current_queue_activity"
+    # All Talk API endpoints (catch-all): 15,000 requests per 5 minutes
+    - type: FixedWindowCallRatePolicy
+      period: "PT5M"
+      call_limit: 15000
+      matchers: []
+  ratelimit_reset_header: "Retry-After"
+  status_codes_for_ratelimit_hit: [429]
+
 spec:
   type: Spec
   connection_specification:

--- a/airbyte-integrations/connectors/source-zendesk-talk/manifest.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-talk/manifest.yaml
@@ -552,6 +552,20 @@ streams:
   - $ref: "#/definitions/streams/ivr_menus"
   - $ref: "#/definitions/streams/ivr_routes"
 
+# Zendesk Talk API rate limits:
+# - Support API base limits vary by plan: Team (200 req/min), Growth (400), Professional (400),
+#   Enterprise (700), Enterprise Plus (2500)
+# - Talk API additional limits: All endpoints (15,000 reqs/5 min),
+#   Current Queue Activity (2,500 reqs/5 min)
+# - Incremental Exports (calls, call_legs): 10 requests per minute (bottleneck)
+#
+# Starting concurrency is set to 4 based on the special-case rule:
+# floor(10 / 4) = 2, which is <= 2, so we override to starting_concurrency = 4, step = 1.
+concurrency_level:
+  type: ConcurrencyLevel
+  default_concurrency: 4
+  max_concurrency: 40
+
 spec:
   type: Spec
   connection_specification:

--- a/airbyte-integrations/connectors/source-zendesk-talk/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-talk/metadata.yaml
@@ -32,10 +32,8 @@ data:
   registryOverrides:
     cloud:
       enabled: true
-      dockerImageTag: 2.0.10
     oss:
       enabled: true
-      dockerImageTag: 2.0.10
   releaseStage: generally_available
   supportLevel: certified
   releases:

--- a/airbyte-integrations/connectors/source-zendesk-talk/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-talk/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: c8630570-086d-4a40-99ae-ea5b18673071
-  dockerImageTag: 2.0.10
+  dockerImageTag: 2.0.11-rc.1
   dockerRepository: airbyte/source-zendesk-talk
   documentationUrl: https://docs.airbyte.com/integrations/sources/zendesk-talk
   externalDocumentationUrls:
@@ -32,8 +32,10 @@ data:
   registryOverrides:
     cloud:
       enabled: true
+      dockerImageTag: 2.0.10
     oss:
       enabled: true
+      dockerImageTag: 2.0.10
   releaseStage: generally_available
   supportLevel: certified
   releases:
@@ -50,6 +52,8 @@ data:
           stream schema, this migration constitutes a breaking change. After updating,
           please reset your source  before resuming syncs. For more information, see
           our migration documentation for source Zendesk Talk.
+    rolloutConfiguration:
+      enableProgressiveRollout: true
   suggestedStreams:
     streams:
       - calls

--- a/docs/integrations/sources/zendesk-talk.md
+++ b/docs/integrations/sources/zendesk-talk.md
@@ -79,7 +79,7 @@ The Zendesk connector should not run into Zendesk API limitations under normal u
 
 | Version | Date       | Pull Request                                             | Subject                                                                     |
 |:--------|:-----------|:---------------------------------------------------------|:----------------------------------------------------------------------------|
-| 2.0.11-rc.1 | 2026-04-09 | [76203](https://github.com/airbytehq/airbyte/pull/76203) | Add concurrency support with default_concurrency of 4 |
+| 2.0.11-rc.1 | 2026-04-09 | [76203](https://github.com/airbytehq/airbyte/pull/76203) | Add concurrency support with default_concurrency of 12 |
 | 2.0.10 | 2026-04-06 | [](https://github.com/airbytehq/airbyte/pull/) | Add `token_expiry_date` to `complete_oauth_output_specification` so it is hidden from the UI as an OAuth-managed field |
 | 2.0.9 | 2026-03-31 | [75808](https://github.com/airbytehq/airbyte/pull/75808) | Update dependencies |
 | 2.0.8 | 2026-03-11 | [74395](https://github.com/airbytehq/airbyte/pull/74395) | Migrate to scopes object array format |

--- a/docs/integrations/sources/zendesk-talk.md
+++ b/docs/integrations/sources/zendesk-talk.md
@@ -79,7 +79,7 @@ The Zendesk connector should not run into Zendesk API limitations under normal u
 
 | Version | Date       | Pull Request                                             | Subject                                                                     |
 |:--------|:-----------|:---------------------------------------------------------|:----------------------------------------------------------------------------|
-| 2.0.11-rc.1 | 2026-04-09 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Add concurrency support with default_concurrency of 4 |
+| 2.0.11-rc.1 | 2026-04-09 | [76203](https://github.com/airbytehq/airbyte/pull/76203) | Add concurrency support with default_concurrency of 4 |
 | 2.0.10 | 2026-04-06 | [](https://github.com/airbytehq/airbyte/pull/) | Add `token_expiry_date` to `complete_oauth_output_specification` so it is hidden from the UI as an OAuth-managed field |
 | 2.0.9 | 2026-03-31 | [75808](https://github.com/airbytehq/airbyte/pull/75808) | Update dependencies |
 | 2.0.8 | 2026-03-11 | [74395](https://github.com/airbytehq/airbyte/pull/74395) | Migrate to scopes object array format |

--- a/docs/integrations/sources/zendesk-talk.md
+++ b/docs/integrations/sources/zendesk-talk.md
@@ -79,6 +79,7 @@ The Zendesk connector should not run into Zendesk API limitations under normal u
 
 | Version | Date       | Pull Request                                             | Subject                                                                     |
 |:--------|:-----------|:---------------------------------------------------------|:----------------------------------------------------------------------------|
+| 2.0.11-rc.1 | 2026-04-09 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Add concurrency support with default_concurrency of 4 |
 | 2.0.10 | 2026-04-06 | [](https://github.com/airbytehq/airbyte/pull/) | Add `token_expiry_date` to `complete_oauth_output_specification` so it is hidden from the UI as an OAuth-managed field |
 | 2.0.9 | 2026-03-31 | [75808](https://github.com/airbytehq/airbyte/pull/75808) | Update dependencies |
 | 2.0.8 | 2026-03-11 | [74395](https://github.com/airbytehq/airbyte/pull/74395) | Migrate to scopes object array format |


### PR DESCRIPTION
## What

Adds concurrency support and HTTP API budget to `source-zendesk-talk` as part of the concurrency tuning epic ([airbytehq/airbyte-internal-issues#15262](https://github.com/airbytehq/airbyte-internal-issues/issues/15262)). Connector-specific issue: [airbytehq/airbyte-internal-issues#15316](https://github.com/airbytehq/airbyte-internal-issues/issues/15316).

This connector previously had no `concurrency_level` or `HTTPAPIBudget` configured. This PR adds both as an RC for progressive rollout testing on Tier 2 connections before GA promotion.

## How

1. **`manifest.yaml`**: Added a `concurrency_level` block with `default_concurrency: 12` and `max_concurrency: 48`, with comments documenting the Zendesk Talk API rate limits and the calculation rationale.
2. **`manifest.yaml`**: Added an `api_budget` (`HTTPAPIBudget`) block with three `FixedWindowCallRatePolicy` entries matching Zendesk Talk's documented rate limits:
   - **Incremental Exports** (`/stats/incremental/`): 10 requests per minute — applies to `calls` and `call_legs` streams
   - **Current Queue Activity** (`/stats/current_queue_activity`): 2,500 requests per 5 minutes
   - **All endpoints** (catch-all, empty matchers): 15,000 requests per 5 minutes
3. **`metadata.yaml`**: Bumped version to `2.0.11-rc.1` and enabled progressive rollout via `rolloutConfiguration`.
4. **Changelog**: Added entry for the RC version.

**Rate limit rationale**: Per the [implementation guide](https://github.com/airbytehq/airbyte-internal-issues/issues/15262), concurrency is calculated using the **highest** rate limit across all endpoints. The Talk API general limit is 15,000 reqs/5 min = 50 req/sec ([docs](https://developer.zendesk.com/api-reference/voice/talk-api/rate_limits/)). Using the formula `floor(50 / 4) = 12`, giving `default_concurrency: 12` and `max_concurrency: 48` (4× default).

**Budget rationale**: Without a budget, concurrent requests can hammer lower-rate-limit endpoints (especially incremental exports at 10 req/min), causing 429s that are artifacts of missing throttling rather than concurrency being too high. The budget ensures per-endpoint limits are respected even under concurrency.

## Review guide

1. `airbyte-integrations/connectors/source-zendesk-talk/manifest.yaml` — the `concurrency_level` block and `api_budget` block with rate limit comments
2. `airbyte-integrations/connectors/source-zendesk-talk/metadata.yaml` — version bump and rollout config

**Key items for reviewer**:
- [ ] Is `default_concurrency: 12` reasonable given the 50 req/sec Talk API general limit?
- [ ] Is `max_concurrency: 48` appropriate? Lower-tier plans (Team: 200 req/min) have much lower effective limits — progressive rollout monitoring should catch issues, but worth considering.
- [ ] Do the `url_path_pattern` matchers correctly match the request paths used by the connector? Incremental streams use paths like `/stats/incremental/legs` and `/stats/incremental/calls` (relative to the `url_base`).
- [ ] Is the incremental exports budget of 10 req/min sufficient to avoid starving the `calls`/`call_legs` streams under concurrency?

## User Impact

No immediate user impact. This is an RC version behind progressive rollout — only pinned Tier 2 test connections will receive this version initially. Once validated, it will be promoted to GA, at which point all users benefit from concurrent stream reads with proper rate limit protection.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/a8b7ef49ffb0424c93226baac20ab5e3
Requested by: @sophiecuiy