### PR TITLE
feat(source-microsoft-sharepoint): migrate scope string to scopes array in oauthConnectorInputSpecification

### DIFF
--- a/airbyte-integrations/connectors/source-microsoft-sharepoint/metadata.yaml
+++ b/airbyte-integrations/connectors/source-microsoft-sharepoint/metadata.yaml
@@ -20,7 +20,7 @@ data:
   connectorSubtype: file
   connectorType: source
   definitionId: 59353119-f0f2-4e5a-a8ba-15d887bc34f6
-  dockerImageTag: 0.10.4
+  dockerImageTag: 0.10.5
   dockerRepository: airbyte/source-microsoft-sharepoint
   githubIssueLabel: source-microsoft-sharepoint
   icon: microsoft-sharepoint.svg

--- a/airbyte-integrations/connectors/source-microsoft-sharepoint/pyproject.toml
+++ b/airbyte-integrations/connectors/source-microsoft-sharepoint/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "0.10.4"
+version = "0.10.5"
 name = "source-microsoft-sharepoint"
 description = "Source implementation for Microsoft SharePoint."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-microsoft-sharepoint/source_microsoft_sharepoint/source.py
+++ b/airbyte-integrations/connectors/source-microsoft-sharepoint/source_microsoft_sharepoint/source.py
@@ -51,8 +51,6 @@ class SourceMicrosoftSharePoint(FileBasedSource):
             .set_path("/{{tenant_id}}/oauth2/v2.0/token")
             .build()
         )
-        scopes = " ".join(SourceMicrosoftSharePoint.SCOPES)
-
         oauth_connector_input_specification = OauthConnectorInputSpecification(
             consent_url=consent_url,
             access_token_url=access_token_url,
@@ -66,7 +64,7 @@ class SourceMicrosoftSharePoint(FileBasedSource):
                 "client_secret": "{{ client_secret_value }}",
                 "grant_type": "authorization_code",
             },
-            scope=scopes,
+            scopes=[{"scope": s} for s in SourceMicrosoftSharePoint.SCOPES],
         )
 
         return ConnectorSpecification(

--- a/docs/integrations/sources/microsoft-sharepoint.md
+++ b/docs/integrations/sources/microsoft-sharepoint.md
@@ -306,6 +306,7 @@ The connector is restricted by normal Microsoft Graph [requests limitation](http
 
 | Version | Date       | Pull Request                                             | Subject                                                                   |
 |:--------|:-----------|:---------------------------------------------------------|:--------------------------------------------------------------------------|
+| 0.10.5 | 2026-04-10 | [76219](https://github.com/airbytehq/airbyte/pull/76219) | feat(source-microsoft-sharepoint): migrate scope string to scopes array in oauthConnectorInputSpecification |
 | 0.10.4 | 2025-08-21 | [65118](https://github.com/airbytehq/airbyte/pull/65118) | Decertify connector |
 | 0.10.3 | 2025-07-13 | [60562](https://github.com/airbytehq/airbyte/pull/60562) | Update dependencies |
 | 0.10.2 | 2025-05-10 | [59113](https://github.com/airbytehq/airbyte/pull/59113) | Update dependencies |


### PR DESCRIPTION
## What
Migrates the OAuth scope configuration in source-microsoft-sharepoint from a single concatenated `scope` string to a structured `scopes` array in `OauthConnectorInputSpecification`.

## How
Updated `source.py` to pass `scopes=[{"scope": s} for s in SourceMicrosoftSharePoint.SCOPES]` instead of building a space-separated `scope` string. This aligns with the granular OAuth scopes format expected by the CDK.