### PR TITLE
fix(source-open-exchange-rates): fix invalid_date on incremental sync

### DIFF
--- a/airbyte-integrations/connectors/source-open-exchange-rates/manifest.yaml
+++ b/airbyte-integrations/connectors/source-open-exchange-rates/manifest.yaml
@@ -15,8 +15,7 @@ definitions:
           type: HttpRequester
           url_base: https://openexchangerates.org/api/
           path: >-
-            historical/{{ format_datetime( config['start_date'] if not
-            stream_state else stream_state['timestamp'], '%Y-%m-%d' ) }}.json
+            historical/{{ format_datetime(stream_interval['start_time']|int, '%Y-%m-%d', '%s') }}.json
           http_method: GET
           request_parameters:
             app_id: "{{ config['app_id'] }}"
@@ -32,8 +31,7 @@ definitions:
         name: open_exchange_rates
         incremental_cursor: timestamp
         path: >-
-          historical/{{ format_datetime( config['start_date'] if not
-          stream_state else stream_state['timestamp'], '%Y-%m-%d' ) }}.json
+          historical/{{ format_datetime(stream_interval['start_time']|int, '%Y-%m-%d', '%s') }}.json
         cursor_datetime_formats:
           - "%s"
         datetime_format: "%s"
@@ -953,8 +951,7 @@ streams:
         type: HttpRequester
         url_base: https://openexchangerates.org/api/
         path: >-
-          historical/{{ format_datetime( config['start_date'] if not
-          stream_state else stream_state['timestamp'], '%Y-%m-%d' ) }}.json
+          historical/{{ format_datetime(stream_interval['start_time']|int, '%Y-%m-%d', '%s') }}.json
         http_method: GET
         request_parameters:
           app_id: "{{ config['app_id'] }}"
@@ -970,8 +967,7 @@ streams:
       name: open_exchange_rates
       incremental_cursor: timestamp
       path: >-
-        historical/{{ format_datetime( config['start_date'] if not
-        stream_state else stream_state['timestamp'], '%Y-%m-%d' ) }}.json
+        historical/{{ format_datetime(stream_interval['start_time']|int, '%Y-%m-%d', '%s') }}.json
       cursor_datetime_formats:
         - "%s"
       datetime_format: "%s"

--- a/airbyte-integrations/connectors/source-open-exchange-rates/metadata.yaml
+++ b/airbyte-integrations/connectors/source-open-exchange-rates/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 77d5ca6b-d345-4dce-ba1e-1935a75778b8
-  dockerImageTag: 0.3.13
+  dockerImageTag: 0.3.14
   dockerRepository: airbyte/source-open-exchange-rates
   documentationUrl: https://docs.airbyte.com/integrations/sources/open-exchange-rates
   githubIssueLabel: source-open-exchange-rates

--- a/docs/integrations/sources/open-exchange-rates.md
+++ b/docs/integrations/sources/open-exchange-rates.md
@@ -48,6 +48,7 @@ If you have `free` subscription plan \(you may check it [here](https://openexcha
 
 | Version | Date       | Pull Request                                               | Subject                                                                         |
 | :------ | :--------- | :--------------------------------------------------------- | :------------------------------------------------------------------------------ |
+| 0.3.14 | 2026-04-13 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) | Migrate path interpolation from deprecated `stream_state` to `stream_interval`; fixes `invalid_date` errors on incremental syncs |
 | 0.3.13 | 2025-02-15 | [53979](https://github.com/airbytehq/airbyte/pull/53979) | Update dependencies |
 | 0.3.12 | 2025-02-08 | [53469](https://github.com/airbytehq/airbyte/pull/53469) | Update dependencies |
 | 0.3.11 | 2025-02-01 | [52968](https://github.com/airbytehq/airbyte/pull/52968) | Update dependencies |

--- a/docs/integrations/sources/open-exchange-rates.md
+++ b/docs/integrations/sources/open-exchange-rates.md
@@ -48,7 +48,7 @@ If you have `free` subscription plan \(you may check it [here](https://openexcha
 
 | Version | Date       | Pull Request                                               | Subject                                                                         |
 | :------ | :--------- | :--------------------------------------------------------- | :------------------------------------------------------------------------------ |
-| 0.3.14 | 2026-04-13 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) | Migrate path interpolation from deprecated `stream_state` to `stream_interval`; fixes `invalid_date` errors on incremental syncs |
+| 0.3.14 | 2026-04-13 | [76258](https://github.com/airbytehq/airbyte/pull/76258) | Migrate path interpolation from deprecated `stream_state` to `stream_interval`; fixes `invalid_date` errors on incremental syncs |
 | 0.3.13 | 2025-02-15 | [53979](https://github.com/airbytehq/airbyte/pull/53979) | Update dependencies |
 | 0.3.12 | 2025-02-08 | [53469](https://github.com/airbytehq/airbyte/pull/53469) | Update dependencies |
 | 0.3.11 | 2025-02-01 | [52968](https://github.com/airbytehq/airbyte/pull/52968) | Update dependencies |


### PR DESCRIPTION
## What
Fix incremental sync for `source-open-exchange-rates`, which has been failing with
`'invalid_date'` (HTTP 400) on every sync after the first one. The path template
references `stream_state`, which the latest CDK has removed from interpolation
(`AirbyteTracedException: stream_state is no longer supported for interpolation`).
On older CDK versions bundled with `source-declarative-manifest:6.33.6`, the
template silently fails to render when the cursor (a Unix epoch int) is passed
to `format_datetime`, sending the literal `{{ ... }}` to the API.

This connector was the only one in the repo still using the deprecated
`stream_state` interpolation pattern.

fixes https://github.com/airbytehq/airbyte/issues/48722 and https://github.com/airbytehq/airbyte/issues/38760

## How
Migrated the 4 functional `path:` templates in `manifest.yaml` to use
`stream_interval`, following the precedent set by `source-zendesk-support`
(also a Unix-epoch cursor):

```yaml
path: >-
  historical/{{ format_datetime(stream_interval['start_time']|int, '%Y-%m-%d', '%s') }}.json
```

The cursor's datetime_format: "%s" and cursor_datetime_formats: ["%s"] are
unchanged, so existing user state (int epochs) remains valid — no state migration
needed.

## Review guide
1. `airbyte-integrations/connectors/source-open-exchange-rates/manifest.yaml` — 4 path templates updated
2. `airbyte-integrations/connectors/source-open-exchange-rates/metadata.yaml` — version bump 0.3.13 → 0.3.14
3. `docs/integrations/sources/open-exchange-rates.md` — changelog entry

## User Impact
Users on the latest CDK regain incremental sync, which is currently broken for
everyone. No config or state changes required — pulling 0.3.14 fixes existing
connections automatically.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
