### PR TITLE
docs(docusaurus): move Release Notes and Community to tier-one navbar items

### DIFF
--- a/docusaurus/docusaurus.config.ts
+++ b/docusaurus/docusaurus.config.ts
@@ -387,21 +387,9 @@ const config: Config = {
             },
             {
               type: "docSidebar",
-              docsPluginId: "release_notes",
-              sidebarId: "releaseNotes",
-              label: "Release notes",
-            },
-            {
-              type: "docSidebar",
               docsPluginId: "developers",
               sidebarId: "developers",
               label: "Developers",
-            },
-            {
-              type: "docSidebar",
-              docsPluginId: "community",
-              sidebarId: "community",
-              label: "Community",
             },
           ],
         },
@@ -412,6 +400,21 @@ const config: Config = {
           docsPluginId: "ai-agents",
           docId: "README",
           label: "Agent Engine",
+        },
+        // "Release notes" and "Community" are tier-one nav items
+        {
+          type: "docSidebar",
+          position: "left",
+          docsPluginId: "release_notes",
+          sidebarId: "releaseNotes",
+          label: "Release notes",
+        },
+        {
+          type: "docSidebar",
+          position: "left",
+          docsPluginId: "community",
+          sidebarId: "community",
+          label: "Community",
         },
         {
           href: "https://status.airbyte.com",

--- a/docusaurus/src/theme/NavbarItem/DropdownNavbarItem/Desktop/index.js
+++ b/docusaurus/src/theme/NavbarItem/DropdownNavbarItem/Desktop/index.js
@@ -3,8 +3,7 @@
  *
  * Adds route-based "active" styling to the dropdown parent label so that
  * "Data Replication" is underlined whenever the user is viewing any of its
- * child doc instances (Platform, Connectors, Release Notes, Developers,
- * Community).
+ * child doc instances (Platform, Connectors, Developers).
  *
  * The only behavioural change vs. the upstream component is the
  * `containsActivePage` check and the conditional `navbar__link--active` class.
@@ -23,9 +22,7 @@ import NavbarItem from "@theme/NavbarItem";
 const DATA_REPLICATION_PREFIXES = [
   "/platform",
   "/integrations",
-  "/release_notes",
   "/developers",
-  "/community",
 ];
 
 /**


### PR DESCRIPTION
## What

Moves "Release notes" and "Community" out of the "Data Replication" dropdown and into tier-one (top-level) navigation positions in the Docusaurus navbar header.

Resolves [AGENTIC-901](https://linear.app/airbyteio/issue/AGENTIC-901/update-header-navigation).

## How

1. In `docusaurus/docusaurus.config.ts`: removed the Release notes and Community `docSidebar` entries from the Data Replication dropdown items array, and added them as new top-level navbar items (after Agent Engine, before Status).
2. In `docusaurus/src/theme/NavbarItem/DropdownNavbarItem/Desktop/index.js`: removed `/release_notes` and `/community` from the `DATA_REPLICATION_PREFIXES` array so the dropdown no longer highlights when visiting those routes. Updated the file's doc comment to reflect the remaining children.

No content, routes, sidebar files, plugin configs, CSS, or homepage changes were made.

## Review guide

1. `docusaurus/docusaurus.config.ts` - navbar items restructuring
2. `docusaurus/src/theme/NavbarItem/DropdownNavbarItem/Desktop/index.js` - active-state route prefix update

## User Impact

The site header navbar changes from:

**Before:** Data Replication (dropdown with Platform, Connectors, Release notes, Developers, Community) | Agent Engine | Status

**After:** Data Replication (dropdown with Platform, Connectors, Developers) | Agent Engine | Release notes | Community | Status

Release notes and Community are now directly accessible from the top-level navbar without opening the dropdown.

## Can this PR be safely reverted and rolled back?

- [x] YES

Link to Devin session: https://app.devin.ai/sessions/360309823008450c8f9bb39f61e46e1c
Requested by: @ian-at-airbyte