### PR TITLE
fix: load CDK timestamp coercion perf

### DIFF
--- a/airbyte-cdk/bulk/core/load/build.gradle
+++ b/airbyte-cdk/bulk/core/load/build.gradle
@@ -17,6 +17,7 @@ dependencies {
 
     api "io.airbyte.bulk-cdk:bulk-cdk-core-base:1.0.1"
     implementation 'org.apache.commons:commons-lang3:3.17.0'
+    implementation 'com.ethlo.time:itu:1.14.0'
 
     // For ranges and rangesets
     implementation("com.google.guava:guava:33.3.0-jre")

--- a/airbyte-cdk/bulk/core/load/changelog.md
+++ b/airbyte-cdk/bulk/core/load/changelog.md
@@ -9,6 +9,7 @@ The Load CDK provides functionality for destination connectors including stream-
 
 | Version | Date       | Pull Request | Subject                                                                                         |
 |---------|------------|--------------|-------------------------------------------------------------------------------------------------|
+| 1.0.9   | 2026-04-15 | [#76246](https://github.com/airbytehq/airbyte/pull/76246) | Perf: fix timestamp coercion using exception-as-control-flow. Use ethlo/itu for ISO-8601 fast path (~25x faster), JDK TemporalQueries fallback for exotic formats. Eliminates ~56% destination CPU on timestamp-heavy workloads. |
 | 1.0.8   | 2026-04-14 | [#74728](https://github.com/airbytehq/airbyte/pull/74728) | Fix OAuthAuthenticator to track token expiry via `expires_in` and refresh expired tokens. |
 | 1.0.7   | 2026-03-27 | | Fix: update Iceberg sort order before schema evolution to prevent ValidationException when deleting columns referenced by the sort order. Handles Dedupe-to-Append mode switches and PK changes. |
 | 1.0.6   | 2026-03-12 | [#74715](https://github.com/airbytehq/airbyte/pull/74715) | Fix: drop temp table after successful upsert to prevent duplicate records across syncs. |

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/AirbyteValueCoercer.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/AirbyteValueCoercer.kt
@@ -4,10 +4,13 @@
 
 package io.airbyte.cdk.load.data
 
+import com.ethlo.time.ITU
+import com.ethlo.time.ParseConfig
 import io.airbyte.cdk.load.data.json.JsonToAirbyteValue
 import io.airbyte.cdk.load.util.serializeToString
 import java.math.BigDecimal
 import java.math.BigInteger
+import java.text.ParsePosition
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -16,6 +19,7 @@ import java.time.OffsetTime
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
+import java.time.temporal.TemporalQueries
 
 /**
  * Utility class to coerce AirbyteValue to specific types. Does **not** support recursive coercion.
@@ -128,11 +132,17 @@ object AirbyteValueCoercer {
             is TimeWithTimezoneValue -> value
             else ->
                 requireType<StringValue, TimeWithTimezoneValue>(value) {
+                    // Single parse + temporal query to detect timezone, avoiding the old
+                    // try-OffsetTime.parse/catch-fallback-to-LocalTime pattern.
+                    val parsed = TIME_FORMATTER.parse(it.value)
+                    val offset = parsed.query(TemporalQueries.offset())
                     val ot =
-                        try {
-                            OffsetTime.parse(it.value, TIME_FORMATTER)
-                        } catch (e: Exception) {
-                            LocalTime.parse(it.value, TIME_FORMATTER).atOffset(ZoneOffset.UTC)
+                        if (offset != null) {
+                            // Has timezone offset (e.g. "12:00:00+01:00") — use it directly
+                            OffsetTime.from(parsed)
+                        } else {
+                            // No timezone (e.g. "12:00:00") — assume UTC
+                            LocalTime.from(parsed).atOffset(ZoneOffset.UTC)
                         }
                     TimeWithTimezoneValue(ot)
                 }
@@ -166,13 +176,64 @@ object AirbyteValueCoercer {
         }
 
     private fun offsetDateTime(it: StringValue): OffsetDateTime {
-        val odt =
-            try {
-                ZonedDateTime.parse(it.value, DATE_TIME_FORMATTER).toOffsetDateTime()
-            } catch (e: Exception) {
-                LocalDateTime.parse(it.value, DATE_TIME_FORMATTER).atOffset(ZoneOffset.UTC)
+        val s = it.value
+        if (looksLikeIso8601(s)) {
+            // Fast path: ITU handles ISO-8601/RFC-3339 ~25x faster than JDK DateTimeFormatter,
+            // and determines with/without timezone via position-based parsing (no exceptions).
+            val pos = ParsePosition(0)
+            val parsed =
+                try {
+                    ITU.parseLenient(s, ParseConfig.DEFAULT, pos)
+                } catch (_: Exception) {
+                    // ITU can throw on some edge cases that pass looksLikeIso8601 (e.g.
+                    // "2021-01-01 01:01:01 +0000" has dashes but a space-separated compact offset).
+                    null
+                }
+            // Only use the ITU result if it successfully consumed the entire input string.
+            // Partial parses (e.g. ITU parsed the date but stopped at a named timezone like
+            // "GMT+08:00") must fall through to the JDK formatter which handles those.
+            if (parsed != null && pos.index == s.length) {
+                return if (parsed.offset.isPresent) {
+                    // Timestamp included timezone info (Z, +05:30, etc.) — use it directly
+                    parsed.toOffsetDatetime()
+                } else {
+                    // No timezone info — assume UTC
+                    parsed.toLocalDatetime().atOffset(ZoneOffset.UTC)
+                }
             }
-        return odt
+        }
+        // Non-ISO format (slashes, dots, abbreviated months) or ITU couldn't fully parse
+        return offsetDateTimeJdk(s)
+    }
+
+    /**
+     * JDK fallback for non-ISO formats. Uses a single parse + temporal query to determine whether
+     * timezone info is present, avoiding the old try-ZonedDateTime/catch pattern.
+     */
+    private fun offsetDateTimeJdk(s: String): OffsetDateTime {
+        val parsed = DATE_TIME_FORMATTER.parse(s)
+        // Check for explicit offset (+05:30, Z) first, then named zone (UTC, PST, GMT+08:00).
+        // Named zones like "GMT+08:00" are parsed as a ZoneId, not an offset, so we need both
+        // checks.
+        val offset = parsed.query(TemporalQueries.offset())
+        val zone = parsed.query(TemporalQueries.zone())
+        return if (offset != null || zone != null) {
+            // Has timezone — construct ZonedDateTime to resolve the zone to an offset
+            ZonedDateTime.from(parsed).toOffsetDateTime()
+        } else {
+            // No timezone — assume UTC
+            LocalDateTime.from(parsed).atOffset(ZoneOffset.UTC)
+        }
+    }
+
+    /**
+     * Quick check for ISO-8601-ish format. ITU expects dashes as date separators (e.g.
+     * "2024-01-15T..."). Non-ISO formats like "2024/01/15", "2024.01.15", or "2024 Jan 15" are
+     * routed directly to the JDK fallback.
+     */
+    private fun looksLikeIso8601(s: String): Boolean {
+        // Minimum: "yyyy-MM-dd" = 10 chars
+        return s.length >= 10 && s[4] == '-' && s[7] == '-'
     }
 
     // In theory, we could e.g. Jsons.readTree((value as StringValue).value).

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/AirbyteValueCoercer.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/AirbyteValueCoercer.kt
@@ -6,8 +6,11 @@ package io.airbyte.cdk.load.data
 
 import com.ethlo.time.ITU
 import com.ethlo.time.ParseConfig
+import io.airbyte.cdk.load.data.TemporalFormatters.DATE_TIME_FORMATTER
 import io.airbyte.cdk.load.data.json.JsonToAirbyteValue
 import io.airbyte.cdk.load.util.serializeToString
+import io.micronaut.context.annotation.Property
+import jakarta.inject.Singleton
 import java.math.BigDecimal
 import java.math.BigInteger
 import java.text.ParsePosition
@@ -18,7 +21,6 @@ import java.time.OffsetDateTime
 import java.time.OffsetTime
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
-import java.time.format.DateTimeFormatter
 import java.time.temporal.TemporalQueries
 
 /**
@@ -27,8 +29,21 @@ import java.time.temporal.TemporalQueries
  * More specifically: This class coerces the output of [JsonToAirbyteValue] to strongly-typed
  * [AirbyteValue]. In particular, this class will parse temporal types, and performs some
  * common-sense conversions among numeric types, as well as upcasting any value to StringValue.
+ *
+ * The [useFastTimestampParsing] flag controls timestamp parsing behavior:
+ * - When false (default): uses the original try-ZonedDateTime/catch-fallback-to-LocalDateTime
+ * pattern. Safe but slow due to exception-as-control-flow.
+ * - When true: uses ethlo/itu for fast ISO-8601 parsing (~25x faster) with a JDK TemporalQueries
+ * fallback for exotic formats. No exceptions on the hot path.
+ *
+ * Destinations opt in via the Micronaut property
+ * `airbyte.destination.core.coercion.use-fast-timestamp-parsing`.
  */
-object AirbyteValueCoercer {
+@Singleton
+class AirbyteValueCoercer(
+    @Property(name = "airbyte.destination.core.coercion.use-fast-timestamp-parsing")
+    private val useFastTimestampParsing: Boolean = false,
+) {
     fun coerce(
         value: AirbyteValue,
         type: AirbyteType,
@@ -68,7 +83,7 @@ object AirbyteValueCoercer {
                 // leave it unchanged.
                 is UnknownType -> value
             }
-        } catch (e: Exception) {
+        } catch (_: Exception) {
             null
         }
     }
@@ -123,7 +138,7 @@ object AirbyteValueCoercer {
             is DateValue -> value
             else ->
                 requireType<StringValue, DateValue>(value) {
-                    DateValue(LocalDate.parse(it.value, DATE_TIME_FORMATTER))
+                    DateValue(LocalDate.parse(it.value, TemporalFormatters.DATE_TIME_FORMATTER))
                 }
         }
 
@@ -132,17 +147,26 @@ object AirbyteValueCoercer {
             is TimeWithTimezoneValue -> value
             else ->
                 requireType<StringValue, TimeWithTimezoneValue>(value) {
-                    // Single parse + temporal query to detect timezone, avoiding the old
-                    // try-OffsetTime.parse/catch-fallback-to-LocalTime pattern.
-                    val parsed = TIME_FORMATTER.parse(it.value)
-                    val offset = parsed.query(TemporalQueries.offset())
                     val ot =
-                        if (offset != null) {
-                            // Has timezone offset (e.g. "12:00:00+01:00") — use it directly
-                            OffsetTime.from(parsed)
+                        if (useFastTimestampParsing) {
+                            // Single parse + temporal query to detect timezone, avoiding the
+                            // try-OffsetTime.parse/catch-fallback-to-LocalTime pattern.
+                            val parsed = TemporalFormatters.TIME_FORMATTER.parse(it.value)
+                            val offset = parsed.query(TemporalQueries.offset())
+                            if (offset != null) {
+                                // Has timezone offset (e.g. "12:00:00+01:00") — use it directly
+                                OffsetTime.from(parsed)
+                            } else {
+                                // No timezone (e.g. "12:00:00") — assume UTC
+                                LocalTime.from(parsed).atOffset(ZoneOffset.UTC)
+                            }
                         } else {
-                            // No timezone (e.g. "12:00:00") — assume UTC
-                            LocalTime.from(parsed).atOffset(ZoneOffset.UTC)
+                            try {
+                                OffsetTime.parse(it.value, TemporalFormatters.TIME_FORMATTER)
+                            } catch (_: Exception) {
+                                LocalTime.parse(it.value, TemporalFormatters.TIME_FORMATTER)
+                                    .atOffset(ZoneOffset.UTC)
+                            }
                         }
                     TimeWithTimezoneValue(ot)
                 }
@@ -153,7 +177,9 @@ object AirbyteValueCoercer {
             is TimeWithoutTimezoneValue -> value
             else ->
                 requireType<StringValue, TimeWithoutTimezoneValue>(value) {
-                    TimeWithoutTimezoneValue(LocalTime.parse(it.value, TIME_FORMATTER))
+                    TimeWithoutTimezoneValue(
+                        LocalTime.parse(it.value, TemporalFormatters.TIME_FORMATTER)
+                    )
                 }
         }
 
@@ -176,7 +202,27 @@ object AirbyteValueCoercer {
         }
 
     private fun offsetDateTime(it: StringValue): OffsetDateTime {
-        val s = it.value
+        return if (useFastTimestampParsing) {
+            offsetDateTimeFast(it.value)
+        } else {
+            offsetDateTimeLegacy(it.value)
+        }
+    }
+
+    /** Legacy path: try ZonedDateTime.parse, catch, fall back to LocalDateTime.parse. */
+    private fun offsetDateTimeLegacy(s: String): OffsetDateTime {
+        return try {
+            ZonedDateTime.parse(s, DATE_TIME_FORMATTER).toOffsetDateTime()
+        } catch (e: Exception) {
+            LocalDateTime.parse(s, DATE_TIME_FORMATTER).atOffset(ZoneOffset.UTC)
+        }
+    }
+
+    /**
+     * Fast path: uses ethlo/itu for ISO-8601 (~25x faster, no exceptions), with a JDK
+     * TemporalQueries fallback for non-ISO formats.
+     */
+    private fun offsetDateTimeFast(s: String): OffsetDateTime {
         if (looksLikeIso8601(s)) {
             // Fast path: ITU handles ISO-8601/RFC-3339 ~25x faster than JDK DateTimeFormatter,
             // and determines with/without timezone via position-based parsing (no exceptions).
@@ -256,13 +302,4 @@ object AirbyteValueCoercer {
             null
         }
     }
-
-    val DATE_TIME_FORMATTER: DateTimeFormatter =
-        DateTimeFormatter.ofPattern(
-            "[yyyy][yy]['-']['/']['.'][' '][MMM][MM][M]['-']['/']['.'][' '][dd][d][[' '][G]][[' ']['T']HH:mm[':'ss[.][SSSSSS][SSSSS][SSSS][SSS][' '][z][zzz][Z][O][x][XXX][XX][X][[' '][G]]]]"
-        )
-    val TIME_FORMATTER: DateTimeFormatter =
-        DateTimeFormatter.ofPattern(
-            "HH:mm[':'ss[.][SSSSSS][SSSSS][SSSS][SSS][' '][z][zzz][Z][O][x][XXX][XX][X]]"
-        )
 }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/TemporalFormatters.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/TemporalFormatters.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.data
+
+import java.time.format.DateTimeFormatter
+
+/**
+ * Lenient DateTimeFormatter patterns used across the CDK for parsing temporal strings from sources.
+ * These support a wide range of formats (ISO-8601, slashes, dots, abbreviated months, eras, etc.)
+ * to handle the variety of timestamp representations emitted by different source connectors.
+ */
+object TemporalFormatters {
+    val DATE_TIME_FORMATTER: DateTimeFormatter =
+        DateTimeFormatter.ofPattern(
+            "[yyyy][yy]['-']['/']['.'][' '][MMM][MM][M]['-']['/']['.'][' '][dd][d][[' '][G]][[' ']['T']HH:mm[':'ss[.][SSSSSS][SSSSS][SSSS][SSS][' '][z][zzz][Z][O][x][XXX][XX][X][[' '][G]]]]"
+        )
+    val TIME_FORMATTER: DateTimeFormatter =
+        DateTimeFormatter.ofPattern(
+            "HH:mm[':'ss[.][SSSSSS][SSSSS][SSSS][SSS][' '][z][zzz][Z][O][x][XXX][XX][X]]"
+        )
+}

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/transform/medium/JsonConverter.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/transform/medium/JsonConverter.kt
@@ -5,6 +5,7 @@
 package io.airbyte.cdk.load.dataflow.transform.medium
 
 import io.airbyte.cdk.load.data.AirbyteValue
+import io.airbyte.cdk.load.data.AirbyteValueCoercer
 import io.airbyte.cdk.load.dataflow.config.model.MediumConverterConfig
 import io.airbyte.cdk.load.dataflow.transform.ValueCoercer
 import io.airbyte.cdk.load.dataflow.transform.data.ValidationResultHandler
@@ -15,10 +16,12 @@ class JsonConverter(
     private val coercer: ValueCoercer,
     private val validationResultHandler: ValidationResultHandler,
     private val converterConfig: MediumConverterConfig,
+    private val airbyteValueCoercer: AirbyteValueCoercer,
 ) : MediumConverter {
     override fun convert(input: ConversionInput): Map<String, AirbyteValue> {
         val enriched =
             input.msg.asEnrichedDestinationRecordAirbyteValue(
+                coercer = airbyteValueCoercer,
                 extractedAtAsTimestampWithTimezone =
                     converterConfig.extractedAtAsTimestampWithTimezone,
             )

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/DestinationRecordRaw.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/DestinationRecordRaw.kt
@@ -41,6 +41,7 @@ data class DestinationRecordRaw(
      * [TimestampWithTimezoneValue]).
      */
     fun asEnrichedDestinationRecordAirbyteValue(
+        coercer: AirbyteValueCoercer = AirbyteValueCoercer(),
         extractedAtAsTimestampWithTimezone: Boolean = false,
         respectLegacyUnions: Boolean = false,
     ): EnrichedDestinationRecordAirbyteValue {
@@ -64,7 +65,8 @@ data class DestinationRecordRaw(
                     name = fieldName,
                     airbyteMetaField = null,
                 )
-            AirbyteValueCoercer.coerce(
+            coercer
+                .coerce(
                     fieldValue.toAirbyteValue(),
                     fieldType.type,
                     respectLegacyUnions = respectLegacyUnions,

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/DestinationRecordRaw.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/DestinationRecordRaw.kt
@@ -41,7 +41,7 @@ data class DestinationRecordRaw(
      * [TimestampWithTimezoneValue]).
      */
     fun asEnrichedDestinationRecordAirbyteValue(
-        coercer: AirbyteValueCoercer = AirbyteValueCoercer(),
+        coercer: AirbyteValueCoercer,
         extractedAtAsTimestampWithTimezone: Boolean = false,
         respectLegacyUnions: Boolean = false,
     ): EnrichedDestinationRecordAirbyteValue {

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/Meta.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/Meta.kt
@@ -7,7 +7,6 @@ package io.airbyte.cdk.load.message
 import com.fasterxml.jackson.databind.JsonNode
 import io.airbyte.cdk.load.data.AirbyteType
 import io.airbyte.cdk.load.data.AirbyteValue
-import io.airbyte.cdk.load.data.AirbyteValueCoercer.DATE_TIME_FORMATTER
 import io.airbyte.cdk.load.data.ArrayType
 import io.airbyte.cdk.load.data.FieldType
 import io.airbyte.cdk.load.data.IntegerType
@@ -16,6 +15,7 @@ import io.airbyte.cdk.load.data.ObjectType
 import io.airbyte.cdk.load.data.ObjectValue
 import io.airbyte.cdk.load.data.StringType
 import io.airbyte.cdk.load.data.StringValue
+import io.airbyte.cdk.load.data.TemporalFormatters.DATE_TIME_FORMATTER
 import io.airbyte.cdk.load.data.TimestampWithTimezoneValue
 import io.airbyte.cdk.load.data.json.toAirbyteValue
 import io.airbyte.cdk.load.util.deserializeToNode

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/data/AirbyteValueCoercerTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/data/AirbyteValueCoercerTest.kt
@@ -1,0 +1,265 @@
+/*
+ * Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+ */
+
+// Test cases ported from legacy-task-loader's AirbyteValueDeepCoercingMapperTest.kt,
+// adapted to call AirbyteValueCoercer.coerce() directly.
+
+package io.airbyte.cdk.load.data
+
+import io.airbyte.cdk.load.data.AirbyteValueCoercer.DATE_TIME_FORMATTER
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.OffsetDateTime
+import java.time.OffsetTime
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class AirbyteValueCoercerTest {
+
+    // ==================== Timestamp with timezone ====================
+
+    private val timestampPairs: List<Pair<String, OffsetDateTime>> =
+        listOf(
+            // ISO formats — no timezone (should assume UTC)
+            "2018-09-15 12:00:00" to
+                LocalDateTime.parse("2018-09-15 12:00:00", DATE_TIME_FORMATTER)
+                    .atOffset(ZoneOffset.UTC),
+            "2018-09-15 12:00:00.006542" to
+                LocalDateTime.parse("2018-09-15 12:00:00.006542", DATE_TIME_FORMATTER)
+                    .atOffset(ZoneOffset.UTC),
+            // Slash separators
+            "2018/09/15 12:00:00" to
+                LocalDateTime.parse("2018/09/15 12:00:00", DATE_TIME_FORMATTER)
+                    .atOffset(ZoneOffset.UTC),
+            // Dot separators
+            "2018.09.15 12:00:00" to
+                LocalDateTime.parse("2018.09.15 12:00:00", DATE_TIME_FORMATTER)
+                    .atOffset(ZoneOffset.UTC),
+            // Abbreviated month name
+            "2018 Jul 15 12:00:00" to
+                LocalDateTime.parse("2018 Jul 15 12:00:00", DATE_TIME_FORMATTER)
+                    .atOffset(ZoneOffset.UTC),
+            // Single-digit month/day
+            "2021-1-1 01:01:01" to
+                LocalDateTime.parse("2021-1-1 01:01:01", DATE_TIME_FORMATTER)
+                    .atOffset(ZoneOffset.UTC),
+            "2021.1.1 01:01:01" to
+                LocalDateTime.parse("2021.1.1 01:01:01", DATE_TIME_FORMATTER)
+                    .atOffset(ZoneOffset.UTC),
+            "2021/1/1 01:01:01" to
+                LocalDateTime.parse("2021/1/1 01:01:01", DATE_TIME_FORMATTER)
+                    .atOffset(ZoneOffset.UTC),
+            "2021-01-01 01:01:01" to
+                LocalDateTime.parse("2021-01-01 01:01:01", DATE_TIME_FORMATTER)
+                    .atOffset(ZoneOffset.UTC),
+            // With timezone offset — various formats
+            "2021-1-1 01:01:01 +01" to
+                ZonedDateTime.parse("2021-1-1 01:01:01 +01", DATE_TIME_FORMATTER)
+                    .toOffsetDateTime(),
+            "2018 Jul 15 12:00:00 GMT+08:00" to
+                ZonedDateTime.parse("2018 Jul 15 12:00:00 GMT+08:00", DATE_TIME_FORMATTER)
+                    .toOffsetDateTime(),
+            "2018 Jul 15 12:00:00GMT+07" to
+                ZonedDateTime.parse("2018 Jul 15 12:00:00GMT+07", DATE_TIME_FORMATTER)
+                    .toOffsetDateTime(),
+            "2021-01-01T01:01:01+01:00" to
+                ZonedDateTime.parse("2021-01-01T01:01:01+01:00", DATE_TIME_FORMATTER)
+                    .toOffsetDateTime(),
+            "2021-01-01T01:01:01.546+01:00" to
+                ZonedDateTime.parse("2021-01-01T01:01:01.546+01:00", DATE_TIME_FORMATTER)
+                    .toOffsetDateTime(),
+            "2021-01-01 01:01:01 +0000" to
+                ZonedDateTime.parse("2021-01-01 01:01:01 +0000", DATE_TIME_FORMATTER)
+                    .toOffsetDateTime(),
+            "2021/01/01 01:01:01 +0000" to
+                ZonedDateTime.parse("2021/01/01 01:01:01 +0000", DATE_TIME_FORMATTER)
+                    .toOffsetDateTime(),
+            // Z suffix
+            "2021-01-01T01:01:01Z" to
+                ZonedDateTime.parse("2021-01-01T01:01:01Z", DATE_TIME_FORMATTER)
+                    .toOffsetDateTime(),
+            // Negative offsets
+            "2021-01-01T01:01:01-01:00" to
+                ZonedDateTime.parse("2021-01-01T01:01:01-01:00", DATE_TIME_FORMATTER)
+                    .toOffsetDateTime(),
+            "2021-01-01T01:01:01+01:00" to
+                ZonedDateTime.parse("2021-01-01T01:01:01+01:00", DATE_TIME_FORMATTER)
+                    .toOffsetDateTime(),
+            // Named timezones
+            "2021-01-01 01:01:01 UTC" to
+                ZonedDateTime.parse("2021-01-01 01:01:01 UTC", DATE_TIME_FORMATTER)
+                    .toOffsetDateTime(),
+            "2021-01-01T01:01:01 PST" to
+                ZonedDateTime.parse("2021-01-01T01:01:01 PST", DATE_TIME_FORMATTER)
+                    .toOffsetDateTime(),
+            // Compact offsets
+            "2021-01-01T01:01:01 +0000" to
+                ZonedDateTime.parse("2021-01-01T01:01:01 +0000", DATE_TIME_FORMATTER)
+                    .toOffsetDateTime(),
+            "2021-01-01T01:01:01+0000" to
+                ZonedDateTime.parse("2021-01-01T01:01:01+0000", DATE_TIME_FORMATTER)
+                    .toOffsetDateTime(),
+            // Appended named timezone
+            "2021-01-01T01:01:01UTC" to
+                ZonedDateTime.parse("2021-01-01T01:01:01UTC", DATE_TIME_FORMATTER)
+                    .toOffsetDateTime(),
+            // Short offset
+            "2021-01-01T01:01:01+01" to
+                ZonedDateTime.parse("2021-01-01T01:01:01+01", DATE_TIME_FORMATTER)
+                    .toOffsetDateTime(),
+            // BC era
+            "2022-01-23T01:23:45.678-11:30 BC" to
+                ZonedDateTime.parse("2022-01-23T01:23:45.678-11:30 BC", DATE_TIME_FORMATTER)
+                    .toOffsetDateTime(),
+            "2022-01-23T01:23:45.678-11:30" to
+                ZonedDateTime.parse("2022-01-23T01:23:45.678-11:30", DATE_TIME_FORMATTER)
+                    .toOffsetDateTime(),
+        )
+
+    @Test
+    fun testCoerceTimestampWithTimezone() {
+        timestampPairs.forEach { (input, expectedOdt) ->
+            val result = AirbyteValueCoercer.coerce(
+                StringValue(input),
+                TimestampTypeWithTimezone,
+            )
+            assertEquals(
+                TimestampWithTimezoneValue(expectedOdt),
+                result,
+                "Failed for input: $input"
+            )
+        }
+    }
+
+    @Test
+    fun testCoerceTimestampWithoutTimezone() {
+        timestampPairs.forEach { (input, expectedOdt) ->
+            val result = AirbyteValueCoercer.coerce(
+                StringValue(input),
+                TimestampTypeWithoutTimezone,
+            )
+            assertEquals(
+                TimestampWithoutTimezoneValue(expectedOdt.toLocalDateTime()),
+                result,
+                "Failed for input: $input"
+            )
+        }
+    }
+
+    // ==================== Time with/without timezone ====================
+
+    private val timePairs: List<Pair<String, OffsetTime>> =
+        listOf(
+            // Bare times — no timezone, assumes UTC
+            "01:01:01" to LocalTime.parse("01:01:01").atOffset(ZoneOffset.UTC),
+            "01:01" to LocalTime.parse("01:01").atOffset(ZoneOffset.UTC),
+            "12:23:01.541" to LocalTime.parse("12:23:01.541").atOffset(ZoneOffset.UTC),
+            "12:23:01.541214" to LocalTime.parse("12:23:01.541214").atOffset(ZoneOffset.UTC),
+            // With timezone offset
+            "12:00:00.000000+01:00" to OffsetTime.parse("12:00:00.000000+01:00"),
+            "10:00:00.000000-01:00" to OffsetTime.parse("10:00:00.000000-01:00"),
+            "03:30:00.000000+04:00" to OffsetTime.parse("03:30:00.000000+04:00"),
+        )
+
+    @Test
+    fun testCoerceTimeWithTimezone() {
+        timePairs.forEach { (input, expectedOt) ->
+            val result = AirbyteValueCoercer.coerce(
+                StringValue(input),
+                TimeTypeWithTimezone,
+            )
+            assertEquals(
+                TimeWithTimezoneValue(expectedOt),
+                result,
+                "Failed for input: $input"
+            )
+        }
+    }
+
+    @Test
+    fun testCoerceTimeWithoutTimezone() {
+        timePairs.forEach { (input, expectedOt) ->
+            val result = AirbyteValueCoercer.coerce(
+                StringValue(input),
+                TimeTypeWithoutTimezone,
+            )
+            assertEquals(
+                TimeWithoutTimezoneValue(expectedOt.toLocalTime()),
+                result,
+                "Failed for input: $input"
+            )
+        }
+    }
+
+    // ==================== Date ====================
+
+    @Test
+    fun testCoerceDate() {
+        listOf(
+            "2021-1-1",
+            "2021-01-01",
+            "2021/01/02",
+            "2021.01.03",
+            "2021 Jan 04",
+            "2021-1-1 BC",
+        ).forEach { input ->
+            val expected = LocalDate.parse(input, DATE_TIME_FORMATTER)
+            val result = AirbyteValueCoercer.coerce(StringValue(input), DateType)
+            assertEquals(
+                DateValue(expected),
+                result,
+                "Failed for input: $input"
+            )
+        }
+    }
+
+    // ==================== Edge cases ====================
+
+    @Test
+    fun testCoerceNullValue() {
+        assertEquals(
+            NullValue,
+            AirbyteValueCoercer.coerce(NullValue, TimestampTypeWithTimezone)
+        )
+    }
+
+    @Test
+    fun testCoerceAlreadyTypedTimestamp() {
+        val odt = OffsetDateTime.parse("2024-01-23T01:23:45Z")
+        val value = TimestampWithTimezoneValue(odt)
+        assertEquals(
+            value,
+            AirbyteValueCoercer.coerce(value, TimestampTypeWithTimezone)
+        )
+    }
+
+    @Test
+    fun testCoerceAlreadyTypedTime() {
+        val ot = OffsetTime.parse("01:23:45Z")
+        val value = TimeWithTimezoneValue(ot)
+        assertEquals(
+            value,
+            AirbyteValueCoercer.coerce(value, TimeTypeWithTimezone)
+        )
+    }
+
+    @Test
+    fun testCoerceWrongTypeReturnsNull() {
+        // IntegerValue can't be coerced to a timestamp
+        assertNull(
+            AirbyteValueCoercer.coerce(IntegerValue(12345), TimestampTypeWithTimezone)
+        )
+    }
+
+    @Test
+    fun testCoerceInvalidStringReturnsNull() {
+        assertNull(
+            AirbyteValueCoercer.coerce(StringValue("not-a-timestamp"), TimestampTypeWithTimezone)
+        )
+    }
+}

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/data/AirbyteValueCoercerTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/data/AirbyteValueCoercerTest.kt
@@ -81,8 +81,7 @@ class AirbyteValueCoercerTest {
                     .toOffsetDateTime(),
             // Z suffix
             "2021-01-01T01:01:01Z" to
-                ZonedDateTime.parse("2021-01-01T01:01:01Z", DATE_TIME_FORMATTER)
-                    .toOffsetDateTime(),
+                ZonedDateTime.parse("2021-01-01T01:01:01Z", DATE_TIME_FORMATTER).toOffsetDateTime(),
             // Negative offsets
             "2021-01-01T01:01:01-01:00" to
                 ZonedDateTime.parse("2021-01-01T01:01:01-01:00", DATE_TIME_FORMATTER)
@@ -124,10 +123,11 @@ class AirbyteValueCoercerTest {
     @Test
     fun testCoerceTimestampWithTimezone() {
         timestampPairs.forEach { (input, expectedOdt) ->
-            val result = AirbyteValueCoercer.coerce(
-                StringValue(input),
-                TimestampTypeWithTimezone,
-            )
+            val result =
+                AirbyteValueCoercer.coerce(
+                    StringValue(input),
+                    TimestampTypeWithTimezone,
+                )
             assertEquals(
                 TimestampWithTimezoneValue(expectedOdt),
                 result,
@@ -139,10 +139,11 @@ class AirbyteValueCoercerTest {
     @Test
     fun testCoerceTimestampWithoutTimezone() {
         timestampPairs.forEach { (input, expectedOdt) ->
-            val result = AirbyteValueCoercer.coerce(
-                StringValue(input),
-                TimestampTypeWithoutTimezone,
-            )
+            val result =
+                AirbyteValueCoercer.coerce(
+                    StringValue(input),
+                    TimestampTypeWithoutTimezone,
+                )
             assertEquals(
                 TimestampWithoutTimezoneValue(expectedOdt.toLocalDateTime()),
                 result,
@@ -169,25 +170,23 @@ class AirbyteValueCoercerTest {
     @Test
     fun testCoerceTimeWithTimezone() {
         timePairs.forEach { (input, expectedOt) ->
-            val result = AirbyteValueCoercer.coerce(
-                StringValue(input),
-                TimeTypeWithTimezone,
-            )
-            assertEquals(
-                TimeWithTimezoneValue(expectedOt),
-                result,
-                "Failed for input: $input"
-            )
+            val result =
+                AirbyteValueCoercer.coerce(
+                    StringValue(input),
+                    TimeTypeWithTimezone,
+                )
+            assertEquals(TimeWithTimezoneValue(expectedOt), result, "Failed for input: $input")
         }
     }
 
     @Test
     fun testCoerceTimeWithoutTimezone() {
         timePairs.forEach { (input, expectedOt) ->
-            val result = AirbyteValueCoercer.coerce(
-                StringValue(input),
-                TimeTypeWithoutTimezone,
-            )
+            val result =
+                AirbyteValueCoercer.coerce(
+                    StringValue(input),
+                    TimeTypeWithoutTimezone,
+                )
             assertEquals(
                 TimeWithoutTimezoneValue(expectedOt.toLocalTime()),
                 result,
@@ -201,59 +200,45 @@ class AirbyteValueCoercerTest {
     @Test
     fun testCoerceDate() {
         listOf(
-            "2021-1-1",
-            "2021-01-01",
-            "2021/01/02",
-            "2021.01.03",
-            "2021 Jan 04",
-            "2021-1-1 BC",
-        ).forEach { input ->
-            val expected = LocalDate.parse(input, DATE_TIME_FORMATTER)
-            val result = AirbyteValueCoercer.coerce(StringValue(input), DateType)
-            assertEquals(
-                DateValue(expected),
-                result,
-                "Failed for input: $input"
+                "2021-1-1",
+                "2021-01-01",
+                "2021/01/02",
+                "2021.01.03",
+                "2021 Jan 04",
+                "2021-1-1 BC",
             )
-        }
+            .forEach { input ->
+                val expected = LocalDate.parse(input, DATE_TIME_FORMATTER)
+                val result = AirbyteValueCoercer.coerce(StringValue(input), DateType)
+                assertEquals(DateValue(expected), result, "Failed for input: $input")
+            }
     }
 
     // ==================== Edge cases ====================
 
     @Test
     fun testCoerceNullValue() {
-        assertEquals(
-            NullValue,
-            AirbyteValueCoercer.coerce(NullValue, TimestampTypeWithTimezone)
-        )
+        assertEquals(NullValue, AirbyteValueCoercer.coerce(NullValue, TimestampTypeWithTimezone))
     }
 
     @Test
     fun testCoerceAlreadyTypedTimestamp() {
         val odt = OffsetDateTime.parse("2024-01-23T01:23:45Z")
         val value = TimestampWithTimezoneValue(odt)
-        assertEquals(
-            value,
-            AirbyteValueCoercer.coerce(value, TimestampTypeWithTimezone)
-        )
+        assertEquals(value, AirbyteValueCoercer.coerce(value, TimestampTypeWithTimezone))
     }
 
     @Test
     fun testCoerceAlreadyTypedTime() {
         val ot = OffsetTime.parse("01:23:45Z")
         val value = TimeWithTimezoneValue(ot)
-        assertEquals(
-            value,
-            AirbyteValueCoercer.coerce(value, TimeTypeWithTimezone)
-        )
+        assertEquals(value, AirbyteValueCoercer.coerce(value, TimeTypeWithTimezone))
     }
 
     @Test
     fun testCoerceWrongTypeReturnsNull() {
         // IntegerValue can't be coerced to a timestamp
-        assertNull(
-            AirbyteValueCoercer.coerce(IntegerValue(12345), TimestampTypeWithTimezone)
-        )
+        assertNull(AirbyteValueCoercer.coerce(IntegerValue(12345), TimestampTypeWithTimezone))
     }
 
     @Test

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/data/AirbyteValueCoercerTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/data/AirbyteValueCoercerTest.kt
@@ -3,248 +3,441 @@
  */
 
 // Test cases ported from legacy-task-loader's AirbyteValueDeepCoercingMapperTest.kt,
-// adapted to call AirbyteValueCoercer.coerce() directly.
+// adapted to call AirbyteValueCoercer.coerce() directly with hardcoded expected values.
+// All tests run against both legacy (flag=false) and fast (flag=true) implementations.
 
 package io.airbyte.cdk.load.data
 
-import io.airbyte.cdk.load.data.AirbyteValueCoercer.DATE_TIME_FORMATTER
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
 import java.time.OffsetDateTime
 import java.time.OffsetTime
 import java.time.ZoneOffset
-import java.time.ZonedDateTime
+import java.util.stream.Stream
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
 
+// spotless:off
+// Formatting disabled — breaking up timestamp creation across lines makes it much harder to read
 class AirbyteValueCoercerTest {
 
-    // ==================== Timestamp with timezone ====================
+    private val legacyCoercer = AirbyteValueCoercer(useFastTimestampParsing = false)
+    private val fastCoercer = AirbyteValueCoercer(useFastTimestampParsing = true)
 
-    private val timestampPairs: List<Pair<String, OffsetDateTime>> =
-        listOf(
-            // ISO formats — no timezone (should assume UTC)
-            "2018-09-15 12:00:00" to
-                LocalDateTime.parse("2018-09-15 12:00:00", DATE_TIME_FORMATTER)
-                    .atOffset(ZoneOffset.UTC),
-            "2018-09-15 12:00:00.006542" to
-                LocalDateTime.parse("2018-09-15 12:00:00.006542", DATE_TIME_FORMATTER)
-                    .atOffset(ZoneOffset.UTC),
-            // Slash separators
-            "2018/09/15 12:00:00" to
-                LocalDateTime.parse("2018/09/15 12:00:00", DATE_TIME_FORMATTER)
-                    .atOffset(ZoneOffset.UTC),
-            // Dot separators
-            "2018.09.15 12:00:00" to
-                LocalDateTime.parse("2018.09.15 12:00:00", DATE_TIME_FORMATTER)
-                    .atOffset(ZoneOffset.UTC),
-            // Abbreviated month name
-            "2018 Jul 15 12:00:00" to
-                LocalDateTime.parse("2018 Jul 15 12:00:00", DATE_TIME_FORMATTER)
-                    .atOffset(ZoneOffset.UTC),
-            // Single-digit month/day
-            "2021-1-1 01:01:01" to
-                LocalDateTime.parse("2021-1-1 01:01:01", DATE_TIME_FORMATTER)
-                    .atOffset(ZoneOffset.UTC),
-            "2021.1.1 01:01:01" to
-                LocalDateTime.parse("2021.1.1 01:01:01", DATE_TIME_FORMATTER)
-                    .atOffset(ZoneOffset.UTC),
-            "2021/1/1 01:01:01" to
-                LocalDateTime.parse("2021/1/1 01:01:01", DATE_TIME_FORMATTER)
-                    .atOffset(ZoneOffset.UTC),
-            "2021-01-01 01:01:01" to
-                LocalDateTime.parse("2021-01-01 01:01:01", DATE_TIME_FORMATTER)
-                    .atOffset(ZoneOffset.UTC),
-            // With timezone offset — various formats
-            "2021-1-1 01:01:01 +01" to
-                ZonedDateTime.parse("2021-1-1 01:01:01 +01", DATE_TIME_FORMATTER)
-                    .toOffsetDateTime(),
-            "2018 Jul 15 12:00:00 GMT+08:00" to
-                ZonedDateTime.parse("2018 Jul 15 12:00:00 GMT+08:00", DATE_TIME_FORMATTER)
-                    .toOffsetDateTime(),
-            "2018 Jul 15 12:00:00GMT+07" to
-                ZonedDateTime.parse("2018 Jul 15 12:00:00GMT+07", DATE_TIME_FORMATTER)
-                    .toOffsetDateTime(),
-            "2021-01-01T01:01:01+01:00" to
-                ZonedDateTime.parse("2021-01-01T01:01:01+01:00", DATE_TIME_FORMATTER)
-                    .toOffsetDateTime(),
-            "2021-01-01T01:01:01.546+01:00" to
-                ZonedDateTime.parse("2021-01-01T01:01:01.546+01:00", DATE_TIME_FORMATTER)
-                    .toOffsetDateTime(),
-            "2021-01-01 01:01:01 +0000" to
-                ZonedDateTime.parse("2021-01-01 01:01:01 +0000", DATE_TIME_FORMATTER)
-                    .toOffsetDateTime(),
-            "2021/01/01 01:01:01 +0000" to
-                ZonedDateTime.parse("2021/01/01 01:01:01 +0000", DATE_TIME_FORMATTER)
-                    .toOffsetDateTime(),
-            // Z suffix
-            "2021-01-01T01:01:01Z" to
-                ZonedDateTime.parse("2021-01-01T01:01:01Z", DATE_TIME_FORMATTER).toOffsetDateTime(),
-            // Negative offsets
-            "2021-01-01T01:01:01-01:00" to
-                ZonedDateTime.parse("2021-01-01T01:01:01-01:00", DATE_TIME_FORMATTER)
-                    .toOffsetDateTime(),
-            "2021-01-01T01:01:01+01:00" to
-                ZonedDateTime.parse("2021-01-01T01:01:01+01:00", DATE_TIME_FORMATTER)
-                    .toOffsetDateTime(),
-            // Named timezones
-            "2021-01-01 01:01:01 UTC" to
-                ZonedDateTime.parse("2021-01-01 01:01:01 UTC", DATE_TIME_FORMATTER)
-                    .toOffsetDateTime(),
-            "2021-01-01T01:01:01 PST" to
-                ZonedDateTime.parse("2021-01-01T01:01:01 PST", DATE_TIME_FORMATTER)
-                    .toOffsetDateTime(),
-            // Compact offsets
-            "2021-01-01T01:01:01 +0000" to
-                ZonedDateTime.parse("2021-01-01T01:01:01 +0000", DATE_TIME_FORMATTER)
-                    .toOffsetDateTime(),
-            "2021-01-01T01:01:01+0000" to
-                ZonedDateTime.parse("2021-01-01T01:01:01+0000", DATE_TIME_FORMATTER)
-                    .toOffsetDateTime(),
-            // Appended named timezone
-            "2021-01-01T01:01:01UTC" to
-                ZonedDateTime.parse("2021-01-01T01:01:01UTC", DATE_TIME_FORMATTER)
-                    .toOffsetDateTime(),
-            // Short offset
-            "2021-01-01T01:01:01+01" to
-                ZonedDateTime.parse("2021-01-01T01:01:01+01", DATE_TIME_FORMATTER)
-                    .toOffsetDateTime(),
-            // BC era
-            "2022-01-23T01:23:45.678-11:30 BC" to
-                ZonedDateTime.parse("2022-01-23T01:23:45.678-11:30 BC", DATE_TIME_FORMATTER)
-                    .toOffsetDateTime(),
-            "2022-01-23T01:23:45.678-11:30" to
-                ZonedDateTime.parse("2022-01-23T01:23:45.678-11:30", DATE_TIME_FORMATTER)
-                    .toOffsetDateTime(),
-        )
-
-    @Test
-    fun testCoerceTimestampWithTimezone() {
-        timestampPairs.forEach { (input, expectedOdt) ->
-            val result =
-                AirbyteValueCoercer.coerce(
-                    StringValue(input),
-                    TimestampTypeWithTimezone,
-                )
-            assertEquals(
-                TimestampWithTimezoneValue(expectedOdt),
-                result,
-                "Failed for input: $input"
-            )
-        }
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("timestampWithTimezoneArgs")
+    fun testCoerceTimestampWithTimezone(input: String, expected: AirbyteValue) {
+        assertEquals(expected, legacyCoercer.coerce(StringValue(input), TimestampTypeWithTimezone))
+        assertEquals(expected, fastCoercer.coerce(StringValue(input), TimestampTypeWithTimezone))
     }
 
-    @Test
-    fun testCoerceTimestampWithoutTimezone() {
-        timestampPairs.forEach { (input, expectedOdt) ->
-            val result =
-                AirbyteValueCoercer.coerce(
-                    StringValue(input),
-                    TimestampTypeWithoutTimezone,
-                )
-            assertEquals(
-                TimestampWithoutTimezoneValue(expectedOdt.toLocalDateTime()),
-                result,
-                "Failed for input: $input"
-            )
-        }
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("timestampWithoutTimezoneArgs")
+    fun testCoerceTimestampWithoutTimezone(input: String, expected: AirbyteValue) {
+        assertEquals(expected, legacyCoercer.coerce(StringValue(input), TimestampTypeWithoutTimezone))
+        assertEquals(expected, fastCoercer.coerce(StringValue(input), TimestampTypeWithoutTimezone))
     }
 
-    // ==================== Time with/without timezone ====================
-
-    private val timePairs: List<Pair<String, OffsetTime>> =
-        listOf(
-            // Bare times — no timezone, assumes UTC
-            "01:01:01" to LocalTime.parse("01:01:01").atOffset(ZoneOffset.UTC),
-            "01:01" to LocalTime.parse("01:01").atOffset(ZoneOffset.UTC),
-            "12:23:01.541" to LocalTime.parse("12:23:01.541").atOffset(ZoneOffset.UTC),
-            "12:23:01.541214" to LocalTime.parse("12:23:01.541214").atOffset(ZoneOffset.UTC),
-            // With timezone offset
-            "12:00:00.000000+01:00" to OffsetTime.parse("12:00:00.000000+01:00"),
-            "10:00:00.000000-01:00" to OffsetTime.parse("10:00:00.000000-01:00"),
-            "03:30:00.000000+04:00" to OffsetTime.parse("03:30:00.000000+04:00"),
-        )
-
-    @Test
-    fun testCoerceTimeWithTimezone() {
-        timePairs.forEach { (input, expectedOt) ->
-            val result =
-                AirbyteValueCoercer.coerce(
-                    StringValue(input),
-                    TimeTypeWithTimezone,
-                )
-            assertEquals(TimeWithTimezoneValue(expectedOt), result, "Failed for input: $input")
-        }
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("timeWithTimezoneArgs")
+    fun testCoerceTimeWithTimezone(input: String, expected: AirbyteValue) {
+        assertEquals(expected, legacyCoercer.coerce(StringValue(input), TimeTypeWithTimezone))
+        assertEquals(expected, fastCoercer.coerce(StringValue(input), TimeTypeWithTimezone))
     }
 
-    @Test
-    fun testCoerceTimeWithoutTimezone() {
-        timePairs.forEach { (input, expectedOt) ->
-            val result =
-                AirbyteValueCoercer.coerce(
-                    StringValue(input),
-                    TimeTypeWithoutTimezone,
-                )
-            assertEquals(
-                TimeWithoutTimezoneValue(expectedOt.toLocalTime()),
-                result,
-                "Failed for input: $input"
-            )
-        }
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("timeWithoutTimezoneArgs")
+    fun testCoerceTimeWithoutTimezone(input: String, expected: AirbyteValue) {
+        assertEquals(expected, legacyCoercer.coerce(StringValue(input), TimeTypeWithoutTimezone))
+        assertEquals(expected, fastCoercer.coerce(StringValue(input), TimeTypeWithoutTimezone))
     }
 
-    // ==================== Date ====================
-
-    @Test
-    fun testCoerceDate() {
-        listOf(
-                "2021-1-1",
-                "2021-01-01",
-                "2021/01/02",
-                "2021.01.03",
-                "2021 Jan 04",
-                "2021-1-1 BC",
-            )
-            .forEach { input ->
-                val expected = LocalDate.parse(input, DATE_TIME_FORMATTER)
-                val result = AirbyteValueCoercer.coerce(StringValue(input), DateType)
-                assertEquals(DateValue(expected), result, "Failed for input: $input")
-            }
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("dateArgs")
+    fun testCoerceDate(input: String, expected: AirbyteValue) {
+        assertEquals(expected, legacyCoercer.coerce(StringValue(input), DateType))
+        assertEquals(expected, fastCoercer.coerce(StringValue(input), DateType))
     }
-
-    // ==================== Edge cases ====================
 
     @Test
     fun testCoerceNullValue() {
-        assertEquals(NullValue, AirbyteValueCoercer.coerce(NullValue, TimestampTypeWithTimezone))
+        assertEquals(NullValue, legacyCoercer.coerce(NullValue, TimestampTypeWithTimezone))
+        assertEquals(NullValue, fastCoercer.coerce(NullValue, TimestampTypeWithTimezone))
     }
 
     @Test
     fun testCoerceAlreadyTypedTimestamp() {
-        val odt = OffsetDateTime.parse("2024-01-23T01:23:45Z")
-        val value = TimestampWithTimezoneValue(odt)
-        assertEquals(value, AirbyteValueCoercer.coerce(value, TimestampTypeWithTimezone))
+        val value: AirbyteValue = TimestampWithTimezoneValue(OffsetDateTime.of(2024, 1, 23, 1, 23, 45, 0, ZoneOffset.UTC))
+        assertEquals(value, legacyCoercer.coerce(value, TimestampTypeWithTimezone))
+        assertEquals(value, fastCoercer.coerce(value, TimestampTypeWithTimezone))
     }
 
     @Test
     fun testCoerceAlreadyTypedTime() {
-        val ot = OffsetTime.parse("01:23:45Z")
-        val value = TimeWithTimezoneValue(ot)
-        assertEquals(value, AirbyteValueCoercer.coerce(value, TimeTypeWithTimezone))
+        val value: AirbyteValue = TimeWithTimezoneValue(OffsetTime.of(1, 23, 45, 0, ZoneOffset.UTC))
+        assertEquals(value, legacyCoercer.coerce(value, TimeTypeWithTimezone))
+        assertEquals(value, fastCoercer.coerce(value, TimeTypeWithTimezone))
     }
 
     @Test
     fun testCoerceWrongTypeReturnsNull() {
-        // IntegerValue can't be coerced to a timestamp
-        assertNull(AirbyteValueCoercer.coerce(IntegerValue(12345), TimestampTypeWithTimezone))
+        assertNull(legacyCoercer.coerce(IntegerValue(12345), TimestampTypeWithTimezone))
+        assertNull(fastCoercer.coerce(IntegerValue(12345), TimestampTypeWithTimezone))
     }
 
     @Test
     fun testCoerceInvalidStringReturnsNull() {
-        assertNull(
-            AirbyteValueCoercer.coerce(StringValue("not-a-timestamp"), TimestampTypeWithTimezone)
+        assertNull(legacyCoercer.coerce(StringValue("not-a-timestamp"), TimestampTypeWithTimezone))
+        assertNull(fastCoercer.coerce(StringValue("not-a-timestamp"), TimestampTypeWithTimezone))
+    }
+
+    companion object {
+        // Expected values below were captured from the output of the legacy coercion code
+        // (the original try-ZonedDateTime/catch-LocalDateTime pattern) to ensure the new
+        // fast path produces identical results.
+
+        private val UTC = ZoneOffset.UTC
+
+        @JvmStatic
+        fun timestampWithTimezoneArgs(): Stream<Arguments> = Stream.of(
+            // ISO formats — no timezone (assumes UTC)
+            Arguments.of(
+                "2018-09-15 12:00:00",
+                TimestampWithTimezoneValue(OffsetDateTime.of(2018, 9, 15, 12, 0, 0, 0, UTC)),
+            ),
+            Arguments.of(
+                "2018-09-15 12:00:00.006542",
+                TimestampWithTimezoneValue(OffsetDateTime.of(2018, 9, 15, 12, 0, 0, 6542000, UTC)),
+            ),
+            // Slash separators
+            Arguments.of(
+                "2018/09/15 12:00:00",
+                TimestampWithTimezoneValue(OffsetDateTime.of(2018, 9, 15, 12, 0, 0, 0, UTC)),
+            ),
+            // Dot separators
+            Arguments.of(
+                "2018.09.15 12:00:00",
+                TimestampWithTimezoneValue(OffsetDateTime.of(2018, 9, 15, 12, 0, 0, 0, UTC)),
+            ),
+            // Abbreviated month name
+            Arguments.of(
+                "2018 Jul 15 12:00:00",
+                TimestampWithTimezoneValue(OffsetDateTime.of(2018, 7, 15, 12, 0, 0, 0, UTC)),
+            ),
+            // Single-digit month/day
+            Arguments.of(
+                "2021-1-1 01:01:01",
+                TimestampWithTimezoneValue(OffsetDateTime.of(2021, 1, 1, 1, 1, 1, 0, UTC)),
+            ),
+            Arguments.of(
+                "2021.1.1 01:01:01",
+                TimestampWithTimezoneValue(OffsetDateTime.of(2021, 1, 1, 1, 1, 1, 0, UTC)),
+            ),
+            Arguments.of(
+                "2021/1/1 01:01:01",
+                TimestampWithTimezoneValue(OffsetDateTime.of(2021, 1, 1, 1, 1, 1, 0, UTC)),
+            ),
+            Arguments.of(
+                "2021-01-01 01:01:01",
+                TimestampWithTimezoneValue(OffsetDateTime.of(2021, 1, 1, 1, 1, 1, 0, UTC)),
+            ),
+            // With timezone offset — various formats
+            Arguments.of(
+                "2021-1-1 01:01:01 +01",
+                TimestampWithTimezoneValue(OffsetDateTime.of(2021, 1, 1, 1, 1, 1, 0, ZoneOffset.ofHours(1))),
+            ),
+            Arguments.of(
+                "2018 Jul 15 12:00:00 GMT+08:00",
+                TimestampWithTimezoneValue(OffsetDateTime.of(2018, 7, 15, 12, 0, 0, 0, ZoneOffset.ofHours(8))),
+            ),
+            // Known bug: 'GMT+07' without a space is parsed as a ZoneId (not a ZoneOffset),
+            // causing toOffsetDateTime() to normalize to UTC instead of preserving +07:00.
+            // TODO: The correct result should be
+            // TimestampWithTimezoneValue(OffsetDateTime.of(2018, 7, 15, 12, 0, 0, 0, ZoneOffset.ofHours(7))).
+            Arguments.of(
+                "2018 Jul 15 12:00:00GMT+07",
+                TimestampWithTimezoneValue(OffsetDateTime.of(2018, 7, 15, 5, 0, 0, 0, UTC)),
+            ),
+            Arguments.of(
+                "2021-01-01T01:01:01+01:00",
+                TimestampWithTimezoneValue(OffsetDateTime.of(2021, 1, 1, 1, 1, 1, 0, ZoneOffset.ofHours(1))),
+            ),
+            Arguments.of(
+                "2021-01-01T01:01:01.546+01:00",
+                TimestampWithTimezoneValue(OffsetDateTime.of(2021, 1, 1, 1, 1, 1, 546000000, ZoneOffset.ofHours(1))),
+            ),
+            Arguments.of(
+                "2021-01-01 01:01:01 +0000",
+                TimestampWithTimezoneValue(OffsetDateTime.of(2021, 1, 1, 1, 1, 1, 0, UTC)),
+            ),
+            Arguments.of(
+                "2021/01/01 01:01:01 +0000",
+                TimestampWithTimezoneValue(OffsetDateTime.of(2021, 1, 1, 1, 1, 1, 0, UTC)),
+            ),
+            // Z suffix
+            Arguments.of(
+                "2021-01-01T01:01:01Z",
+                TimestampWithTimezoneValue(OffsetDateTime.of(2021, 1, 1, 1, 1, 1, 0, UTC)),
+            ),
+            // Negative offsets
+            Arguments.of(
+                "2021-01-01T01:01:01-01:00",
+                TimestampWithTimezoneValue(OffsetDateTime.of(2021, 1, 1, 1, 1, 1, 0, ZoneOffset.ofHours(-1))),
+            ),
+            Arguments.of(
+                "2021-01-01T01:01:01+01:00",
+                TimestampWithTimezoneValue(OffsetDateTime.of(2021, 1, 1, 1, 1, 1, 0, ZoneOffset.ofHours(1))),
+            ),
+            // Named timezones
+            Arguments.of(
+                "2021-01-01 01:01:01 UTC",
+                TimestampWithTimezoneValue(OffsetDateTime.of(2021, 1, 1, 1, 1, 1, 0, UTC)),
+            ),
+            Arguments.of(
+                "2021-01-01T01:01:01 PST",
+                TimestampWithTimezoneValue(OffsetDateTime.of(2021, 1, 1, 1, 1, 1, 0, ZoneOffset.ofHours(-8))),
+            ),
+            // Compact offsets
+            Arguments.of(
+                "2021-01-01T01:01:01 +0000",
+                TimestampWithTimezoneValue(OffsetDateTime.of(2021, 1, 1, 1, 1, 1, 0, UTC)),
+            ),
+            Arguments.of(
+                "2021-01-01T01:01:01+0000",
+                TimestampWithTimezoneValue(OffsetDateTime.of(2021, 1, 1, 1, 1, 1, 0, UTC)),
+            ),
+            // Appended named timezone
+            Arguments.of(
+                "2021-01-01T01:01:01UTC",
+                TimestampWithTimezoneValue(OffsetDateTime.of(2021, 1, 1, 1, 1, 1, 0, UTC)),
+            ),
+            // Short offset
+            Arguments.of(
+                "2021-01-01T01:01:01+01",
+                TimestampWithTimezoneValue(OffsetDateTime.of(2021, 1, 1, 1, 1, 1, 0, ZoneOffset.ofHours(1))),
+            ),
+            // BC era — year 2022 BC maps to proleptic year -2021
+            Arguments.of(
+                "2022-01-23T01:23:45.678-11:30 BC",
+                TimestampWithTimezoneValue(OffsetDateTime.of(-2021, 1, 23, 1, 23, 45, 678000000, ZoneOffset.ofHoursMinutes(-11, -30))),
+            ),
+            Arguments.of(
+                "2022-01-23T01:23:45.678-11:30",
+                TimestampWithTimezoneValue(OffsetDateTime.of(2022, 1, 23, 1, 23, 45, 678000000, ZoneOffset.ofHoursMinutes(-11, -30))),
+            ),
+        )
+
+        @JvmStatic
+        fun timestampWithoutTimezoneArgs(): Stream<Arguments> = Stream.of(
+            Arguments.of(
+                "2018-09-15 12:00:00",
+                TimestampWithoutTimezoneValue(LocalDateTime.of(2018, 9, 15, 12, 0, 0, 0)),
+            ),
+            Arguments.of(
+                "2018-09-15 12:00:00.006542",
+                TimestampWithoutTimezoneValue(LocalDateTime.of(2018, 9, 15, 12, 0, 0, 6542000)),
+            ),
+            Arguments.of(
+                "2018/09/15 12:00:00",
+                TimestampWithoutTimezoneValue(LocalDateTime.of(2018, 9, 15, 12, 0, 0, 0)),
+            ),
+            Arguments.of(
+                "2018.09.15 12:00:00",
+                TimestampWithoutTimezoneValue(LocalDateTime.of(2018, 9, 15, 12, 0, 0, 0)),
+            ),
+            Arguments.of(
+                "2018 Jul 15 12:00:00",
+                TimestampWithoutTimezoneValue(LocalDateTime.of(2018, 7, 15, 12, 0, 0, 0)),
+            ),
+            Arguments.of(
+                "2021-1-1 01:01:01",
+                TimestampWithoutTimezoneValue(LocalDateTime.of(2021, 1, 1, 1, 1, 1, 0)),
+            ),
+            Arguments.of(
+                "2021.1.1 01:01:01",
+                TimestampWithoutTimezoneValue(LocalDateTime.of(2021, 1, 1, 1, 1, 1, 0)),
+            ),
+            Arguments.of(
+                "2021/1/1 01:01:01",
+                TimestampWithoutTimezoneValue(LocalDateTime.of(2021, 1, 1, 1, 1, 1, 0)),
+            ),
+            Arguments.of(
+                "2021-01-01 01:01:01",
+                TimestampWithoutTimezoneValue(LocalDateTime.of(2021, 1, 1, 1, 1, 1, 0)),
+            ),
+            Arguments.of(
+                "2021-1-1 01:01:01 +01",
+                TimestampWithoutTimezoneValue(LocalDateTime.of(2021, 1, 1, 1, 1, 1, 0)),
+            ),
+            Arguments.of(
+                "2018 Jul 15 12:00:00 GMT+08:00",
+                TimestampWithoutTimezoneValue(LocalDateTime.of(2018, 7, 15, 12, 0, 0, 0)),
+            ),
+            // Known bug: see timestampWithTimezoneArgs for details
+            Arguments.of(
+                "2018 Jul 15 12:00:00GMT+07",
+                TimestampWithoutTimezoneValue(LocalDateTime.of(2018, 7, 15, 5, 0, 0, 0)),
+            ),
+            Arguments.of(
+                "2021-01-01T01:01:01+01:00",
+                TimestampWithoutTimezoneValue(LocalDateTime.of(2021, 1, 1, 1, 1, 1, 0)),
+            ),
+            Arguments.of(
+                "2021-01-01T01:01:01.546+01:00",
+                TimestampWithoutTimezoneValue(LocalDateTime.of(2021, 1, 1, 1, 1, 1, 546000000)),
+            ),
+            Arguments.of(
+                "2021-01-01 01:01:01 +0000",
+                TimestampWithoutTimezoneValue(LocalDateTime.of(2021, 1, 1, 1, 1, 1, 0)),
+            ),
+            Arguments.of(
+                "2021/01/01 01:01:01 +0000",
+                TimestampWithoutTimezoneValue(LocalDateTime.of(2021, 1, 1, 1, 1, 1, 0)),
+            ),
+            Arguments.of(
+                "2021-01-01T01:01:01Z",
+                TimestampWithoutTimezoneValue(LocalDateTime.of(2021, 1, 1, 1, 1, 1, 0)),
+            ),
+            Arguments.of(
+                "2021-01-01T01:01:01-01:00",
+                TimestampWithoutTimezoneValue(LocalDateTime.of(2021, 1, 1, 1, 1, 1, 0)),
+            ),
+            Arguments.of(
+                "2021-01-01T01:01:01+01:00",
+                TimestampWithoutTimezoneValue(LocalDateTime.of(2021, 1, 1, 1, 1, 1, 0)),
+            ),
+            Arguments.of(
+                "2021-01-01 01:01:01 UTC",
+                TimestampWithoutTimezoneValue(LocalDateTime.of(2021, 1, 1, 1, 1, 1, 0)),
+            ),
+            Arguments.of(
+                "2021-01-01T01:01:01 PST",
+                TimestampWithoutTimezoneValue(LocalDateTime.of(2021, 1, 1, 1, 1, 1, 0)),
+            ),
+            Arguments.of(
+                "2021-01-01T01:01:01 +0000",
+                TimestampWithoutTimezoneValue(LocalDateTime.of(2021, 1, 1, 1, 1, 1, 0)),
+            ),
+            Arguments.of(
+                "2021-01-01T01:01:01+0000",
+                TimestampWithoutTimezoneValue(LocalDateTime.of(2021, 1, 1, 1, 1, 1, 0)),
+            ),
+            Arguments.of(
+                "2021-01-01T01:01:01UTC",
+                TimestampWithoutTimezoneValue(LocalDateTime.of(2021, 1, 1, 1, 1, 1, 0)),
+            ),
+            Arguments.of(
+                "2021-01-01T01:01:01+01",
+                TimestampWithoutTimezoneValue(LocalDateTime.of(2021, 1, 1, 1, 1, 1, 0)),
+            ),
+            Arguments.of(
+                "2022-01-23T01:23:45.678-11:30 BC",
+                TimestampWithoutTimezoneValue(LocalDateTime.of(-2021, 1, 23, 1, 23, 45, 678000000)),
+            ),
+            Arguments.of(
+                "2022-01-23T01:23:45.678-11:30",
+                TimestampWithoutTimezoneValue(LocalDateTime.of(2022, 1, 23, 1, 23, 45, 678000000)),
+            ),
+        )
+
+        @JvmStatic
+        fun timeWithTimezoneArgs(): Stream<Arguments> = Stream.of(
+            // Bare times — no timezone, assumes UTC
+            Arguments.of(
+                "01:01:01",
+                TimeWithTimezoneValue(OffsetTime.of(1, 1, 1, 0, UTC)),
+            ),
+            Arguments.of(
+                "01:01",
+                TimeWithTimezoneValue(OffsetTime.of(1, 1, 0, 0, UTC)),
+            ),
+            Arguments.of(
+                "12:23:01.541",
+                TimeWithTimezoneValue(OffsetTime.of(12, 23, 1, 541000000, UTC)),
+            ),
+            Arguments.of(
+                "12:23:01.541214",
+                TimeWithTimezoneValue(OffsetTime.of(12, 23, 1, 541214000, UTC)),
+            ),
+            // With timezone offset
+            Arguments.of(
+                "12:00:00.000000+01:00",
+                TimeWithTimezoneValue(OffsetTime.of(12, 0, 0, 0, ZoneOffset.ofHours(1))),
+            ),
+            Arguments.of(
+                "10:00:00.000000-01:00",
+                TimeWithTimezoneValue(OffsetTime.of(10, 0, 0, 0, ZoneOffset.ofHours(-1))),
+            ),
+            Arguments.of(
+                "03:30:00.000000+04:00",
+                TimeWithTimezoneValue(OffsetTime.of(3, 30, 0, 0, ZoneOffset.ofHours(4))),
+            ),
+        )
+
+        @JvmStatic
+        fun timeWithoutTimezoneArgs(): Stream<Arguments> = Stream.of(
+            Arguments.of(
+                "01:01:01",
+                TimeWithoutTimezoneValue(LocalTime.of(1, 1, 1, 0)),
+            ),
+            Arguments.of(
+                "01:01",
+                TimeWithoutTimezoneValue(LocalTime.of(1, 1, 0, 0)),
+            ),
+            Arguments.of(
+                "12:23:01.541",
+                TimeWithoutTimezoneValue(LocalTime.of(12, 23, 1, 541000000)),
+            ),
+            Arguments.of(
+                "12:23:01.541214",
+                TimeWithoutTimezoneValue(LocalTime.of(12, 23, 1, 541214000)),
+            ),
+            Arguments.of(
+                "12:00:00.000000+01:00",
+                TimeWithoutTimezoneValue(LocalTime.of(12, 0, 0, 0)),
+            ),
+            Arguments.of(
+                "10:00:00.000000-01:00",
+                TimeWithoutTimezoneValue(LocalTime.of(10, 0, 0, 0)),
+            ),
+            Arguments.of(
+                "03:30:00.000000+04:00",
+                TimeWithoutTimezoneValue(LocalTime.of(3, 30, 0, 0)),
+            ),
+        )
+
+        @JvmStatic
+        fun dateArgs(): Stream<Arguments> = Stream.of(
+            Arguments.of(
+                "2021-1-1",
+                DateValue(LocalDate.of(2021, 1, 1)),
+            ),
+            Arguments.of(
+                "2021-01-01",
+                DateValue(LocalDate.of(2021, 1, 1)),
+            ),
+            Arguments.of(
+                "2021/01/02",
+                DateValue(LocalDate.of(2021, 1, 2)),
+            ),
+            Arguments.of(
+                "2021.01.03",
+                DateValue(LocalDate.of(2021, 1, 3)),
+            ),
+            Arguments.of(
+                "2021 Jan 04",
+                DateValue(LocalDate.of(2021, 1, 4)),
+            ),
+            Arguments.of(
+                "2021-1-1 BC",
+                DateValue(LocalDate.of(-2020, 1, 1)),
+            ),
         )
     }
 }
+// spotless:on

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/transform/medium/JsonRecordConversionTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/transform/medium/JsonRecordConversionTest.kt
@@ -118,7 +118,7 @@ class JsonRecordConversionTest {
 
         val input =
             mockk<DestinationRecordRaw>(relaxed = true) {
-                every { asEnrichedDestinationRecordAirbyteValue(any()) } answers { coerced }
+                every { asEnrichedDestinationRecordAirbyteValue(any(), any(), any()) } answers { coerced }
                 every { schemaFields } returns
                     linkedMapOf(
                         "user_field_1" to FieldType(StringType, false),
@@ -137,7 +137,8 @@ class JsonRecordConversionTest {
         verify {
             input.asEnrichedDestinationRecordAirbyteValue(
                 any(),
-                extractedAtAsTimestampWithTimezone = true
+                extractedAtAsTimestampWithTimezone = true,
+                respectLegacyUnions = any(),
             )
         }
         nonUnionUserFields.forEach { verify { valueCoercer.validate(it.value) } }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/transform/medium/JsonRecordConversionTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/transform/medium/JsonRecordConversionTest.kt
@@ -5,6 +5,7 @@
 package io.airbyte.cdk.load.dataflow.transform.medium
 
 import io.airbyte.cdk.load.data.AirbyteValue
+import io.airbyte.cdk.load.data.AirbyteValueCoercer
 import io.airbyte.cdk.load.data.BooleanType
 import io.airbyte.cdk.load.data.BooleanValue
 import io.airbyte.cdk.load.data.EnrichedAirbyteValue
@@ -45,7 +46,13 @@ class JsonRecordConversionTest {
     @BeforeEach
     fun setup() {
         validationResultHandler = ValidationResultHandler(mockk(relaxed = true))
-        jsonConverter = JsonConverter(valueCoercer, validationResultHandler, jsonConverterConfig)
+        jsonConverter =
+            JsonConverter(
+                valueCoercer,
+                validationResultHandler,
+                jsonConverterConfig,
+                AirbyteValueCoercer()
+            )
     }
 
     @Test

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/transform/medium/JsonRecordConversionTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/transform/medium/JsonRecordConversionTest.kt
@@ -51,7 +51,7 @@ class JsonRecordConversionTest {
                 valueCoercer,
                 validationResultHandler,
                 jsonConverterConfig,
-                AirbyteValueCoercer()
+                AirbyteValueCoercer(useFastTimestampParsing = true),
             )
     }
 
@@ -135,7 +135,10 @@ class JsonRecordConversionTest {
         // just validate we call the coercing logic here
         // if we refactor to do the coercing directly here, we need more comprehensive tests
         verify {
-            input.asEnrichedDestinationRecordAirbyteValue(extractedAtAsTimestampWithTimezone = true)
+            input.asEnrichedDestinationRecordAirbyteValue(
+                any(),
+                extractedAtAsTimestampWithTimezone = true
+            )
         }
         nonUnionUserFields.forEach { verify { valueCoercer.validate(it.value) } }
         // the stringified field is also validated

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/transform/medium/JsonRecordConversionTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/transform/medium/JsonRecordConversionTest.kt
@@ -118,7 +118,10 @@ class JsonRecordConversionTest {
 
         val input =
             mockk<DestinationRecordRaw>(relaxed = true) {
-                every { asEnrichedDestinationRecordAirbyteValue(any(), any(), any()) } answers { coerced }
+                every { asEnrichedDestinationRecordAirbyteValue(any(), any(), any()) } answers
+                    {
+                        coerced
+                    }
                 every { schemaFields } returns
                     linkedMapOf(
                         "user_field_1" to FieldType(StringType, false),

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/transform/medium/ProtobufRecordConversionTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/transform/medium/ProtobufRecordConversionTest.kt
@@ -287,7 +287,7 @@ class ProtobufRecordConversionTest {
         record =
             mockk(relaxed = false) {
                 every { asJsonRecord() } answers { callOriginal() }
-                every { asEnrichedDestinationRecordAirbyteValue(any(), any()) } answers
+                every { asEnrichedDestinationRecordAirbyteValue(any(), any(), any()) } answers
                     {
                         callOriginal()
                     }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/message/DestinationMessageTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/message/DestinationMessageTest.kt
@@ -10,6 +10,7 @@ import io.airbyte.cdk.load.command.DestinationCatalog
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.command.NamespaceMapper
 import io.airbyte.cdk.load.config.DataChannelMedium
+import io.airbyte.cdk.load.data.AirbyteValueCoercer
 import io.airbyte.cdk.load.data.FieldType
 import io.airbyte.cdk.load.data.IntegerType
 import io.airbyte.cdk.load.data.IntegerValue
@@ -49,6 +50,7 @@ import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 
 internal class DestinationMessageTest {
+    private val coercer = AirbyteValueCoercer(useFastTimestampParsing = true)
     private val uuidGenerator = UUIDGenerator()
 
     private fun factory(
@@ -551,14 +553,14 @@ internal class DestinationMessageTest {
             1234,
             destinationRecord
                 .asDestinationRecordRaw()
-                .asEnrichedDestinationRecordAirbyteValue()
+                .asEnrichedDestinationRecordAirbyteValue(coercer)
                 .emittedAtMs
         )
         assertEquals(
             1,
             destinationRecord
                 .asDestinationRecordRaw()
-                .asEnrichedDestinationRecordAirbyteValue()
+                .asEnrichedDestinationRecordAirbyteValue(coercer)
                 .declaredFields["id"]
                 ?.let { (it.abValue as IntegerValue).value.toInt() }
         )
@@ -566,7 +568,7 @@ internal class DestinationMessageTest {
             "test",
             destinationRecord
                 .asDestinationRecordRaw()
-                .asEnrichedDestinationRecordAirbyteValue()
+                .asEnrichedDestinationRecordAirbyteValue(coercer)
                 .declaredFields["name"]
                 ?.let { (it.abValue as StringValue).value }
         )

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/message/DestinationRecordRawTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/message/DestinationRecordRawTest.kt
@@ -21,6 +21,8 @@ import org.junit.jupiter.api.Test
 
 class DestinationRecordRawTest {
 
+    private val coercer = AirbyteValueCoercer(useFastTimestampParsing = true)
+
     // Create a schema with various field types for testing
     private val recordSchema =
         ObjectType(
@@ -98,7 +100,7 @@ class DestinationRecordRawTest {
                 airbyteRawId = UUID.randomUUID(),
             )
 
-        val enrichedRecord = rawRecord.asEnrichedDestinationRecordAirbyteValue()
+        val enrichedRecord = rawRecord.asEnrichedDestinationRecordAirbyteValue(coercer)
 
         // Verify declared fields are processed correctly
         assertEquals(2, enrichedRecord.declaredFields.size)
@@ -152,7 +154,7 @@ class DestinationRecordRawTest {
                 airbyteRawId = UUID.randomUUID(),
             )
 
-        val enrichedRecord = rawRecord.asEnrichedDestinationRecordAirbyteValue()
+        val enrichedRecord = rawRecord.asEnrichedDestinationRecordAirbyteValue(coercer)
 
         // Check coerced string field
         val stringField = enrichedRecord.declaredFields["string_field"]
@@ -206,7 +208,7 @@ class DestinationRecordRawTest {
                 airbyteRawId = UUID.randomUUID(),
             )
 
-        val enrichedRecord = rawRecord.asEnrichedDestinationRecordAirbyteValue()
+        val enrichedRecord = rawRecord.asEnrichedDestinationRecordAirbyteValue(coercer)
 
         // Check valid field is preserved
         val stringField = enrichedRecord.declaredFields["string_field"]
@@ -265,7 +267,7 @@ class DestinationRecordRawTest {
                 airbyteRawId = UUID.randomUUID(),
             )
 
-        val enrichedRecord = rawRecord.asEnrichedDestinationRecordAirbyteValue()
+        val enrichedRecord = rawRecord.asEnrichedDestinationRecordAirbyteValue(coercer)
 
         // Verify meta changes are preserved
         assertNotNull(enrichedRecord.sourceMeta)
@@ -331,7 +333,7 @@ class DestinationRecordRawTest {
                 airbyteRawId = UUID.randomUUID(),
             )
 
-        val enrichedRecord = rawRecord.asEnrichedDestinationRecordAirbyteValue()
+        val enrichedRecord = rawRecord.asEnrichedDestinationRecordAirbyteValue(coercer)
 
         // Verify all fields are treated as undeclared
         assertEquals(0, enrichedRecord.declaredFields.size)
@@ -441,7 +443,7 @@ class DestinationRecordRawTest {
                 airbyteRawId = UUID.randomUUID(),
             )
 
-        val enrichedRecord = rawRecord.asEnrichedDestinationRecordAirbyteValue()
+        val enrichedRecord = rawRecord.asEnrichedDestinationRecordAirbyteValue(coercer)
 
         // Verify complex fields are processed correctly
         assertEquals(2, enrichedRecord.declaredFields.size)
@@ -487,7 +489,7 @@ class DestinationRecordRawTest {
                 airbyteRawId = UUID.randomUUID(),
             )
 
-        val enrichedRecord = rawRecord.asEnrichedDestinationRecordAirbyteValue()
+        val enrichedRecord = rawRecord.asEnrichedDestinationRecordAirbyteValue(coercer)
 
         // Verify fields are processed correctly
         assertEquals(2, enrichedRecord.declaredFields.size)

--- a/airbyte-cdk/bulk/core/load/version.properties
+++ b/airbyte-cdk/bulk/core/load/version.properties
@@ -1,1 +1,1 @@
-version=1.0.8
+version=1.0.9

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/IcebergUtil.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/IcebergUtil.kt
@@ -49,7 +49,10 @@ private val logger = KotlinLogging.logger {}
 const val AIRBYTE_CDC_DELETE_COLUMN = "_ab_cdc_deleted_at"
 
 @Singleton
-class IcebergUtil(private val tableIdGenerator: TableIdGenerator) {
+class IcebergUtil(
+    private val tableIdGenerator: TableIdGenerator,
+    private val coercer: AirbyteValueCoercer,
+) {
     private val airbyteValueToIcebergRecord = AirbyteValueToIcebergRecord()
 
     fun constructGenerationIdSuffix(stream: DestinationStream): String {
@@ -199,66 +202,70 @@ class IcebergUtil(private val tableIdGenerator: TableIdGenerator) {
         } else {
             Operation.INSERT
         }
-}
 
-/**
- * Our Airbyte<>Iceberg schema conversion generates strongly-typed arrays.
- *
- * This function applies a function to every non-array-typed value, recursing into arrays as needed.
- * [transformer] may assume that the AirbyteValue is a valid value for the AirbyteType. For example,
- * if [transformer] is called with a [NumberType], it is safe to cast the value to [NumberValue].
- */
-fun EnrichedAirbyteValue.transformValueRecursingIntoArrays(
-    transformer: (AirbyteValue, AirbyteType) -> ChangedValue?
-): EnrichedAirbyteValue {
     /**
-     * Recurse through ArrayValues, until we find a non-ArrayType field, coercing to ArrayValue as
-     * needed, then apply [transformer]. If [transformer] returns a [ChangedValue], modify the
-     * original ArrayValue's element (and populate [EnrichedAirbyteValue.changes] if needed).
+     * RB: I just moved this inside the class. I do not take ownership of this code.
+     *
+     * Our Airbyte<>Iceberg schema conversion generates strongly-typed arrays.
+     *
+     * This function applies a function to every non-array-typed value, recursing into arrays as
+     * needed. [transformer] may assume that the AirbyteValue is a valid value for the AirbyteType.
+     * For example, if [transformer] is called with a [NumberType], it is safe to cast the value to
+     * [NumberValue].
      */
-    fun recurseArray(
-        currentValue: AirbyteValue,
-        currentType: AirbyteType,
-        path: String,
-    ): AirbyteValue {
-        if (currentValue == NullValue) {
-            return NullValue
-        } else if (currentType is ArrayType) {
-            // If the type is another array, we recurse deeper.
-            val coercedArray = AirbyteValueCoercer.coerceArray(currentValue)
-            if (coercedArray == null) {
-                changes.add(
-                    Meta.Change(path, Change.NULLED, Reason.DESTINATION_SERIALIZATION_ERROR),
-                )
+    fun EnrichedAirbyteValue.transformValueRecursingIntoArrays(
+        transformer: (AirbyteValue, AirbyteType) -> ChangedValue?
+    ): EnrichedAirbyteValue {
+        /**
+         * Recurse through ArrayValues, until we find a non-ArrayType field, coercing to ArrayValue
+         * as needed, then apply [transformer]. If [transformer] returns a [ChangedValue], modify
+         * the original ArrayValue's element (and populate [EnrichedAirbyteValue.changes] if
+         * needed).
+         */
+        fun recurseArray(
+            currentValue: AirbyteValue,
+            currentType: AirbyteType,
+            path: String,
+        ): AirbyteValue {
+            if (currentValue == NullValue) {
                 return NullValue
-            }
-            return ArrayValue(
-                coercedArray.values.mapIndexed { index, element ->
-                    val newPath = "$path.$index"
-                    recurseArray(element, currentType.items.type, newPath)
-                },
-            )
-        } else {
-            // If we're at a leaf node, call the transformer.
-            val coercedValue = AirbyteValueCoercer.coerce(currentValue, currentType)
-            if (coercedValue == null) {
-                changes.add(
-                    Meta.Change(path, Change.NULLED, Reason.DESTINATION_SERIALIZATION_ERROR),
+            } else if (currentType is ArrayType) {
+                // If the type is another array, we recurse deeper.
+                val coercedArray = coercer.coerceArray(currentValue)
+                if (coercedArray == null) {
+                    changes.add(
+                        Meta.Change(path, Change.NULLED, Reason.DESTINATION_SERIALIZATION_ERROR),
+                    )
+                    return NullValue
+                }
+                return ArrayValue(
+                    coercedArray.values.mapIndexed { index, element ->
+                        val newPath = "$path.$index"
+                        recurseArray(element, currentType.items.type, newPath)
+                    },
                 )
-                return NullValue
+            } else {
+                // If we're at a leaf node, call the transformer.
+                val coercedValue = coercer.coerce(currentValue, currentType)
+                if (coercedValue == null) {
+                    changes.add(
+                        Meta.Change(path, Change.NULLED, Reason.DESTINATION_SERIALIZATION_ERROR),
+                    )
+                    return NullValue
+                }
+                val transformedValue = transformer(coercedValue, currentType) ?: return coercedValue
+                val (newValue, changeDescription) = transformedValue
+                changeDescription?.let { (change, reason) ->
+                    changes.add(Meta.Change(path, change, reason))
+                }
+                return newValue
             }
-            val transformedValue = transformer(coercedValue, currentType) ?: return coercedValue
-            val (newValue, changeDescription) = transformedValue
-            changeDescription?.let { (change, reason) ->
-                changes.add(Meta.Change(path, change, reason))
-            }
-            return newValue
         }
+
+        abValue = recurseArray(abValue, type, name)
+
+        return this
     }
-
-    abValue = recurseArray(abValue, type, name)
-
-    return this
 }
 
 data class ChangeDescription(val change: Change, val reason: Reason)

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/testFixtures/kotlin/io/airbyte/cdk/load/data/icerberg/parquet/IcebergDestinationCleaner.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/testFixtures/kotlin/io/airbyte/cdk/load/data/icerberg/parquet/IcebergDestinationCleaner.kt
@@ -4,6 +4,7 @@
 
 package io.airbyte.cdk.load.data.icerberg.parquet
 
+import io.airbyte.cdk.load.data.AirbyteValueCoercer
 import io.airbyte.cdk.load.test.util.DestinationCleaner
 import io.airbyte.cdk.load.test.util.IntegrationTest.Companion.isNamespaceOld
 import io.airbyte.cdk.load.test.util.IntegrationTest.Companion.randomizedNamespaceRegex
@@ -26,7 +27,7 @@ class IcebergDestinationCleaner(private val catalog: Catalog) : DestinationClean
             }
 
         // we're passing explicit TableIdentifier to clearTable, so just use SimpleTableIdGenerator
-        val tableCleaner = IcebergTableCleaner(IcebergUtil(SimpleTableIdGenerator()))
+        val tableCleaner = IcebergTableCleaner(IcebergUtil(SimpleTableIdGenerator(), AirbyteValueCoercer()))
 
         runBlocking(Dispatchers.IO) {
             namespaces.forEach { namespace ->

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/testFixtures/kotlin/io/airbyte/cdk/load/data/icerberg/parquet/IcebergDestinationCleaner.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/testFixtures/kotlin/io/airbyte/cdk/load/data/icerberg/parquet/IcebergDestinationCleaner.kt
@@ -27,7 +27,8 @@ class IcebergDestinationCleaner(private val catalog: Catalog) : DestinationClean
             }
 
         // we're passing explicit TableIdentifier to clearTable, so just use SimpleTableIdGenerator
-        val tableCleaner = IcebergTableCleaner(IcebergUtil(SimpleTableIdGenerator(), AirbyteValueCoercer()))
+        val tableCleaner =
+            IcebergTableCleaner(IcebergUtil(SimpleTableIdGenerator(), AirbyteValueCoercer()))
 
         runBlocking(Dispatchers.IO) {
             namespaces.forEach { namespace ->

--- a/spotless-maven-pom.xml
+++ b/spotless-maven-pom.xml
@@ -51,6 +51,7 @@
                             <includes>
                                 <include>**/*.kt</include>
                             </includes>
+                            <toggleOffOn />
                             <ktfmt>
                                 <version>0.39</version>
                                 <style>KOTLINLANG</style>


### PR DESCRIPTION
## What
Timestamp coercion in `AirbyteValueCoercer` used exception-as-control-flow, trying `ZonedDateTime.parse()` on every field, catching the failure, then retrying. This made it the dominant CPU cost for timestamp-heavy syncs.

Relates to: [OC ticket](https://github.com/airbytehq/oncall/issues/11753)

## How
- Use [ethlo/itu](https://github.com/ethlo/itu) as a fast path for ISO-8601 timestamps (~25x faster, no exceptions, no deps), with a JDK `TemporalQueries` fallback for exotic formats
- Same pattern for `coerceTimeTz()` — single parse + query instead of try/catch
- Port coercion test cases from `legacy-task-loader` into `core/load`

## Other
- `AirbyteValueCoercer` is now a proper singleton
- New fast parsing behavior is behind a micronaut flag
- `IcebergUtil` now takes `AirbyteValueCoercer` as a parameter (to work nicely with DI)
- Factors out `TemporalFormatters` for better organization
- Enable spotless on/off ignore comments -- necessary for test formatting

## Recommended reading order
1. `AirbyteValueCoercerTest.kt`
2. `AirbyteValueCoercer.kt`

## User Impact
Improved destination throughput on timestamp-heavy syncs.

## Can this PR be safely reverted and rolled back?
- [x] YES
- [ ] NO