### PR TITLE
feat(source-amazon-seller-partner): add oauthConnectorInputSpecification with LWA OAuth params

### DIFF
--- a/airbyte-integrations/connectors/source-amazon-seller-partner/manifest.yaml
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/manifest.yaml
@@ -327,6 +327,17 @@ spec:
     - auth_type
     predicate_value: oauth2.0
     oauth_config_specification:
+      oauth_connector_input_specification:
+        consent_url: "https://sellercentral.amazon.com/apps/authorize/consent?application_id={{app_id}}&{{redirect_uri_param}}&{{state_param}}&version=beta"
+        access_token_url: "https://api.amazon.com/auth/o2/token"
+        access_token_params:
+          grant_type: "authorization_code"
+          code: "{{ auth_code_value }}"
+          client_id: "{{ client_id_value }}"
+          client_secret: "{{ client_secret_value }}"
+          redirect_uri: "{{ redirect_uri_value }}"
+        extract_output:
+          - refresh_token
       oauth_user_input_from_connector_config_specification:
         type: object
         properties:
@@ -338,6 +349,10 @@ spec:
             type: string
             path_in_connector_config:
             - account_type
+          app_id:
+            type: string
+            path_in_connector_config:
+            - app_id
       complete_oauth_output_specification:
         type: object
         additionalProperties: false

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/metadata.yaml
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/metadata.yaml
@@ -15,7 +15,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: e55879a8-0ef8-4557-abcf-ab34c53ec460
-  dockerImageTag: 5.7.1
+  dockerImageTag: 5.7.2
   dockerRepository: airbyte/source-amazon-seller-partner
   documentationUrl: https://docs.airbyte.com/integrations/sources/amazon-seller-partner
   erdUrl: https://dbdocs.io/airbyteio/source-amazon-seller-partner?view=relationships

--- a/docs/integrations/sources/amazon-seller-partner.md
+++ b/docs/integrations/sources/amazon-seller-partner.md
@@ -306,6 +306,7 @@ You may also combine this with a smaller **Financial Events Step Size** (e.g., 1
 
 | Version    | Date       | Pull Request                                              | Subject                                                                                                                                                                             |
 |:-----------|:-----------|:----------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 5.7.2 | 2026-04-10 | [76224](https://github.com/airbytehq/airbyte/pull/76224) | Add oauthConnectorInputSpecification with LWA OAuth params |
 | 5.7.1 | 2026-04-02 | [76031](https://github.com/airbytehq/airbyte/pull/76031) | Deprecate non-functional `wait_to_avoid_fatal_errors` config option (hidden from UI) |
 | 5.7.0 | 2026-03-23 | [74740](https://github.com/airbytehq/airbyte/pull/74740) | Add configurable `asinGranularity` for GET_SALES_AND_TRAFFIC_REPORT streams, enabling CHILD and SKU level data with populated childAsin and sku values |
 | 5.6.1 | 2026-03-17 | [74538](https://github.com/airbytehq/airbyte/pull/74538) | Update dependencies |


### PR DESCRIPTION
## What
Adds `oauth_connector_input_specification` to source-amazon-seller-partner for Amazon's Login with Amazon (LWA) OAuth flow.

## How
Inserted `oauth_connector_input_specification` into the existing `advanced_auth.oauth_config_specification` block with:
- Consent URL using `application_id={{app_id}}` (Amazon SP uses a separate application ID in the consent URL, not the LWA client_id)
- Token URL: `https://api.amazon.com/auth/o2/token`
- Standard authorization_code token exchange (platform maps `client_id`/`client_secret` to `lwa_app_id`/`lwa_client_secret`)
- Added `app_id` to `oauth_user_input_from_connector_config_specification` so it can be interpolated in the consent URL template

Note: Amazon SP-API does not use traditional LWA OAuth scopes for seller/vendor operations — permissions are controlled at the application level in Seller Central.

Bumped connector version to `5.7.2`.