### PR TITLE
fix(connectors): write matrix JSON to file to avoid MAX_ARG_STRLEN overflow

### DIFF
--- a/.github/workflows/connectors-up-to-date.yml
+++ b/.github/workflows/connectors-up-to-date.yml
@@ -49,8 +49,8 @@ jobs:
             --repo-path "$GITHUB_WORKSPACE" \
             $CONNECTOR_OPTIONS \
             --output-format=json-gh-matrix \
-            > "$RUNNER_TEMP/matrix-override.json"
-          echo "Matrix entry count: $(jq '.include | length' "$RUNNER_TEMP/matrix-override.json")"
+            > "$RUNNER_TEMP/matrix.json"
+          echo "Matrix entry count: $(jq '.include | length' "$RUNNER_TEMP/matrix.json")"
 
       # Default path — Call 1: Sources (all support levels)
       - name: List source connectors
@@ -93,23 +93,20 @@ jobs:
             --repo-path "$GITHUB_WORKSPACE" \
             --connectors-filter="${{ steps.list-sources.outputs.sources }},${{ steps.list-destinations.outputs.destinations }}" \
             --output-format=json-gh-matrix \
-            > "$RUNNER_TEMP/matrix-default.json"
-          echo "Matrix entry count: $(jq '.include | length' "$RUNNER_TEMP/matrix-default.json")"
+            > "$RUNNER_TEMP/matrix.json"
+          echo "Matrix entry count: $(jq '.include | length' "$RUNNER_TEMP/matrix.json")"
 
       # Merge: pick whichever path ran, and validate non-empty.
       # IMPORTANT: We write the matrix JSON to a file and use `cat` to
-      # pipe it into $GITHUB_OUTPUT. Passing large JSON (~300 KB for
-      # 1000+ connectors) through environment variables or shell
-      # expansion hits Linux's ARG_MAX limit and causes:
+      # pipe it into $GITHUB_OUTPUT.  Passing ~155 KB of JSON through
+      # an environment variable exceeds Linux's per-string execve()
+      # limit (MAX_ARG_STRLEN = 128 KB) and causes:
       #   "Argument list too long"
       - name: Set final matrix output
         id: generate_matrix
         run: |
-          if [ -f "$RUNNER_TEMP/matrix-override.json" ]; then
-            MATRIX_FILE="$RUNNER_TEMP/matrix-override.json"
-          elif [ -f "$RUNNER_TEMP/matrix-default.json" ]; then
-            MATRIX_FILE="$RUNNER_TEMP/matrix-default.json"
-          else
+          MATRIX_FILE="$RUNNER_TEMP/matrix.json"
+          if [ ! -f "$MATRIX_FILE" ]; then
             echo "::error::No matrix file found. Check CLI commands above for errors."
             exit 1
           fi
@@ -118,9 +115,9 @@ jobs:
             echo "::error::Matrix generation produced empty output (0 entries)."
             exit 1
           fi
-          echo "Using $MATRIX_FILE ($ENTRY_COUNT connectors)"
+          echo "Matrix: $MATRIX_FILE ($ENTRY_COUNT connectors)"
           # Stream file contents into GITHUB_OUTPUT via heredoc + cat
-          # to avoid shell variable expansion hitting ARG_MAX.
+          # to avoid shell variable expansion hitting MAX_ARG_STRLEN.
           {
             echo 'generated_matrix<<MATRIX_EOF'
             cat "$MATRIX_FILE"

--- a/.github/workflows/connectors-up-to-date.yml
+++ b/.github/workflows/connectors-up-to-date.yml
@@ -45,17 +45,12 @@ jobs:
         env:
           CONNECTOR_OPTIONS: ${{ github.event.inputs.connectors-options }}
         run: |
-          MATRIX=$(
-            airbyte-ops local connector list \
-              --repo-path "$GITHUB_WORKSPACE" \
-              $CONNECTOR_OPTIONS \
-              --output-format=json-gh-matrix
-          )
-          echo "Matrix: $MATRIX"
-          # Use heredoc delimiter for multiline JSON
-          echo "generated_matrix<<MATRIX_EOF" >> $GITHUB_OUTPUT
-          echo "$MATRIX" >> $GITHUB_OUTPUT
-          echo "MATRIX_EOF" >> $GITHUB_OUTPUT
+          airbyte-ops local connector list \
+            --repo-path "$GITHUB_WORKSPACE" \
+            $CONNECTOR_OPTIONS \
+            --output-format=json-gh-matrix \
+            > "$RUNNER_TEMP/matrix-override.json"
+          echo "Matrix entry count: $(jq '.include | length' "$RUNNER_TEMP/matrix-override.json")"
 
       # Default path — Call 1: Sources (all support levels)
       - name: List source connectors
@@ -94,35 +89,43 @@ jobs:
         id: list-default
         if: github.event.inputs.connectors-options == '' || github.event_name == 'schedule'
         run: |
-          MATRIX=$(
-            airbyte-ops local connector list \
-              --repo-path "$GITHUB_WORKSPACE" \
-              --connectors-filter="${{ steps.list-sources.outputs.sources }},${{ steps.list-destinations.outputs.destinations }}" \
-              --output-format=json-gh-matrix
-          )
-          echo "Matrix: $MATRIX"
-          # Use heredoc delimiter for multiline JSON
-          echo "generated_matrix<<MATRIX_EOF" >> $GITHUB_OUTPUT
-          echo "$MATRIX" >> $GITHUB_OUTPUT
-          echo "MATRIX_EOF" >> $GITHUB_OUTPUT
+          airbyte-ops local connector list \
+            --repo-path "$GITHUB_WORKSPACE" \
+            --connectors-filter="${{ steps.list-sources.outputs.sources }},${{ steps.list-destinations.outputs.destinations }}" \
+            --output-format=json-gh-matrix \
+            > "$RUNNER_TEMP/matrix-default.json"
+          echo "Matrix entry count: $(jq '.include | length' "$RUNNER_TEMP/matrix-default.json")"
 
-      # Merge: pick whichever path ran, and validate non-empty
+      # Merge: pick whichever path ran, and validate non-empty.
+      # IMPORTANT: We write the matrix JSON to a file and use `cat` to
+      # pipe it into $GITHUB_OUTPUT. Passing large JSON (~300 KB for
+      # 1000+ connectors) through environment variables or shell
+      # expansion hits Linux's ARG_MAX limit and causes:
+      #   "Argument list too long"
       - name: Set final matrix output
         id: generate_matrix
-        env:
-          OVERRIDE_MATRIX: ${{ steps.list-override.outputs.generated_matrix }}
-          DEFAULT_MATRIX: ${{ steps.list-default.outputs.generated_matrix }}
         run: |
-          FINAL_MATRIX="${OVERRIDE_MATRIX:-$DEFAULT_MATRIX}"
-          if [ -z "$FINAL_MATRIX" ]; then
-            echo "::error::Matrix generation produced empty output. Check CLI commands above for errors."
+          if [ -f "$RUNNER_TEMP/matrix-override.json" ]; then
+            MATRIX_FILE="$RUNNER_TEMP/matrix-override.json"
+          elif [ -f "$RUNNER_TEMP/matrix-default.json" ]; then
+            MATRIX_FILE="$RUNNER_TEMP/matrix-default.json"
+          else
+            echo "::error::No matrix file found. Check CLI commands above for errors."
             exit 1
           fi
-          echo "Final matrix: $FINAL_MATRIX"
-          # Use heredoc delimiter for multiline JSON
-          echo "generated_matrix<<MATRIX_EOF" >> $GITHUB_OUTPUT
-          echo "$FINAL_MATRIX" >> $GITHUB_OUTPUT
-          echo "MATRIX_EOF" >> $GITHUB_OUTPUT
+          ENTRY_COUNT=$(jq '.include | length' "$MATRIX_FILE")
+          if [ "$ENTRY_COUNT" -eq 0 ]; then
+            echo "::error::Matrix generation produced empty output (0 entries)."
+            exit 1
+          fi
+          echo "Using $MATRIX_FILE ($ENTRY_COUNT connectors)"
+          # Stream file contents into GITHUB_OUTPUT via heredoc + cat
+          # to avoid shell variable expansion hitting ARG_MAX.
+          {
+            echo 'generated_matrix<<MATRIX_EOF'
+            cat "$MATRIX_FILE"
+            echo 'MATRIX_EOF'
+          } >> "$GITHUB_OUTPUT"
 
   run_connectors_up_to_date:
     needs: generate_matrix


### PR DESCRIPTION
## What

Both scheduled cron runs of `connectors-up-to-date` (April 7 and April 14) failed at the "Generate matrix" job with:

```
An error occurred trying to start process '/usr/bin/bash' with working directory '...'. Argument list too long
```

The matrix JSON for **566 connectors (~155 KB)** exceeded Linux's per-string `MAX_ARG_STRLEN` limit (**128 KB**) when GitHub Actions attempted to pass it as an environment variable to the "Set final matrix output" step via `execve()`. Call 3 (generate matrix) itself succeeded — the *next* step failed to even launch because its `env:` block expanded the full JSON into `DEFAULT_MATRIX`.

## How

Changed the matrix generation steps to write CLI output directly to a shared temp file (`$RUNNER_TEMP/matrix.json`) instead of capturing it in shell variables. Since only the override *or* the default code path ever runs, both write to the same file name — no resolution logic needed.

The final "Set final matrix output" step now:
1. Checks the file exists and is non-empty (entry count > 0)
2. Uses `cat` to stream file contents into `$GITHUB_OUTPUT` via a heredoc block, completely bypassing `execve()` for the large payload

The `list-sources` and `list-destinations` steps are unchanged — their CSV output is small enough for env vars.

## Review guide

1. `.github/workflows/connectors-up-to-date.yml` — the only file changed. Focus on:
   - The `cat` + heredoc pattern writing to `$GITHUB_OUTPUT` — this is the core fix
   - Confirm the `if:` conditions on override vs default steps are mutually exclusive (they are — override requires `connectors-options != ''`, default requires `== '' || schedule`), which makes the single file name safe
   - Verify no other steps depended on the removed intermediate step outputs (`list-override.outputs.generated_matrix`, `list-default.outputs.generated_matrix`)

### Recommended human-review checklist

- [ ] Confirm `$RUNNER_TEMP/matrix.json` cannot be written by both code paths in a single run
- [ ] Verify the heredoc `MATRIX_EOF` delimiter won't collide with JSON content (it won't — JSON never produces a bare `MATRIX_EOF` line)
- [ ] Spot-check that no downstream job references the removed per-step outputs

## User Impact

- The weekly `connectors-up-to-date` cron will stop failing and actually process connectors at scale
- No change to the `workflow_dispatch` (manual trigger) path behavior — it already worked for small connector filters

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Reverting restores the previous behavior, which still works for small connector lists via `workflow_dispatch` but fails on the scheduled full run.

Link to Devin session: https://app.devin.ai/sessions/b0b3701b43b54d81a0c98c66734fdbfe
Requested by: @aaronsteers