### PR TITLE
docs: update speed improvements page with all supported connectors

### DIFF
--- a/docs/integrations/speed-improvements.md
+++ b/docs/integrations/speed-improvements.md
@@ -61,11 +61,17 @@ Currently, these are the source and destination connectors that support faster s
 
 ### Sources
 
+- [MSSQL (SQL Server)](sources/mssql)
 - [MySQL](sources/mysql)
+- [PostgreSQL](sources/postgres)
+- [Snowflake](sources/snowflake)
 
 ### Destinations
 
-- [S3](destinations/s3)
 - [Azure Blob Storage](destinations/azure-blob-storage)
 - [BigQuery](destinations/bigquery)
 - [ClickHouse](destinations/clickhouse)
+- [GCS Data Lake](destinations/gcs-data-lake)
+- [PostgreSQL](destinations/postgres)
+- [S3](destinations/s3)
+- [S3 Data Lake](destinations/s3-data-lake)


### PR DESCRIPTION
## What

The [Faster sync speed](https://docs.airbyte.com/integrations/speed-improvements) documentation page only listed MySQL as a supported source connector. It was missing several other database sources and destinations that now use the Bulk CDK and support faster sync speed.

Requested by @rwask.

## How

Updated the "What connectors use faster speed" section to include all connectors that use the Bulk CDK (`airbyte-bulk-connector` plugin):

**Sources added:**
- MSSQL (SQL Server)
- PostgreSQL
- Snowflake

**Destinations added:**
- GCS Data Lake
- PostgreSQL
- S3 Data Lake

Also alphabetized both lists for consistency.

## Review guide

1. `docs/integrations/speed-improvements.md`

## User Impact

Users will now see the full list of source and destination connectors that support faster sync speed, rather than only MySQL.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/e1fd0804d76d47c2ae06e1532d8b8dc3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/76238" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
