### PR TITLE
chore(source-sendgrid): Set concurrency to 6 for tuning iteration 4 (1.3.28-rc.4)

### DIFF
--- a/airbyte-integrations/connectors/source-sendgrid/manifest.yaml
+++ b/airbyte-integrations/connectors/source-sendgrid/manifest.yaml
@@ -676,7 +676,7 @@ streams:
 
 concurrency_level:
   type: ConcurrencyLevel
-  default_concurrency: 9
+  default_concurrency: 6
   max_concurrency: 20
 
 # api_budget:  # Commented out for Phase 1 concurrency tuning - will be added in Phase 2

--- a/airbyte-integrations/connectors/source-sendgrid/metadata.yaml
+++ b/airbyte-integrations/connectors/source-sendgrid/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: fbb5fbe2-16ad-4cf4-af7d-ff9d9c316c87
-  dockerImageTag: 1.3.28-rc.3
+  dockerImageTag: 1.3.28-rc.4
   releases:
     rolloutConfiguration:
       enableProgressiveRollout: true

--- a/docs/integrations/sources/sendgrid.md
+++ b/docs/integrations/sources/sendgrid.md
@@ -105,7 +105,7 @@ If you encounter 403 errors, check the following:
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                                                                                                                           |
 |:--------|:-----------| :------------------------------------------------------- |:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 1.3.28-rc.3 | 2026-04-08 | [74713](https://github.com/airbytehq/airbyte/pull/74713) | Add concurrency_level for parallel stream processing |
+| 1.3.28-rc.4 | 2026-04-12 | [74713](https://github.com/airbytehq/airbyte/pull/74713) | Add concurrency_level for parallel stream processing (concurrency=6) |
 | 1.3.27 | 2026-03-24 | [75331](https://github.com/airbytehq/airbyte/pull/75331) | Update dependencies |
 | 1.3.26 | 2026-02-24 | [73950](https://github.com/airbytehq/airbyte/pull/73950) | Update dependencies |
 | 1.3.25 | 2026-02-10 | [73157](https://github.com/airbytehq/airbyte/pull/73157) | Update dependencies |


### PR DESCRIPTION
## What

Concurrency tuning iteration 4 for source-sendgrid, reducing `default_concurrency` from 9 → 6 as part of the progressive rollout described in https://github.com/airbytehq/airbyte-internal-issues/issues/15312.

**Tuning history:**
| Iteration | Concurrency | Result |
|---|---|---|
| 1 | 12 | PASS |
| 2 | 15 | Canceled |
| 3 | 9 | PASS (−43% avg duration vs baseline) |
| 4 | **6** | **This PR** |

## How

- `manifest.yaml`: `default_concurrency` 9 → 6
- `metadata.yaml`: `dockerImageTag` `1.3.28-rc.3` → `1.3.28-rc.4`
- `sendgrid.md`: Changelog entry updated to rc.4

The `HTTPAPIBudget` remains commented out — it will be added in Phase 2 after concurrency is settled.

## Review guide

1. `manifest.yaml` — single-line concurrency value change
2. `metadata.yaml` — version bump
3. `docs/integrations/sources/sendgrid.md` — changelog update

**Note:** The changelog entry references PR #74713 (the original merged PR that introduced concurrency tuning). Reviewer should confirm this is the desired attribution.

## User Impact

No user-facing behavior change yet — this RC version will be deployed via progressive rollout to a small set of Tier 2 actors only. Once concurrency is settled and the connector reaches GA, users will see parallel stream processing with the tuned concurrency value.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/f2e0baae475143b39e31875e49f6163b
Requested by: @sophiecuiy