### PR TITLE
feat(source-typeform): add concurrency_level and HTTPAPIBudget for concurrent stream reads

### DIFF
--- a/airbyte-integrations/connectors/source-typeform/manifest.yaml
+++ b/airbyte-integrations/connectors/source-typeform/manifest.yaml
@@ -1,5 +1,11 @@
 version: 4.3.2
 type: DeclarativeSource
+
+concurrency_level:
+  type: ConcurrencyLevel
+  default_concurrency: 4
+  max_concurrency: 8
+
 check:
   type: CheckStream
   stream_names:

--- a/airbyte-integrations/connectors/source-typeform/manifest.yaml
+++ b/airbyte-integrations/connectors/source-typeform/manifest.yaml
@@ -6,6 +6,15 @@ concurrency_level:
   default_concurrency: 4
   max_concurrency: 8
 
+api_budget:
+  type: HTTPAPIBudget
+  policies:
+    - type: FixedWindowCallRatePolicy
+      period: PT1S
+      call_limit: 2
+      matchers:
+        - {}
+
 check:
   type: CheckStream
   stream_names:

--- a/airbyte-integrations/connectors/source-typeform/metadata.yaml
+++ b/airbyte-integrations/connectors/source-typeform/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: e7eff203-90bf-43e5-a240-19ea3056c474
-  dockerImageTag: 1.4.7
+  dockerImageTag: 1.4.8-rc.1
   dockerRepository: airbyte/source-typeform
   documentationUrl: https://docs.airbyte.com/integrations/sources/typeform
   externalDocumentationUrls:
@@ -35,7 +35,7 @@ data:
   releaseStage: generally_available
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
     breakingChanges:
       1.1.0:
         message: This version migrates the Typeform connector to the low-code framework for greater maintainability. This introduces a breaking change to the state format for the `responses` stream. If you are using the incremental sync mode for this stream, you will need to reset affected connections after upgrading to prevent sync failures.

--- a/docs/integrations/sources/typeform.md
+++ b/docs/integrations/sources/typeform.md
@@ -106,6 +106,7 @@ The Forms, Responses, and Webhooks streams make separate API calls for each form
 
 | Version | Date       | Pull Request                                             | Subject                                                                                         |
 |:--------|:-----------|:---------------------------------------------------------|:------------------------------------------------------------------------------------------------|
+| 1.4.8-rc.1 | 2026-04-09 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) | Add concurrency_level for concurrent stream reads |
 | 1.4.7 | 2026-04-02 | [76030](https://github.com/airbytehq/airbyte/pull/76030) | Promoted release candidate to GA |
 | 1.4.7-rc.2 | 2026-03-31 | [75898](https://github.com/airbytehq/airbyte/pull/75898) | Update CDK to 7.15.0 |
 | 1.4.7-rc.1 | 2026-03-26 | [75506](https://github.com/airbytehq/airbyte/pull/75506) | Upgrade CDK version to 7.13.0 |

--- a/docs/integrations/sources/typeform.md
+++ b/docs/integrations/sources/typeform.md
@@ -106,7 +106,7 @@ The Forms, Responses, and Webhooks streams make separate API calls for each form
 
 | Version | Date       | Pull Request                                             | Subject                                                                                         |
 |:--------|:-----------|:---------------------------------------------------------|:------------------------------------------------------------------------------------------------|
-| 1.4.8-rc.1 | 2026-04-09 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) | Add concurrency_level for concurrent stream reads |
+| 1.4.8-rc.1 | 2026-04-09 | [76204](https://github.com/airbytehq/airbyte/pull/76204) | Add concurrency_level for concurrent stream reads |
 | 1.4.7 | 2026-04-02 | [76030](https://github.com/airbytehq/airbyte/pull/76030) | Promoted release candidate to GA |
 | 1.4.7-rc.2 | 2026-03-31 | [75898](https://github.com/airbytehq/airbyte/pull/75898) | Update CDK to 7.15.0 |
 | 1.4.7-rc.1 | 2026-03-26 | [75506](https://github.com/airbytehq/airbyte/pull/75506) | Upgrade CDK version to 7.13.0 |


### PR DESCRIPTION
## What

Adds `concurrency_level` and `HTTPAPIBudget` configuration to `source-typeform` to enable concurrent stream reads as part of the concurrency tuning epic ([airbytehq/airbyte-internal-issues#15262](https://github.com/airbytehq/airbyte-internal-issues/issues/15262), connector issue [#15314](https://github.com/airbytehq/airbyte-internal-issues/issues/15314)).

Budget is included alongside concurrency from the first RC per updated playbook guidance — without budget, lower-rate-limit endpoints get hammered by concurrent requests, causing 429s that are artifacts of missing budget rather than concurrency being too high.

## How

1. **`manifest.yaml`**: Added `concurrency_level` block with `default_concurrency: 4` and `max_concurrency: 8`. The starting value of 4 follows the playbook's special-case override for low-rate-limit APIs (`floor(2/4) = 0 ≤ 2` → start at 4, step 1). Added `api_budget` block with a `FixedWindowCallRatePolicy` of 2 calls per 1-second window, matching Typeform's [documented rate limit](https://www.typeform.com/developers/get-started/#rate-limits).
2. **`metadata.yaml`**: Bumped version to `1.4.8-rc.1` and set `enableProgressiveRollout: true` so this version rolls out progressively to a controlled cohort before GA.
3. **`typeform.md`**: Added changelog entry for `1.4.8-rc.1`.

No user-facing `num_workers` config parameter is exposed — concurrency is controlled entirely via the manifest default during tuning.

## Review guide

1. `airbyte-integrations/connectors/source-typeform/manifest.yaml` — the core change (15 new lines: concurrency + budget)
2. `airbyte-integrations/connectors/source-typeform/metadata.yaml` — version bump + rollout flag
3. `docs/integrations/sources/typeform.md` — changelog entry

**Key review points:**
- Typeform API rate limit is **2 req/s per account**. The `api_budget` enforces this via `FixedWindowCallRatePolicy` with `period: PT1S` and `call_limit: 2`.
- The budget matcher `- {}` is an empty/catch-all matcher — it applies the 2 req/s limit to all HTTP requests made by the connector.
- `default_concurrency: 4` with `max_concurrency: 8` allows up to 4 streams to read concurrently, while the budget ensures the aggregate request rate stays within the API limit.

**Human review checklist:**
- [ ] Verify `FixedWindowCallRatePolicy` with `period: PT1S` and `call_limit: 2` correctly represents "2 requests per second"
- [ ] Verify empty matcher `- {}` is the correct catch-all pattern for applying the budget to all requests
- [ ] Confirm `default_concurrency: 4` is appropriate given the 2 req/s budget constraint

## User Impact

No immediate user-facing impact. This RC version will be progressively rolled out to a controlled Tier 2 cohort (~34 actors) behind `enableProgressiveRollout: true`. Users on the stable version (1.4.7) are unaffected.

If tuning succeeds, users will eventually see faster syncs from concurrent stream reads.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Reverting restores `1.4.7` as the current version with no concurrency or budget. The progressive rollout can also be canceled independently via the rollout system.

Link to Devin session: https://app.devin.ai/sessions/6dcb0ce3acb04fdaa5d90bad560ac37f
Requested by: @sophiecuiy
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/76204" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
