### PR TITLE
feat(source-snapchat-marketing): bump concurrency to 5 for tuning iteration 2

### DIFF
--- a/airbyte-integrations/connectors/source-snapchat-marketing/manifest.yaml
+++ b/airbyte-integrations/connectors/source-snapchat-marketing/manifest.yaml
@@ -10706,5 +10706,5 @@ api_budget:
 
 concurrency_level:
   type: ConcurrencyLevel
-  default_concurrency: 4
+  default_concurrency: 5
   max_concurrency: 10

--- a/airbyte-integrations/connectors/source-snapchat-marketing/metadata.yaml
+++ b/airbyte-integrations/connectors/source-snapchat-marketing/metadata.yaml
@@ -8,7 +8,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 200330b2-ea62-4d11-ac6d-cfe3e3f8ab2b
-  dockerImageTag: 1.5.33-rc.1
+  dockerImageTag: 1.5.33-rc.2
   dockerRepository: airbyte/source-snapchat-marketing
   githubIssueLabel: source-snapchat-marketing
   icon: snapchat.svg

--- a/docs/integrations/sources/snapchat-marketing.md
+++ b/docs/integrations/sources/snapchat-marketing.md
@@ -143,6 +143,8 @@ Syncing data with an hourly granularity often generates large data volumes and c
 
 | Version    | Date       | Pull Request                                             | Subject                                                                        |
 |:-----------|:-----------|:---------------------------------------------------------|:-------------------------------------------------------------------------------|
+| 1.5.33-rc.2 | 2026-04-13 | [76255](https://github.com/airbytehq/airbyte/pull/76255) | Increase default_concurrency to 5 for tuning iteration 2 |
+| 1.5.33-rc.1 | 2026-04-10 | [70866](https://github.com/airbytehq/airbyte/pull/70866) | Add HTTPAPIBudget and concurrency_level for progressive rollout tuning |
 | 1.5.32 | 2026-03-24 | [75098](https://github.com/airbytehq/airbyte/pull/75098) | Update dependencies |
 | 1.5.31 | 2026-03-10 | [74573](https://github.com/airbytehq/airbyte/pull/74573) | Update dependencies |
 | 1.5.30 | 2026-03-03 | [72736](https://github.com/airbytehq/airbyte/pull/72736) | Update dependencies |


### PR DESCRIPTION
## What

Concurrency tuning iteration 2 for `source-snapchat-marketing`, part of the progressive rollout tuning process tracked in https://github.com/airbytehq/airbyte-internal-issues/issues/15313.

Increases `default_concurrency` from 4 → 5 and bumps the RC version to `1.5.33-rc.2`.

## How

- `manifest.yaml`: `default_concurrency` changed from `4` to `5` (step size = 1)
- `metadata.yaml`: `dockerImageTag` bumped from `1.5.33-rc.1` to `1.5.33-rc.2`

No changes to `api_budget` (remains at 80 calls / 10s via `MovingWindowCallRatePolicy`) or `max_concurrency` (remains 10).

## Context: Day 1 monitoring results (rc.1, concurrency=4)

| Metric | Result |
|---|---|
| Failure rate (concurrency-related) | 0% |
| Aggregate duration vs stable | +3% (within 5% gate) |
| 429 errors | None observed |
| Retries | None |
| HITL decision | Approved increase to 5 |

Two Tier 2 connections monitored over 24h — both healthy with no regressions exceeding thresholds.

## Review guide

1. `manifest.yaml` — single-line change at line 10709: `default_concurrency: 4` → `5`
2. `metadata.yaml` — single-line change at line 11: version bump `1.5.33-rc.1` → `1.5.33-rc.2`

Key things to verify:
- Concurrency of 5 is safe given Snapchat's token-level rate limit of 10 req/s (budget caps at 8 req/s)
- No unintended file changes

## User Impact

No direct user impact yet — this RC will be deployed via progressive rollout to the same 2 pinned Tier 2 connections for further monitoring before any broader rollout.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/9239df45723948cd8dfdb91b65b84593
Requested by: @sophiecuiy