### PR TITLE
chore(source-sendgrid): Phase 2 - Add HTTPAPIBudget rate limiting (1.3.28-rc.5)

### DIFF
--- a/airbyte-integrations/connectors/source-sendgrid/manifest.yaml
+++ b/airbyte-integrations/connectors/source-sendgrid/manifest.yaml
@@ -679,18 +679,18 @@ concurrency_level:
   default_concurrency: 6
   max_concurrency: 20
 
-# api_budget:  # Commented out for Phase 1 concurrency tuning - will be added in Phase 2
-#   type: HTTPAPIBudget
-#   policies:
-#     - type: MovingWindowCallRatePolicy
-#       rates:
-#         - limit: 50
-#           interval: PT1S
-#       matchers: []
-#   ratelimit_reset_header: X-RateLimit-Reset
-#   ratelimit_remaining_header: X-RateLimit-Remaining
-#   status_codes_for_ratelimit_hit:
-#     - 429
+api_budget:
+  type: HTTPAPIBudget
+  policies:
+    - type: MovingWindowCallRatePolicy
+      rates:
+        - limit: 50
+          interval: PT1S
+      matchers: []
+  ratelimit_reset_header: X-RateLimit-Reset
+  ratelimit_remaining_header: X-RateLimit-Remaining
+  status_codes_for_ratelimit_hit:
+    - 429
 
 spec:
   type: Spec

--- a/airbyte-integrations/connectors/source-sendgrid/metadata.yaml
+++ b/airbyte-integrations/connectors/source-sendgrid/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: fbb5fbe2-16ad-4cf4-af7d-ff9d9c316c87
-  dockerImageTag: 1.3.28-rc.4
+  dockerImageTag: 1.3.28-rc.5
   releases:
     rolloutConfiguration:
       enableProgressiveRollout: true

--- a/docs/integrations/sources/sendgrid.md
+++ b/docs/integrations/sources/sendgrid.md
@@ -105,6 +105,7 @@ If you encounter 403 errors, check the following:
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                                                                                                                           |
 |:--------|:-----------| :------------------------------------------------------- |:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1.3.28-rc.5 | 2026-04-13 | [74713](https://github.com/airbytehq/airbyte/pull/74713) | Add HTTPAPIBudget rate limiting (Phase 2) with concurrency=6 |
 | 1.3.28-rc.4 | 2026-04-12 | [74713](https://github.com/airbytehq/airbyte/pull/74713) | Add concurrency_level for parallel stream processing (concurrency=6) |
 | 1.3.27 | 2026-03-24 | [75331](https://github.com/airbytehq/airbyte/pull/75331) | Update dependencies |
 | 1.3.26 | 2026-02-24 | [73950](https://github.com/airbytehq/airbyte/pull/73950) | Update dependencies |


### PR DESCRIPTION
## What

Phase 2 of the source-sendgrid concurrency tuning & rollout ([#15312](https://github.com/airbytehq/airbyte-internal-issues/issues/15312)).

Phase 1 settled `default_concurrency=6` after testing concurrency values of 12, 9, and 6 across 12 Tier 2 actors over multiple 24h health-check windows. All three values passed; concurrency=6 had the best sync duration (avg 88s, −29% vs concurrency=9).

This PR enables the `HTTPAPIBudget` that was commented out during Phase 1 so concurrency could be tuned in isolation. The budget enforces SendGrid's documented ~50 req/s general rate limit.

## How

1. **`manifest.yaml`** — Uncomment the `api_budget` section, enabling a `MovingWindowCallRatePolicy` at 50 req/s with `X-RateLimit-Reset` / `X-RateLimit-Remaining` header awareness and 429 handling.
2. **`metadata.yaml`** — Bump `dockerImageTag` from `1.3.28-rc.4` → `1.3.28-rc.5`.
3. **`sendgrid.md`** — Add changelog entry for rc.5.

No changes to `default_concurrency` (remains 6) or `max_concurrency` (remains 20).

## Review guide

1. `manifest.yaml` (lines 682–693) — verify the `api_budget` block is valid YAML and matches the CDK `HTTPAPIBudget` schema.
2. `metadata.yaml` — version bump only.
3. **Note:** The changelog entry references PR #74713 (the original concurrency tuning PR that carried through all RC iterations). Verify this is acceptable or if it should reference this PR's number instead.

## User Impact

- Connectors pinned to rc.5 during progressive rollout will have client-side rate limiting (50 req/s moving window) in addition to `default_concurrency=6`.
- This should reduce or eliminate 429 errors from SendGrid under concurrent stream processing.
- No impact to unpinned users until the rollout progresses beyond Tier 2.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/f2e0baae475143b39e31875e49f6163b
Requested by: @sophiecuiy