### PR TITLE
chore(source-freshdesk): increase default_concurrency from 5 to 6 (3.2.14-rc.3)

### DIFF
--- a/airbyte-integrations/connectors/source-freshdesk/manifest.yaml
+++ b/airbyte-integrations/connectors/source-freshdesk/manifest.yaml
@@ -1692,7 +1692,7 @@ spec:
           Number of concurrent threads for syncing. Higher values can speed up
           syncs but may increase API rate limit usage. Adjust based on your
           Freshdesk API plan.
-        default: 5
+        default: 6
         minimum: 2
         maximum: 16
         order: 5
@@ -3739,7 +3739,7 @@ schemas:
 
 concurrency_level:
   type: ConcurrencyLevel
-  default_concurrency: "{{ config.get('num_workers', 5) }}"
+  default_concurrency: "{{ config.get('num_workers', 6) }}"
   max_concurrency: 16
 
 api_budget:

--- a/airbyte-integrations/connectors/source-freshdesk/metadata.yaml
+++ b/airbyte-integrations/connectors/source-freshdesk/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: ec4b9503-13cb-48ab-a4ab-6ade4be46567
-  dockerImageTag: 3.2.14-rc.2
+  dockerImageTag: 3.2.14-rc.3
   dockerRepository: airbyte/source-freshdesk
   documentationUrl: https://docs.airbyte.com/integrations/sources/freshdesk
   externalDocumentationUrls:

--- a/docs/integrations/sources/freshdesk.md
+++ b/docs/integrations/sources/freshdesk.md
@@ -72,6 +72,7 @@ If you don't use the start date Freshdesk will retrieve only the last 30 days. M
 
 | Version | Date       | Pull Request                                             | Subject                                                                               |
 | :------ | :--------- | :------------------------------------------------------- | :------------------------------------------------------------------------------------ |
+| 3.2.14-rc.3 | 2026-04-14 | | Concurrency tuning iteration 3: increase default_concurrency from 5 to 6 |
 | 3.2.14-rc.2 | 2026-04-13 | [76272](https://github.com/airbytehq/airbyte/pull/76272) | Concurrency tuning iteration 2: increase default_concurrency from 4 to 5 |
 | 3.2.14-rc.1 | 2026-04-10 | [76202](https://github.com/airbytehq/airbyte/pull/76202) | Add concurrency_level and num_workers for concurrency tuning |
 | 3.2.13 | 2026-03-31 | [75719](https://github.com/airbytehq/airbyte/pull/75719) | Update dependencies |


### PR DESCRIPTION
## What

Concurrency tuning iteration 3 for source-freshdesk, part of the [concurrency tuning epic](https://github.com/airbytehq/airbyte-internal-issues/issues/15262) ([connector issue](https://github.com/airbytehq/airbyte-internal-issues/issues/15331)).

Bumps `default_concurrency` from 5 → 6 and publishes as `3.2.14-rc.3`.

**Prior iterations:**
- rc.1 (c=4, [#76202](https://github.com/airbytehq/airbyte/pull/76202)): 0% failures, +5.7% duration vs stable (marginal gate fail)
- rc.2 (c=5, [#76272](https://github.com/airbytehq/airbyte/pull/76272)): 0% failures, −0.8% duration vs stable (gate pass). The one outlier connection (BQ-Connexin, +10% duration) was attributed to organic volume growth (+14.5% records during the stable window itself), not concurrency regression.

Sophie approved the increase to c=6 after reviewing the BQ-Connexin volume analysis.

## How

- `manifest.yaml`: Update `num_workers` spec default 5→6 and `default_concurrency` template fallback 5→6
- `metadata.yaml`: Bump `dockerImageTag` to `3.2.14-rc.3`
- `freshdesk.md`: Add changelog entry

## Review guide

1. `manifest.yaml` — two lines changed, both from 5→6. Verify they are consistent with each other.
2. `metadata.yaml` — version bump only
3. `freshdesk.md` — changelog entry (PR link intentionally blank, will be backfilled)

## User Impact

No user-facing impact yet. This RC will be rolled out to the same 7 pinned Tier 2 actors for a 24-hour monitoring window. The existing `HTTPAPIBudget` (50 calls/min) remains unchanged.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/f5e7f185cbaf4e49b5d1ff5af45e3749
Requested by: @sophiecuiy