### PR TITLE
feat(source-typeform): add oauthConnectorInputSpecification with scopes array

### DIFF
--- a/airbyte-integrations/connectors/source-typeform/manifest.yaml
+++ b/airbyte-integrations/connectors/source-typeform/manifest.yaml
@@ -1894,6 +1894,27 @@ spec:
       - auth_type
     predicate_value: oauth2.0
     oauth_config_specification:
+      oauth_connector_input_specification:
+        consent_url: "https://api.typeform.com/oauth/authorize?{{client_id_param}}&{{redirect_uri_param}}&{{scopes_param}}&{{state_param}}&response_type=code"
+        access_token_url: "https://api.typeform.com/oauth/token"
+        scopes:
+          - scope: "responses:read"
+          - scope: "forms:read"
+          - scope: "accounts:read"
+          - scope: "workspaces:read"
+          - scope: "images:read"
+          - scope: "themes:read"
+          - scope: "hooks:read"
+          - scope: "hooks:write"
+        access_token_params:
+          grant_type: "authorization_code"
+          code: "{{ auth_code_value }}"
+          client_id: "{{ client_id_value }}"
+          client_secret: "{{ client_secret_value }}"
+          redirect_uri: "{{ redirect_uri_value }}"
+        extract_output:
+          - access_token
+          - refresh_token
       complete_oauth_output_specification:
         type: object
         properties:


### PR DESCRIPTION
## What
Add `oauthConnectorInputSpecification` to source-typeform with structured `scopes` array format, as part of the Granular OAuth Scopes project (airbyte-internal-issues#16023).

## How
- Add `oauth_connector_input_specification` block to the existing `advanced_auth.oauth_config_specification`
- Define Typeform consent URL, access token URL, and `scopes` array covering all read scopes plus hooks write
- Add standard `access_token_params` and `extract_output` fields (both access_token and refresh_token)