### PR TITLE
chore(destination-hubspot): Bump Bulk CDK to 1.0.8 for OAuth token expiry fix

### DIFF
--- a/airbyte-integrations/connectors/destination-hubspot/gradle.properties
+++ b/airbyte-integrations/connectors/destination-hubspot/gradle.properties
@@ -1,2 +1,2 @@
 testExecutionConcurrency=-1
-cdkVersion=1.0.1
+cdkVersion=1.0.8

--- a/airbyte-integrations/connectors/destination-hubspot/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-hubspot/metadata.yaml
@@ -12,7 +12,7 @@ data:
   connectorSubtype: api
   connectorType: destination
   definitionId: c8ccd253-8525-4bbd-801c-f0b84ac71f61
-  dockerImageTag: 0.0.10
+  dockerImageTag: 0.0.11
   dockerRepository: airbyte/destination-hubspot
   githubIssueLabel: destination-hubspot
   icon: hubspot.svg

--- a/docs/integrations/destinations/hubspot.md
+++ b/docs/integrations/destinations/hubspot.md
@@ -117,6 +117,7 @@ This destination does not support [namespaces](https://docs.airbyte.com/platform
 
 | Version | Date       | Pull Request                                                    | Subject                                   |
 |:--------|:-----------|:----------------------------------------------------------------|:------------------------------------------|
+| 0.0.11  | 2026-04-15 | [74728](https://github.com/airbytehq/airbyte/pull/74728) | Upgrade Bulk CDK to 1.0.8 (OAuth token expiry fix) |
 | 0.0.10  | 2026-02-09 | [72975](https://github.com/airbytehq/airbyte/pull/72975) | Upgrade CDK to 1.0.1                      |
 | 0.0.9   | 2026-01-26 | [72304](https://github.com/airbytehq/airbyte/pull/72304) | Upgrade CDK to 0.2.0                      |
 | 0.0.8   | 2025-11-05 | [69131](https://github.com/airbytehq/airbyte/pull/69131) | Upgrade to Bulk CDK 0.1.61.               |

--- a/docs/integrations/destinations/hubspot.md
+++ b/docs/integrations/destinations/hubspot.md
@@ -117,7 +117,7 @@ This destination does not support [namespaces](https://docs.airbyte.com/platform
 
 | Version | Date       | Pull Request                                                    | Subject                                   |
 |:--------|:-----------|:----------------------------------------------------------------|:------------------------------------------|
-| 0.0.11  | 2026-04-15 | [74728](https://github.com/airbytehq/airbyte/pull/74728) | Upgrade Bulk CDK to 1.0.8 (OAuth token expiry fix) |
+| 0.0.11  | 2026-04-15 | [76336](https://github.com/airbytehq/airbyte/pull/76336) | Upgrade Bulk CDK to 1.0.8 (OAuth token expiry fix) |
 | 0.0.10  | 2026-02-09 | [72975](https://github.com/airbytehq/airbyte/pull/72975) | Upgrade CDK to 1.0.1                      |
 | 0.0.9   | 2026-01-26 | [72304](https://github.com/airbytehq/airbyte/pull/72304) | Upgrade CDK to 0.2.0                      |
 | 0.0.8   | 2025-11-05 | [69131](https://github.com/airbytehq/airbyte/pull/69131) | Upgrade to Bulk CDK 0.1.61.               |


### PR DESCRIPTION
## What

Bumps the Bulk CDK version for `destination-hubspot` from 1.0.1 to 1.0.8 to pick up the OAuth token expiry tracking fix merged in [#74728](https://github.com/airbytehq/airbyte/pull/74728). That fix ensures `OAuthAuthenticator` respects the `expires_in` field from OAuth token responses and proactively refreshes expired tokens.

`destination-hubspot` is the only connector that directly uses `OAuthAuthenticator` from the Bulk CDK `load-http` toolkit.

## How

- `gradle.properties`: `cdkVersion` 1.0.1 → 1.0.8
- `metadata.yaml`: `dockerImageTag` 0.0.10 → 0.0.11
- `docs/integrations/destinations/hubspot.md`: Added changelog entry for 0.0.11

## Review guide

1. `gradle.properties` — version bump
2. `metadata.yaml` — image tag bump
3. `docs/integrations/destinations/hubspot.md` — changelog entry (now correctly links to this PR)

### Human review checklist

- [ ] Verify no intermediate CDK versions (1.0.2–1.0.7) introduced breaking changes affecting `destination-hubspot`
- [ ] Confirm CI tests for `destination-hubspot` pass with the new CDK version

## User Impact

HubSpot destination users with OAuth authentication will benefit from automatic token refresh based on the `expires_in` field, preventing sync failures due to expired OAuth tokens.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/23a190cabc0645879de822eb628a7801
Requested by: @pedroslopez