### PR TITLE
chore(source-mailchimp): increase default_concurrency to 6 (iteration 3, final tuning)

### DIFF
--- a/airbyte-integrations/connectors/source-mailchimp/manifest.yaml
+++ b/airbyte-integrations/connectors/source-mailchimp/manifest.yaml
@@ -10,7 +10,7 @@ check:
 # Mailchimp has a limit of 10 simultaneous connections
 concurrency_level:
   type: ConcurrencyLevel
-  default_concurrency: "{{ config.get('num_workers', 5) }}"
+  default_concurrency: "{{ config.get('num_workers', 6) }}"
   max_concurrency: 10
 
 # HTTPAPIBudget commented out for Phase 1 concurrency tuning (will be re-enabled in Phase 2)

--- a/airbyte-integrations/connectors/source-mailchimp/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mailchimp/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: b03a9f3e-22a5-11eb-adc1-0242ac120002
-  dockerImageTag: 2.1.23-rc.2
+  dockerImageTag: 2.1.23-rc.3
   dockerRepository: airbyte/source-mailchimp
   documentationUrl: https://docs.airbyte.com/integrations/sources/mailchimp
   externalDocumentationUrls:

--- a/docs/integrations/sources/mailchimp.md
+++ b/docs/integrations/sources/mailchimp.md
@@ -128,7 +128,7 @@ Now that you have set up the Mailchimp source connector, check out the following
 
 | Version | Date       | Pull Request                                             | Subject                                                                   |
 |--------|------------|----------------------------------------------------------|---------------------------------------------------------------------------|
-| 2.1.23-rc.3 | 2026-04-10 | [70860](https://github.com/airbytehq/airbyte/pull/70860) | Increase default_concurrency to 6 (iteration 3, final concurrency tuning) |
+| 2.1.23-rc.3 | 2026-04-10 | [76232](https://github.com/airbytehq/airbyte/pull/76232) | Increase default_concurrency to 6 (iteration 3, final concurrency tuning) |
 | 2.1.23-rc.2 | 2026-04-08 | [70860](https://github.com/airbytehq/airbyte/pull/70860) | Increase default_concurrency to 5 (iteration 2 of concurrency tuning) |
 | 2.1.23-rc.1 | 2026-04-06 | [70860](https://github.com/airbytehq/airbyte/pull/70860) | Add concurrency_level and num_workers configuration for concurrency tuning |
 | 2.1.22 | 2026-04-01 | [75576](https://github.com/airbytehq/airbyte/pull/75576) | Add `oauth_connector_input_specification` for declarative OAuth |

--- a/docs/integrations/sources/mailchimp.md
+++ b/docs/integrations/sources/mailchimp.md
@@ -128,6 +128,7 @@ Now that you have set up the Mailchimp source connector, check out the following
 
 | Version | Date       | Pull Request                                             | Subject                                                                   |
 |--------|------------|----------------------------------------------------------|---------------------------------------------------------------------------|
+| 2.1.23-rc.3 | 2026-04-10 | [70860](https://github.com/airbytehq/airbyte/pull/70860) | Increase default_concurrency to 6 (iteration 3, final concurrency tuning) |
 | 2.1.23-rc.2 | 2026-04-08 | [70860](https://github.com/airbytehq/airbyte/pull/70860) | Increase default_concurrency to 5 (iteration 2 of concurrency tuning) |
 | 2.1.23-rc.1 | 2026-04-06 | [70860](https://github.com/airbytehq/airbyte/pull/70860) | Add concurrency_level and num_workers configuration for concurrency tuning |
 | 2.1.22 | 2026-04-01 | [75576](https://github.com/airbytehq/airbyte/pull/75576) | Add `oauth_connector_input_specification` for declarative OAuth |


### PR DESCRIPTION
## What

Increases `default_concurrency` from 5 to 6 for source-mailchimp as the **third and final iteration** of Phase 1 concurrency tuning, per the Connector Concurrency Tuning & Rollout playbook.

Tracks: https://github.com/airbytehq/airbyte-internal-issues/issues/15310

### Tuning history
| Iteration | Concurrency | RC Version | Result |
|-----------|-------------|------------|--------|
| 1 | 4 | 2.1.23-rc.1 | ✅ 0% concurrency failures (39 Tier 2 actors) |
| 2 | 5 | 2.1.23-rc.2 | ✅ 0% concurrency failures (228 syncs, 224 succeeded, 4 failed — all config/server errors) |
| **3** | **6** | **2.1.23-rc.3** | **This PR — to be validated via progressive rollout** |

Mailchimp's API limit is **10 simultaneous connections**, so 6 is well within the safe range.

## How

- `manifest.yaml`: Bump default in `default_concurrency` from 5 → 6
- `metadata.yaml`: Bump `dockerImageTag` from `2.1.23-rc.2` → `2.1.23-rc.3`
- `docs/.../mailchimp.md`: Add changelog entry

Note: `HTTPAPIBudget` remains intentionally commented out — it will be re-enabled in Phase 2 after concurrency tuning is finalized.

## Review guide

1. `airbyte-integrations/connectors/source-mailchimp/manifest.yaml` — single-line default change
2. `airbyte-integrations/connectors/source-mailchimp/metadata.yaml` — version bump
3. `docs/integrations/sources/mailchimp.md` — changelog entry

Key things to verify:
- [ ] `default_concurrency=6` is safe given Mailchimp's 10-connection limit
- [ ] Version `2.1.23-rc.3` is the correct next RC version
- [ ] HTTPAPIBudget is intentionally still commented out (Phase 2)

## User Impact

No user-facing impact yet — this RC will be deployed via progressive rollout to 39 Tier 2 actors only. If iteration 3 passes (0% concurrency-related failures after 24h), concurrency=6 becomes the final tuned value before proceeding to Phase 2 (budget addition).

Users who have set a custom `num_workers` config value are unaffected (the default is only used when the config key is absent).

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/707014b936e2463ab12579f4b6a7e620
Requested by: @sophiecuiy