### PR TITLE
chore(source-mailchimp): add HTTPAPIBudget for rate limit enforcement (Phase 2)

### DIFF
--- a/airbyte-integrations/connectors/source-mailchimp/manifest.yaml
+++ b/airbyte-integrations/connectors/source-mailchimp/manifest.yaml
@@ -13,16 +13,15 @@ concurrency_level:
   default_concurrency: "{{ config.get('num_workers', 6) }}"
   max_concurrency: 10
 
-# HTTPAPIBudget commented out for Phase 1 concurrency tuning (will be re-enabled in Phase 2)
-# api_budget:
-#   type: HTTPAPIBudget
-#   policies:
-#     - type: MovingWindowCallRatePolicy
-#       rates:
-#         - limit: 10
-#           interval: PT1S
-#       matchers: []  # Catch-all for all endpoints
-#   status_codes_for_ratelimit_hit: [429, 403]
+api_budget:
+  type: HTTPAPIBudget
+  policies:
+    - type: MovingWindowCallRatePolicy
+      rates:
+        - limit: 10
+          interval: PT1S
+      matchers: []  # Catch-all for all endpoints
+  status_codes_for_ratelimit_hit: [429, 403]
 
 definitions:
   bearer_authenticator:

--- a/airbyte-integrations/connectors/source-mailchimp/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mailchimp/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: b03a9f3e-22a5-11eb-adc1-0242ac120002
-  dockerImageTag: 2.1.23-rc.3
+  dockerImageTag: 2.1.23-rc.4
   dockerRepository: airbyte/source-mailchimp
   documentationUrl: https://docs.airbyte.com/integrations/sources/mailchimp
   externalDocumentationUrls:

--- a/docs/integrations/sources/mailchimp.md
+++ b/docs/integrations/sources/mailchimp.md
@@ -128,7 +128,7 @@ Now that you have set up the Mailchimp source connector, check out the following
 
 | Version | Date       | Pull Request                                             | Subject                                                                   |
 |--------|------------|----------------------------------------------------------|---------------------------------------------------------------------------|
-| 2.1.23-rc.4 | 2026-04-13 | [TBD](https://github.com/airbytehq/airbyte/pull/TBD) | Add HTTPAPIBudget for rate limit enforcement (Phase 2 of concurrency tuning) |
+| 2.1.23-rc.4 | 2026-04-13 | [76268](https://github.com/airbytehq/airbyte/pull/76268) | Add HTTPAPIBudget for rate limit enforcement (Phase 2 of concurrency tuning) |
 | 2.1.23-rc.3 | 2026-04-10 | [76232](https://github.com/airbytehq/airbyte/pull/76232) | Increase default_concurrency to 6 (iteration 3, final concurrency tuning) |
 | 2.1.23-rc.2 | 2026-04-08 | [70860](https://github.com/airbytehq/airbyte/pull/70860) | Increase default_concurrency to 5 (iteration 2 of concurrency tuning) |
 | 2.1.23-rc.1 | 2026-04-06 | [70860](https://github.com/airbytehq/airbyte/pull/70860) | Add concurrency_level and num_workers configuration for concurrency tuning |

--- a/docs/integrations/sources/mailchimp.md
+++ b/docs/integrations/sources/mailchimp.md
@@ -128,6 +128,7 @@ Now that you have set up the Mailchimp source connector, check out the following
 
 | Version | Date       | Pull Request                                             | Subject                                                                   |
 |--------|------------|----------------------------------------------------------|---------------------------------------------------------------------------|
+| 2.1.23-rc.4 | 2026-04-13 | [TBD](https://github.com/airbytehq/airbyte/pull/TBD) | Add HTTPAPIBudget for rate limit enforcement (Phase 2 of concurrency tuning) |
 | 2.1.23-rc.3 | 2026-04-10 | [76232](https://github.com/airbytehq/airbyte/pull/76232) | Increase default_concurrency to 6 (iteration 3, final concurrency tuning) |
 | 2.1.23-rc.2 | 2026-04-08 | [70860](https://github.com/airbytehq/airbyte/pull/70860) | Increase default_concurrency to 5 (iteration 2 of concurrency tuning) |
 | 2.1.23-rc.1 | 2026-04-06 | [70860](https://github.com/airbytehq/airbyte/pull/70860) | Add concurrency_level and num_workers configuration for concurrency tuning |


### PR DESCRIPTION
## What

Phase 2 of the source-mailchimp concurrency tuning rollout ([#15310](https://github.com/airbytehq/airbyte-internal-issues/issues/15310)). Enables the `HTTPAPIBudget` in the connector manifest, which was intentionally commented out during Phase 1 so concurrency could be tuned in isolation.

Phase 1 completed successfully across 3 iterations, landing on `default_concurrency=6` with 0% concurrency-related failures and ~38% average sync speed improvement across 39 Tier 2 actors.

## How

- **manifest.yaml**: Uncomments the `api_budget` block, enabling an `HTTPAPIBudget` with a `MovingWindowCallRatePolicy` of 10 requests/second (approximating Mailchimp's documented limit of 10 simultaneous connections). Rate-limit status codes: `429`, `403`.
- **metadata.yaml**: Bumps `dockerImageTag` from `2.1.23-rc.3` → `2.1.23-rc.4`.
- **mailchimp.md**: Adds changelog entry for `2.1.23-rc.4`.

## Review guide

1. `manifest.yaml` — the only functional change. Verify the rate limit policy values and status codes align with [Mailchimp API docs](https://mailchimp.com/developer/marketing/docs/fundamentals/#api-limits).
2. Note: the changelog entry has a `[TBD]` PR link that should be updated to this PR number before merge.
3. The `matchers: []` catch-all applies the rate limit uniformly to all endpoints — confirm this is the desired behavior.

## User Impact

Adds server-side rate limit enforcement to source-mailchimp. If the connector approaches 10 req/s, the SDK will throttle requests instead of hitting Mailchimp's rate limiter and receiving 429/403 errors. This is deployed as an RC behind progressive rollout — only pinned Tier 2 actors are affected initially.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/707014b936e2463ab12579f4b6a7e620
Requested by: @sophiecuiy