### PR TITLE
ci(connectors): implement batched cron scheduling for 566+ connectors

### DIFF
--- a/.github/workflows/connectors-up-to-date.yml
+++ b/.github/workflows/connectors-up-to-date.yml
@@ -44,6 +44,7 @@ jobs:
       # GitHub Actions' 256-job matrix limit.
       - name: Resolve batch offset from cron schedule
         id: resolve-batch
+        if: github.event_name == 'schedule'
         run: |
           BATCH_LIMIT=200
           case "${{ github.event.schedule }}" in

--- a/.github/workflows/connectors-up-to-date.yml
+++ b/.github/workflows/connectors-up-to-date.yml
@@ -29,8 +29,10 @@ jobs:
     outputs:
       generated_matrix: ${{ steps.generate_matrix.outputs.generated_matrix }}
     steps:
-      - name: Checkout Airbyte
+      - name: Checkout Airbyte (default branch)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.repository.default_branch }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
@@ -188,10 +190,11 @@ jobs:
       # Checkout with the App token so git push authenticates as the
       # GitHub App. Pushes made with GITHUB_TOKEN do not trigger
       # pull_request workflows; pushes made with a GitHub App token do.
-      - name: Checkout Airbyte
+      - name: Checkout Airbyte (default branch)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ steps.get-app-token.outputs.token }}
+          ref: ${{ github.event.repository.default_branch }}
 
       - name: Get GitHub App User ID
         id: get-user-id
@@ -288,6 +291,7 @@ jobs:
           token: ${{ steps.get-app-token.outputs.token }}
           commit-message: "deps(${{ env.CONNECTOR_NAME }}): update dependencies [skip ci]"
           branch: "up-to-date/${{ env.CONNECTOR_NAME }}"
+          base: ${{ github.event.repository.default_branch }}
           delete-branch: true
           title: "deps(${{ env.CONNECTOR_NAME }}): 🐙 update dependencies [${{ env.TODAY }}]"
           body: |

--- a/.github/workflows/connectors-up-to-date.yml
+++ b/.github/workflows/connectors-up-to-date.yml
@@ -9,9 +9,9 @@ on:
   schedule:
     # Batched runs — each cron triggers a different slice of the full connector list.
     # See the "Resolve batch offset from cron schedule" step for the mapping.
-    - cron: "0 3 * * 2"   # Batch 1/3: offset=0   (connectors 1–200)
-    - cron: "0 5 * * 2"   # Batch 2/3: offset=200 (connectors 201–400)
-    - cron: "0 7 * * 2"   # Batch 3/3: offset=400 (connectors 401+)
+    - cron: "0 3 * * 2" # Batch 1/3: offset=0   (connectors 1–200)
+    - cron: "0 5 * * 2" # Batch 2/3: offset=200 (connectors 201–400)
+    - cron: "0 7 * * 2" # Batch 3/3: offset=400 (connectors 401+)
   workflow_dispatch:
     inputs:
       connectors-options:

--- a/.github/workflows/connectors-up-to-date.yml
+++ b/.github/workflows/connectors-up-to-date.yml
@@ -1,12 +1,17 @@
 name: Connectors up-to-date
 concurrency:
-  group: ${{ github.workflow }}
+  # Each cron schedule gets its own concurrency group so batches run in parallel.
+  # workflow_dispatch runs share a single group to avoid conflicts.
+  group: ${{ github.workflow }}-${{ github.event.schedule || 'dispatch' }}
   cancel-in-progress: false
 
 on:
   schedule:
-    # Runs every Tuesday at 03:00 UTC (8 PM Pacific Monday evening)
-    - cron: "0 3 * * 2"
+    # Batched runs — each cron triggers a different slice of the full connector list.
+    # See the "Resolve batch offset from cron schedule" step for the mapping.
+    - cron: "0 3 * * 2"   # Batch 1/3: offset=0   (connectors 1–200)
+    - cron: "0 5 * * 2"   # Batch 2/3: offset=200 (connectors 201–400)
+    - cron: "0 7 * * 2"   # Batch 3/3: offset=400 (connectors 401+)
   workflow_dispatch:
     inputs:
       connectors-options:
@@ -32,6 +37,24 @@ jobs:
 
       - name: Install airbyte-ops CLI
         run: uv tool install airbyte-internal-ops
+
+      # Resolve batch offset from cron schedule.
+      # Each cron expression above maps to a (offset, limit) pair so the
+      # full connector set is split across multiple runs, staying under
+      # GitHub Actions' 256-job matrix limit.
+      - name: Resolve batch offset from cron schedule
+        id: resolve-batch
+        run: |
+          BATCH_LIMIT=200
+          case "${{ github.event.schedule }}" in
+            "0 3 * * 2") BATCH_OFFSET=0   ;;
+            "0 5 * * 2") BATCH_OFFSET=200 ;;
+            "0 7 * * 2") BATCH_OFFSET=400 ;;
+            *)           BATCH_OFFSET=0   ;;
+          esac
+          echo "batch_offset=$BATCH_OFFSET" >> "$GITHUB_OUTPUT"
+          echo "batch_limit=$BATCH_LIMIT"   >> "$GITHUB_OUTPUT"
+          echo "Batch: offset=$BATCH_OFFSET, limit=$BATCH_LIMIT"
 
       # --- Connector selection ---
       # When connectors-options is provided, use it directly as an override.
@@ -84,14 +107,24 @@ jobs:
           echo "Destinations: $DESTINATIONS"
           echo "destinations=$DESTINATIONS" | tee -a $GITHUB_OUTPUT
 
-      # Default path — Call 3: Combine both sets into GH Actions matrix
+      # Default path — Call 3: Combine both sets into GH Actions matrix.
+      # On scheduled runs, apply --sort-by / --offset / --limit so each
+      # cron batch processes a distinct, deterministic slice.
       - name: Generate matrix from source + destination lists
         id: list-default
         if: github.event.inputs.connectors-options == '' || github.event_name == 'schedule'
+        env:
+          BATCH_OFFSET: ${{ steps.resolve-batch.outputs.batch_offset }}
+          BATCH_LIMIT: ${{ steps.resolve-batch.outputs.batch_limit }}
         run: |
+          BATCH_ARGS=""
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            BATCH_ARGS="--sort-by=name --offset=$BATCH_OFFSET --limit=$BATCH_LIMIT"
+          fi
           airbyte-ops local connector list \
             --repo-path "$GITHUB_WORKSPACE" \
             --connectors-filter="${{ steps.list-sources.outputs.sources }},${{ steps.list-destinations.outputs.destinations }}" \
+            $BATCH_ARGS \
             --output-format=json-gh-matrix \
             > "$RUNNER_TEMP/matrix.json"
           echo "Matrix entry count: $(jq '.include | length' "$RUNNER_TEMP/matrix.json")"


### PR DESCRIPTION
## What

The `connectors-up-to-date` weekly cron run generates a matrix of ~566 connectors, which exceeds GitHub Actions' hard limit of 256 jobs per matrix. The full-scale run silently fails with no downstream jobs created.

This PR splits the single weekly cron into 3 batched runs of up to 200 connectors each, staying under the matrix limit.

## How

1. **3 cron entries** replace the single `0 3 * * 2` schedule — each fires at a different hour (03:00, 05:00, 07:00 UTC Tuesday).
2. **"Resolve batch offset from cron schedule" step** — a `case` statement maps `github.event.schedule` to `(offset, limit)` pairs: `(0, 200)`, `(200, 200)`, `(400, 200)`. This step is conditional on `github.event_name == 'schedule'` so it's skipped for `workflow_dispatch`.
3. **Conditional batch args** — on `schedule` events, `--sort-by=name --offset=$N --limit=200` is appended to the connector list command. `workflow_dispatch` runs are unaffected.
4. **Concurrency group per schedule** — changed from `${{ github.workflow }}` to `${{ github.workflow }}-${{ github.event.schedule || 'dispatch' }}` so the 3 batches can run in parallel instead of queueing.
5. **Always target default branch** — both checkout steps use `ref: ${{ github.event.repository.default_branch }}` and `peter-evans/create-pull-request` uses `base: ${{ github.event.repository.default_branch }}`. This ensures connector PRs always target the repo's default branch even when the workflow is triggered from a non-default branch (e.g., via `workflow_dispatch` on a PR branch).

**Dependency:** Requires `--sort-by`, `--offset`, `--limit` flags in the `airbyte-internal-ops` CLI, added in [airbytehq/airbyte-ops-mcp#707](https://github.com/airbytehq/airbyte-ops-mcp/pull/707). ✅ Released in `v0.45.0` on PyPI.

## Review guide

1. `.github/workflows/connectors-up-to-date.yml` — single file, all changes are in the `generate_matrix` and `run_connectors_up_to_date` jobs

Key areas:
- **Lines 2–5**: Concurrency group change — verify batches won't interfere with each other or with manual dispatch runs
- **Lines 10–14**: Cron entries with inline comments pointing to the batch resolution step
- **Lines 45–58**: Batch resolution step (conditional on `schedule`) — verify the cron-to-offset mapping matches the inline comments
- **Lines 120–128**: Conditional `BATCH_ARGS` — only applied on `schedule`, not `workflow_dispatch`
- **Lines 32–35, 193–195**: Checkout steps — both now pin to `github.event.repository.default_branch`
- **Line 292**: `peter-evans/create-pull-request` — `base` set to default branch

### Human review checklist

- [ ] Cron expressions in the `schedule:` block match the `case` patterns in the resolution step exactly — a single-character mismatch would cause the `*) BATCH_OFFSET=0` fallback to apply silently
- [ ] `github.event.repository.default_branch` is available in both `schedule` and `workflow_dispatch` event contexts
- [ ] `workflow_dispatch` without `--connectors-filter` still hits the 256-job limit (unchanged from before) — acceptable for now?

### Tested

- Triggered `workflow_dispatch` from PR branch with `--sort-by=name --offset=50 --limit=3` → matrix produced exactly 3 connectors (destination-pgvector, destination-pinecone, destination-postgres) ✅

## User Impact

- Scheduled weekly runs will now succeed end-to-end, processing all ~566 connectors across 3 batches
- `workflow_dispatch` with `--connectors-filter` (small sets) is unaffected
- Connector PRs always target the default branch regardless of how the workflow was triggered
- ⚠️ `workflow_dispatch` without a filter (full set) will still hit the 256-job limit — this is unchanged from before and requires a filter override for large manual runs

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Reverting restores the single-cron behavior. The scheduled run will fail at scale (as it does today), but `workflow_dispatch` with filters continues to work.

Link to Devin session: https://app.devin.ai/sessions/b0b3701b43b54d81a0c98c66734fdbfe
Requested by: @aaronsteers