### PR TITLE
fix(source-github): reduce ReactionStream state size and checkpoint frequency

### DIFF
--- a/airbyte-integrations/connectors/source-github/metadata.yaml
+++ b/airbyte-integrations/connectors/source-github/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: ef69ef6e-aa7f-4af1-a01d-ef775033524e
-  dockerImageTag: 2.1.20
+  dockerImageTag: 2.1.21
   dockerRepository: airbyte/source-github
   documentationUrl: https://docs.airbyte.com/integrations/sources/github
   erdUrl: https://dbdocs.io/airbyteio/source-github?view=relationships

--- a/airbyte-integrations/connectors/source-github/pyproject.toml
+++ b/airbyte-integrations/connectors/source-github/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "2.1.20"
+version = "2.1.21"
 name = "source-github"
 description = "Source implementation for GitHub."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-github/source_github/streams.py
+++ b/airbyte-integrations/connectors/source-github/source_github/streams.py
@@ -1177,19 +1177,31 @@ class ReactionStream(GithubStream, CheckpointMixin, ABC):
 
     def _get_updated_state(self, current_stream_state: MutableMapping[str, Any], latest_record: Mapping[str, Any]):
         repository = latest_record["repository"]
-        parent_id = str(latest_record[self.copy_parent_key])
         updated_state = latest_record[self.cursor_field]
-        stream_state_value = current_stream_state.get(repository, {}).get(parent_id, {}).get(self.cursor_field)
+        stream_state_value = current_stream_state.get(repository, {}).get(self.cursor_field)
         if stream_state_value:
             updated_state = max(updated_state, stream_state_value)
-        current_stream_state.setdefault(repository, {}).setdefault(parent_id, {})[self.cursor_field] = updated_state
+        current_stream_state.setdefault(repository, {})[self.cursor_field] = updated_state
         return current_stream_state
+
+    def _get_starting_point_from_old_state(self, stream_state: Mapping[str, Any], repository: str, parent_id: str) -> Optional[str]:
+        """Extract cursor from legacy per-comment state format: {repository: {comment_id: {cursor_field: value}}}"""
+        repo_state = stream_state.get(repository, {})
+        comment_state = repo_state.get(parent_id, {})
+        if isinstance(comment_state, dict) and self.cursor_field in comment_state:
+            return comment_state[self.cursor_field]
+        return None
 
     def get_starting_point(self, stream_state: Mapping[str, Any], stream_slice: Mapping[str, Any]) -> str:
         if stream_state:
             repository = stream_slice["repository"]
-            parent_id = str(stream_slice[self.copy_parent_key])
-            stream_state_value = stream_state.get(repository, {}).get(parent_id, {}).get(self.cursor_field)
+            repo_state = stream_state.get(repository, {})
+            # New per-repository state format: {repository: {cursor_field: value}}
+            stream_state_value = repo_state.get(self.cursor_field)
+            if not stream_state_value:
+                # Legacy per-comment state format: {repository: {comment_id: {cursor_field: value}}}
+                parent_id = str(stream_slice[self.copy_parent_key])
+                stream_state_value = self._get_starting_point_from_old_state(stream_state, repository, parent_id)
             if stream_state_value:
                 if self._start_date:
                     return max(self._start_date, stream_state_value)

--- a/airbyte-integrations/connectors/source-github/source_github/streams.py
+++ b/airbyte-integrations/connectors/source-github/source_github/streams.py
@@ -1143,6 +1143,7 @@ class ReactionStream(GithubStream, CheckpointMixin, ABC):
     parent_key = "id"
     copy_parent_key = "comment_id"
     cursor_field = "created_at"
+    state_checkpoint_interval = 1000
 
     def __init__(self, start_date: str = "", **kwargs):
         super().__init__(**kwargs)

--- a/airbyte-integrations/connectors/source-github/unit_tests/test_stream.py
+++ b/airbyte-integrations/connectors/source-github/unit_tests/test_stream.py
@@ -1378,8 +1378,7 @@ def test_stream_commit_comment_reactions_incremental_read(requests_mock):
 
     assert stream_state == {
         "airbytehq/integration-test": {
-            "55538825": {"created_at": "2022-01-01T16:00:00Z"},
-            "55538826": {"created_at": "2022-01-01T17:00:00Z"},
+            "created_at": "2022-01-01T17:00:00Z",
         }
     }
 

--- a/docs/integrations/sources/github.md
+++ b/docs/integrations/sources/github.md
@@ -229,6 +229,7 @@ Your token should have at least the `repo` scope. Depending on which streams you
 
 | Version    | Date       | Pull Request                                                                                                      | Subject                                                                                                                                                                |
 |:-----------|:-----------|:------------------------------------------------------------------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 2.1.21 | 2026-04-15 | [76356](https://github.com/airbytehq/airbyte/pull/76356) | Add state_checkpoint_interval to ReactionStream to reduce orchestrator CPU usage from excessive state emissions |
 | 2.1.20 | 2026-04-10 | [74758](https://github.com/airbytehq/airbyte/pull/74758) | Fix rate limit sleep blocking heartbeat; classify rate limit errors as transient; increase default max_waiting_time to 120 minutes to cover GitHub's hourly rate limit window |
 | 2.1.19 | 2026-04-06 | [76090](https://github.com/airbytehq/airbyte/pull/76090) | Fix 403 permission errors misclassified as retryable, causing infinite retry loops |
 | 2.1.18 | 2026-04-07 | [76124](https://github.com/airbytehq/airbyte/pull/76124) | Fix silent error swallowing in exception handlers for ContributorActivity, GithubStreamABC, and Releases streams |


### PR DESCRIPTION
## What

Reduces orchestrator CPU usage caused by excessive state message emissions during `issue_comment_reactions` (and other reaction streams) syncing.

Without these changes, `ReactionStream` emits a STATE message after **every stream slice** (i.e., every parent comment), and each STATE contains a per-comment cursor (`{repo: {comment_id: {created_at: value}}}`). For connections with many repositories and comments (e.g., 30 repos, 921 tracked comment IDs), this produces ~921 STATE messages per sync — each containing a full accumulated state that grows up to ~48 KB. The orchestrator must deserialize, validate, checksum, and persist each one, totaling ~21 MB of state JSON processing vs ~529 KB of actual record data. This causes CPU spikes (observed at 1,710 mcores against a 1,000m limit) and can lead to orchestrator timeouts.

## How

Two complementary changes:

1. **Reduce state granularity** (`_get_updated_state`, `get_starting_point`): State now tracks a single cursor per repository (`{repo: {created_at: value}}`) instead of per comment ID. Shrinks state from ~48 KB to ~2 KB for the observed connection. Includes backward compatibility with the legacy per-comment state format via `_get_starting_point_from_old_state`.

2. **Add `state_checkpoint_interval = 1000`**: State is emitted every 1,000 records instead of after every slice. Reduces STATE messages from ~921 to ~5 for a sync producing ~5,000 records.

Also bumps connector version from 2.1.20 → 2.1.21.

## Review guide

1. `source_github/streams.py` — `ReactionStream` class changes:
   - `state_checkpoint_interval = 1000` class attribute
   - `_get_updated_state` simplified to per-repository granularity
   - `get_starting_point` checks new format first, falls back to legacy per-comment format
   - `_get_starting_point_from_old_state` helper for backward compat
2. `unit_tests/test_stream.py` — updated expected state format in `test_stream_commit_comment_reactions_incremental_read`
3. `metadata.yaml`, `pyproject.toml` — version bump
4. `docs/integrations/sources/github.md` — changelog entry

**Key things to verify:**
- [ ] `state_checkpoint_interval` as a class attribute correctly shadows the `@property` defined on the base `Stream` class (it does — subclass `__dict__` entry is resolved first in MRO)
- [ ] The interval interacts correctly with `ReactionStream.read_records()` override, which yields records and updates `self.state` inline — the CDK's `Stream.read()` should still count records and checkpoint at the interval boundary
- [ ] Backward compat: `get_starting_point` correctly distinguishes new state format (`{repo: {created_at: val}}`) from legacy (`{repo: {comment_id: {created_at: val}}}`) — note this relies on comment IDs never equaling `"created_at"`, which holds since they are numeric strings
- [ ] On first sync after upgrade with old state: the per-repo cursor will be the max across all comments in that repo. This is safe because reactions are append-only, but may cause some re-reading of reactions for comments whose individual cursor was below the repo max
- [ ] Applies to all `ReactionStream` subclasses: `IssueCommentReactions`, `CommitCommentReactions` (but NOT `PullRequestCommentReactions`, which extends `SemiIncrementalMixin`)

## User Impact

- Reduces orchestrator CPU usage during reaction stream syncing, preventing timeouts on connections with many repositories/comments
- Tradeoff: on sync failure, up to 999 records since the last checkpoint may be re-read, and all comments in a repo share one cursor (some re-reading possible after failures). This is safe because reactions are append-only and deduplicated at the destination

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

No config or catalog changes. State format change is forward-only (old state is read via backward compat path), but reverting would cause the connector to misinterpret the new per-repo state format as a comment ID key. A state reset on affected streams would be needed after revert.

Link to Devin session: https://app.devin.ai/sessions/61059280af2a4e93a52db6796a43e03f
Requested by: @darynaishchenko