### PR TITLE
feat(destination-redshift-v2): add schema layer 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -53,6 +53,7 @@
 /airbyte-integrations/connectors/destination-mssql/ @airbytehq/move-destinations
 /airbyte-integrations/connectors/destination-postgres/ @airbytehq/move-destinations
 /airbyte-integrations/connectors/destination-redshift/ @airbytehq/move-destinations
+/airbyte-integrations/connectors/destination-redshift-v2/ @airbytehq/move-destinations
 /airbyte-integrations/connectors/destination-s3/ @airbytehq/move-destinations
 /airbyte-integrations/connectors/destination-s3-data-lake/ @airbytehq/move-destinations
 /airbyte-integrations/connectors/destination-snowflake/ @airbytehq/move-destinations

--- a/airbyte-integrations/connectors/destination-redshift-v2/src/main/kotlin/io/airbyte/integrations/destination/redshift2/schema/RedshiftNamingUtils.kt
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/main/kotlin/io/airbyte/integrations/destination/redshift2/schema/RedshiftNamingUtils.kt
@@ -36,13 +36,10 @@ fun String.toRedshiftCompatibleName(): String {
         transformed = "_$transformed"
     }
 
-    // Truncate to 127 bytes if needed (Redshift identifier limit).
-    // Since the string is ASCII-only at this point, 1 char = 1 byte.
-    // Keep a prefix and append a hex hash suffix to avoid collisions.
+    // Truncate to 127 bytes by keeping a prefix and append a hex hash suffix to avoid collisions.
     if (transformed.length > REDSHIFT_MAX_IDENTIFIER_LENGTH) {
         val hash = transformed.hashCode().toUInt().toString(16).takeLast(8)
-        transformed =
-            transformed.take(REDSHIFT_MAX_IDENTIFIER_LENGTH - 1 - hash.length) + "_" + hash
+        transformed = transformed.take(118) + "_" + hash
     }
 
     return transformed

--- a/airbyte-integrations/connectors/destination-redshift-v2/src/main/kotlin/io/airbyte/integrations/destination/redshift2/schema/RedshiftNamingUtils.kt
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/main/kotlin/io/airbyte/integrations/destination/redshift2/schema/RedshiftNamingUtils.kt
@@ -15,18 +15,15 @@ import io.airbyte.cdk.load.data.Transformations.Companion.toAlphanumericAndUnder
  * Standard identifier rules:
  * - Begin with an ASCII single-byte alphabetic character or underscore character
  * - Subsequent characters can be ASCII single-byte alphanumeric characters, underscores, etc.
- * - Maximum of 127 bytes in length
+ * - Maximum of 127 bytes in length (truncated with a hash suffix to avoid collisions)
  * - Contain no quotation marks and no spaces.
- * - Not be a reserved system column/SQL key word. // not handled for performnace reasons
- *
- * Identifiers are case-insensitive by default; we follow lowercase globally across Redshift.
- *
- * Compatibility note: Below features are intentionally NOT handled, to stay compatible with v1:
- * - Empty string handling -- V1 does not produce a fallback name for empty inputs.
- * - Max length truncation -- V1 does not explicitly truncate identifiers to 127 characters.
+ * - Not be a reserved system column/SQL key word. // not handled for performance reasons
+ * - Identifiers are case-insensitive by default; we follow lowercase globally across Redshift.
  *
  * @return The transformed string suitable for Redshift identifiers.
  */
+private const val REDSHIFT_MAX_IDENTIFIER_LENGTH = 127
+
 fun String.toRedshiftCompatibleName(): String {
     // Replace any character that is not a alphanumeric, or an underscore with a single underscore
     var transformed = toAlphanumericAndUnderscore(this)
@@ -37,6 +34,15 @@ fun String.toRedshiftCompatibleName(): String {
     // Handle Standard identifier Rule (1), If it starts with a digit, prepend an underscore.
     if (transformed.isNotEmpty() && transformed[0].isDigit()) {
         transformed = "_$transformed"
+    }
+
+    // Truncate to 127 bytes if needed (Redshift identifier limit).
+    // Since the string is ASCII-only at this point, 1 char = 1 byte.
+    // Keep a prefix and append a hex hash suffix to avoid collisions.
+    if (transformed.length > REDSHIFT_MAX_IDENTIFIER_LENGTH) {
+        val hash = transformed.hashCode().toUInt().toString(16).takeLast(8)
+        transformed =
+            transformed.take(REDSHIFT_MAX_IDENTIFIER_LENGTH - 1 - hash.length) + "_" + hash
     }
 
     return transformed

--- a/airbyte-integrations/connectors/destination-redshift-v2/src/main/kotlin/io/airbyte/integrations/destination/redshift2/schema/RedshiftNamingUtils.kt
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/main/kotlin/io/airbyte/integrations/destination/redshift2/schema/RedshiftNamingUtils.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.redshift2.schema
+
+import io.airbyte.cdk.load.data.Transformations.Companion.toAlphanumericAndUnderscore
+
+/**
+ * Redshift identifier naming rules.
+ *
+ * We follow the **standard (non-delimited) identifier** rules described at:
+ * https://docs.aws.amazon.com/redshift/latest/dg/r_names.html
+ *
+ * Standard identifier rules:
+ * - Begin with an ASCII single-byte alphabetic character or underscore character
+ * - Subsequent characters can be ASCII single-byte alphanumeric characters, underscores, etc.
+ * - Maximum of 127 bytes in length
+ * - Contain no quotation marks and no spaces.
+ * - Not be a reserved system column/SQL key word. // not handled for performnace reasons
+ *
+ * Identifiers are case-insensitive by default; we follow lowercase globally across Redshift.
+ *
+ * Compatibility note: Below features are intentionally NOT handled, to stay compatible with v1:
+ * - Empty string handling -- V1 does not produce a fallback name for empty inputs.
+ * - Max length truncation -- V1 does not explicitly truncate identifiers to 127 characters.
+ *
+ * @return The transformed string suitable for Redshift identifiers.
+ */
+fun String.toRedshiftCompatibleName(): String {
+    // Replace any character that is not a alphanumeric, or an underscore with a single underscore
+    var transformed = toAlphanumericAndUnderscore(this)
+
+    // Force lowercase (Redshift convention).
+    transformed = transformed.lowercase()
+
+    // Handle Standard identifier Rule (1), If it starts with a digit, prepend an underscore.
+    if (transformed.isNotEmpty() && transformed[0].isDigit()) {
+        transformed = "_$transformed"
+    }
+
+    return transformed
+}

--- a/airbyte-integrations/connectors/destination-redshift-v2/src/main/kotlin/io/airbyte/integrations/destination/redshift2/schema/RedshiftTableSchemaMapper.kt
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/main/kotlin/io/airbyte/integrations/destination/redshift2/schema/RedshiftTableSchemaMapper.kt
@@ -45,13 +45,10 @@ class RedshiftTableSchemaMapper(
         )
     }
 
-    override fun toTempTableName(tableName: TableName): TableName {
-        return tempTableNameGenerator.generate(tableName)
-    }
+    override fun toTempTableName(tableName: TableName): TableName =
+        tempTableNameGenerator.generate(tableName)
 
-    override fun toColumnName(name: String): String {
-        return name.toRedshiftCompatibleName()
-    }
+    override fun toColumnName(name: String): String = name.toRedshiftCompatibleName()
 
     override fun toColumnType(fieldType: FieldType): ColumnType {
         val redshiftType =

--- a/airbyte-integrations/connectors/destination-redshift-v2/src/main/kotlin/io/airbyte/integrations/destination/redshift2/schema/RedshiftTableSchemaMapper.kt
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/main/kotlin/io/airbyte/integrations/destination/redshift2/schema/RedshiftTableSchemaMapper.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.redshift2.schema
+
+import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.component.ColumnType
+import io.airbyte.cdk.load.data.ArrayType
+import io.airbyte.cdk.load.data.ArrayTypeWithoutSchema
+import io.airbyte.cdk.load.data.BooleanType
+import io.airbyte.cdk.load.data.DateType
+import io.airbyte.cdk.load.data.FieldType
+import io.airbyte.cdk.load.data.IntegerType
+import io.airbyte.cdk.load.data.NumberType
+import io.airbyte.cdk.load.data.ObjectType
+import io.airbyte.cdk.load.data.ObjectTypeWithEmptySchema
+import io.airbyte.cdk.load.data.ObjectTypeWithoutSchema
+import io.airbyte.cdk.load.data.StringType
+import io.airbyte.cdk.load.data.TimeTypeWithTimezone
+import io.airbyte.cdk.load.data.TimeTypeWithoutTimezone
+import io.airbyte.cdk.load.data.TimestampTypeWithTimezone
+import io.airbyte.cdk.load.data.TimestampTypeWithoutTimezone
+import io.airbyte.cdk.load.data.UnionType
+import io.airbyte.cdk.load.data.UnknownType
+import io.airbyte.cdk.load.schema.TableSchemaMapper
+import io.airbyte.cdk.load.schema.model.TableName
+import io.airbyte.cdk.load.table.TempTableNameGenerator
+import io.airbyte.integrations.destination.redshift2.config.RedshiftConfiguration
+import io.airbyte.integrations.destination.redshift2.sql.RedshiftDataType
+import jakarta.inject.Singleton
+
+/** Maps Airbyte stream schemas to Redshift-specific table names, column names, and column types. */
+@Singleton
+class RedshiftTableSchemaMapper(
+    private val config: RedshiftConfiguration,
+    private val tempTableNameGenerator: TempTableNameGenerator,
+) : TableSchemaMapper {
+
+    override fun toFinalTableName(desc: DestinationStream.Descriptor): TableName {
+        val namespace = desc.namespace ?: config.schema
+        return TableName(
+            namespace = namespace.toRedshiftCompatibleName(),
+            name = desc.name.toRedshiftCompatibleName(),
+        )
+    }
+
+    override fun toTempTableName(tableName: TableName): TableName {
+        return tempTableNameGenerator.generate(tableName)
+    }
+
+    override fun toColumnName(name: String): String {
+        return name.toRedshiftCompatibleName()
+    }
+
+    override fun toColumnType(fieldType: FieldType): ColumnType {
+        val redshiftType =
+            when (fieldType.type) {
+                // Simple types
+                BooleanType -> RedshiftDataType.BOOLEAN.typeName
+                IntegerType -> RedshiftDataType.BIGINT.typeName
+                NumberType -> RedshiftDataType.NUMERIC.typeName
+                StringType -> RedshiftDataType.VARCHAR.typeName
+
+                // Temporal types
+                DateType -> RedshiftDataType.DATE.typeName
+                TimeTypeWithTimezone -> RedshiftDataType.TIMETZ.typeName
+                TimeTypeWithoutTimezone -> RedshiftDataType.TIME.typeName
+                TimestampTypeWithTimezone -> RedshiftDataType.TIMESTAMPTZ.typeName
+                TimestampTypeWithoutTimezone -> RedshiftDataType.TIMESTAMP.typeName
+
+                // Semi-structured types (all map to Redshift SUPER)
+                is ArrayType,
+                ArrayTypeWithoutSchema,
+                is ObjectType,
+                ObjectTypeWithEmptySchema,
+                ObjectTypeWithoutSchema,
+                is UnionType,
+                is UnknownType -> RedshiftDataType.SUPER.typeName
+            }
+
+        return ColumnType(redshiftType, fieldType.nullable)
+    }
+}

--- a/airbyte-integrations/connectors/destination-redshift-v2/src/test/kotlin/io/airbyte/integrations/destination/redshift2/schema/RedshiftNamingUtilsTest.kt
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/test/kotlin/io/airbyte/integrations/destination/redshift2/schema/RedshiftNamingUtilsTest.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.redshift2.schema
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class RedshiftNamingUtilsTest {
+
+    @Test
+    fun `basic alphanumeric name is lowercased`() {
+        assertEquals("my_table", "my_table".toRedshiftCompatibleName())
+    }
+
+    @Test
+    fun `mixed case name is lowercased`() {
+        assertEquals("mytable", "MyTable".toRedshiftCompatibleName())
+    }
+
+    @Test
+    fun `special characters replaced with underscores`() {
+        assertEquals("my_table_name", "my-table.name".toRedshiftCompatibleName())
+    }
+
+    @Test
+    fun `spaces replaced with underscores`() {
+        assertEquals("my_table_name", "my table name".toRedshiftCompatibleName())
+    }
+
+    @Test
+    fun `at sign and other symbols replaced`() {
+        assertEquals("user_email_address", "user@email+address".toRedshiftCompatibleName())
+    }
+
+    @Test
+    fun `digit prefixed name gets underscore prepended`() {
+        assertEquals("_1foo", "1foo".toRedshiftCompatibleName())
+    }
+
+    @Test
+    fun `already lowercase name unchanged`() {
+        assertEquals("public", "public".toRedshiftCompatibleName())
+    }
+
+    @Test
+    fun `unicode characters replaced with underscores`() {
+        // Unicode characters that aren't simple alphanumeric are replaced
+        val result = "table_\u00e9\u00e8".toRedshiftCompatibleName()
+        // After NFKD normalization, accented chars decompose and combining marks are stripped
+        assertEquals("table_ee", result)
+    }
+
+    @Test
+    fun `underscores preserved`() {
+        assertEquals("my_table_name", "my_table_name".toRedshiftCompatibleName())
+    }
+
+    @Test
+    fun `consecutive special characters collapsed to underscores`() {
+        assertEquals("a___b", "a---b".toRedshiftCompatibleName())
+    }
+}

--- a/airbyte-integrations/connectors/destination-redshift-v2/src/test/kotlin/io/airbyte/integrations/destination/redshift2/schema/RedshiftNamingUtilsTest.kt
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/test/kotlin/io/airbyte/integrations/destination/redshift2/schema/RedshiftNamingUtilsTest.kt
@@ -5,6 +5,7 @@
 package io.airbyte.integrations.destination.redshift2.schema
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class RedshiftNamingUtilsTest {
@@ -60,5 +61,53 @@ class RedshiftNamingUtilsTest {
     @Test
     fun `consecutive special characters collapsed to underscores`() {
         assertEquals("a___b", "a---b".toRedshiftCompatibleName())
+    }
+
+    // ================================================================
+    // Truncation (127-byte Redshift identifier limit)
+    // ================================================================
+
+    @Test
+    fun `name exactly 127 chars is not truncated`() {
+        val input = "a".repeat(127)
+        val result = input.toRedshiftCompatibleName()
+        assertEquals(127, result.length)
+        assertEquals(input, result)
+    }
+
+    @Test
+    fun `name exceeding 127 chars is truncated`() {
+        val input = "a".repeat(200)
+        val result = input.toRedshiftCompatibleName()
+        assertTrue(result.length <= 127, "Expected <= 127 chars but got ${result.length}")
+    }
+
+    @Test
+    fun `truncation is deterministic`() {
+        val input = "x".repeat(200)
+        val first = input.toRedshiftCompatibleName()
+        val second = input.toRedshiftCompatibleName()
+        assertEquals(first, second)
+    }
+
+    @Test
+    fun `two long names sharing a prefix produce different truncated results`() {
+        val base = "a".repeat(130)
+        val input1 = base + "_suffix_one"
+        val input2 = base + "_suffix_two"
+        val result1 = input1.toRedshiftCompatibleName()
+        val result2 = input2.toRedshiftCompatibleName()
+        assertTrue(result1 != result2, "Expected different results for different inputs")
+        assertTrue(result1.length <= 127)
+        assertTrue(result2.length <= 127)
+    }
+
+    @Test
+    fun `truncated name with digit prefix still prepends underscore and stays within limit`() {
+        // Input starts with a digit and exceeds 127 chars after underscore prepend
+        val input = "1" + "a".repeat(200)
+        val result = input.toRedshiftCompatibleName()
+        assertTrue(result.startsWith("_"), "Expected leading underscore for digit-prefixed name")
+        assertTrue(result.length <= 127, "Expected <= 127 chars but got ${result.length}")
     }
 }

--- a/airbyte-integrations/connectors/destination-redshift-v2/src/test/kotlin/io/airbyte/integrations/destination/redshift2/schema/RedshiftTableSchemaMapperTest.kt
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/test/kotlin/io/airbyte/integrations/destination/redshift2/schema/RedshiftTableSchemaMapperTest.kt
@@ -1,0 +1,221 @@
+/*
+ * Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.redshift2.schema
+
+import io.airbyte.cdk.load.command.Append
+import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.component.ColumnType
+import io.airbyte.cdk.load.data.ArrayType
+import io.airbyte.cdk.load.data.ArrayTypeWithoutSchema
+import io.airbyte.cdk.load.data.BooleanType
+import io.airbyte.cdk.load.data.DateType
+import io.airbyte.cdk.load.data.FieldType
+import io.airbyte.cdk.load.data.IntegerType
+import io.airbyte.cdk.load.data.NumberType
+import io.airbyte.cdk.load.data.ObjectType
+import io.airbyte.cdk.load.data.ObjectTypeWithEmptySchema
+import io.airbyte.cdk.load.data.ObjectTypeWithoutSchema
+import io.airbyte.cdk.load.data.StringType
+import io.airbyte.cdk.load.data.TimeTypeWithTimezone
+import io.airbyte.cdk.load.data.TimeTypeWithoutTimezone
+import io.airbyte.cdk.load.data.TimestampTypeWithTimezone
+import io.airbyte.cdk.load.data.TimestampTypeWithoutTimezone
+import io.airbyte.cdk.load.data.UnionType
+import io.airbyte.cdk.load.data.UnknownType
+import io.airbyte.cdk.load.schema.model.ColumnSchema
+import io.airbyte.cdk.load.schema.model.StreamTableSchema
+import io.airbyte.cdk.load.schema.model.TableName
+import io.airbyte.cdk.load.schema.model.TableNames
+import io.airbyte.cdk.load.table.TempTableNameGenerator
+import io.airbyte.integrations.destination.redshift2.config.RedshiftConfiguration
+import io.airbyte.integrations.destination.redshift2.sql.RedshiftDataType
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+
+class RedshiftTableSchemaMapperTest {
+
+    private lateinit var config: RedshiftConfiguration
+    private lateinit var tempTableNameGenerator: TempTableNameGenerator
+    private lateinit var mapper: RedshiftTableSchemaMapper
+
+    @BeforeEach
+    fun setup() {
+        config = mockk()
+        every { config.schema } returns "public"
+
+        tempTableNameGenerator = mockk()
+        mapper = RedshiftTableSchemaMapper(config, tempTableNameGenerator)
+    }
+
+    // ================================================================
+    // toFinalTableName
+    // ================================================================
+
+    @Test
+    fun `toFinalTableName maps namespace and name with lowercasing`() {
+        val desc = DestinationStream.Descriptor(namespace = "MySchema", name = "MyTable")
+
+        val result = mapper.toFinalTableName(desc)
+
+        assertEquals("myschema", result.namespace)
+        assertEquals("mytable", result.name)
+    }
+
+    @Test
+    fun `toFinalTableName sanitizes special characters`() {
+        val desc = DestinationStream.Descriptor(namespace = "my-schema", name = "my.table")
+
+        val result = mapper.toFinalTableName(desc)
+
+        assertEquals("my_schema", result.namespace)
+        assertEquals("my_table", result.name)
+    }
+
+    @Test
+    fun `toFinalTableName uses config schema when descriptor namespace is null`() {
+        every { config.schema } returns "default_schema"
+        val desc = DestinationStream.Descriptor(namespace = null, name = "my_table")
+
+        val result = mapper.toFinalTableName(desc)
+
+        assertEquals("default_schema", result.namespace)
+        assertEquals("my_table", result.name)
+    }
+
+    // ================================================================
+    // toTempTableName
+    // ================================================================
+
+    @Test
+    fun `toTempTableName delegates to TempTableNameGenerator`() {
+        val tableName = TableName(namespace = "public", name = "my_table")
+        val expectedTemp = TableName(namespace = "public", name = "tmp_my_table_abc123")
+        every { tempTableNameGenerator.generate(tableName) } returns expectedTemp
+
+        val result = mapper.toTempTableName(tableName)
+
+        assertEquals(expectedTemp, result)
+        verify { tempTableNameGenerator.generate(tableName) }
+    }
+
+    // ================================================================
+    // toColumnName
+    // ================================================================
+
+    @Test
+    fun `toColumnName applies naming transformation`() {
+        assertEquals("my_column", mapper.toColumnName("my_column"))
+        assertEquals("my_column", mapper.toColumnName("My-Column"))
+        assertEquals("_1col", mapper.toColumnName("1col"))
+    }
+
+    // ================================================================
+    // toColumnType
+    // ================================================================
+
+    @ParameterizedTest(name = "{0} -> {1}")
+    @MethodSource("typeMapping")
+    fun `toColumnType maps all Airbyte types correctly`(
+        fieldType: FieldType,
+        expectedTypeName: String,
+    ) {
+        val result = mapper.toColumnType(fieldType)
+
+        assertEquals(expectedTypeName, result.type)
+        assertEquals(fieldType.nullable, result.nullable)
+    }
+
+    // ================================================================
+    // toFinalSchema
+    // ================================================================
+
+    @Test
+    fun `toFinalSchema returns schema unchanged`() {
+        val tableName = TableName(namespace = "public", name = "test")
+        val tableSchema =
+            StreamTableSchema(
+                tableNames = TableNames(finalTableName = tableName, tempTableName = tableName),
+                columnSchema =
+                    ColumnSchema(
+                        inputToFinalColumnNames = mapOf("col" to "col"),
+                        finalSchema =
+                            mapOf("col" to ColumnType(RedshiftDataType.VARCHAR.typeName, false)),
+                        inputSchema = emptyMap(),
+                    ),
+                importType = Append,
+            )
+
+        val result = mapper.toFinalSchema(tableSchema)
+
+        assertEquals(tableSchema, result)
+    }
+
+    // ================================================================
+    // colsConflict
+    // ================================================================
+
+    @Test
+    fun `colsConflict is case-insensitive`() {
+        assertTrue(mapper.colsConflict("MyColumn", "mycolumn"))
+        assertTrue(mapper.colsConflict("ABC", "abc"))
+        assertFalse(mapper.colsConflict("col_a", "col_b"))
+    }
+
+    companion object {
+        @JvmStatic
+        fun typeMapping() =
+            listOf(
+                // Simple types
+                Arguments.of(FieldType(BooleanType, false), "boolean"),
+                Arguments.of(FieldType(IntegerType, true), "bigint"),
+                Arguments.of(FieldType(NumberType, false), "numeric(38,9)"),
+                Arguments.of(FieldType(StringType, true), "varchar(65535)"),
+                // Temporal types
+                Arguments.of(FieldType(DateType, false), "date"),
+                Arguments.of(FieldType(TimeTypeWithTimezone, false), "timetz"),
+                Arguments.of(FieldType(TimeTypeWithoutTimezone, true), "time"),
+                Arguments.of(FieldType(TimestampTypeWithTimezone, false), "timestamptz"),
+                Arguments.of(FieldType(TimestampTypeWithoutTimezone, true), "timestamp"),
+                // Semi-structured types -> SUPER
+                Arguments.of(
+                    FieldType(ArrayType(FieldType(StringType, true)), false),
+                    "super",
+                ),
+                Arguments.of(FieldType(ArrayTypeWithoutSchema, true), "super"),
+                Arguments.of(
+                    FieldType(
+                        ObjectType(linkedMapOf("k" to FieldType(StringType, true))),
+                        false,
+                    ),
+                    "super",
+                ),
+                Arguments.of(FieldType(ObjectTypeWithEmptySchema, true), "super"),
+                Arguments.of(FieldType(ObjectTypeWithoutSchema, false), "super"),
+                Arguments.of(
+                    FieldType(
+                        UnionType(setOf(StringType, IntegerType), isLegacyUnion = false),
+                        true,
+                    ),
+                    "super",
+                ),
+                Arguments.of(
+                    FieldType(
+                        UnknownType(com.fasterxml.jackson.databind.node.NullNode.instance),
+                        false,
+                    ),
+                    "super",
+                ),
+            )
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `RedshiftTableSchemaMapper` which implements `TableSchemaMapper` to map Airbyte stream schemas to Redshift-specific table names, column names, and column types.
- Adds `RedshiftNamingUtils` (`String.toRedshiftCompatibleName()`) for converting identifiers to Redshift-compatible standard identifier format (alphanumeric + underscore, lowercase, digit-prefix handling).
- Includes full unit tests for both classes (`RedshiftTableSchemaMapperTest`, `RedshiftNamingUtilsTest`).