### PR TITLE
feat(source-youtube-analytics): add oauthConnectorInputSpecification with granular scopes

### DIFF
--- a/airbyte-integrations/connectors/source-youtube-analytics/manifest.yaml
+++ b/airbyte-integrations/connectors/source-youtube-analytics/manifest.yaml
@@ -548,6 +548,13 @@ spec:
   advanced_auth:
     auth_flow_type: oauth2.0
     oauth_config_specification:
+      oauth_connector_input_specification:
+        consent_url: "https://accounts.google.com/o/oauth2/v2/auth?{{client_id_param}}&{{redirect_uri_param}}&response_type=code&{{scopes_param}}&access_type=offline&{{state_param}}&include_granted_scopes=true&prompt=consent"
+        access_token_url: "https://oauth2.googleapis.com/token?{{client_id_param}}&{{client_secret_param}}&{{auth_code_param}}&{{redirect_uri_param}}&grant_type=authorization_code"
+        scopes:
+          - scope: "https://www.googleapis.com/auth/yt-analytics.readonly"
+        extract_output:
+          - refresh_token
       complete_oauth_output_specification:
         type: object
         additionalProperties: true

--- a/airbyte-integrations/connectors/source-youtube-analytics/metadata.yaml
+++ b/airbyte-integrations/connectors/source-youtube-analytics/metadata.yaml
@@ -8,7 +8,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: afa734e4-3571-11ec-991a-1e0031268139
-  dockerImageTag: 1.2.3
+  dockerImageTag: 1.2.4
   dockerRepository: airbyte/source-youtube-analytics
   documentationUrl: https://docs.airbyte.com/integrations/sources/youtube-analytics
   githubIssueLabel: source-youtube-analytics

--- a/docs/integrations/sources/youtube-analytics.md
+++ b/docs/integrations/sources/youtube-analytics.md
@@ -96,6 +96,7 @@ The connector retrieves bulk report data from YouTube's reporting jobs, which mi
 
 | Version    | Date       | Pull Request                                             | Subject                                             |
 |:-----------|:-----------|:---------------------------------------------------------|:----------------------------------------------------|
+| 1.2.4 | 2026-04-10 | [76221](https://github.com/airbytehq/airbyte/pull/76221) | Add oauthConnectorInputSpecification with granular scopes |
 | 1.2.3 | 2026-02-24 | [73149](https://github.com/airbytehq/airbyte/pull/73149) | Update dependencies |
 | 1.2.2 | 2026-02-03 | [72635](https://github.com/airbytehq/airbyte/pull/72635) | Update dependencies |
 | 1.2.1 | 2026-01-20 | [72048](https://github.com/airbytehq/airbyte/pull/72048) | Update dependencies |


### PR DESCRIPTION
## What
Adds `oauth_connector_input_specification` to source-youtube-analytics with the `yt-analytics.readonly` Google OAuth scope.

## How
Inserted `oauth_connector_input_specification` into the existing `advanced_auth.oauth_config_specification` block with:
- Google consent URL (with `access_type=offline&prompt=consent` for refresh token support)
- Google token exchange URL
- Scope: `https://www.googleapis.com/auth/yt-analytics.readonly`

Bumped connector version to `1.2.4`.