### PR TITLE
fix(source-amazon-ads): fix cursorId type for attribution_report_products pagination

### DIFF
--- a/airbyte-integrations/connectors/source-amazon-ads/manifest.yaml
+++ b/airbyte-integrations/connectors/source-amazon-ads/manifest.yaml
@@ -1104,7 +1104,8 @@ definitions:
           pagination_strategy:
             type: CursorPagination
             page_size: 300
-            cursor_value: "{{ response.cursorId }}"
+            cursor_value: "'{{ response.cursorId }}'"
+            stop_condition: "{{ response.cursorId is none}}"
       schema_loader:
         type: InlineSchemaLoader
         schema:

--- a/airbyte-integrations/connectors/source-amazon-ads/manifest.yaml
+++ b/airbyte-integrations/connectors/source-amazon-ads/manifest.yaml
@@ -1104,7 +1104,7 @@ definitions:
           pagination_strategy:
             type: CursorPagination
             page_size: 300
-            cursor_value: "'{{ response.cursorId }}'"
+            cursor_value: '{{ response.get("cursorId", "") | tojson }}'
             stop_condition: "{{ response.cursorId is none}}"
       schema_loader:
         type: InlineSchemaLoader
@@ -1187,7 +1187,7 @@ definitions:
           pagination_strategy:
             type: CursorPagination
             page_size: 300
-            cursor_value: "'{{ response.cursorId }}'"
+            cursor_value: '{{ response.get("cursorId", "") | tojson }}'
             stop_condition: "{{ response.cursorId is none}}"
       schema_loader:
         type: InlineSchemaLoader
@@ -1270,7 +1270,7 @@ definitions:
           pagination_strategy:
             type: CursorPagination
             page_size: 300
-            cursor_value: "'{{ response.cursorId }}'"
+            cursor_value: '{{ response.get("cursorId", "") | tojson }}'
             stop_condition: "{{ response.cursorId is none}}"
       schema_loader:
         type: InlineSchemaLoader
@@ -1352,7 +1352,7 @@ definitions:
           pagination_strategy:
             type: CursorPagination
             page_size: 300
-            cursor_value: "'{{ response.cursorId }}'"
+            cursor_value: '{{ response.get("cursorId", "") | tojson }}'
             stop_condition: "{{ response.cursorId is none}}"
       schema_loader:
         type: InlineSchemaLoader

--- a/airbyte-integrations/connectors/source-amazon-ads/manifest.yaml
+++ b/airbyte-integrations/connectors/source-amazon-ads/manifest.yaml
@@ -1187,7 +1187,8 @@ definitions:
           pagination_strategy:
             type: CursorPagination
             page_size: 300
-            cursor_value: "{{ response.cursorId }}"
+            cursor_value: "'{{ response.cursorId }}'"
+            stop_condition: "{{ response.cursorId is none}}"
       schema_loader:
         type: InlineSchemaLoader
         schema:
@@ -1269,7 +1270,8 @@ definitions:
           pagination_strategy:
             type: CursorPagination
             page_size: 300
-            cursor_value: "{{ response.cursorId }}"
+            cursor_value: "'{{ response.cursorId }}'"
+            stop_condition: "{{ response.cursorId is none}}"
       schema_loader:
         type: InlineSchemaLoader
         schema:
@@ -1350,7 +1352,8 @@ definitions:
           pagination_strategy:
             type: CursorPagination
             page_size: 300
-            cursor_value: "{{ response.cursorId }}"
+            cursor_value: "'{{ response.cursorId }}'"
+            stop_condition: "{{ response.cursorId is none}}"
       schema_loader:
         type: InlineSchemaLoader
         schema:

--- a/airbyte-integrations/connectors/source-amazon-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-amazon-ads/metadata.yaml
@@ -13,7 +13,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: c6b0a29e-1da9-4512-9002-7bfd0cba2246
-  dockerImageTag: 7.3.17
+  dockerImageTag: 7.3.18
   dockerRepository: airbyte/source-amazon-ads
   documentationUrl: https://docs.airbyte.com/integrations/sources/amazon-ads
   githubIssueLabel: source-amazon-ads

--- a/airbyte-integrations/connectors/source-amazon-ads/unit_tests/integrations/ad_responses/pagination_strategies/__init__.py
+++ b/airbyte-integrations/connectors/source-amazon-ads/unit_tests/integrations/ad_responses/pagination_strategies/__init__.py
@@ -1,3 +1,5 @@
 from .count_based_pagination_strategy import CountBasedPaginationStrategy
 from .cursor_based_pagination_strategy import CursorBasedPaginationStrategy
+from .json_cursor_pagination_strategy import JsonCursorPaginationStrategy
+from .null_cursor_pagination_strategy import NullCursorPaginationStrategy
 from .sponsored_cursor_based_pagination_strategy import SponsoredCursorBasedPaginationStrategy

--- a/airbyte-integrations/connectors/source-amazon-ads/unit_tests/integrations/ad_responses/pagination_strategies/json_cursor_pagination_strategy.py
+++ b/airbyte-integrations/connectors/source-amazon-ads/unit_tests/integrations/ad_responses/pagination_strategies/json_cursor_pagination_strategy.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+
+from typing import Any, Dict
+
+from airbyte_cdk.test.mock_http.response_builder import PaginationStrategy
+
+JSON_CURSOR_TOKEN = '{"key":"abc123"}'
+
+
+class JsonCursorPaginationStrategy(PaginationStrategy):
+    @staticmethod
+    def update(response: Dict[str, Any]) -> None:
+        response["cursorId"] = JSON_CURSOR_TOKEN

--- a/airbyte-integrations/connectors/source-amazon-ads/unit_tests/integrations/ad_responses/pagination_strategies/json_cursor_pagination_strategy.py
+++ b/airbyte-integrations/connectors/source-amazon-ads/unit_tests/integrations/ad_responses/pagination_strategies/json_cursor_pagination_strategy.py
@@ -4,6 +4,7 @@ from typing import Any, Dict
 
 from airbyte_cdk.test.mock_http.response_builder import PaginationStrategy
 
+
 JSON_CURSOR_TOKEN = '{"key":"abc123"}'
 
 

--- a/airbyte-integrations/connectors/source-amazon-ads/unit_tests/integrations/ad_responses/pagination_strategies/null_cursor_pagination_strategy.py
+++ b/airbyte-integrations/connectors/source-amazon-ads/unit_tests/integrations/ad_responses/pagination_strategies/null_cursor_pagination_strategy.py
@@ -1,0 +1,11 @@
+# Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+
+from typing import Any, Dict
+
+from airbyte_cdk.test.mock_http.response_builder import PaginationStrategy
+
+
+class NullCursorPaginationStrategy(PaginationStrategy):
+    @staticmethod
+    def update(response: Dict[str, Any]) -> None:
+        response["cursorId"] = None

--- a/airbyte-integrations/connectors/source-amazon-ads/unit_tests/integrations/test_attribution_report_streams.py
+++ b/airbyte-integrations/connectors/source-amazon-ads/unit_tests/integrations/test_attribution_report_streams.py
@@ -13,7 +13,8 @@ from airbyte_cdk.test.mock_http import HttpMocker
 
 from .ad_requests import AttributionReportRequestBuilder, OAuthRequestBuilder, ProfilesRequestBuilder
 from .ad_responses import AttributionReportResponseBuilder, ErrorResponseBuilder, OAuthResponseBuilder, ProfilesResponseBuilder
-from .ad_responses.pagination_strategies import CursorBasedPaginationStrategy
+from .ad_responses.pagination_strategies import CursorBasedPaginationStrategy, JsonCursorPaginationStrategy, NullCursorPaginationStrategy
+from .ad_responses.pagination_strategies.json_cursor_pagination_strategy import JSON_CURSOR_TOKEN
 from .ad_responses.records import AttributionReportRecordBuilder, ErrorRecordBuilder, ProfilesRecordBuilder
 from .config import ConfigBuilder
 from .utils import get_log_messages_by_log_level, read_stream
@@ -522,3 +523,237 @@ class TestAttributionReportStreamsFullRefresh(TestCase):
 
         output = read_stream("attribution_report_performance_creative", SyncMode.full_refresh, self._config)
         assert len(output.records) == 2
+
+    # --- cursorId as JSON-shaped string: must remain a string through pagination ---
+
+    @HttpMocker()
+    def test_given_json_cursor_when_read_products_then_cursor_stays_string(self, http_mocker):
+        self._given_oauth_and_profiles(http_mocker, self._config)
+        profile_timezone = ProfilesRecordBuilder.profiles_record().build().get("timezone")
+
+        http_mocker.post(
+            AttributionReportRequestBuilder.products_endpoint(
+                self._config["client_id"],
+                self._config["access_token"],
+                self._config["profiles"][0],
+                start_date=_A_START_DATE.astimezone(ZoneInfo(profile_timezone)).date(),
+                end_date=_NOW.astimezone(ZoneInfo(profile_timezone)).date(),
+            ).build(),
+            AttributionReportResponseBuilder.products_response(JsonCursorPaginationStrategy())
+            .with_record(AttributionReportRecordBuilder.products_record())
+            .with_pagination()
+            .build(),
+        )
+        http_mocker.post(
+            AttributionReportRequestBuilder.products_endpoint(
+                self._config["client_id"],
+                self._config["access_token"],
+                self._config["profiles"][0],
+                start_date=_A_START_DATE.astimezone(ZoneInfo(profile_timezone)).date(),
+                end_date=_NOW.astimezone(ZoneInfo(profile_timezone)).date(),
+            )
+            .with_cursor_field(JSON_CURSOR_TOKEN)
+            .build(),
+            AttributionReportResponseBuilder.products_response().with_record(AttributionReportRecordBuilder.products_record()).build(),
+        )
+
+        output = read_stream("attribution_report_products", SyncMode.full_refresh, self._config)
+        assert len(output.records) == 2
+
+    @HttpMocker()
+    def test_given_json_cursor_when_read_performance_adgroup_then_cursor_stays_string(self, http_mocker):
+        self._given_oauth_and_profiles(http_mocker, self._config)
+        profile_timezone = ProfilesRecordBuilder.profiles_record().build().get("timezone")
+
+        http_mocker.post(
+            AttributionReportRequestBuilder.performance_adgroup_endpoint(
+                self._config["client_id"],
+                self._config["access_token"],
+                self._config["profiles"][0],
+                start_date=_A_START_DATE.astimezone(ZoneInfo(profile_timezone)).date(),
+                end_date=_NOW.astimezone(ZoneInfo(profile_timezone)).date(),
+            ).build(),
+            AttributionReportResponseBuilder.performance_adgroup_response(JsonCursorPaginationStrategy())
+            .with_record(AttributionReportRecordBuilder.performance_adgroup_record())
+            .with_pagination()
+            .build(),
+        )
+        http_mocker.post(
+            AttributionReportRequestBuilder.performance_adgroup_endpoint(
+                self._config["client_id"],
+                self._config["access_token"],
+                self._config["profiles"][0],
+                start_date=_A_START_DATE.astimezone(ZoneInfo(profile_timezone)).date(),
+                end_date=_NOW.astimezone(ZoneInfo(profile_timezone)).date(),
+            )
+            .with_cursor_field(JSON_CURSOR_TOKEN)
+            .build(),
+            AttributionReportResponseBuilder.performance_adgroup_response()
+            .with_record(AttributionReportRecordBuilder.performance_adgroup_record())
+            .build(),
+        )
+
+        output = read_stream("attribution_report_performance_adgroup", SyncMode.full_refresh, self._config)
+        assert len(output.records) == 2
+
+    @HttpMocker()
+    def test_given_json_cursor_when_read_performance_campaign_then_cursor_stays_string(self, http_mocker):
+        self._given_oauth_and_profiles(http_mocker, self._config)
+        profile_timezone = ProfilesRecordBuilder.profiles_record().build().get("timezone")
+
+        http_mocker.post(
+            AttributionReportRequestBuilder.performance_campaign_endpoint(
+                self._config["client_id"],
+                self._config["access_token"],
+                self._config["profiles"][0],
+                start_date=_A_START_DATE.astimezone(ZoneInfo(profile_timezone)).date(),
+                end_date=_NOW.astimezone(ZoneInfo(profile_timezone)).date(),
+            ).build(),
+            AttributionReportResponseBuilder.performance_campaign_response(JsonCursorPaginationStrategy())
+            .with_record(AttributionReportRecordBuilder.performance_campaign_record())
+            .with_pagination()
+            .build(),
+        )
+        http_mocker.post(
+            AttributionReportRequestBuilder.performance_campaign_endpoint(
+                self._config["client_id"],
+                self._config["access_token"],
+                self._config["profiles"][0],
+                start_date=_A_START_DATE.astimezone(ZoneInfo(profile_timezone)).date(),
+                end_date=_NOW.astimezone(ZoneInfo(profile_timezone)).date(),
+            )
+            .with_cursor_field(JSON_CURSOR_TOKEN)
+            .build(),
+            AttributionReportResponseBuilder.performance_campaign_response()
+            .with_record(AttributionReportRecordBuilder.performance_campaign_record())
+            .build(),
+        )
+
+        output = read_stream("attribution_report_performance_campaign", SyncMode.full_refresh, self._config)
+        assert len(output.records) == 2
+
+    @HttpMocker()
+    def test_given_json_cursor_when_read_performance_creative_then_cursor_stays_string(self, http_mocker):
+        self._given_oauth_and_profiles(http_mocker, self._config)
+        profile_timezone = ProfilesRecordBuilder.profiles_record().build().get("timezone")
+
+        http_mocker.post(
+            AttributionReportRequestBuilder.performance_creative_endpoint(
+                self._config["client_id"],
+                self._config["access_token"],
+                self._config["profiles"][0],
+                start_date=_A_START_DATE.astimezone(ZoneInfo(profile_timezone)).date(),
+                end_date=_NOW.astimezone(ZoneInfo(profile_timezone)).date(),
+            ).build(),
+            AttributionReportResponseBuilder.performance_creative_response(JsonCursorPaginationStrategy())
+            .with_record(AttributionReportRecordBuilder.performance_creative_record())
+            .with_pagination()
+            .build(),
+        )
+        http_mocker.post(
+            AttributionReportRequestBuilder.performance_creative_endpoint(
+                self._config["client_id"],
+                self._config["access_token"],
+                self._config["profiles"][0],
+                start_date=_A_START_DATE.astimezone(ZoneInfo(profile_timezone)).date(),
+                end_date=_NOW.astimezone(ZoneInfo(profile_timezone)).date(),
+            )
+            .with_cursor_field(JSON_CURSOR_TOKEN)
+            .build(),
+            AttributionReportResponseBuilder.performance_creative_response()
+            .with_record(AttributionReportRecordBuilder.performance_creative_record())
+            .build(),
+        )
+
+        output = read_stream("attribution_report_performance_creative", SyncMode.full_refresh, self._config)
+        assert len(output.records) == 2
+
+    # --- cursorId = null in response: pagination must stop ---
+
+    @HttpMocker()
+    def test_given_null_cursor_when_read_products_then_pagination_stops(self, http_mocker):
+        self._given_oauth_and_profiles(http_mocker, self._config)
+        profile_timezone = ProfilesRecordBuilder.profiles_record().build().get("timezone")
+
+        http_mocker.post(
+            AttributionReportRequestBuilder.products_endpoint(
+                self._config["client_id"],
+                self._config["access_token"],
+                self._config["profiles"][0],
+                start_date=_A_START_DATE.astimezone(ZoneInfo(profile_timezone)).date(),
+                end_date=_NOW.astimezone(ZoneInfo(profile_timezone)).date(),
+            ).build(),
+            AttributionReportResponseBuilder.products_response(NullCursorPaginationStrategy())
+            .with_record(AttributionReportRecordBuilder.products_record())
+            .with_pagination()
+            .build(),
+        )
+
+        output = read_stream("attribution_report_products", SyncMode.full_refresh, self._config)
+        assert len(output.records) == 1
+
+    @HttpMocker()
+    def test_given_null_cursor_when_read_performance_adgroup_then_pagination_stops(self, http_mocker):
+        self._given_oauth_and_profiles(http_mocker, self._config)
+        profile_timezone = ProfilesRecordBuilder.profiles_record().build().get("timezone")
+
+        http_mocker.post(
+            AttributionReportRequestBuilder.performance_adgroup_endpoint(
+                self._config["client_id"],
+                self._config["access_token"],
+                self._config["profiles"][0],
+                start_date=_A_START_DATE.astimezone(ZoneInfo(profile_timezone)).date(),
+                end_date=_NOW.astimezone(ZoneInfo(profile_timezone)).date(),
+            ).build(),
+            AttributionReportResponseBuilder.performance_adgroup_response(NullCursorPaginationStrategy())
+            .with_record(AttributionReportRecordBuilder.performance_adgroup_record())
+            .with_pagination()
+            .build(),
+        )
+
+        output = read_stream("attribution_report_performance_adgroup", SyncMode.full_refresh, self._config)
+        assert len(output.records) == 1
+
+    @HttpMocker()
+    def test_given_null_cursor_when_read_performance_campaign_then_pagination_stops(self, http_mocker):
+        self._given_oauth_and_profiles(http_mocker, self._config)
+        profile_timezone = ProfilesRecordBuilder.profiles_record().build().get("timezone")
+
+        http_mocker.post(
+            AttributionReportRequestBuilder.performance_campaign_endpoint(
+                self._config["client_id"],
+                self._config["access_token"],
+                self._config["profiles"][0],
+                start_date=_A_START_DATE.astimezone(ZoneInfo(profile_timezone)).date(),
+                end_date=_NOW.astimezone(ZoneInfo(profile_timezone)).date(),
+            ).build(),
+            AttributionReportResponseBuilder.performance_campaign_response(NullCursorPaginationStrategy())
+            .with_record(AttributionReportRecordBuilder.performance_campaign_record())
+            .with_pagination()
+            .build(),
+        )
+
+        output = read_stream("attribution_report_performance_campaign", SyncMode.full_refresh, self._config)
+        assert len(output.records) == 1
+
+    @HttpMocker()
+    def test_given_null_cursor_when_read_performance_creative_then_pagination_stops(self, http_mocker):
+        self._given_oauth_and_profiles(http_mocker, self._config)
+        profile_timezone = ProfilesRecordBuilder.profiles_record().build().get("timezone")
+
+        http_mocker.post(
+            AttributionReportRequestBuilder.performance_creative_endpoint(
+                self._config["client_id"],
+                self._config["access_token"],
+                self._config["profiles"][0],
+                start_date=_A_START_DATE.astimezone(ZoneInfo(profile_timezone)).date(),
+                end_date=_NOW.astimezone(ZoneInfo(profile_timezone)).date(),
+            ).build(),
+            AttributionReportResponseBuilder.performance_creative_response(NullCursorPaginationStrategy())
+            .with_record(AttributionReportRecordBuilder.performance_creative_record())
+            .with_pagination()
+            .build(),
+        )
+
+        output = read_stream("attribution_report_performance_creative", SyncMode.full_refresh, self._config)
+        assert len(output.records) == 1

--- a/docs/integrations/sources/amazon-ads.md
+++ b/docs/integrations/sources/amazon-ads.md
@@ -155,6 +155,7 @@ If you need better sync performance and are not experiencing rate limiting error
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:-----------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 7.3.18 | 2026-04-15 | [76333](https://github.com/airbytehq/airbyte/pull/76333) | Fix cursorId pagination for all attribution report streams: ensure cursorId remains a string and stop pagination on null cursor |
 | 7.3.17 | 2026-04-13 | [76276](https://github.com/airbytehq/airbyte/pull/76276) | Rename "concurrent workers" to "concurrent threads" in connector spec |
 | 7.3.16 | 2026-03-30 | [74313](https://github.com/airbytehq/airbyte/pull/74313) | Fix profile ID type mismatch in record filter |
 | 7.3.15 | 2026-03-17 | [74975](https://github.com/airbytehq/airbyte/pull/74975) | Update dependencies |


### PR DESCRIPTION
## Summary
- Wraps `cursor_value` in quotes so `cursorId` is treated as a string rather than an object in the `attribution_report_products` stream paginator
- Adds a `stop_condition` to halt pagination when `cursorId` is `None`

## Test plan
- [ ] Run connector acceptance tests for source-amazon-ads
- [ ] Verify attribution_report_products stream paginates correctly and stops when there are no more pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)