### PR TITLE
feat(source-xero): add oauthConnectorInputSpecification with granular scopes

### DIFF
--- a/airbyte-integrations/connectors/source-xero/manifest.yaml
+++ b/airbyte-integrations/connectors/source-xero/manifest.yaml
@@ -577,7 +577,7 @@ spec:
         title: Authentication Method
     additionalProperties: true
   advanced_auth:
-    auth_flow_type: oauth2_0
+    auth_flow_type: oauth2.0
     predicate_key:
       - credentials
       - auth_type

--- a/airbyte-integrations/connectors/source-xero/manifest.yaml
+++ b/airbyte-integrations/connectors/source-xero/manifest.yaml
@@ -576,6 +576,62 @@ spec:
         order: 2
         title: Authentication Method
     additionalProperties: true
+  advanced_auth:
+    auth_flow_type: oauth2_0
+    predicate_key:
+      - credentials
+      - auth_type
+    predicate_value: oauth2_confidential_application
+    oauth_config_specification:
+      oauth_connector_input_specification:
+        consent_url: "https://login.xero.com/identity/connect/authorize?{{client_id_param}}&{{redirect_uri_param}}&{{scopes_param}}&{{state_param}}&response_type=code"
+        access_token_url: "https://identity.xero.com/connect/token"
+        scopes:
+          - scope: "offline_access"
+          - scope: "accounting.transactions.read"
+          - scope: "accounting.reports.read"
+          - scope: "accounting.budgets.read"
+          - scope: "accounting.reports.tenninetynine.read"
+          - scope: "accounting.journals.read"
+          - scope: "accounting.settings.read"
+          - scope: "accounting.contacts.read"
+          - scope: "accounting.attachments.read"
+          - scope: "assets.read"
+          - scope: "files.read"
+          - scope: "projects.read"
+          - scope: "openid"
+        access_token_params:
+          grant_type: "client_credentials"
+          client_id: "{{ client_id_value }}"
+          client_secret: "{{ client_secret_value }}"
+        extract_output:
+          - access_token
+      complete_oauth_output_specification:
+        type: object
+        additionalProperties: false
+        properties: {}
+      complete_oauth_server_input_specification:
+        type: object
+        additionalProperties: false
+        properties:
+          client_id:
+            type: string
+          client_secret:
+            type: string
+      complete_oauth_server_output_specification:
+        type: object
+        additionalProperties: false
+        properties:
+          client_id:
+            type: string
+            path_in_connector_config:
+              - credentials
+              - client_id
+          client_secret:
+            type: string
+            path_in_connector_config:
+              - credentials
+              - client_secret
 
 metadata:
   autoImportSchema:

--- a/airbyte-integrations/connectors/source-xero/metadata.yaml
+++ b/airbyte-integrations/connectors/source-xero/metadata.yaml
@@ -31,7 +31,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 6fd1e833-dd6e-45ec-a727-ab917c5be892
-  dockerImageTag: 2.1.5
+  dockerImageTag: 2.1.6
   dockerRepository: airbyte/source-xero
   githubIssueLabel: source-xero
   icon: xero.svg

--- a/docs/integrations/sources/xero.md
+++ b/docs/integrations/sources/xero.md
@@ -121,6 +121,7 @@ If you are upgrading from a previous version of the connector, please refer to t
 
 | Version | Date       | Pull Request                                             | Subject                                                   |
 |:--------|:-----------|:---------------------------------------------------------|:----------------------------------------------------------|
+| 2.1.6 | 2026-04-10 | [76222](https://github.com/airbytehq/airbyte/pull/76222) | Add oauthConnectorInputSpecification with granular scopes |
 | 2.1.5 | 2026-02-25 | [71340](https://github.com/airbytehq/airbyte/pull/71340) | Resolve the generator returned from JsonDecoder into dictionary |
 | 2.1.4 | 2025-03-01 | [55142](https://github.com/airbytehq/airbyte/pull/55142) | Update dependencies |
 | 2.1.3 | 2025-02-22 | [54526](https://github.com/airbytehq/airbyte/pull/54526) | Update dependencies |


### PR DESCRIPTION
## What
Adds `advanced_auth` with `oauth_connector_input_specification` to source-xero, declaring all 13 OAuth scopes used by the connector's `oauth2_confidential_application` auth path.

## How
Added a full `advanced_auth` block to the manifest spec, predicated on `credentials.auth_type == oauth2_confidential_application`, with:
- Xero authorization and token URLs
- All 13 scopes already defined in the `OAuthAuthenticator` (accounting, assets, files, projects, openid, offline_access)
- `client_credentials` grant type in `access_token_params`
- `complete_oauth_server_output_specification` mapping `client_id` and `client_secret` to their config paths

Bumped connector version to `2.1.6`.