### PR TITLE
docs: add cross-linking banners between DR and Agent connector pages

### DIFF
--- a/docusaurus/docusaurus.config.ts
+++ b/docusaurus/docusaurus.config.ts
@@ -19,6 +19,7 @@ const getRemarkPlugins = () => ({
   addButtonToTitle: require("./src/remark/addButtonToTitle"),
   npm2yarn: require("@docusaurus/remark-plugin-npm2yarn"),
   agentConnectorHeaderDecoration: require("./src/remark/agentConnectorHeaderDecoration"),
+  connectorTypeBanner: require("./src/remark/connectorTypeBanner"),
 });
 
 const plugins = getRemarkPlugins();
@@ -222,6 +223,7 @@ const config: Config = {
           plugins.docsHeaderDecoration,
           plugins.enterpriseDocsHeaderInformation,
           plugins.productInformation,
+          plugins.connectorTypeBanner,
           plugins.docMetaTags,
         ],
       },

--- a/docusaurus/src/components/ConnectorTypeBanner.jsx
+++ b/docusaurus/src/components/ConnectorTypeBanner.jsx
@@ -26,18 +26,15 @@ export const ConnectorTypeBanner = ({
       <span className={styles.text}>
         {isAgent ? (
           <>
-            Agent connector for Airbyte Agents. For data replication, see the{" "}
-            <a href={counterpartUrl}>
-              {connectorName} data replication connector
-            </a>
-            . {ARROW_ICON}
+            This connector is optimized for AI agents. For the data replication
+            connector, see{" "}
+            <a href={counterpartUrl}>{connectorName}</a>. {ARROW_ICON}
           </>
         ) : (
           <>
-            Data replication connector for Airbyte Core and Cloud. For agentic
-            operations, see the{" "}
-            <a href={counterpartUrl}>{connectorName} agent connector</a>.{" "}
-            {ARROW_ICON}
+            This connector is optimized for data replication, not AI agents. For
+            agentic operations, see{" "}
+            <a href={counterpartUrl}>{connectorName}</a>. {ARROW_ICON}
           </>
         )}
       </span>

--- a/docusaurus/src/components/ConnectorTypeBanner.jsx
+++ b/docusaurus/src/components/ConnectorTypeBanner.jsx
@@ -1,18 +1,6 @@
+import { faRightLeft, faRobot } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import styles from "./ConnectorTypeBanner.module.css";
-
-const ARROW_ICON = (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    height="0.75em"
-    viewBox="0 0 512 512"
-    style={{ verticalAlign: "middle" }}
-  >
-    <path
-      fill="currentColor"
-      d="M502.6 278.6c12.5-12.5 12.5-32.8 0-45.3l-128-128c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L402.7 224 32 224c-17.7 0-32 14.3-32 32s14.3 32 32 32l370.7 0-73.4 73.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0l128-128z"
-    />
-  </svg>
-);
 
 export const ConnectorTypeBanner = ({
   connectorType,
@@ -26,15 +14,16 @@ export const ConnectorTypeBanner = ({
       <span className={styles.text}>
         {isAgent ? (
           <>
-            This connector is optimized for AI agents. For the data replication
-            connector, see{" "}
-            <a href={counterpartUrl}>{connectorName}</a>. {ARROW_ICON}
+            <FontAwesomeIcon icon={faRobot} className={styles.icon} /> This
+            connector is optimized for AI agents. For the data replication
+            connector, see <a href={counterpartUrl}>{connectorName}</a>.
           </>
         ) : (
           <>
-            This connector is optimized for data replication, not AI agents. For
+            <FontAwesomeIcon icon={faRightLeft} className={styles.icon} /> This
+            connector is optimized for data replication, not AI agents. For
             agentic operations, see{" "}
-            <a href={counterpartUrl}>{connectorName}</a>. {ARROW_ICON}
+            <a href={counterpartUrl}>{connectorName}</a>.
           </>
         )}
       </span>

--- a/docusaurus/src/components/ConnectorTypeBanner.jsx
+++ b/docusaurus/src/components/ConnectorTypeBanner.jsx
@@ -1,0 +1,46 @@
+import styles from "./ConnectorTypeBanner.module.css";
+
+const ARROW_ICON = (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    height="0.75em"
+    viewBox="0 0 512 512"
+    style={{ verticalAlign: "middle" }}
+  >
+    <path
+      fill="currentColor"
+      d="M502.6 278.6c12.5-12.5 12.5-32.8 0-45.3l-128-128c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L402.7 224 32 224c-17.7 0-32 14.3-32 32s14.3 32 32 32l370.7 0-73.4 73.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0l128-128z"
+    />
+  </svg>
+);
+
+export const ConnectorTypeBanner = ({
+  connectorType,
+  counterpartUrl,
+  connectorName,
+}) => {
+  const isAgent = connectorType === "agent";
+
+  return (
+    <div className={styles.banner}>
+      <span className={styles.text}>
+        {isAgent ? (
+          <>
+            Agent connector for Airbyte Agents. For data replication, see the{" "}
+            <a href={counterpartUrl}>
+              {connectorName} data replication connector
+            </a>
+            . {ARROW_ICON}
+          </>
+        ) : (
+          <>
+            Data replication connector for Airbyte Core and Cloud. For agentic
+            operations, see the{" "}
+            <a href={counterpartUrl}>{connectorName} agent connector</a>.{" "}
+            {ARROW_ICON}
+          </>
+        )}
+      </span>
+    </div>
+  );
+};

--- a/docusaurus/src/components/ConnectorTypeBanner.module.css
+++ b/docusaurus/src/components/ConnectorTypeBanner.module.css
@@ -1,0 +1,22 @@
+.banner {
+  background: var(--color-grey-40);
+  border-radius: var(--ifm-alert-border-radius);
+  border-left-style: solid;
+  border-left-width: var(--ifm-alert-border-left-width);
+  border-left-color: var(--ifm-color-primary);
+  margin-bottom: 1em;
+  padding: var(--ifm-alert-padding-vertical) var(--ifm-alert-padding-horizontal);
+  font-size: 0.9rem;
+}
+
+[data-theme="dark"] .banner {
+  background: var(--ifm-background-surface-color);
+}
+
+.text {
+  color: var(--ifm-font-color-secondary);
+}
+
+.text a {
+  font-weight: 600;
+}

--- a/docusaurus/src/components/ConnectorTypeBanner.module.css
+++ b/docusaurus/src/components/ConnectorTypeBanner.module.css
@@ -6,7 +6,6 @@
   border-left-color: var(--ifm-color-primary);
   margin-bottom: 1em;
   padding: var(--ifm-alert-padding-vertical) var(--ifm-alert-padding-horizontal);
-  font-size: 0.9rem;
 }
 
 [data-theme="dark"] .banner {
@@ -19,4 +18,8 @@
 
 .text a {
   font-weight: 600;
+}
+
+.icon {
+  margin-right: 0.4em;
 }

--- a/docusaurus/src/remark/agentConnectorHeaderDecoration.js
+++ b/docusaurus/src/remark/agentConnectorHeaderDecoration.js
@@ -35,39 +35,37 @@ const plugin = () => {
     const iconUrl = `${ICON_BASE_URL}/source-${slug}/latest/icon.svg`;
     const connectorName = formatConnectorName(slug);
 
-    let firstHeading = true;
+    let inserted = false;
 
-    visit(ast, "heading", (node) => {
-      if (firstHeading && node.depth === 1 && node.children.length === 1) {
-        const originalTitle = node.children[0].value;
+    visit(ast, "heading", (node, index, parent) => {
+      if (inserted) return;
+      if (node.depth !== 1 || node.children.length !== 1) return;
 
-        firstHeading = false;
-        node.children = [];
-        node.type = "mdxJsxFlowElement";
-        node.name = "AgentConnectorTitle";
-        node.attributes = toAttributes({ iconUrl, originalTitle });
+      const originalTitle = node.children[0].value;
+
+      // Transform heading into AgentConnectorTitle
+      node.children = [];
+      node.type = "mdxJsxFlowElement";
+      node.name = "AgentConnectorTitle";
+      node.attributes = toAttributes({ iconUrl, originalTitle });
+
+      // Insert banner immediately after the heading in its parent
+      if (parent && typeof index === "number") {
+        const bannerNode = {
+          type: "mdxJsxFlowElement",
+          name: "ConnectorTypeBanner",
+          attributes: toAttributes({
+            connectorType: "agent",
+            counterpartUrl: `/integrations/sources/${slug}`,
+            connectorName,
+          }),
+          children: [],
+        };
+        parent.children.splice(index + 1, 0, bannerNode);
       }
+
+      inserted = true;
     });
-
-    const headingIndex = ast.children.findIndex(
-      (ch) =>
-        ch.type === "mdxJsxFlowElement" && ch.name === "AgentConnectorTitle",
-    );
-
-    if (headingIndex === -1) return;
-
-    const bannerNode = {
-      type: "mdxJsxFlowElement",
-      name: "ConnectorTypeBanner",
-      attributes: toAttributes({
-        connectorType: "agent",
-        counterpartUrl: `/integrations/sources/${slug}`,
-        connectorName,
-      }),
-      children: [],
-    };
-
-    ast.children.splice(headingIndex + 1, 0, bannerNode);
   };
   return transformer;
 };

--- a/docusaurus/src/remark/agentConnectorHeaderDecoration.js
+++ b/docusaurus/src/remark/agentConnectorHeaderDecoration.js
@@ -36,7 +36,6 @@ const plugin = () => {
     const connectorName = formatConnectorName(slug);
 
     let firstHeading = true;
-    let headingIndex = -1;
 
     visit(ast, "heading", (node) => {
       if (firstHeading && node.depth === 1 && node.children.length === 1) {
@@ -47,10 +46,13 @@ const plugin = () => {
         node.type = "mdxJsxFlowElement";
         node.name = "AgentConnectorTitle";
         node.attributes = toAttributes({ iconUrl, originalTitle });
-
-        headingIndex = ast.children.indexOf(node);
       }
     });
+
+    const headingIndex = ast.children.findIndex(
+      (ch) =>
+        ch.type === "mdxJsxFlowElement" && ch.name === "AgentConnectorTitle",
+    );
 
     if (headingIndex === -1) return;
 

--- a/docusaurus/src/remark/agentConnectorHeaderDecoration.js
+++ b/docusaurus/src/remark/agentConnectorHeaderDecoration.js
@@ -1,4 +1,5 @@
 const visit = require("unist-util-visit").visit;
+const { u } = require("unist-builder");
 const { toAttributes } = require("../helpers/objects");
 
 const ICON_BASE_URL =
@@ -18,6 +19,13 @@ const getConnectorSlug = (vfile) => {
   return parts[connectorsIdx + 1];
 };
 
+function formatConnectorName(slug) {
+  return slug
+    .split("-")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
 const plugin = () => {
   const transformer = async (ast, vfile) => {
     if (!isAgentConnectorPage(vfile)) return;
@@ -26,25 +34,44 @@ const plugin = () => {
     if (!slug) return;
 
     const iconUrl = `${ICON_BASE_URL}/source-${slug}/latest/icon.svg`;
+    const connectorName = formatConnectorName(slug);
 
-    let firstHeading = true;
+    let headingIndex = -1;
 
-    visit(ast, "heading", (node) => {
-      if (firstHeading && node.depth === 1 && node.children.length === 1) {
+    ast.children.forEach((node, idx) => {
+      if (
+        headingIndex === -1 &&
+        node.type === "heading" &&
+        node.depth === 1 &&
+        node.children.length === 1
+      ) {
         const originalTitle = node.children[0].value;
 
-        const attrDict = {
-          iconUrl,
-          originalTitle,
-        };
-
-        firstHeading = false;
         node.children = [];
         node.type = "mdxJsxFlowElement";
         node.name = "AgentConnectorTitle";
-        node.attributes = toAttributes(attrDict);
+        node.attributes = toAttributes({ iconUrl, originalTitle });
+
+        headingIndex = idx;
       }
     });
+
+    if (headingIndex === -1) return;
+
+    const bannerNode = u(
+      "mdxJsxFlowElement",
+      {
+        name: "ConnectorTypeBanner",
+        attributes: toAttributes({
+          connectorType: "agent",
+          counterpartUrl: `/integrations/sources/${slug}`,
+          connectorName,
+        }),
+      },
+      [],
+    );
+
+    ast.children.splice(headingIndex + 1, 0, bannerNode);
   };
   return transformer;
 };

--- a/docusaurus/src/remark/agentConnectorHeaderDecoration.js
+++ b/docusaurus/src/remark/agentConnectorHeaderDecoration.js
@@ -1,5 +1,4 @@
 const visit = require("unist-util-visit").visit;
-const { u } = require("unist-builder");
 const { toAttributes } = require("../helpers/objects");
 
 const ICON_BASE_URL =
@@ -36,40 +35,35 @@ const plugin = () => {
     const iconUrl = `${ICON_BASE_URL}/source-${slug}/latest/icon.svg`;
     const connectorName = formatConnectorName(slug);
 
+    let firstHeading = true;
     let headingIndex = -1;
 
-    ast.children.forEach((node, idx) => {
-      if (
-        headingIndex === -1 &&
-        node.type === "heading" &&
-        node.depth === 1 &&
-        node.children.length === 1
-      ) {
+    visit(ast, "heading", (node) => {
+      if (firstHeading && node.depth === 1 && node.children.length === 1) {
         const originalTitle = node.children[0].value;
 
+        firstHeading = false;
         node.children = [];
         node.type = "mdxJsxFlowElement";
         node.name = "AgentConnectorTitle";
         node.attributes = toAttributes({ iconUrl, originalTitle });
 
-        headingIndex = idx;
+        headingIndex = ast.children.indexOf(node);
       }
     });
 
     if (headingIndex === -1) return;
 
-    const bannerNode = u(
-      "mdxJsxFlowElement",
-      {
-        name: "ConnectorTypeBanner",
-        attributes: toAttributes({
-          connectorType: "agent",
-          counterpartUrl: `/integrations/sources/${slug}`,
-          connectorName,
-        }),
-      },
-      [],
-    );
+    const bannerNode = {
+      type: "mdxJsxFlowElement",
+      name: "ConnectorTypeBanner",
+      attributes: toAttributes({
+        connectorType: "agent",
+        counterpartUrl: `/integrations/sources/${slug}`,
+        connectorName,
+      }),
+      children: [],
+    };
 
     ast.children.splice(headingIndex + 1, 0, bannerNode);
   };

--- a/docusaurus/src/remark/agentConnectorHeaderDecoration.js
+++ b/docusaurus/src/remark/agentConnectorHeaderDecoration.js
@@ -35,10 +35,10 @@ const plugin = () => {
     const iconUrl = `${ICON_BASE_URL}/source-${slug}/latest/icon.svg`;
     const connectorName = formatConnectorName(slug);
 
-    let inserted = false;
+    let headingTransformed = false;
 
-    visit(ast, "heading", (node, index, parent) => {
-      if (inserted) return;
+    visit(ast, "heading", (node) => {
+      if (headingTransformed) return;
       if (node.depth !== 1 || node.children.length !== 1) return;
 
       const originalTitle = node.children[0].value;
@@ -49,23 +49,35 @@ const plugin = () => {
       node.name = "AgentConnectorTitle";
       node.attributes = toAttributes({ iconUrl, originalTitle });
 
-      // Insert banner immediately after the heading in its parent
-      if (parent && typeof index === "number") {
-        const bannerNode = {
-          type: "mdxJsxFlowElement",
-          name: "ConnectorTypeBanner",
-          attributes: toAttributes({
-            connectorType: "agent",
-            counterpartUrl: `/integrations/sources/${slug}`,
-            connectorName,
-          }),
-          children: [],
-        };
-        parent.children.splice(index + 1, 0, bannerNode);
-      }
-
-      inserted = true;
+      headingTransformed = true;
     });
+
+    if (!headingTransformed) return;
+
+    // Insert banner at the root level, after the heading node.
+    // The heading may be wrapped by Docusaurus (e.g. in a <header> element),
+    // so we find it by looking for the transformed AgentConnectorTitle or
+    // any wrapper that contains it.
+    const headingIdx = ast.children.findIndex(
+      (ch) =>
+        (ch.type === "mdxJsxFlowElement" && ch.name === "AgentConnectorTitle") ||
+        (ch.type === "mdxJsxFlowElement" && ch.name === "header") ||
+        (ch.type === "heading" && ch.depth === 1),
+    );
+
+    if (headingIdx !== -1) {
+      const bannerNode = {
+        type: "mdxJsxFlowElement",
+        name: "ConnectorTypeBanner",
+        attributes: toAttributes({
+          connectorType: "agent",
+          counterpartUrl: `/integrations/sources/${slug}`,
+          connectorName,
+        }),
+        children: [],
+      };
+      ast.children.splice(headingIdx + 1, 0, bannerNode);
+    }
   };
   return transformer;
 };

--- a/docusaurus/src/remark/connectorTypeBanner.js
+++ b/docusaurus/src/remark/connectorTypeBanner.js
@@ -1,5 +1,3 @@
-const { select } = require("unist-util-select");
-const { u } = require("unist-builder");
 const { toAttributes } = require("../helpers/objects");
 const { isDocsPage } = require("./utils");
 
@@ -45,31 +43,27 @@ const plugin = () => {
       .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
       .join(" ");
 
-    // Find the first heading (which may already be transformed to an mdxJsxFlowElement by docsHeaderDecoration)
-    const heading =
-      select("root > mdxJsxFlowElement[name='HeaderDecoration']", ast) ||
-      select("root > heading[depth='1']", ast);
-
-    if (!heading) return;
-
-    const headingIndex = ast.children.findIndex((ch) => ch === heading);
-    if (headingIndex === -1) return;
-
-    const bannerNode = u(
-      "mdxJsxFlowElement",
-      {
-        name: "ConnectorTypeBanner",
-        attributes: toAttributes({
-          connectorType: "data-replication",
-          counterpartUrl: `/ai-agents/connectors/${slug}/`,
-          connectorName,
-        }),
-      },
-      [],
+    // Find the first heading — may be a transformed HeaderDecoration or a plain H1
+    const headingIndex = ast.children.findIndex(
+      (ch) =>
+        (ch.type === "mdxJsxFlowElement" && ch.name === "HeaderDecoration") ||
+        (ch.type === "heading" && ch.depth === 1),
     );
 
-    // Insert after the heading (and after any ProductInformation that may have been added)
-    // Find the right insertion point: after heading and any immediately following mdxJsxFlowElement nodes
+    if (headingIndex === -1) return;
+
+    const bannerNode = {
+      type: "mdxJsxFlowElement",
+      name: "ConnectorTypeBanner",
+      attributes: toAttributes({
+        connectorType: "data-replication",
+        counterpartUrl: `/ai-agents/connectors/${slug}/`,
+        connectorName,
+      }),
+      children: [],
+    };
+
+    // Insert after the heading and any ProductInformation that may follow it
     let insertIdx = headingIndex + 1;
     while (
       insertIdx < ast.children.length &&

--- a/docusaurus/src/remark/connectorTypeBanner.js
+++ b/docusaurus/src/remark/connectorTypeBanner.js
@@ -28,7 +28,6 @@ function getSourceSlug(vfile) {
 }
 
 const plugin = () => {
-  let logged = false;
   const transformer = async (ast, vfile) => {
     const docsPageInfo = isDocsPage(vfile);
     if (!docsPageInfo.isTrueDocsPage) return;
@@ -39,29 +38,21 @@ const plugin = () => {
     const slugs = loadAgentConnectorSlugs();
     if (!slugs.includes(slug)) return;
 
-    // Debug: log once to verify plugin is running
-    if (!logged) {
-      console.log(`[connectorTypeBanner] Processing slug="${slug}", children types:`,
-        ast.children.slice(0, 5).map(c => `${c.type}${c.name ? ':' + c.name : ''}${c.depth ? ':d' + c.depth : ''}`));
-      logged = true;
-    }
-
     const connectorName = slug
       .split("-")
       .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
       .join(" ");
 
-    // Find the first heading — may be a transformed HeaderDecoration or a plain H1
+    // Find the first heading — may be a Docusaurus-wrapped header element,
+    // a transformed HeaderDecoration, or a plain H1
     const headingIndex = ast.children.findIndex(
       (ch) =>
-        (ch.type === "mdxJsxFlowElement" && ch.name === "HeaderDecoration") ||
+        (ch.type === "mdxJsxFlowElement" &&
+          (ch.name === "header" || ch.name === "HeaderDecoration")) ||
         (ch.type === "heading" && ch.depth === 1),
     );
 
-    if (headingIndex === -1) {
-      console.log(`[connectorTypeBanner] No heading found for slug="${slug}"`);
-      return;
-    }
+    if (headingIndex === -1) return;
 
     const bannerNode = {
       type: "mdxJsxFlowElement",

--- a/docusaurus/src/remark/connectorTypeBanner.js
+++ b/docusaurus/src/remark/connectorTypeBanner.js
@@ -1,0 +1,87 @@
+const { select } = require("unist-util-select");
+const { u } = require("unist-builder");
+const { toAttributes } = require("../helpers/objects");
+const { isDocsPage } = require("./utils");
+
+let agentConnectorSlugs = null;
+
+function loadAgentConnectorSlugs() {
+  if (agentConnectorSlugs !== null) return agentConnectorSlugs;
+  try {
+    agentConnectorSlugs = require("../data/agent_connectors.json");
+  } catch {
+    agentConnectorSlugs = [];
+  }
+  return agentConnectorSlugs;
+}
+
+/**
+ * Extract the connector slug from a DR connector page path.
+ * e.g. "integrations/sources/hubspot.md" -> "hubspot"
+ */
+function getSourceSlug(vfile) {
+  if (!vfile.path.includes("integrations/sources")) return null;
+
+  const pathParts = vfile.path.split("/");
+  const sourcesIdx = pathParts.indexOf("sources");
+  if (sourcesIdx === -1 || sourcesIdx + 1 >= pathParts.length) return null;
+
+  return pathParts[sourcesIdx + 1].split(".")[0];
+}
+
+const plugin = () => {
+  const transformer = async (ast, vfile) => {
+    const docsPageInfo = isDocsPage(vfile);
+    if (!docsPageInfo.isTrueDocsPage) return;
+
+    const slug = getSourceSlug(vfile);
+    if (!slug) return;
+
+    const slugs = loadAgentConnectorSlugs();
+    if (!slugs.includes(slug)) return;
+
+    const connectorName = slug
+      .split("-")
+      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+      .join(" ");
+
+    // Find the first heading (which may already be transformed to an mdxJsxFlowElement by docsHeaderDecoration)
+    const heading =
+      select("root > mdxJsxFlowElement[name='HeaderDecoration']", ast) ||
+      select("root > heading[depth='1']", ast);
+
+    if (!heading) return;
+
+    const headingIndex = ast.children.findIndex((ch) => ch === heading);
+    if (headingIndex === -1) return;
+
+    const bannerNode = u(
+      "mdxJsxFlowElement",
+      {
+        name: "ConnectorTypeBanner",
+        attributes: toAttributes({
+          connectorType: "data-replication",
+          counterpartUrl: `/ai-agents/connectors/${slug}/`,
+          connectorName,
+        }),
+      },
+      [],
+    );
+
+    // Insert after the heading (and after any ProductInformation that may have been added)
+    // Find the right insertion point: after heading and any immediately following mdxJsxFlowElement nodes
+    let insertIdx = headingIndex + 1;
+    while (
+      insertIdx < ast.children.length &&
+      ast.children[insertIdx].type === "mdxJsxFlowElement" &&
+      ast.children[insertIdx].name === "ProductInformation"
+    ) {
+      insertIdx++;
+    }
+
+    ast.children.splice(insertIdx, 0, bannerNode);
+  };
+  return transformer;
+};
+
+module.exports = plugin;

--- a/docusaurus/src/remark/connectorTypeBanner.js
+++ b/docusaurus/src/remark/connectorTypeBanner.js
@@ -28,6 +28,7 @@ function getSourceSlug(vfile) {
 }
 
 const plugin = () => {
+  let logged = false;
   const transformer = async (ast, vfile) => {
     const docsPageInfo = isDocsPage(vfile);
     if (!docsPageInfo.isTrueDocsPage) return;
@@ -37,6 +38,13 @@ const plugin = () => {
 
     const slugs = loadAgentConnectorSlugs();
     if (!slugs.includes(slug)) return;
+
+    // Debug: log once to verify plugin is running
+    if (!logged) {
+      console.log(`[connectorTypeBanner] Processing slug="${slug}", children types:`,
+        ast.children.slice(0, 5).map(c => `${c.type}${c.name ? ':' + c.name : ''}${c.depth ? ':d' + c.depth : ''}`));
+      logged = true;
+    }
 
     const connectorName = slug
       .split("-")
@@ -50,7 +58,10 @@ const plugin = () => {
         (ch.type === "heading" && ch.depth === 1),
     );
 
-    if (headingIndex === -1) return;
+    if (headingIndex === -1) {
+      console.log(`[connectorTypeBanner] No heading found for slug="${slug}"`);
+      return;
+    }
 
     const bannerNode = {
       type: "mdxJsxFlowElement",

--- a/docusaurus/src/theme/MDXComponents/index.js
+++ b/docusaurus/src/theme/MDXComponents/index.js
@@ -1,6 +1,7 @@
 // Import the original mapper
 import { AgentConnectorTitle } from "@site/src/components/AgentConnectorTitle";
 import { AppliesTo } from "@site/src/components/AppliesTo";
+import { ConnectorTypeBanner } from "@site/src/components/ConnectorTypeBanner";
 import { Arcade } from "@site/src/components/Arcade";
 import { FieldAnchor } from "@site/src/components/FieldAnchor";
 import { HeaderDecoration } from "@site/src/components/HeaderDecoration";
@@ -24,6 +25,7 @@ export default {
   AgentConnectorTitle,
   Arcade,
   AppliesTo,
+  ConnectorTypeBanner,
   FieldAnchor,
   HideInUI,
   HeaderDecoration,


### PR DESCRIPTION
## What

Adds cross-linking banners between Data Replication (DR) and Agent connector documentation pages so users have a strong indicator that they're on the right/wrong connector type, and can easily navigate to the counterpart connector type. Resolves [AGENTIC-899](https://linear.app/airbyteio/issue/AGENTIC-899).

<img width="1710" height="360" alt="image" src="https://github.com/user-attachments/assets/d57c05b3-e50b-4d0a-89b3-133c003f9919" />

<img width="1710" height="527" alt="image" src="https://github.com/user-attachments/assets/4c0fc414-2af3-4d53-8baf-9fad3b18f45a" />


## How

- **New `ConnectorTypeBanner` component** (`ConnectorTypeBanner.jsx` + `.module.css`): A subtle info banner (styled like `AppliesTo`) with a left-border accent. Uses FontAwesome icons inline — `faRobot` for agent connector banners and `faRightLeft` (left/right arrows) for DR connector banners. Links to the counterpart connector page.

- **Modified `agentConnectorHeaderDecoration.js`**: After transforming the H1 into `AgentConnectorTitle`, the plugin injects a `ConnectorTypeBanner` at the AST root level (below the heading wrapper). All 51 agent connector pages get a banner linking to `/integrations/sources/<slug>`.

- **New remark plugin `connectorTypeBanner.js`**: Runs on DR connector pages. Loads the build-time `agent_connectors.json` manifest and checks if the current source slug has an agent counterpart. If so, injects a `ConnectorTypeBanner` linking to `/ai-agents/connectors/<slug>/`. Only ~51 of ~611 source pages are affected.

- **Updated `docusaurus.config.ts`**: Registered the new `connectorTypeBanner` plugin in the connectors docs plugin instance, ordered after `productInformation` and before `docMetaTags`.

- **Registered `ConnectorTypeBanner` in `MDXComponents/index.js`** so the component is available in the MDX rendering scope.

## Review guide

1. `docusaurus/src/components/ConnectorTypeBanner.jsx` — New React component with FontAwesome icons
2. `docusaurus/src/components/ConnectorTypeBanner.module.css` — Styling (AppliesTo pattern)
3. `docusaurus/src/remark/connectorTypeBanner.js` — New remark plugin for DR pages
4. `docusaurus/src/remark/agentConnectorHeaderDecoration.js` — Modified to inject banner on agent pages
5. `docusaurus/docusaurus.config.ts` — Plugin registration
6. `docusaurus/src/theme/MDXComponents/index.js` — Component registration

## User Impact

- Agent connector pages now show: *"🤖 This connector is optimized for AI agents. For the data replication connector, see [Connector Name]."*
- DR connector pages (with an agent counterpart) now show: *"⇄ This connector is optimized for data replication, not AI agents. For agentic operations, see [Connector Name]."*
- Helps users avoid confusion between the two connector types and easily find the right one.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/166ee4a4ca564e18a43632ea4073cf84
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/76339" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
