### PR TITLE
chore(source-zendesk-talk): decrease default_concurrency from 12 to 9 for tuning iteration 2

### DIFF
--- a/airbyte-integrations/connectors/source-zendesk-talk/manifest.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-talk/manifest.yaml
@@ -559,12 +559,13 @@ streams:
 #   Current Queue Activity (2,500 reqs/5 min), Incremental Exports (10 req/min)
 #
 # Concurrency calculated using highest rate limit across all endpoints:
-# highest = 50 req/sec (Talk API all endpoints), concurrency = floor(50 / 4) = 12
+# highest = 50 req/sec (Talk API all endpoints), initial = floor(50 / 4) = 12
+# Tuning iteration 2: decreased to 9 after Phase 1 showed +6% duration regression
 # Ref: https://developer.zendesk.com/api-reference/voice/talk-api/rate_limits/
 concurrency_level:
   type: ConcurrencyLevel
-  default_concurrency: 12
-  max_concurrency: 48
+  default_concurrency: 9
+  max_concurrency: 36
 
 # HTTP API Budget: throttle requests per Zendesk Talk API rate limits
 # Ref: https://developer.zendesk.com/api-reference/voice/talk-api/rate_limits/

--- a/airbyte-integrations/connectors/source-zendesk-talk/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-talk/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: c8630570-086d-4a40-99ae-ea5b18673071
-  dockerImageTag: 2.0.11-rc.1
+  dockerImageTag: 2.0.11-rc.2
   dockerRepository: airbyte/source-zendesk-talk
   documentationUrl: https://docs.airbyte.com/integrations/sources/zendesk-talk
   externalDocumentationUrls:

--- a/docs/integrations/sources/zendesk-talk.md
+++ b/docs/integrations/sources/zendesk-talk.md
@@ -79,7 +79,7 @@ The Zendesk connector should not run into Zendesk API limitations under normal u
 
 | Version | Date       | Pull Request                                             | Subject                                                                     |
 |:--------|:-----------|:---------------------------------------------------------|:----------------------------------------------------------------------------|
-| 2.0.11-rc.2 | 2026-04-13 | [](https://github.com/airbytehq/airbyte/pull/) | Decrease default_concurrency from 12 to 9 for tuning iteration 2 |
+| 2.0.11-rc.2 | 2026-04-13 | [76266](https://github.com/airbytehq/airbyte/pull/76266) | Decrease default_concurrency from 12 to 9 for tuning iteration 2 |
 | 2.0.11-rc.1 | 2026-04-09 | [76203](https://github.com/airbytehq/airbyte/pull/76203) | Add concurrency support with default_concurrency of 12 |
 | 2.0.10 | 2026-04-06 | [](https://github.com/airbytehq/airbyte/pull/) | Add `token_expiry_date` to `complete_oauth_output_specification` so it is hidden from the UI as an OAuth-managed field |
 | 2.0.9 | 2026-03-31 | [75808](https://github.com/airbytehq/airbyte/pull/75808) | Update dependencies |

--- a/docs/integrations/sources/zendesk-talk.md
+++ b/docs/integrations/sources/zendesk-talk.md
@@ -79,6 +79,7 @@ The Zendesk connector should not run into Zendesk API limitations under normal u
 
 | Version | Date       | Pull Request                                             | Subject                                                                     |
 |:--------|:-----------|:---------------------------------------------------------|:----------------------------------------------------------------------------|
+| 2.0.11-rc.2 | 2026-04-13 | [](https://github.com/airbytehq/airbyte/pull/) | Decrease default_concurrency from 12 to 9 for tuning iteration 2 |
 | 2.0.11-rc.1 | 2026-04-09 | [76203](https://github.com/airbytehq/airbyte/pull/76203) | Add concurrency support with default_concurrency of 12 |
 | 2.0.10 | 2026-04-06 | [](https://github.com/airbytehq/airbyte/pull/) | Add `token_expiry_date` to `complete_oauth_output_specification` so it is hidden from the UI as an OAuth-managed field |
 | 2.0.9 | 2026-03-31 | [75808](https://github.com/airbytehq/airbyte/pull/75808) | Update dependencies |


### PR DESCRIPTION
## What

Concurrency tuning iteration 2 for `source-zendesk-talk`. Decreases `default_concurrency` from 12 to 9 (and `max_concurrency` from 48 to 36, maintaining 4x ratio) based on Phase 1 rollout monitoring results.

Related: PR #76203 introduced concurrency at 12 with HTTPAPIBudget in rc.1. Phase 1 monitoring (50% Tier 2, 24h window) showed:
- Aggregate duration +6.0% vs stable baseline
- 2 connections flagged as regressions (>20% slower), though each had only 1 RC sync
- 0% failure rate, no retries

Connector-specific issue: https://github.com/airbytehq/airbyte-internal-issues/issues/15316

## How

- `manifest.yaml`: Updated `default_concurrency: 12 → 9`, `max_concurrency: 48 → 36`, added tuning rationale comment
- `metadata.yaml`: Bumped `dockerImageTag` from `2.0.11-rc.1` to `2.0.11-rc.2`
- `docs/.../zendesk-talk.md`: Added changelog entry for rc.2

HTTPAPIBudget configuration is unchanged from rc.1.

## Review guide

1. `airbyte-integrations/connectors/source-zendesk-talk/manifest.yaml` — concurrency values and comment update
2. `airbyte-integrations/connectors/source-zendesk-talk/metadata.yaml` — version bump
3. `docs/integrations/sources/zendesk-talk.md` — changelog entry (note: PR number placeholder is empty, to be filled post-merge)

## User Impact

Connections pinned to the new RC will run with lower concurrency (9 instead of 12). This is expected to reduce duration regression observed in Phase 1 while still providing concurrency benefits over the stable baseline (no concurrency).

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/a8b7ef49ffb0424c93226baac20ab5e3
Requested by: @sophiecuiy