### PR TITLE
feat(source-tiktok-marketing): add oauthConnectorInputSpecification

### DIFF
--- a/airbyte-integrations/connectors/source-tiktok-marketing/manifest.yaml
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/manifest.yaml
@@ -5984,6 +5984,16 @@ spec:
       - auth_type
     predicate_value: oauth2.0
     oauth_config_specification:
+      oauth_connector_input_specification:
+        consent_url: "https://business-api.tiktok.com/portal/auth?app_id={{client_id_value}}&redirect_uri={{redirect_uri_value}}&state={{state_value}}&response_type=code"
+        access_token_url: "https://business-api.tiktok.com/open_api/v1.3/oauth2/access_token/"
+        access_token_params:
+          grant_type: "authorization_code"
+          auth_code: "{{ auth_code_value }}"
+          app_id: "{{ client_id_value }}"
+          secret: "{{ client_secret_value }}"
+        extract_output:
+          - access_token
       complete_oauth_output_specification:
         title: CompleteOauthOutputSpecification
         type: object

--- a/airbyte-integrations/connectors/source-tiktok-marketing/metadata.yaml
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 4bfac00d-ce15-44ff-95b9-9e3c3e8fbd35
-  dockerImageTag: 5.0.5
+  dockerImageTag: 5.0.6
   dockerRepository: airbyte/source-tiktok-marketing
   documentationUrl: https://docs.airbyte.com/integrations/sources/tiktok-marketing
   externalDocumentationUrls:

--- a/docs/integrations/sources/tiktok-marketing.md
+++ b/docs/integrations/sources/tiktok-marketing.md
@@ -155,6 +155,7 @@ For information on breaking changes and migration steps, see the [TikTok Marketi
 
 | Version    | Date       | Pull Request                                              | Subject                                                                                                                                                                |
 |:-----------|:-----------|:----------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 5.0.6 | 2026-04-10 | [76215](https://github.com/airbytehq/airbyte/pull/76215) | feat(source-tiktok-marketing): add oauthConnectorInputSpecification |
 | 5.0.5 | 2026-03-31 | [75063](https://github.com/airbytehq/airbyte/pull/75063) | Update dependencies |
 | 5.0.4 | 2026-03-23 | [74376](https://github.com/airbytehq/airbyte/pull/74376) | Handle TikTok API error 60001 (service maintenance) as retryable instead of fatal; ignore error 40002 (resource not accessible or does not exist) |
 | 5.0.3 | 2026-03-12 | [74762](https://github.com/airbytehq/airbyte/pull/74762) | Promoting release candidate 5.0.3-rc.1 to a main version. |
@@ -166,29 +167,29 @@ For information on breaking changes and migration steps, see the [TikTok Marketi
 | 4.8.13 | 2026-01-20 | [64958](https://github.com/airbytehq/airbyte/pull/64958) | Update dependencies |
 | 4.8.12 | 2026-01-15 | [70241](https://github.com/airbytehq/airbyte/pull/70241) | Fix `pixel_events_statistics` stream: `pixel_ids` format, `date_range` calculation, and add error handler to skip advertisers without pixel permissions |
 | 4.8.11 | 2026-01-15 | [71773](https://github.com/airbytehq/airbyte/pull/71773) | Finalize progressive rollout for version 4.8.11 |
-| 4.8.11-rc.1| 2025-11-14 | [65623](https://github.com/airbytehq/airbyte/pull/65623) | Fix missing deleted data on some streams                                                                                                                               |
-| 4.8.10     | 2025-11-04 | [69170](https://github.com/airbytehq/airbyte/pull/69170) | Revert api budget and concurrency back to a safe number                                                                                                                |
-| 4.8.9      | 2025-10-30 | [69101](https://github.com/airbytehq/airbyte/pull/69101) | Revert aggressive rate limiting                                                                                                                                        |
-| 4.8.8      | 2025-10-29 | [69082](https://github.com/airbytehq/airbyte/pull/69082) | Aggressively fail on rate limiting issues                                                                                                                              |
-| 4.8.7      | 2025-10-29 | [69081](https://github.com/airbytehq/airbyte/pull/69081) | Reduce concurrency                                                                                                                                                     |
-| 4.8.6      | 2025-10-29 | [69075](https://github.com/airbytehq/airbyte/pull/69075) | Add API Budget                                                                                                                                                         |
-| 4.8.5      | 2025-10-29 | [69074](https://github.com/airbytehq/airbyte/pull/69074) | Improving on rate limiting issue.                                                                                                                                      |
-| 4.8.4      | 2025-10-08 | [67432](https://github.com/airbytehq/airbyte/pull/67432) | Promoting release candidate 4.8.4 to a main version.                                                                                                                   |
-| 4.8.4-rc.1 | 2025-09-30 | [66823](https://github.com/airbytehq/airbyte/pull/66823) | Up CDK version to 7.                                                                                                                                                   |
-| 4.8.3      | 2025-09-23 | [66584](https://github.com/airbytehq/airbyte/pull/66584) | Promoting release candidate 4.8.3-rc.1 to a main version.                                                                                                              |
-| 4.8.3-rc.1 | 2025-09-16 | [62058](https://github.com/airbytehq/airbyte/pull/62058) | Add new video metrics in `ads_reports` streams                                                                                                                         |
-| 4.8.2      | 2025-09-16 | [66233](https://github.com/airbytehq/airbyte/pull/66233) | Promoting release candidate 4.8.2-rc.1 to a main version.                                                                                                              |
-| 4.8.2-rc.1 | 2025-09-11 | [65527](https://github.com/airbytehq/airbyte/pull/65527) | Fix missing records for hourly streams: remove record filter                                                                                                           |
-| 4.8.1      | 2025-09-11 | [66161](https://github.com/airbytehq/airbyte/pull/66161) | Promoting release candidate 4.8.1-rc.1 to a main version.                                                                                                              |
-| 4.8.1-rc.1 | 2025-09-05 | [65602](https://github.com/airbytehq/airbyte/pull/65602) | Add record filter to `ads` stream to filter records without `modify_time`.                                                                                             |
-| 4.8.0      | 2025-06-24 | [62048](https://github.com/airbytehq/airbyte/pull/62048) | Promoting release candidate 4.8.0-rc.1 to a main version.                                                                                                              |
-| 4.8.0-rc.1 | 2025-06-16 | [61580](https://github.com/airbytehq/airbyte/pull/61580)  | Convert to manifest-only format                                                                                                                                        |
-| 4.7.0      | 2025-03-10 | [55681](https://github.com/airbytehq/airbyte/pull/55681)  | Ads / AdGroups report by country streams                                                                                                                               |
-| 4.6.2      | 2024-10-30 | [48003](https://github.com/airbytehq/airbyte/pull/48003) | Add new metrics to ads_reports_daily stream                                                                                                                            |
-| 4.6.1      | 2025-03-22 | [51959](https://github.com/airbytehq/airbyte/pull/51959) | Update dependencies                                                                                                                                                    |
-| 4.6.0      | 2025-03-09 | [55669](https://github.com/airbytehq/airbyte/pull/55669)  | Add `Pixels`, `PixelInstantPageEvents`, `PixelEventsStatistics` streams                                                                                                |
-| 4.5.0      | 2025-03-07 | [45081](https://github.com/airbytehq/airbyte/pull/45081)  | Add SparkAds stream                                                                                                                                                    |
-| 4.4.0      | 2025-03-07 | [55242](https://github.com/airbytehq/airbyte/pull/55242)  | Promoting release candidate 4.4.0-rc3 to a main version.                                                                                                               |
+| 4.8.11-rc.1 | 2025-11-14 | [65623](https://github.com/airbytehq/airbyte/pull/65623) | Fix missing deleted data on some streams |
+| 4.8.10 | 2025-11-04 | [69170](https://github.com/airbytehq/airbyte/pull/69170) | Revert api budget and concurrency back to a safe number |
+| 4.8.9 | 2025-10-30 | [69101](https://github.com/airbytehq/airbyte/pull/69101) | Revert aggressive rate limiting |
+| 4.8.8 | 2025-10-29 | [69082](https://github.com/airbytehq/airbyte/pull/69082) | Aggressively fail on rate limiting issues |
+| 4.8.7 | 2025-10-29 | [69081](https://github.com/airbytehq/airbyte/pull/69081) | Reduce concurrency |
+| 4.8.6 | 2025-10-29 | [69075](https://github.com/airbytehq/airbyte/pull/69075) | Add API Budget |
+| 4.8.5 | 2025-10-29 | [69074](https://github.com/airbytehq/airbyte/pull/69074) | Improving on rate limiting issue. |
+| 4.8.4 | 2025-10-08 | [67432](https://github.com/airbytehq/airbyte/pull/67432) | Promoting release candidate 4.8.4 to a main version. |
+| 4.8.4-rc.1 | 2025-09-30 | [66823](https://github.com/airbytehq/airbyte/pull/66823) | Up CDK version to 7. |
+| 4.8.3 | 2025-09-23 | [66584](https://github.com/airbytehq/airbyte/pull/66584) | Promoting release candidate 4.8.3-rc.1 to a main version. |
+| 4.8.3-rc.1 | 2025-09-16 | [62058](https://github.com/airbytehq/airbyte/pull/62058) | Add new video metrics in `ads_reports` streams |
+| 4.8.2 | 2025-09-16 | [66233](https://github.com/airbytehq/airbyte/pull/66233) | Promoting release candidate 4.8.2-rc.1 to a main version. |
+| 4.8.2-rc.1 | 2025-09-11 | [65527](https://github.com/airbytehq/airbyte/pull/65527) | Fix missing records for hourly streams: remove record filter |
+| 4.8.1 | 2025-09-11 | [66161](https://github.com/airbytehq/airbyte/pull/66161) | Promoting release candidate 4.8.1-rc.1 to a main version. |
+| 4.8.1-rc.1 | 2025-09-05 | [65602](https://github.com/airbytehq/airbyte/pull/65602) | Add record filter to `ads` stream to filter records without `modify_time`. |
+| 4.8.0 | 2025-06-24 | [62048](https://github.com/airbytehq/airbyte/pull/62048) | Promoting release candidate 4.8.0-rc.1 to a main version. |
+| 4.8.0-rc.1 | 2025-06-16 | [61580](https://github.com/airbytehq/airbyte/pull/61580) | Convert to manifest-only format |
+| 4.7.0 | 2025-03-10 | [55681](https://github.com/airbytehq/airbyte/pull/55681) | Ads / AdGroups report by country streams |
+| 4.6.2 | 2024-10-30 | [48003](https://github.com/airbytehq/airbyte/pull/48003) | Add new metrics to ads_reports_daily stream |
+| 4.6.1 | 2025-03-22 | [51959](https://github.com/airbytehq/airbyte/pull/51959) | Update dependencies |
+| 4.6.0 | 2025-03-09 | [55669](https://github.com/airbytehq/airbyte/pull/55669) | Add `Pixels`, `PixelInstantPageEvents`, `PixelEventsStatistics` streams |
+| 4.5.0 | 2025-03-07 | [45081](https://github.com/airbytehq/airbyte/pull/45081) | Add SparkAds stream |
+| 4.4.0 | 2025-03-07 | [55242](https://github.com/airbytehq/airbyte/pull/55242) | Promoting release candidate 4.4.0-rc3 to a main version. |
 | 4.4.0-rc3  | 2025-03-04 | [55194](https://github.com/airbytehq/airbyte/pull/55194)  | Resolve state format issue                                                                                                                                             |
 | 4.4.0-rc2  | 2025-02-20 | [53645](https://github.com/airbytehq/airbyte/pull/53645) | Remove stream_state interpolation and custom cursors                                                                                                                   |
 | 4.4.0-rc1  | 2025-01-29 | [51584](https://github.com/airbytehq/airbyte/pull/51584)  | Update to concurrent CDK                                                                                                                                               |


### PR DESCRIPTION
## What
Add `oauthConnectorInputSpecification` to source-tiktok-marketing as part of the Granular OAuth Scopes project (airbyte-internal-issues#16023).

## How
- Add `oauth_connector_input_specification` block to the existing `advanced_auth.oauth_config_specification`
- Define TikTok Business API consent URL and access token URL
- TikTok uses non-standard field names (`app_id`, `secret`, `auth_code`) instead of standard OAuth names — reflected in `access_token_params`