### PR TITLE
feat(source-microsoft-teams): add oauthConnectorInputSpecification with scopes array

### DIFF
--- a/airbyte-integrations/connectors/source-microsoft-teams/manifest.yaml
+++ b/airbyte-integrations/connectors/source-microsoft-teams/manifest.yaml
@@ -5854,6 +5854,19 @@ spec:
       - auth_type
     predicate_value: Client
     oauth_config_specification:
+      oauth_connector_input_specification:
+        consent_url: "https://login.microsoftonline.com/{{tenant_id}}/oauth2/v2.0/authorize?{{client_id_param}}&{{redirect_uri_param}}&{{scopes_param}}&{{state_param}}&response_type=code"
+        access_token_url: "https://login.microsoftonline.com/{{tenant_id}}/oauth2/v2.0/token"
+        scopes:
+          - scope: "https://graph.microsoft.com/.default"
+        access_token_params:
+          grant_type: "authorization_code"
+          code: "{{ auth_code_value }}"
+          client_id: "{{ client_id_value }}"
+          client_secret: "{{ client_secret_value }}"
+          redirect_uri: "{{ redirect_uri_value }}"
+        extract_output:
+          - refresh_token
       complete_oauth_output_specification:
         type: object
         additionalProperties: false

--- a/airbyte-integrations/connectors/source-microsoft-teams/metadata.yaml
+++ b/airbyte-integrations/connectors/source-microsoft-teams/metadata.yaml
@@ -19,7 +19,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: eaf50f04-21dd-4620-913b-2a83f5635227
-  dockerImageTag: 1.2.15
+  dockerImageTag: 1.2.16
   dockerRepository: airbyte/source-microsoft-teams
   githubIssueLabel: source-microsoft-teams
   icon: microsoft-teams.svg

--- a/docs/integrations/sources/microsoft-teams.md
+++ b/docs/integrations/sources/microsoft-teams.md
@@ -164,6 +164,7 @@ Token acquiring implemented by [instantiate](https://docs.microsoft.com/en-us/az
 
 | Version | Date       | Pull Request                                             | Subject                        |
 | :------ | :--------- | :------------------------------------------------------- | :----------------------------- |
+| 1.2.16 | 2026-04-10 | [76218](https://github.com/airbytehq/airbyte/pull/76218) | feat(source-microsoft-teams): add oauthConnectorInputSpecification with scopes array |
 | 1.2.15 | 2026-03-31 | [75805](https://github.com/airbytehq/airbyte/pull/75805) | Update dependencies |
 | 1.2.14 | 2026-03-17 | [74567](https://github.com/airbytehq/airbyte/pull/74567) | Update dependencies |
 | 1.2.13 | 2026-03-03 | [73414](https://github.com/airbytehq/airbyte/pull/73414) | Update dependencies |


### PR DESCRIPTION
## What
Add `oauthConnectorInputSpecification` to source-microsoft-teams with structured `scopes` array format, as part of the Granular OAuth Scopes project (airbyte-internal-issues#16023).

## How
- Add `oauth_connector_input_specification` block to the existing `advanced_auth.oauth_config_specification`
- Define Microsoft consent URL and token URL (tenant-aware, using `{{tenant_id}}` placeholder)
- Add `scopes` array with `https://graph.microsoft.com/.default` scope
- Add standard `access_token_params` and `extract_output` fields