### PR TITLE
chore(source-freshdesk): increase default_concurrency from 4 to 5 (3.2.14-rc.2)

### DIFF
--- a/airbyte-integrations/connectors/source-freshdesk/manifest.yaml
+++ b/airbyte-integrations/connectors/source-freshdesk/manifest.yaml
@@ -1692,7 +1692,7 @@ spec:
           Number of concurrent threads for syncing. Higher values can speed up
           syncs but may increase API rate limit usage. Adjust based on your
           Freshdesk API plan.
-        default: 4
+        default: 5
         minimum: 2
         maximum: 16
         order: 5
@@ -3739,7 +3739,7 @@ schemas:
 
 concurrency_level:
   type: ConcurrencyLevel
-  default_concurrency: "{{ config.get('num_workers', 4) }}"
+  default_concurrency: "{{ config.get('num_workers', 5) }}"
   max_concurrency: 16
 
 api_budget:

--- a/airbyte-integrations/connectors/source-freshdesk/metadata.yaml
+++ b/airbyte-integrations/connectors/source-freshdesk/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: ec4b9503-13cb-48ab-a4ab-6ade4be46567
-  dockerImageTag: 3.2.14-rc.1
+  dockerImageTag: 3.2.14-rc.2
   dockerRepository: airbyte/source-freshdesk
   documentationUrl: https://docs.airbyte.com/integrations/sources/freshdesk
   externalDocumentationUrls:

--- a/docs/integrations/sources/freshdesk.md
+++ b/docs/integrations/sources/freshdesk.md
@@ -72,7 +72,7 @@ If you don't use the start date Freshdesk will retrieve only the last 30 days. M
 
 | Version | Date       | Pull Request                                             | Subject                                                                               |
 | :------ | :--------- | :------------------------------------------------------- | :------------------------------------------------------------------------------------ |
-| 3.2.14-rc.2 | 2026-04-13 | | Concurrency tuning iteration 2: increase default_concurrency from 4 to 5 |
+| 3.2.14-rc.2 | 2026-04-13 | [76272](https://github.com/airbytehq/airbyte/pull/76272) | Concurrency tuning iteration 2: increase default_concurrency from 4 to 5 |
 | 3.2.14-rc.1 | 2026-04-10 | [76202](https://github.com/airbytehq/airbyte/pull/76202) | Add concurrency_level and num_workers for concurrency tuning |
 | 3.2.13 | 2026-03-31 | [75719](https://github.com/airbytehq/airbyte/pull/75719) | Update dependencies |
 | 3.2.12 | 2026-03-24 | [74647](https://github.com/airbytehq/airbyte/pull/74647) | Update dependencies |

--- a/docs/integrations/sources/freshdesk.md
+++ b/docs/integrations/sources/freshdesk.md
@@ -72,6 +72,7 @@ If you don't use the start date Freshdesk will retrieve only the last 30 days. M
 
 | Version | Date       | Pull Request                                             | Subject                                                                               |
 | :------ | :--------- | :------------------------------------------------------- | :------------------------------------------------------------------------------------ |
+| 3.2.14-rc.2 | 2026-04-13 | | Concurrency tuning iteration 2: increase default_concurrency from 4 to 5 |
 | 3.2.14-rc.1 | 2026-04-10 | [76202](https://github.com/airbytehq/airbyte/pull/76202) | Add concurrency_level and num_workers for concurrency tuning |
 | 3.2.13 | 2026-03-31 | [75719](https://github.com/airbytehq/airbyte/pull/75719) | Update dependencies |
 | 3.2.12 | 2026-03-24 | [74647](https://github.com/airbytehq/airbyte/pull/74647) | Update dependencies |


### PR DESCRIPTION
## What

Concurrency tuning iteration 2 for source-freshdesk, as part of the concurrency tuning epic ([#15262](https://github.com/airbytehq/airbyte-internal-issues/issues/15262)) and connector-specific issue ([#15331](https://github.com/airbytehq/airbyte-internal-issues/issues/15331)).

After 24h monitoring of rc.1 (c=4) showed **0% concurrency-related failures** across 91 syncs and no rate limit hits, Sophie approved increasing concurrency to 5. Prior PR: [#76202](https://github.com/airbytehq/airbyte/pull/76202).

## How

- Bump `default_concurrency` from 4 → 5 in `concurrency_level` block (`manifest.yaml`)
- Bump `num_workers` spec default from 4 → 5 (`manifest.yaml`)
- Bump version from `3.2.14-rc.1` → `3.2.14-rc.2` (`metadata.yaml`)
- Add changelog entry for rc.2 (`freshdesk.md`)

No changes to `max_concurrency` (16), `minimum` (2), or the existing `HTTPAPIBudget` (50 calls/min).

## Review guide

1. `manifest.yaml` — two one-line default value changes (lines ~1695 and ~3742)
2. `metadata.yaml` — version tag bump
3. `docs/integrations/sources/freshdesk.md` — new changelog row

**Note**: The rc.2 changelog entry has an empty PR link field — it will be backfilled after this PR is created.

## User Impact

- Connections using source-freshdesk that are pinned to this RC will sync with 5 concurrent workers by default (up from 4). Users who have explicitly set `num_workers` in their config are unaffected.
- This RC will be deployed via progressive rollout to the same Tier 2 cohort before wider release.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/f5e7f185cbaf4e49b5d1ff5af45e3749
Requested by: @sophiecuiy