### PR TITLE
fix(bulk-cdk): stream failure on catalog validation failure

### DIFF
--- a/airbyte-cdk/bulk/core/extract/changelog.md
+++ b/airbyte-cdk/bulk/core/extract/changelog.md
@@ -7,14 +7,15 @@ The Extract CDK provides functionality for source connectors including schema di
 <details>
   <summary>Expand to review</summary>
 
-| Version | Date       | Pull Request                                              | Subject                                                                                                                                              |
-|---------|------------|-----------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 1.1.2   | 2026-03-31 | [74124](https://github.com/airbytehq/airbyte/pull/74124)  | Change the default implementation of JDBC incremental partition to non splittable                                                                    |
-| 1.1.1   | 2026-04-02 | [76054](https://github.com/airbytehq/airbyte/pull/76054)  | Clarified CDC termination condition. Ensure querySingleValue returns one result or throws.                                                           |
-| 1.1.0   | 2026-03-30 | [75636](https://github.com/airbytehq/airbyte/pull/75636)  | CDC positions are partially ordered. Added optional CDC startup hook. Field is now EmittedField.                                                     |
-| 1.0.2   | 2026-02-24 | [74007](https://github.com/airbytehq/airbyte/pull/74007)  | Fix infinite loop when cursor-based incremental sync encounters an empty table with prior state by caching NULL cursor upper bound values (toolkit). |
-| 1.0.1   | 2026-02-24 |                                                           | Bump bulk-cdk-core-base to 1.0.1 to pick up CVE fixes (CVE-2021-47621, CVE-2022-36944).                                                              |
-| 1.0.0   | 2026-02-02 | [#72376](https://github.com/airbytehq/airbyte/pull/72376) | Initial independent release of bulk-cdk-core-extract. Separate versioning for extract package begins.                                                |
+| Version | Date       | Pull Request                                         | Subject                                                                                                                                            |
+|---------|------------|------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1.1.3   | 2026-04-14 | [76320](https://github.com/airbytehq/airbyte/pull/76320) | Catalog validation failures are captured as stream-level sync failures.                                                                            |
+| 1.1.2   | 2026-03-31 | [74124](https://github.com/airbytehq/airbyte/pull/74124) | Change the default implementation of JDBC incremental partition to non splittable                                                                  |
+| 1.1.1   | 2026-04-02 | [76054](https://github.com/airbytehq/airbyte/pull/76054) | Clarified CDC termination condition. Ensure querySingleValue returns one result or throws.                                                         |
+| 1.1.0   | 2026-03-30 | [75636](https://github.com/airbytehq/airbyte/pull/75636) | CDC positions are partially ordered. Added optional CDC startup hook. Field is now EmittedField.                                                   |
+| 1.0.2   | 2026-02-24 | [74007](https://github.com/airbytehq/airbyte/pull/74007) | Fix infinite loop when cursor-based incremental sync encounters an empty table with prior state by caching NULL cursor upper bound values (toolkit). |
+| 1.0.1   | 2026-02-24 |                                                      | Bump bulk-cdk-core-base to 1.0.1 to pick up CVE fixes (CVE-2021-47621, CVE-2022-36944).                                                            |
+| 1.0.0   | 2026-02-02 | [#72376](https://github.com/airbytehq/airbyte/pull/72376) | Initial independent release of bulk-cdk-core-extract. Separate versioning for extract package begins.                                              |
 
 </details>
 

--- a/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/output/CatalogValidationFailureHandler.kt
+++ b/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/output/CatalogValidationFailureHandler.kt
@@ -32,29 +32,32 @@ sealed interface CatalogValidationFailure {
             .withMessage(message)
 }
 
+private val StreamIdentifier.label: String
+    get() = if (namespace == null) "'$name'" else "'$namespace.$name'"
+
 data class StreamNotFound(
     override val streamID: StreamIdentifier,
 ) : CatalogValidationFailure {
-    override val message = "Stream not found or not accessible in source."
+    override val message = "Stream ${streamID.label} not found or not accessible in source."
 }
 
 data class MultipleStreamsFound(
     override val streamID: StreamIdentifier,
 ) : CatalogValidationFailure {
-    override val message = "Multiple matching streams found in source."
+    override val message = "Multiple matching streams found for ${streamID.label} in source."
 }
 
 data class StreamHasNoFields(
     override val streamID: StreamIdentifier,
 ) : CatalogValidationFailure {
-    override val message = "Stream has no accessible data fields."
+    override val message = "Stream ${streamID.label} has no accessible data fields."
 }
 
 data class FieldNotFound(
     override val streamID: StreamIdentifier,
     val fieldName: String,
 ) : CatalogValidationFailure {
-    override val message = "Field '$fieldName' not found in source."
+    override val message = "Field '$fieldName' not found in stream ${streamID.label}."
 }
 
 data class FieldTypeMismatch(
@@ -64,34 +67,34 @@ data class FieldTypeMismatch(
     val actual: AirbyteSchemaType,
 ) : CatalogValidationFailure {
     override val message =
-        "Field '$fieldName' has type $actual in source but catalog expects $expected."
+        "Field '$fieldName' in stream ${streamID.label} has type $actual in source but catalog expects $expected."
 }
 
 data class InvalidPrimaryKey(
     override val streamID: StreamIdentifier,
     val primaryKey: List<String>,
 ) : CatalogValidationFailure {
-    override val message = "Primary key $primaryKey not found in source."
+    override val message = "Primary key $primaryKey not found in stream ${streamID.label}."
 }
 
 data class InvalidCursor(
     override val streamID: StreamIdentifier,
     val cursor: String,
 ) : CatalogValidationFailure {
-    override val message = "Cursor '$cursor' not found in source."
+    override val message = "Cursor '$cursor' not found in stream ${streamID.label}."
 }
 
 data class InvalidIncrementalSyncMode(
     override val streamID: StreamIdentifier,
 ) : CatalogValidationFailure {
     override val message =
-        "No cursor configured for incremental sync; falling back to full refresh."
+        "Stream ${streamID.label} has no cursor configured for incremental sync; falling back to full refresh."
 }
 
 data class ResetStream(
     override val streamID: StreamIdentifier,
 ) : CatalogValidationFailure {
-    override val message = "Resetting stream."
+    override val message = "Resetting stream ${streamID.label}."
     override fun asErrorTrace(): AirbyteErrorTraceMessage? = null
 }
 
@@ -102,14 +105,7 @@ private class LoggingCatalogValidationFailureHandler(
     val outputConsumer: OutputConsumer,
 ) : CatalogValidationFailureHandler {
     override fun accept(f: CatalogValidationFailure) {
-        log.warn { "${f.prettyName()}: ${f.message}" }
+        log.warn { f.message }
         f.asErrorTrace()?.let { outputConsumer.accept(it) }
     }
-
-    private fun CatalogValidationFailure.prettyName(): String =
-        if (streamID.namespace == null) {
-            "'${streamID.name}' in unspecified namespace"
-        } else {
-            "'${streamID.name}' in namespace '${streamID.namespace}'"
-        }
 }

--- a/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/output/CatalogValidationFailureHandler.kt
+++ b/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/output/CatalogValidationFailureHandler.kt
@@ -2,7 +2,9 @@
 package io.airbyte.cdk.output
 
 import io.airbyte.cdk.StreamIdentifier
+import io.airbyte.cdk.asProtocolStreamDescriptor
 import io.airbyte.cdk.data.AirbyteSchemaType
+import io.airbyte.protocol.models.v0.AirbyteErrorTraceMessage
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.micronaut.context.annotation.DefaultImplementation
 import jakarta.inject.Singleton
@@ -21,75 +23,87 @@ interface CatalogValidationFailureHandler : Consumer<CatalogValidationFailure>
 /** Union type for all validation failures. */
 sealed interface CatalogValidationFailure {
     val streamID: StreamIdentifier
+    val message: String
+
+    fun asErrorTrace(): AirbyteErrorTraceMessage? =
+        AirbyteErrorTraceMessage()
+            .withStreamDescriptor(streamID.asProtocolStreamDescriptor())
+            .withFailureType(AirbyteErrorTraceMessage.FailureType.CONFIG_ERROR)
+            .withMessage(message)
 }
 
 data class StreamNotFound(
     override val streamID: StreamIdentifier,
-) : CatalogValidationFailure
+) : CatalogValidationFailure {
+    override val message = "Stream not found or not accessible in source."
+}
 
 data class MultipleStreamsFound(
     override val streamID: StreamIdentifier,
-) : CatalogValidationFailure
+) : CatalogValidationFailure {
+    override val message = "Multiple matching streams found in source."
+}
 
 data class StreamHasNoFields(
     override val streamID: StreamIdentifier,
-) : CatalogValidationFailure
+) : CatalogValidationFailure {
+    override val message = "Stream has no accessible data fields."
+}
 
 data class FieldNotFound(
     override val streamID: StreamIdentifier,
     val fieldName: String,
-) : CatalogValidationFailure
+) : CatalogValidationFailure {
+    override val message = "Field '$fieldName' not found in source."
+}
 
 data class FieldTypeMismatch(
     override val streamID: StreamIdentifier,
     val fieldName: String,
     val expected: AirbyteSchemaType,
     val actual: AirbyteSchemaType,
-) : CatalogValidationFailure
+) : CatalogValidationFailure {
+    override val message =
+        "Field '$fieldName' has type $actual in source but catalog expects $expected."
+}
 
 data class InvalidPrimaryKey(
     override val streamID: StreamIdentifier,
     val primaryKey: List<String>,
-) : CatalogValidationFailure
+) : CatalogValidationFailure {
+    override val message = "Primary key $primaryKey not found in source."
+}
 
 data class InvalidCursor(
     override val streamID: StreamIdentifier,
     val cursor: String,
-) : CatalogValidationFailure
+) : CatalogValidationFailure {
+    override val message = "Cursor '$cursor' not found in source."
+}
 
 data class InvalidIncrementalSyncMode(
     override val streamID: StreamIdentifier,
-) : CatalogValidationFailure
+) : CatalogValidationFailure {
+    override val message =
+        "No cursor configured for incremental sync; falling back to full refresh."
+}
 
 data class ResetStream(
     override val streamID: StreamIdentifier,
-) : CatalogValidationFailure
+) : CatalogValidationFailure {
+    override val message = "Resetting stream."
+    override fun asErrorTrace(): AirbyteErrorTraceMessage? = null
+}
 
 private val log = KotlinLogging.logger {}
 
 @Singleton
-private class LoggingCatalogValidationFailureHandler : CatalogValidationFailureHandler {
+private class LoggingCatalogValidationFailureHandler(
+    val outputConsumer: OutputConsumer,
+) : CatalogValidationFailureHandler {
     override fun accept(f: CatalogValidationFailure) {
-        when (f) {
-            is FieldNotFound ->
-                log.warn { "In stream ${f.prettyName()}: field '${f.fieldName}' not found." }
-            is FieldTypeMismatch ->
-                log.warn {
-                    "In stream ${f.prettyName()}: " +
-                        "field '${f.fieldName}' is ${f.actual} but catalog expects ${f.expected}."
-                }
-            is StreamHasNoFields -> log.warn { "In stream ${f.prettyName()}: no data fields found" }
-            is InvalidCursor ->
-                log.warn { "In stream ${f.prettyName()}: invalid cursor '${f.cursor}'." }
-            is InvalidPrimaryKey ->
-                log.warn { "In stream ${f.prettyName()}: invalid primary key '${f.primaryKey}'." }
-            is InvalidIncrementalSyncMode ->
-                log.warn { "In stream ${f.prettyName()}: incremental sync not possible." }
-            is MultipleStreamsFound ->
-                log.warn { "Multiple matching streams found for ${f.prettyName()}." }
-            is ResetStream -> log.warn { "Resetting stream ${f.prettyName()}." }
-            is StreamNotFound -> log.warn { "No matching stream found for name ${f.prettyName()}." }
-        }
+        log.warn { "${f.prettyName()}: ${f.message}" }
+        f.asErrorTrace()?.let { outputConsumer.accept(it) }
     }
 
     private fun CatalogValidationFailure.prettyName(): String =

--- a/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/read/StateManagerFactory.kt
+++ b/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/read/StateManagerFactory.kt
@@ -34,8 +34,9 @@ import io.airbyte.cdk.output.OutputConsumer
 import io.airbyte.cdk.output.StreamHasNoFields
 import io.airbyte.cdk.output.StreamNotFound
 import io.airbyte.cdk.output.sockets.DATA_CHANNEL_PROPERTY_PREFIX
-import io.airbyte.protocol.models.v0.AirbyteErrorTraceMessage
 import io.airbyte.protocol.models.v0.AirbyteStream
+import io.airbyte.protocol.models.v0.AirbyteStreamStatusTraceMessage
+import io.airbyte.protocol.models.v0.AirbyteStreamStatusTraceMessage.AirbyteStreamStatus
 import io.airbyte.protocol.models.v0.ConfiguredAirbyteCatalog
 import io.airbyte.protocol.models.v0.ConfiguredAirbyteStream
 import io.airbyte.protocol.models.v0.SyncMode
@@ -63,7 +64,23 @@ class StateManagerFactory(
     ): StateManager {
         val allStreams: List<Stream> =
             metadataQuerierFactory.session(config).use { mq ->
-                configuredCatalog.streams.mapNotNull { toStream(mq, it) }
+                configuredCatalog.streams.mapNotNull { configuredStream ->
+                    val streamID = StreamIdentifier.from(configuredStream.stream)
+                    toStream(mq, configuredStream)
+                        ?: run {
+                            outputConsumer.accept(
+                                AirbyteStreamStatusTraceMessage()
+                                    .withStreamDescriptor(streamID.asProtocolStreamDescriptor())
+                                    .withStatus(AirbyteStreamStatus.STARTED),
+                            )
+                            outputConsumer.accept(
+                                AirbyteStreamStatusTraceMessage()
+                                    .withStreamDescriptor(streamID.asProtocolStreamDescriptor())
+                                    .withStatus(AirbyteStreamStatus.INCOMPLETE),
+                            )
+                            null
+                        }
+                }
             }
         return if (config.global) {
             when (inputState) {
@@ -168,27 +185,14 @@ class StateManagerFactory(
         val streamID: StreamIdentifier = StreamIdentifier.from(configuredStream.stream)
         val name: String = streamID.name
         val namespace: String? = streamID.namespace
-        val streamLabel: String = streamID.toString()
         when (metadataQuerier.streamNames(namespace).filter { it.name == name }.size) {
             0 -> {
                 handler.accept(StreamNotFound(streamID))
-                outputConsumer.accept(
-                    AirbyteErrorTraceMessage()
-                        .withStreamDescriptor(streamID.asProtocolStreamDescriptor())
-                        .withFailureType(AirbyteErrorTraceMessage.FailureType.CONFIG_ERROR)
-                        .withMessage("Stream '$streamLabel' not found or not accessible in source.")
-                )
                 return null
             }
             1 -> Unit
             else -> {
                 handler.accept(MultipleStreamsFound(streamID))
-                outputConsumer.accept(
-                    AirbyteErrorTraceMessage()
-                        .withStreamDescriptor(streamID.asProtocolStreamDescriptor())
-                        .withFailureType(AirbyteErrorTraceMessage.FailureType.CONFIG_ERROR)
-                        .withMessage("Multiple streams '$streamLabel' found in source.")
-                )
                 return null
             }
         }
@@ -232,12 +236,6 @@ class StateManagerFactory(
             }
         if (streamFields.isEmpty()) {
             handler.accept(StreamHasNoFields(streamID))
-            outputConsumer.accept(
-                AirbyteErrorTraceMessage()
-                    .withStreamDescriptor(streamID.asProtocolStreamDescriptor())
-                    .withFailureType(AirbyteErrorTraceMessage.FailureType.CONFIG_ERROR)
-                    .withMessage("Stream '$streamLabel' has no accessible fields.")
-            )
             return null
         }
 

--- a/airbyte-cdk/bulk/core/extract/src/testFixtures/kotlin/io/airbyte/cdk/output/DelegatingCatalogValidationFailureHandler.kt
+++ b/airbyte-cdk/bulk/core/extract/src/testFixtures/kotlin/io/airbyte/cdk/output/DelegatingCatalogValidationFailureHandler.kt
@@ -21,5 +21,6 @@ class DelegatingCatalogValidationFailureHandler(
         outputConsumer.accept(
             AirbyteLogMessage().withLevel(AirbyteLogMessage.Level.WARN).withMessage(f.toString()),
         )
+        f.asErrorTrace()?.let { outputConsumer.accept(it) }
     }
 }

--- a/airbyte-cdk/bulk/core/extract/version.properties
+++ b/airbyte-cdk/bulk/core/extract/version.properties
@@ -1,1 +1,1 @@
-version=1.1.2
+version=1.1.3

--- a/airbyte-cdk/bulk/toolkits/extract-jdbc/src/test/resources/h2source/expected-messages-stream-bad-catalog.json
+++ b/airbyte-cdk/bulk/toolkits/extract-jdbc/src/test/resources/h2source/expected-messages-stream-bad-catalog.json
@@ -20,5 +20,35 @@
         "failure_type": "config_error"
       }
     }
+  },
+  {
+    "type":"TRACE",
+    "trace":{
+      "type":"STREAM_STATUS",
+      "emitted_at":3.1336416E12,
+      "stream_status":{
+        "stream_descriptor":{
+          "name":"FOO",
+          "namespace":"PUBLIC"
+        },
+        "status":"STARTED",
+        "reasons":[]
+      }
+    }
+  },
+  {
+    "type":"TRACE",
+    "trace":{
+      "type":"STREAM_STATUS",
+      "emitted_at":3.1336416E12,
+      "stream_status":{
+        "stream_descriptor":{
+          "name":"FOO",
+          "namespace":"PUBLIC"
+        },
+        "status":"INCOMPLETE",
+        "reasons":[]
+      }
+    }
   }
 ]

--- a/airbyte-cdk/bulk/toolkits/extract-jdbc/src/test/resources/h2source/expected-messages-stream-bad-catalog.json
+++ b/airbyte-cdk/bulk/toolkits/extract-jdbc/src/test/resources/h2source/expected-messages-stream-bad-catalog.json
@@ -22,32 +22,32 @@
     }
   },
   {
-    "type":"TRACE",
-    "trace":{
-      "type":"STREAM_STATUS",
-      "emitted_at":3.1336416E12,
-      "stream_status":{
-        "stream_descriptor":{
-          "name":"FOO",
-          "namespace":"PUBLIC"
+    "type": "TRACE",
+    "trace": {
+      "type": "STREAM_STATUS",
+      "emitted_at": 3.1336416e12,
+      "stream_status": {
+        "stream_descriptor": {
+          "name": "FOO",
+          "namespace": "PUBLIC"
         },
-        "status":"STARTED",
-        "reasons":[]
+        "status": "STARTED",
+        "reasons": []
       }
     }
   },
   {
-    "type":"TRACE",
-    "trace":{
-      "type":"STREAM_STATUS",
-      "emitted_at":3.1336416E12,
-      "stream_status":{
-        "stream_descriptor":{
-          "name":"FOO",
-          "namespace":"PUBLIC"
+    "type": "TRACE",
+    "trace": {
+      "type": "STREAM_STATUS",
+      "emitted_at": 3.1336416e12,
+      "stream_status": {
+        "stream_descriptor": {
+          "name": "FOO",
+          "namespace": "PUBLIC"
         },
-        "status":"INCOMPLETE",
-        "reasons":[]
+        "status": "INCOMPLETE",
+        "reasons": []
       }
     }
   }


### PR DESCRIPTION
## Description

Previously, a catalog validation failure would result in WARN level logging and the stream would be ignored:

```
source WARN main i.a.c.o.LoggingCatalogValidationFailureHandler(accept):77 In stream '<redacted>' in namespace '<redacted>': field 'id' is INTEGER but catalog expects NUMBER.
```

The user would see the sync complete successfully and probably not see that streams had been excluded. Now, we handle catalog validation as a stream-level failure which will propagate up as a partial failure of the sync.

## Limitations
As before, we still only surface the first field mismatch for each stream to the user. In practice, they will fix this by rerunning discover, which will surface and fix any other mismatches with the previous catalog that the job didn't surface.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌
