### PR TITLE
feat(source-typeform): adjust concurrency to 3 for rc.2 tuning retry

### DIFF
--- a/airbyte-integrations/connectors/source-typeform/manifest.yaml
+++ b/airbyte-integrations/connectors/source-typeform/manifest.yaml
@@ -3,7 +3,7 @@ type: DeclarativeSource
 
 concurrency_level:
   type: ConcurrencyLevel
-  default_concurrency: 4
+  default_concurrency: 3
   max_concurrency: 8
 
 api_budget:

--- a/airbyte-integrations/connectors/source-typeform/metadata.yaml
+++ b/airbyte-integrations/connectors/source-typeform/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: e7eff203-90bf-43e5-a240-19ea3056c474
-  dockerImageTag: 1.4.8-rc.1
+  dockerImageTag: 1.4.8-rc.2
   dockerRepository: airbyte/source-typeform
   documentationUrl: https://docs.airbyte.com/integrations/sources/typeform
   externalDocumentationUrls:

--- a/docs/integrations/sources/typeform.md
+++ b/docs/integrations/sources/typeform.md
@@ -106,6 +106,7 @@ The Forms, Responses, and Webhooks streams make separate API calls for each form
 
 | Version | Date       | Pull Request                                             | Subject                                                                                         |
 |:--------|:-----------|:---------------------------------------------------------|:------------------------------------------------------------------------------------------------|
+| 1.4.8-rc.2 | 2026-04-13 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) | Adjust default_concurrency from 4 to 3 for tuning retry |
 | 1.4.8-rc.1 | 2026-04-09 | [76204](https://github.com/airbytehq/airbyte/pull/76204) | Add concurrency_level for concurrent stream reads |
 | 1.4.7 | 2026-04-02 | [76030](https://github.com/airbytehq/airbyte/pull/76030) | Promoted release candidate to GA |
 | 1.4.7-rc.2 | 2026-03-31 | [75898](https://github.com/airbytehq/airbyte/pull/75898) | Update CDK to 7.15.0 |


### PR DESCRIPTION
## What

Reduces `default_concurrency` from 4 to 3 for source-typeform and bumps the version to `1.4.8-rc.2`.

This is a follow-up to [#76204](https://github.com/airbytehq/airbyte/pull/76204) (rc.1, c=4), which was rolled back after a 24-hour monitoring window showed a **44.8% sync failure rate** — 23 of 37 connections hit `heartbeat_timeout` (~90-minute hangs). The HTTPAPIBudget (2 req/s) is unchanged; only concurrency is reduced.

Related issue: https://github.com/airbytehq/airbyte-internal-issues/issues/15314

## How

- **`manifest.yaml`**: `default_concurrency: 4` → `default_concurrency: 3` (line 6). `max_concurrency` and `api_budget` are untouched.
- **`metadata.yaml`**: `dockerImageTag: 1.4.8-rc.1` → `dockerImageTag: 1.4.8-rc.2`
- **`docs/.../typeform.md`**: Changelog entry added for 1.4.8-rc.2.

## Review guide

1. `airbyte-integrations/connectors/source-typeform/manifest.yaml` — single integer change
2. `airbyte-integrations/connectors/source-typeform/metadata.yaml` — version bump
3. `docs/integrations/sources/typeform.md` — changelog entry (**note:** PR number is a placeholder `XXXXX` that needs updating after merge)

## User Impact

No user-facing behavior change beyond the connector running with 3 concurrent streams instead of 4. This is a tuning adjustment intended to reduce the hang/timeout failures observed with c=4.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/6dcb0ce3acb04fdaa5d90bad560ac37f
Requested by: @sophiecuiy