### PR TITLE
fix(source-woocommerce): Add HTTPAPIBudget, concurrency_level, and num_workers

### DIFF
--- a/airbyte-integrations/connectors/source-woocommerce/manifest.yaml
+++ b/airbyte-integrations/connectors/source-woocommerce/manifest.yaml
@@ -978,6 +978,21 @@ streams:
   - $ref: "#/definitions/streams/tax_classes"
   - $ref: "#/definitions/streams/tax_rates"
 
+# Rate limits: https://woocommerce.github.io/woocommerce-rest-api-docs/#request/response-format
+# WooCommerce REST API does not have built-in rate limiting by default.
+# Actual rate limits depend on the hosting provider (shared hosting typically 2-5 req/s).
+# Returns HTTP 429 when rate limited by the host.
+api_budget:
+  type: HTTPAPIBudget
+  policies:
+    - type: MovingWindowCallRatePolicy
+      rates:
+        - limit: 5
+          interval: PT1S
+      matchers: []
+  status_codes_for_ratelimit_hit:
+    - 429
+
 concurrency_level:
   type: ConcurrencyLevel
   default_concurrency: "{{ config.get('num_workers', 4) }}"

--- a/airbyte-integrations/connectors/source-woocommerce/manifest.yaml
+++ b/airbyte-integrations/connectors/source-woocommerce/manifest.yaml
@@ -978,6 +978,11 @@ streams:
   - $ref: "#/definitions/streams/tax_classes"
   - $ref: "#/definitions/streams/tax_rates"
 
+concurrency_level:
+  type: ConcurrencyLevel
+  default_concurrency: "{{ config.get('num_workers', 4) }}"
+  max_concurrency: 12
+
 spec:
   type: Spec
   connection_specification:
@@ -1017,6 +1022,18 @@ spec:
         pattern: ^[0-9]{4}-[0-9]{2}-[0-9]{2}$
         examples:
           - "2021-01-01"
+      num_workers:
+        type: integer
+        title: Number of Concurrent Workers
+        description: >-
+          The number of worker threads to use for the sync. Higher values can
+          speed up syncs but may hit rate limits. WooCommerce API rate limits
+          depend on the hosting provider. More info at
+          https://woocommerce.github.io/woocommerce-rest-api-docs/
+        default: 4
+        minimum: 2
+        maximum: 12
+        order: 4
     additionalProperties: true
 
 metadata:

--- a/airbyte-integrations/connectors/source-woocommerce/metadata.yaml
+++ b/airbyte-integrations/connectors/source-woocommerce/metadata.yaml
@@ -8,7 +8,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 2a2552ca-9f78-4c1c-9eb7-4d0dc66d72df
-  dockerImageTag: 0.5.34
+  dockerImageTag: 0.5.35-rc.1
   dockerRepository: airbyte/source-woocommerce
   documentationUrl: https://docs.airbyte.com/integrations/sources/woocommerce
   githubIssueLabel: source-woocommerce
@@ -28,7 +28,7 @@ data:
   releaseStage: generally_available
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
   suggestedStreams:
     streams:
       - orders

--- a/docs/integrations/sources/woocommerce.md
+++ b/docs/integrations/sources/woocommerce.md
@@ -122,6 +122,7 @@ maximum number of seconds between API calls.
 
 | Version | Date       | Pull Request                                             | Subject                                                                |
 |:--------| :--------- |:---------------------------------------------------------|:-----------------------------------------------------------------------|
+| 0.5.35-rc.1 | 2026-04-09 | [76XXX](https://github.com/airbytehq/airbyte/pull/76XXX) | Add concurrency_level and num_workers for concurrent stream syncing |
 | 0.5.34 | 2026-03-31 | [75853](https://github.com/airbytehq/airbyte/pull/75853) | Update dependencies |
 | 0.5.33 | 2026-03-24 | [75380](https://github.com/airbytehq/airbyte/pull/75380) | Update dependencies |
 | 0.5.32 | 2026-03-10 | [74674](https://github.com/airbytehq/airbyte/pull/74674) | Update dependencies |

--- a/docs/integrations/sources/woocommerce.md
+++ b/docs/integrations/sources/woocommerce.md
@@ -122,7 +122,7 @@ maximum number of seconds between API calls.
 
 | Version | Date       | Pull Request                                             | Subject                                                                |
 |:--------| :--------- |:---------------------------------------------------------|:-----------------------------------------------------------------------|
-| 0.5.35-rc.1 | 2026-04-09 | [76XXX](https://github.com/airbytehq/airbyte/pull/76XXX) | Add concurrency_level and num_workers for concurrent stream syncing |
+| 0.5.35-rc.1 | 2026-04-09 | [76205](https://github.com/airbytehq/airbyte/pull/76205) | Add concurrency_level and num_workers for concurrent stream syncing |
 | 0.5.34 | 2026-03-31 | [75853](https://github.com/airbytehq/airbyte/pull/75853) | Update dependencies |
 | 0.5.33 | 2026-03-24 | [75380](https://github.com/airbytehq/airbyte/pull/75380) | Update dependencies |
 | 0.5.32 | 2026-03-10 | [74674](https://github.com/airbytehq/airbyte/pull/74674) | Update dependencies |


### PR DESCRIPTION
## What

Adds concurrent stream syncing and rate limiting to `source-woocommerce` as part of the concurrency tuning initiative ([airbytehq/airbyte-internal-issues#15315](https://github.com/airbytehq/airbyte-internal-issues/issues/15315)). Both `HTTPAPIBudget` and `concurrency_level` are included from the first RC to prevent 429s from concurrent requests hitting lower-rate-limit endpoints without budget protection.

Supersedes draft PR #74710, which used incorrect version (`0.5.33-rc.1` vs current stable `0.5.34`) and downgraded the base image.

## How

- **`manifest.yaml`**:
  - Added `api_budget` block (`HTTPAPIBudget` with `MovingWindowCallRatePolicy` at 5 req/s, `matchers: []` for global application, 429 status code handling).
  - Added `concurrency_level` block (`ConcurrencyLevel` type) with `default_concurrency` of 4 (configurable via `num_workers`) and `max_concurrency` of 12.
  - Added `num_workers` as a user-facing spec property (integer, default 4, min 2, max 12).
- **`metadata.yaml`**: Bumped version `0.5.34` → `0.5.35-rc.1`, enabled progressive rollout.
- **`woocommerce.md`**: Added changelog entry for `0.5.35-rc.1`.

**Why concurrency=4 and budget=5 req/s:**
WooCommerce has no built-in API rate limiting; limits depend on hosting provider (typically 2-5 req/s for shared hosting). Using `max_rate_limit=5`: `floor(5/4)=1 ≤ 2`, triggering the special-case override to `starting_concurrency=4, step=1`. The 5 req/s budget is a conservative estimate for shared hosting environments.

## Review guide

1. `airbyte-integrations/connectors/source-woocommerce/manifest.yaml` — core changes: `api_budget`, `concurrency_level`, and `num_workers` spec field
2. `airbyte-integrations/connectors/source-woocommerce/metadata.yaml` — version bump + progressive rollout toggle
3. `docs/integrations/sources/woocommerce.md` — changelog entry

**Items requiring reviewer attention:**
- **`ConcurrencyLevel` type validity** — No other connector on `master` currently uses this type in a declarative manifest. Confirm it is a supported component in the CDK.
- **Jinja template** — `{{ config.get('num_workers', 4) }}` for `default_concurrency`. Confirm the CDK evaluates this correctly at runtime.
- **`matchers: []`** — Applies the 5 req/s rate limit globally to all requests. WooCommerce uses the same base endpoint (`/wp-json/wc/v3/*`) for all streams with no per-endpoint rate differentiation, so global application is intentional.
- **5 req/s budget** — Conservative estimate for shared hosting. No standard rate limit headers from WooCommerce (no `X-RateLimit-*` or `Retry-After`), so the connector relies on 429 status codes only.

## User Impact

Users gain a new optional `num_workers` config parameter (default: 4) to control sync concurrency. Syncs may complete faster for users with hosting that supports concurrent API requests. The 5 req/s rate budget protects against overwhelming rate-limited hosts. This is released as an RC (`0.5.35-rc.1`) behind progressive rollout — only pinned Tier 2 actors will receive it initially.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/83379dc67b60439e8a938baf68280b2c
Requested by: @sophiecuiy
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/76205" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
