### PR TITLE
feat(source-typeform): adjust concurrency to 2 for rc.3 tuning retry

### DIFF
--- a/airbyte-integrations/connectors/source-typeform/manifest.yaml
+++ b/airbyte-integrations/connectors/source-typeform/manifest.yaml
@@ -3,7 +3,7 @@ type: DeclarativeSource
 
 concurrency_level:
   type: ConcurrencyLevel
-  default_concurrency: 3
+  default_concurrency: 2
   max_concurrency: 8
 
 api_budget:

--- a/airbyte-integrations/connectors/source-typeform/metadata.yaml
+++ b/airbyte-integrations/connectors/source-typeform/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: e7eff203-90bf-43e5-a240-19ea3056c474
-  dockerImageTag: 1.4.8-rc.2
+  dockerImageTag: 1.4.8-rc.3
   dockerRepository: airbyte/source-typeform
   documentationUrl: https://docs.airbyte.com/integrations/sources/typeform
   externalDocumentationUrls:


### PR DESCRIPTION
## What

Reduces `default_concurrency` from 3 to 2 (the floor value) for source-typeform as part of ongoing concurrency tuning ([internal issue #15314](https://github.com/airbytehq/airbyte-internal-issues/issues/15314)).

Previous RCs at higher concurrency levels showed sync stalling and elevated failure rates:
- **rc.1 (c=4):** 44.8% failure rate — heartbeat_timeouts + genuine regressions on non-heartbeat connections
- **rc.2 (c=3):** 54.6% failure rate — continued stalling, 26 connections hitting heartbeat_timeout

This PR drops to `c=2`, the minimum concurrency per the playbook formula (`floor(2 req/s / 4) = 0 → special case floor = 2`). The HTTP API budget (2 req/s `FixedWindowCallRatePolicy`) remains unchanged.

## How

- `manifest.yaml`: `default_concurrency: 3` → `2`
- `metadata.yaml`: `dockerImageTag: 1.4.8-rc.2` → `1.4.8-rc.3`

No other changes. `max_concurrency: 8` and `api_budget` are untouched.

## Review guide

1. `manifest.yaml` — confirm concurrency change on line 6
2. `metadata.yaml` — confirm version bump on line 13

**Key question for reviewer:** If c=2 also fails with stalling/heartbeat_timeouts, the root cause is likely not concurrency-related (heartbeat_timeout was also confirmed as pre-existing on stable 1.4.7). This RC will help isolate whether concurrency is a contributing factor.

## User Impact

- Pinned Tier 2 actors will run source-typeform with 2 concurrent stream reads instead of 3
- Still a 2× improvement over the implicit baseline of c=1
- No breaking changes or schema changes

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/6dcb0ce3acb04fdaa5d90bad560ac37f
Requested by: @sophiecuiy