### PR TITLE
feat(source-outlook): add oauthConnectorInputSpecification with granular scopes

### DIFF
--- a/airbyte-integrations/connectors/source-outlook/manifest.yaml
+++ b/airbyte-integrations/connectors/source-outlook/manifest.yaml
@@ -562,6 +562,60 @@ spec:
         title: Refresh Token
         airbyte_secret: true
     additionalProperties: true
+  advanced_auth:
+    auth_flow_type: oauth2_0
+    oauth_config_specification:
+      oauth_connector_input_specification:
+        consent_url: "https://login.microsoftonline.com/{{tenant_id}}/oauth2/v2.0/authorize?{{client_id_param}}&{{redirect_uri_param}}&{{scopes_param}}&{{state_param}}&response_type=code"
+        access_token_url: "https://login.microsoftonline.com/{{tenant_id}}/oauth2/v2.0/token"
+        scopes:
+          - scope: "https://graph.microsoft.com/Mail.Read"
+          - scope: "https://graph.microsoft.com/User.Read"
+          - scope: "offline_access"
+        access_token_params:
+          grant_type: "authorization_code"
+          code: "{{ auth_code_value }}"
+          client_id: "{{ client_id_value }}"
+          client_secret: "{{ client_secret_value }}"
+          redirect_uri: "{{ redirect_uri_value }}"
+        extract_output:
+          - refresh_token
+      complete_oauth_output_specification:
+        type: object
+        additionalProperties: false
+        properties:
+          refresh_token:
+            type: string
+            path_in_connector_config:
+              - refresh_token
+      complete_oauth_server_input_specification:
+        type: object
+        additionalProperties: false
+        properties:
+          client_id:
+            type: string
+          client_secret:
+            type: string
+      complete_oauth_server_output_specification:
+        type: object
+        additionalProperties: false
+        properties:
+          client_id:
+            type: string
+            path_in_connector_config:
+              - client_id
+          client_secret:
+            type: string
+            path_in_connector_config:
+              - client_secret
+      oauth_user_input_from_connector_config_specification:
+        type: object
+        additionalProperties: false
+        properties:
+          tenant_id:
+            type: string
+            path_in_connector_config:
+              - tenant_id
 
 metadata:
   assist:

--- a/airbyte-integrations/connectors/source-outlook/manifest.yaml
+++ b/airbyte-integrations/connectors/source-outlook/manifest.yaml
@@ -563,7 +563,7 @@ spec:
         airbyte_secret: true
     additionalProperties: true
   advanced_auth:
-    auth_flow_type: oauth2_0
+    auth_flow_type: oauth2.0
     oauth_config_specification:
       oauth_connector_input_specification:
         consent_url: "https://login.microsoftonline.com/{{tenant_id}}/oauth2/v2.0/authorize?{{client_id_param}}&{{redirect_uri_param}}&{{scopes_param}}&{{state_param}}&response_type=code"

--- a/airbyte-integrations/connectors/source-outlook/metadata.yaml
+++ b/airbyte-integrations/connectors/source-outlook/metadata.yaml
@@ -16,7 +16,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 886bdbfe-7935-4d96-b097-e3c1db73b951
-  dockerImageTag: 0.0.16
+  dockerImageTag: 0.0.17
   dockerRepository: airbyte/source-outlook
   githubIssueLabel: source-outlook
   icon: icon.svg

--- a/docs/integrations/sources/outlook.md
+++ b/docs/integrations/sources/outlook.md
@@ -129,6 +129,7 @@ For more information about Microsoft Graph Mail API capabilities, see the [Micro
 
 | Version          | Date              | Pull Request | Subject        |
 |------------------|-------------------|--------------|----------------|
+| 0.0.17 | 2026-04-10 | [76220](https://github.com/airbytehq/airbyte/pull/76220) | Add oauthConnectorInputSpecification with granular scopes |
 | 0.0.16 | 2026-03-17 | [74968](https://github.com/airbytehq/airbyte/pull/74968) | Update dependencies |
 | 0.0.15 | 2026-03-03 | [73816](https://github.com/airbytehq/airbyte/pull/73816) | Update dependencies |
 | 0.0.14 | 2026-01-20 | [72166](https://github.com/airbytehq/airbyte/pull/72166) | Update dependencies |


### PR DESCRIPTION
## What
Adds `oauthConnectorInputSpecification` to source-outlook with granular OAuth scopes: `Mail.Read`, `User.Read`, and `offline_access`.

## How
Added a full `advanced_auth` block to the manifest spec with:
- Tenant-aware consent and token URLs (`login.microsoftonline.com/{tenant_id}/...`)
- Scopes array with the three Microsoft Graph permissions the connector requires
- OAuth output/server/user-input specifications mapping to the flat config fields (`client_id`, `client_secret`, `refresh_token`, `tenant_id`)

Bumped connector version to `0.0.17`.