### PR TITLE
feat(source-paypal-transaction): add oauthConnectorInputSpecification

### DIFF
--- a/airbyte-integrations/connectors/source-paypal-transaction/manifest.yaml
+++ b/airbyte-integrations/connectors/source-paypal-transaction/manifest.yaml
@@ -561,6 +561,49 @@ spec:
         maximum: 31
         order: 7
     additionalProperties: true
+  advanced_auth:
+    auth_flow_type: oauth2.0
+    oauth_config_specification:
+      oauth_connector_input_specification:
+        consent_url: "https://www.paypal.com/signin/authorize?{{client_id_param}}&{{redirect_uri_param}}&response_type=code&{{state_param}}"
+        access_token_url: "https://api-m.paypal.com/v1/oauth2/token"
+        access_token_headers:
+          Authorization: "Basic {{ (client_id_value ~ ':' ~ client_secret_value) | b64encode }}"
+          Content-Type: "application/x-www-form-urlencoded"
+        access_token_params:
+          grant_type: "authorization_code"
+          code: "{{ auth_code_value }}"
+          redirect_uri: "{{ redirect_uri_value }}"
+        extract_output:
+          - refresh_token
+      complete_oauth_output_specification:
+        type: object
+        additionalProperties: false
+        properties:
+          refresh_token:
+            type: string
+            path_in_connector_config:
+              - refresh_token
+      complete_oauth_server_input_specification:
+        type: object
+        additionalProperties: false
+        properties:
+          client_id:
+            type: string
+          client_secret:
+            type: string
+      complete_oauth_server_output_specification:
+        type: object
+        additionalProperties: false
+        properties:
+          client_id:
+            type: string
+            path_in_connector_config:
+              - client_id
+          client_secret:
+            type: string
+            path_in_connector_config:
+              - client_secret
 
 metadata:
   autoImportSchema:

--- a/airbyte-integrations/connectors/source-paypal-transaction/metadata.yaml
+++ b/airbyte-integrations/connectors/source-paypal-transaction/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: d913b0f2-cc51-4e55-a44c-8ba1697b9239
-  dockerImageTag: 2.6.31
+  dockerImageTag: 2.6.32
   dockerRepository: airbyte/source-paypal-transaction
   documentationUrl: https://docs.airbyte.com/integrations/sources/paypal-transaction
   githubIssueLabel: source-paypal-transaction

--- a/docs/integrations/sources/paypal-transaction.md
+++ b/docs/integrations/sources/paypal-transaction.md
@@ -264,6 +264,7 @@ The below table contains the configuraiton parameters available for this connect
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                      |
 | :------ | :--------- | :------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------- |
+| 2.6.32 | 2026-04-10 | [76225](https://github.com/airbytehq/airbyte/pull/76225) | Add oauthConnectorInputSpecification |
 | 2.6.31 | 2026-04-07 | [76135](https://github.com/airbytehq/airbyte/pull/76135) | Fix undefined `security_context` variable in payments generator utility script |
 | 2.6.30 | 2026-03-31 | [75850](https://github.com/airbytehq/airbyte/pull/75850) | Update dependencies |
 | 2.6.29 | 2026-03-24 | [75396](https://github.com/airbytehq/airbyte/pull/75396) | Update dependencies |


### PR DESCRIPTION
## What
Adds `advanced_auth` with `oauth_connector_input_specification` to source-paypal-transaction.

## How
Added a full `advanced_auth` block to the manifest spec with:
- PayPal consent URL and token URL (`api-m.paypal.com/v1/oauth2/token`)
- Basic auth header for token exchange (base64-encoded `client_id:client_secret`), matching PayPal's API requirement
- Authorization code grant with refresh token output
- `complete_oauth_output_specification` mapping `refresh_token` to config
- `complete_oauth_server_output_specification` mapping `client_id`/`client_secret` to flat config paths

Bumped connector version to `2.6.32`.