### PR TITLE
feat(source-bing-ads): add oauthConnectorInputSpecification with granular scopes

### DIFF
--- a/airbyte-integrations/connectors/source-bing-ads/manifest.yaml
+++ b/airbyte-integrations/connectors/source-bing-ads/manifest.yaml
@@ -17677,6 +17677,20 @@ spec:
       - auth_method
     predicate_value: oauth2.0
     oauth_config_specification:
+      oauth_connector_input_specification:
+        consent_url: "https://login.microsoftonline.com/{{tenant_id}}/oauth2/v2.0/authorize?{{client_id_param}}&{{redirect_uri_param}}&{{scopes_param}}&{{state_param}}&response_type=code"
+        access_token_url: "https://login.microsoftonline.com/{{tenant_id}}/oauth2/v2.0/token"
+        scopes:
+          - scope: "https://ads.microsoft.com/msads.manage"
+          - scope: "offline_access"
+        access_token_params:
+          grant_type: "authorization_code"
+          code: "{{ auth_code_value }}"
+          client_id: "{{ client_id_value }}"
+          client_secret: "{{ client_secret_value }}"
+          redirect_uri: "{{ redirect_uri_value }}"
+        extract_output:
+          - refresh_token
       complete_oauth_output_specification:
         type: object
         additionalProperties: false

--- a/airbyte-integrations/connectors/source-bing-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-bing-ads/metadata.yaml
@@ -16,7 +16,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 47f25999-dd5e-4636-8c39-e7cea2453331
-  dockerImageTag: 2.23.15
+  dockerImageTag: 2.23.16
   dockerRepository: airbyte/source-bing-ads
   documentationUrl: https://docs.airbyte.com/integrations/sources/bing-ads
   externalDocumentationUrls:

--- a/docs/integrations/sources/bing-ads.md
+++ b/docs/integrations/sources/bing-ads.md
@@ -319,6 +319,7 @@ The Bing Ads API limits the number of requests for all Microsoft Advertising cli
 
 | Version     | Date       | Pull Request                                                                                                                     | Subject                                                                                                                                                                |
 |:------------|:-----------|:---------------------------------------------------------------------------------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 2.23.16 | 2026-04-10 | [76223](https://github.com/airbytehq/airbyte/pull/76223) | Add oauthConnectorInputSpecification with granular scopes |
 | 2.23.15 | 2026-04-08 | [76165](https://github.com/airbytehq/airbyte/pull/76165) | Promote 2.23.15-rc.3 to GA — fixes SAS token expiry during report downloads |
 | 2.23.15-rc.3 | 2026-04-02 | [76053](https://github.com/airbytehq/airbyte/pull/76053) | Fix SAS token expiry during report downloads by re-polling for fresh URL before each download |
 | 2.23.15-rc.2 | 2026-03-30 | [74885](https://github.com/airbytehq/airbyte/pull/74885) | Fix OOM on large report downloads by using streaming ZIP decoder and reducing concurrency |


### PR DESCRIPTION
## What
Adds `oauth_connector_input_specification` to source-bing-ads with Microsoft Ads OAuth scopes.

## How
Inserted `oauth_connector_input_specification` into the existing `advanced_auth.oauth_config_specification` block with:
- Tenant-aware Microsoft consent and token URLs (`login.microsoftonline.com/{tenant_id}/...`)
- Scopes: `https://ads.microsoft.com/msads.manage` and `offline_access`
- Standard authorization_code token exchange params

Bumped connector version to `2.23.16`.