### PR TITLE
fix(source-woocommerce): Increase default concurrency from 4 to 5 (0.5.35-rc.2)

### DIFF
--- a/airbyte-integrations/connectors/source-woocommerce/manifest.yaml
+++ b/airbyte-integrations/connectors/source-woocommerce/manifest.yaml
@@ -995,7 +995,7 @@ api_budget:
 
 concurrency_level:
   type: ConcurrencyLevel
-  default_concurrency: "{{ config.get('num_workers', 4) }}"
+  default_concurrency: "{{ config.get('num_workers', 5) }}"
   max_concurrency: 12
 
 spec:
@@ -1045,7 +1045,7 @@ spec:
           speed up syncs but may hit rate limits. WooCommerce API rate limits
           depend on the hosting provider. More info at
           https://woocommerce.github.io/woocommerce-rest-api-docs/
-        default: 4
+        default: 5
         minimum: 2
         maximum: 12
         order: 4

--- a/airbyte-integrations/connectors/source-woocommerce/metadata.yaml
+++ b/airbyte-integrations/connectors/source-woocommerce/metadata.yaml
@@ -8,7 +8,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 2a2552ca-9f78-4c1c-9eb7-4d0dc66d72df
-  dockerImageTag: 0.5.35-rc.1
+  dockerImageTag: 0.5.35-rc.2
   dockerRepository: airbyte/source-woocommerce
   documentationUrl: https://docs.airbyte.com/integrations/sources/woocommerce
   githubIssueLabel: source-woocommerce

--- a/docs/integrations/sources/woocommerce.md
+++ b/docs/integrations/sources/woocommerce.md
@@ -122,7 +122,7 @@ maximum number of seconds between API calls.
 
 | Version | Date       | Pull Request                                             | Subject                                                                |
 |:--------| :--------- |:---------------------------------------------------------|:-----------------------------------------------------------------------|
-| 0.5.35-rc.2 | 2026-04-12 | [76XXX](https://github.com/airbytehq/airbyte/pull/76XXX) | Increase default concurrency from 4 to 5 for tuning iteration 2 |
+| 0.5.35-rc.2 | 2026-04-12 | [76253](https://github.com/airbytehq/airbyte/pull/76253) | Increase default concurrency from 4 to 5 for tuning iteration 2 |
 | 0.5.35-rc.1 | 2026-04-09 | [76205](https://github.com/airbytehq/airbyte/pull/76205) | Add concurrency_level and num_workers for concurrent stream syncing |
 | 0.5.34 | 2026-03-31 | [75853](https://github.com/airbytehq/airbyte/pull/75853) | Update dependencies |
 | 0.5.33 | 2026-03-24 | [75380](https://github.com/airbytehq/airbyte/pull/75380) | Update dependencies |

--- a/docs/integrations/sources/woocommerce.md
+++ b/docs/integrations/sources/woocommerce.md
@@ -122,6 +122,7 @@ maximum number of seconds between API calls.
 
 | Version | Date       | Pull Request                                             | Subject                                                                |
 |:--------| :--------- |:---------------------------------------------------------|:-----------------------------------------------------------------------|
+| 0.5.35-rc.2 | 2026-04-12 | [76XXX](https://github.com/airbytehq/airbyte/pull/76XXX) | Increase default concurrency from 4 to 5 for tuning iteration 2 |
 | 0.5.35-rc.1 | 2026-04-09 | [76205](https://github.com/airbytehq/airbyte/pull/76205) | Add concurrency_level and num_workers for concurrent stream syncing |
 | 0.5.34 | 2026-03-31 | [75853](https://github.com/airbytehq/airbyte/pull/75853) | Update dependencies |
 | 0.5.33 | 2026-03-24 | [75380](https://github.com/airbytehq/airbyte/pull/75380) | Update dependencies |


### PR DESCRIPTION
## What

Increases the default concurrency for `source-woocommerce` from 4 to 5 as part of the ongoing concurrency tuning rollout ([#15315](https://github.com/airbytehq/airbyte-internal-issues/issues/15315)).

This is **Phase 1, Iteration 2** of the tuning process. Iteration 1 (`0.5.35-rc.1`, concurrency=4) passed all health checks across 8 Tier 2 connections over 24 hours:
- 98+ RC syncs, 0 failures, 0 rate limit errors
- **-44% mean sync duration** vs stable (25.3m → 45.3m)
- No regressions detected

Sophie Cui approved increasing concurrency to 5 to test higher throughput before locking the value.

## How

- `manifest.yaml`: Bump `default_concurrency` from `4` → `5` and spec `num_workers` default from `4` → `5`
- `metadata.yaml`: Bump `dockerImageTag` from `0.5.35-rc.1` → `0.5.35-rc.2`
- `woocommerce.md`: Add changelog entry for `0.5.35-rc.2`

HTTPAPIBudget (5 req/s) and `max_concurrency` (12) are unchanged.

## Review guide

1. `manifest.yaml` — two lines changed (default value `4` → `5` in both `concurrency_level` and `spec.num_workers`)
2. `metadata.yaml` — version tag bump only
3. `woocommerce.md` — new changelog row

### Human review checklist
- [ ] Verify the budget (5 req/s) still provides adequate headroom at concurrency=5 given WooCommerce's host-dependent rate limits (typically 2–5 req/s on shared hosting)
- [ ] Confirm `max_concurrency: 12` ceiling is still appropriate

## User Impact

Users who don't explicitly set `num_workers` will now default to 5 concurrent workers instead of 4. This may provide ~10-20% additional speedup on higher-volume syncs. The budget cap of 5 req/s remains in place to prevent rate limiting.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/83379dc67b60439e8a938baf68280b2c
Requested by: @sophiecuiy