### PR TITLE
fix(destination-hubspot): Handle 409 Conflict by recursively splitting batch upserts

### DIFF
--- a/airbyte-integrations/connectors/destination-hubspot/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-hubspot/metadata.yaml
@@ -12,7 +12,7 @@ data:
   connectorSubtype: api
   connectorType: destination
   definitionId: c8ccd253-8525-4bbd-801c-f0b84ac71f61
-  dockerImageTag: 0.0.11
+  dockerImageTag: 0.0.12
   dockerRepository: airbyte/destination-hubspot
   githubIssueLabel: destination-hubspot
   icon: hubspot.svg

--- a/airbyte-integrations/connectors/destination-hubspot/src/main/kotlin/HubSpotLoader.kt
+++ b/airbyte-integrations/connectors/destination-hubspot/src/main/kotlin/HubSpotLoader.kt
@@ -72,9 +72,9 @@ class HubSpotState(
     }
 
     /**
-     * Sends a batch upsert request to HubSpot. On a 409 Conflict response, the batch is split
-     * in half and each half is retried recursively. This isolates the problematic record(s) that
-     * cause the conflict while allowing the unaffected records to be loaded successfully.
+     * Sends a batch upsert request to HubSpot. On a 409 Conflict response, the batch is split in
+     * half and each half is retried recursively. This isolates the problematic record(s) that cause
+     * the conflict while allowing the unaffected records to be loaded successfully.
      *
      * When a single-record batch still results in a 409, that record is the root cause of the
      * conflict and is returned as a rejected record for the dead letter queue.
@@ -105,8 +105,7 @@ class HubSpotState(
                 200 -> emptyList()
                 207 -> emptyList() // FIXME generate dlq record with error from hubspot
                 409 -> {
-                    val responseBody =
-                        response.getBodyOrEmpty().reader(Charsets.UTF_8).readText()
+                    val responseBody = response.getBodyOrEmpty().reader(Charsets.UTF_8).readText()
 
                     if (inputs.size == 1) {
                         logger.warn {
@@ -125,13 +124,10 @@ class HubSpotState(
                     val firstHalfInputs = inputs.subList(0, mid)
                     val secondHalfInputs = inputs.subList(mid, inputs.size)
                     val firstHalfRecords = associatedRecords.subList(0, mid)
-                    val secondHalfRecords =
-                        associatedRecords.subList(mid, associatedRecords.size)
+                    val secondHalfRecords = associatedRecords.subList(mid, associatedRecords.size)
 
-                    val rejectedFromFirst =
-                        sendWithSplitRetry(firstHalfInputs, firstHalfRecords)
-                    val rejectedFromSecond =
-                        sendWithSplitRetry(secondHalfInputs, secondHalfRecords)
+                    val rejectedFromFirst = sendWithSplitRetry(firstHalfInputs, firstHalfRecords)
+                    val rejectedFromSecond = sendWithSplitRetry(secondHalfInputs, secondHalfRecords)
 
                     rejectedFromFirst + rejectedFromSecond
                 }

--- a/airbyte-integrations/connectors/destination-hubspot/src/main/kotlin/HubSpotLoader.kt
+++ b/airbyte-integrations/connectors/destination-hubspot/src/main/kotlin/HubSpotLoader.kt
@@ -34,6 +34,7 @@ class HubSpotState(
     val requestBody: ObjectNode = Jsons.objectNode()
     val batch: ArrayNode = requestBody.putArray("inputs")
     val decoder: JsonDecoder = JsonDecoder()
+    val records: MutableList<DestinationRecordRaw> = mutableListOf()
 
     fun accumulate(record: DestinationRecordRaw) {
         if (isFull()) {
@@ -53,30 +54,87 @@ class HubSpotState(
                 data.properties().forEach { (key, value) -> properties.replace(key, value) }
             }
         batch.add(input)
+        records.add(record)
     }
 
     fun isFull(): Boolean = batch.size() >= 100
 
     fun flush(): List<DestinationRecordRaw>? {
-        logger.info { "Flushing data" }
+        logger.info { "Flushing batch of ${batch.size()} records" }
+        if (batch.size() == 0) {
+            return null
+        }
+
+        val inputs = (0 until batch.size()).map { batch.get(it) }
+        val rejectedRecords = sendWithSplitRetry(inputs, records.toList())
+
+        return rejectedRecords.ifEmpty { null }
+    }
+
+    /**
+     * Sends a batch upsert request to HubSpot. On a 409 Conflict response, the batch is split
+     * in half and each half is retried recursively. This isolates the problematic record(s) that
+     * cause the conflict while allowing the unaffected records to be loaded successfully.
+     *
+     * When a single-record batch still results in a 409, that record is the root cause of the
+     * conflict and is returned as a rejected record for the dead letter queue.
+     */
+    internal fun sendWithSplitRetry(
+        inputs: List<JsonNode>,
+        associatedRecords: List<DestinationRecordRaw>
+    ): List<DestinationRecordRaw> {
+        val batchRequestBody = Jsons.objectNode()
+        val batchInputs = batchRequestBody.putArray("inputs")
+        inputs.forEach { batchInputs.add(it) }
+
+        val url =
+            "https://api.hubapi.com/crm/v3/objects/${objectDao.fetchObjectTypeId(stream.destinationObjectName ?: throw IllegalStateException("destinationObjectName required"))}/batch/upsert"
+
         val response: Response =
             httpClient.send(
                 Request(
                     method = RequestMethod.POST,
-                    // Note that knowing all the standard object names could improve performance of
-                    // one HTTP request in the case the user does not sync custom objects so this
-                    // could be optimized.
-                    url =
-                        "https://api.hubapi.com/crm/v3/objects/${objectDao.fetchObjectTypeId(stream.destinationObjectName ?: throw IllegalStateException("destinationObjectName required"))}/batch/upsert",
+                    url = url,
                     headers = mapOf("Content-Type" to "application/json"),
-                    body = requestBody.serializeToJsonBytes()
+                    body = batchRequestBody.serializeToJsonBytes()
                 )
             )
 
         response.use {
             return when (response.statusCode) {
-                200 -> null
-                207 -> null // FIXME generate dlq record with error from hubspot
+                200 -> emptyList()
+                207 -> emptyList() // FIXME generate dlq record with error from hubspot
+                409 -> {
+                    val responseBody =
+                        response.getBodyOrEmpty().reader(Charsets.UTF_8).readText()
+
+                    if (inputs.size == 1) {
+                        logger.warn {
+                            "HubSpot returned 409 Conflict for a single record. " +
+                                "Routing to rejected records. Response: $responseBody"
+                        }
+                        return associatedRecords
+                    }
+
+                    logger.info {
+                        "HubSpot returned 409 Conflict for batch of ${inputs.size} records. " +
+                            "Splitting batch and retrying each half. Response: $responseBody"
+                    }
+
+                    val mid = inputs.size / 2
+                    val firstHalfInputs = inputs.subList(0, mid)
+                    val secondHalfInputs = inputs.subList(mid, inputs.size)
+                    val firstHalfRecords = associatedRecords.subList(0, mid)
+                    val secondHalfRecords =
+                        associatedRecords.subList(mid, associatedRecords.size)
+
+                    val rejectedFromFirst =
+                        sendWithSplitRetry(firstHalfInputs, firstHalfRecords)
+                    val rejectedFromSecond =
+                        sendWithSplitRetry(secondHalfInputs, secondHalfRecords)
+
+                    rejectedFromFirst + rejectedFromSecond
+                }
                 else ->
                     throw IllegalStateException(
                         "Invalid response with status code ${response.statusCode} while starting ingestion: ${response.getBodyOrEmpty().reader(Charsets.UTF_8).readText()}"

--- a/airbyte-integrations/connectors/destination-hubspot/src/test/kotlin/io/airbyte/integrations/destination/hubspot/HubSpotLoaderTest.kt
+++ b/airbyte-integrations/connectors/destination-hubspot/src/test/kotlin/io/airbyte/integrations/destination/hubspot/HubSpotLoaderTest.kt
@@ -5,7 +5,6 @@
 package io.airbyte.integrations.destination.hubspot
 
 import com.fasterxml.jackson.databind.JsonNode
-import io.airbyte.cdk.load.command.Dedupe
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.data.ObjectType
 import io.airbyte.cdk.load.http.HttpClient
@@ -16,8 +15,6 @@ import io.airbyte.cdk.util.Jsons
 import io.airbyte.integrations.destination.hubspot.io.airbyte.integrations.destination.hubspot.http.HubSpotObjectTypeIdMapper
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.verify
-import java.io.InputStream
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -110,24 +107,26 @@ class HubSpotLoaderTest {
         val badRecord = aRecord()
         val goodRecord2 = aRecord()
         val records = listOf(goodRecord1, badRecord, goodRecord2)
-        val inputs = listOf(
-            anInput("good1@example.com"),
-            anInput("bad@example.com"),
-            anInput("good2@example.com")
-        )
+        val inputs =
+            listOf(
+                anInput("good1@example.com"),
+                anInput("bad@example.com"),
+                anInput("good2@example.com")
+            )
 
         // First call: full batch of 3 -> 409
         // Second call: first half [good1] -> 200
         // Third call: second half [bad, good2] -> 409
         // Fourth call: [bad] -> 409 (single record, rejected)
         // Fifth call: [good2] -> 200
-        every { httpClient.send(any<Request>()) } returnsMany listOf(
-            aResponse(409, """{"message":"Conflict"}"""),
-            aResponse(200),
-            aResponse(409, """{"message":"Conflict"}"""),
-            aResponse(409, """{"message":"Conflict"}"""),
-            aResponse(200)
-        )
+        every { httpClient.send(any<Request>()) } returnsMany
+            listOf(
+                aResponse(409, """{"message":"Conflict"}"""),
+                aResponse(200),
+                aResponse(409, """{"message":"Conflict"}"""),
+                aResponse(409, """{"message":"Conflict"}"""),
+                aResponse(200)
+            )
 
         val rejected = state.sendWithSplitRetry(inputs, records)
 
@@ -140,19 +139,17 @@ class HubSpotLoaderTest {
         val badRecord1 = aRecord()
         val badRecord2 = aRecord()
         val records = listOf(badRecord1, badRecord2)
-        val inputs = listOf(
-            anInput("bad1@example.com"),
-            anInput("bad2@example.com")
-        )
+        val inputs = listOf(anInput("bad1@example.com"), anInput("bad2@example.com"))
 
         // Full batch of 2 -> 409
         // First half [bad1] -> 409 (single, rejected)
         // Second half [bad2] -> 409 (single, rejected)
-        every { httpClient.send(any<Request>()) } returnsMany listOf(
-            aResponse(409, """{"message":"Conflict"}"""),
-            aResponse(409, """{"message":"Conflict"}"""),
-            aResponse(409, """{"message":"Conflict"}""")
-        )
+        every { httpClient.send(any<Request>()) } returnsMany
+            listOf(
+                aResponse(409, """{"message":"Conflict"}"""),
+                aResponse(409, """{"message":"Conflict"}"""),
+                aResponse(409, """{"message":"Conflict"}""")
+            )
 
         val rejected = state.sendWithSplitRetry(inputs, records)
 
@@ -175,15 +172,16 @@ class HubSpotLoaderTest {
         // Batch [4] -> 200
         // Batch [5] -> 409 (single bad record, rejected)
         // Batch [6..7] -> 200
-        every { httpClient.send(any<Request>()) } returnsMany listOf(
-            aResponse(409, """{"message":"Conflict"}"""),
-            aResponse(200),
-            aResponse(409, """{"message":"Conflict"}"""),
-            aResponse(409, """{"message":"Conflict"}"""),
-            aResponse(200),
-            aResponse(409, """{"message":"Conflict"}"""),
-            aResponse(200)
-        )
+        every { httpClient.send(any<Request>()) } returnsMany
+            listOf(
+                aResponse(409, """{"message":"Conflict"}"""),
+                aResponse(200),
+                aResponse(409, """{"message":"Conflict"}"""),
+                aResponse(409, """{"message":"Conflict"}"""),
+                aResponse(200),
+                aResponse(409, """{"message":"Conflict"}"""),
+                aResponse(200)
+            )
 
         val rejected = state.sendWithSplitRetry(inputs, records)
 

--- a/airbyte-integrations/connectors/destination-hubspot/src/test/kotlin/io/airbyte/integrations/destination/hubspot/HubSpotLoaderTest.kt
+++ b/airbyte-integrations/connectors/destination-hubspot/src/test/kotlin/io/airbyte/integrations/destination/hubspot/HubSpotLoaderTest.kt
@@ -1,0 +1,212 @@
+/*
+ * Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.hubspot
+
+import com.fasterxml.jackson.databind.JsonNode
+import io.airbyte.cdk.load.command.Dedupe
+import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.data.ObjectType
+import io.airbyte.cdk.load.http.HttpClient
+import io.airbyte.cdk.load.http.Request
+import io.airbyte.cdk.load.http.Response
+import io.airbyte.cdk.load.message.DestinationRecordRaw
+import io.airbyte.cdk.util.Jsons
+import io.airbyte.integrations.destination.hubspot.io.airbyte.integrations.destination.hubspot.http.HubSpotObjectTypeIdMapper
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.io.InputStream
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class HubSpotLoaderTest {
+    private lateinit var httpClient: HttpClient
+    private lateinit var objectDao: HubSpotObjectTypeIdMapper
+    private lateinit var stream: DestinationStream
+    private lateinit var state: HubSpotState
+
+    @BeforeEach
+    fun setUp() {
+        httpClient = mockk()
+        objectDao = mockk()
+        stream = mockk(relaxed = true)
+
+        every { stream.destinationObjectName } returns "CONTACT"
+        every { stream.matchingKey } returns listOf("email")
+        every { stream.schema } returns ObjectType(linkedMapOf())
+        every { objectDao.fetchObjectTypeId("CONTACT") } returns "CONTACT"
+
+        state = HubSpotState(httpClient, objectDao, stream)
+    }
+
+    private fun aResponse(statusCode: Int, body: String = "{}"): Response {
+        val response = mockk<Response>()
+        every { response.statusCode } returns statusCode
+        every { response.body } returns body.byteInputStream()
+        every { response.close() } returns Unit
+        return response
+    }
+
+    private fun aRecord(): DestinationRecordRaw {
+        return mockk(relaxed = true)
+    }
+
+    private fun anInput(email: String): JsonNode {
+        return Jsons.objectNode().apply {
+            put("idProperty", "email")
+            put("id", email)
+            val props = putObject("properties")
+            props.put("email", email)
+        }
+    }
+
+    @Test
+    fun `test sendWithSplitRetry returns empty on 200`() {
+        every { httpClient.send(any<Request>()) } returns aResponse(200)
+
+        val records = listOf(aRecord())
+        val inputs = listOf(anInput("test@example.com"))
+
+        val rejected = state.sendWithSplitRetry(inputs, records)
+
+        assertTrue(rejected.isEmpty())
+    }
+
+    @Test
+    fun `test sendWithSplitRetry returns empty on 207`() {
+        every { httpClient.send(any<Request>()) } returns aResponse(207)
+
+        val records = listOf(aRecord())
+        val inputs = listOf(anInput("test@example.com"))
+
+        val rejected = state.sendWithSplitRetry(inputs, records)
+
+        assertTrue(rejected.isEmpty())
+    }
+
+    @Test
+    fun `test sendWithSplitRetry rejects single record on 409`() {
+        every { httpClient.send(any<Request>()) } returns
+            aResponse(409, """{"message":"Conflict","status":"error"}""")
+
+        val record = aRecord()
+        val records = listOf(record)
+        val inputs = listOf(anInput("conflict@example.com"))
+
+        val rejected = state.sendWithSplitRetry(inputs, records)
+
+        assertEquals(1, rejected.size)
+        assertEquals(record, rejected[0])
+    }
+
+    @Test
+    fun `test sendWithSplitRetry splits batch on 409 and isolates bad record`() {
+        val goodRecord1 = aRecord()
+        val badRecord = aRecord()
+        val goodRecord2 = aRecord()
+        val records = listOf(goodRecord1, badRecord, goodRecord2)
+        val inputs = listOf(
+            anInput("good1@example.com"),
+            anInput("bad@example.com"),
+            anInput("good2@example.com")
+        )
+
+        // First call: full batch of 3 -> 409
+        // Second call: first half [good1] -> 200
+        // Third call: second half [bad, good2] -> 409
+        // Fourth call: [bad] -> 409 (single record, rejected)
+        // Fifth call: [good2] -> 200
+        every { httpClient.send(any<Request>()) } returnsMany listOf(
+            aResponse(409, """{"message":"Conflict"}"""),
+            aResponse(200),
+            aResponse(409, """{"message":"Conflict"}"""),
+            aResponse(409, """{"message":"Conflict"}"""),
+            aResponse(200)
+        )
+
+        val rejected = state.sendWithSplitRetry(inputs, records)
+
+        assertEquals(1, rejected.size)
+        assertEquals(badRecord, rejected[0])
+    }
+
+    @Test
+    fun `test sendWithSplitRetry handles multiple bad records`() {
+        val badRecord1 = aRecord()
+        val badRecord2 = aRecord()
+        val records = listOf(badRecord1, badRecord2)
+        val inputs = listOf(
+            anInput("bad1@example.com"),
+            anInput("bad2@example.com")
+        )
+
+        // Full batch of 2 -> 409
+        // First half [bad1] -> 409 (single, rejected)
+        // Second half [bad2] -> 409 (single, rejected)
+        every { httpClient.send(any<Request>()) } returnsMany listOf(
+            aResponse(409, """{"message":"Conflict"}"""),
+            aResponse(409, """{"message":"Conflict"}"""),
+            aResponse(409, """{"message":"Conflict"}""")
+        )
+
+        val rejected = state.sendWithSplitRetry(inputs, records)
+
+        assertEquals(2, rejected.size)
+        assertEquals(badRecord1, rejected[0])
+        assertEquals(badRecord2, rejected[1])
+    }
+
+    @Test
+    fun `test sendWithSplitRetry with large batch isolates single bad record`() {
+        val records = (0 until 8).map { aRecord() }
+        val inputs = (0 until 8).map { anInput("user$it@example.com") }
+        val badIndex = 5 // The bad record is at index 5
+
+        // Simulate: only batches containing the bad record get 409
+        // Batch [0..7] -> 409
+        // Batch [0..3] -> 200 (no bad record)
+        // Batch [4..7] -> 409 (contains bad record at index 5)
+        // Batch [4..5] -> 409 (contains bad record)
+        // Batch [4] -> 200
+        // Batch [5] -> 409 (single bad record, rejected)
+        // Batch [6..7] -> 200
+        every { httpClient.send(any<Request>()) } returnsMany listOf(
+            aResponse(409, """{"message":"Conflict"}"""),
+            aResponse(200),
+            aResponse(409, """{"message":"Conflict"}"""),
+            aResponse(409, """{"message":"Conflict"}"""),
+            aResponse(200),
+            aResponse(409, """{"message":"Conflict"}"""),
+            aResponse(200)
+        )
+
+        val rejected = state.sendWithSplitRetry(inputs, records)
+
+        assertEquals(1, rejected.size)
+        assertEquals(records[badIndex], rejected[0])
+    }
+
+    @Test
+    fun `test flush returns null on empty batch`() {
+        val result = state.flush()
+        assertNull(result)
+    }
+
+    @Test
+    fun `test throws on non-409 error`() {
+        every { httpClient.send(any<Request>()) } returns
+            aResponse(500, """{"message":"Internal Server Error"}""")
+
+        val records = listOf(aRecord())
+        val inputs = listOf(anInput("test@example.com"))
+
+        org.junit.jupiter.api.assertThrows<IllegalStateException> {
+            state.sendWithSplitRetry(inputs, records)
+        }
+    }
+}


### PR DESCRIPTION
## What

When HubSpot's batch upsert API encounters a conflicting record, it returns a 409 for the **entire batch** — even if only one record is problematic ([community thread](https://community.hubspot.com/t5/APIs-Integrations/Contacts-API-Batch-Upsert-return-409-instead-of-207/td-p/1051941)). Previously, this caused the whole sync to fail. This PR implements recursive batch-splitting so that good records are still loaded and only the problematic record(s) are routed to the rejected records list (DLQ).

Related: [airbytehq/oncall#11606](https://github.com/airbytehq/oncall/issues/11606)

## How

In `HubSpotState`, the new `sendWithSplitRetry()` method handles the core logic:

1. Send the batch upsert request to HubSpot.
2. On **200/207**: success — return no rejected records.
3. On **409**: split the batch in half and recursively retry each half.
4. When a **single-record** batch still returns 409, that record is the root cause — return it as a rejected record for the DLQ.
5. On any **other error**: throw as before (unchanged behavior).

The `HubSpotState` class now also tracks the original `DestinationRecordRaw` objects alongside the batch JSON inputs, so rejected records can be returned to the DLQ framework.

## Review guide

1. `HubSpotLoader.kt` — Main change. Review `sendWithSplitRetry()` for correctness of the recursive split logic, and the new `records` tracking in `accumulate()`.
2. `HubSpotLoaderTest.kt` — New unit tests covering: success (200/207), single-record 409 rejection, multi-record batch splitting, multiple bad records, large batch isolation, empty batch, and non-409 errors.
3. `metadata.yaml` — Version bump `0.0.11` → `0.0.12`.

### Human review checklist

- [ ] **Verify `records` and `batch` stay in sync**: `accumulate()` appends to both `batch` (line 56) and `records` (line 57) sequentially. If either list gets out of sync (e.g. due to a future code change inserting logic between them), the wrong record could be routed to the DLQ. Confirm this pairing is robust enough.
- [ ] **Partially dead `requestBody`/`batch` fields**: `flush()` now extracts inputs from `batch` into a plain list and delegates to `sendWithSplitRetry()`, which builds its own request bodies. The original `requestBody` ObjectNode is no longer sent directly. Decide whether to clean this up now or leave it.
- [ ] **Transient 409 false rejection**: HubSpot eventual consistency could cause a good record to be incorrectly rejected if it happens to be the last record standing in a sub-batch. This is a known trade-off discussed in the oncall thread — the alternative (failing the entire sync) is worse. Confirm this is acceptable.
- [ ] **No recursion depth limit**: Max depth is `log2(100) ≈ 7` for the largest possible batch, which should be safe. Confirm no concern.

## User Impact

- Syncs that previously failed entirely due to a single conflicting record will now succeed, with only the problematic record(s) appearing in the rejected records count.
- Users will see rejected records in their DLQ / sync logs and can investigate the specific conflicting record in HubSpot.
- No change in behavior for syncs that don't encounter 409 errors.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/39526c5dacd04e9f92c598ed7b06ffdd
Requested by: @pedroslopez
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/76340" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
