### PR TITLE
feat(source-typeform): remove API budget, set concurrency to 25 for rc.4

### DIFF
--- a/airbyte-integrations/connectors/source-typeform/manifest.yaml
+++ b/airbyte-integrations/connectors/source-typeform/manifest.yaml
@@ -10,10 +10,12 @@ api_budget:
   type: HTTPAPIBudget
   policies:
     - type: FixedWindowCallRatePolicy
-      period: PT1S
-      call_limit: 2
+      period: PT60S
+      call_limit: 120
       matchers:
         - {}
+  status_codes_for_ratelimit_hit:
+    - 429
 
 check:
   type: CheckStream

--- a/airbyte-integrations/connectors/source-typeform/manifest.yaml
+++ b/airbyte-integrations/connectors/source-typeform/manifest.yaml
@@ -14,8 +14,6 @@ api_budget:
       call_limit: 120
       matchers:
         - {}
-  status_codes_for_ratelimit_hit:
-    - 429
 
 check:
   type: CheckStream

--- a/airbyte-integrations/connectors/source-typeform/manifest.yaml
+++ b/airbyte-integrations/connectors/source-typeform/manifest.yaml
@@ -3,17 +3,8 @@ type: DeclarativeSource
 
 concurrency_level:
   type: ConcurrencyLevel
-  default_concurrency: 2
-  max_concurrency: 8
-
-api_budget:
-  type: HTTPAPIBudget
-  policies:
-    - type: FixedWindowCallRatePolicy
-      period: PT60S
-      call_limit: 120
-      matchers:
-        - {}
+  default_concurrency: 25
+  max_concurrency: 25
 
 check:
   type: CheckStream

--- a/airbyte-integrations/connectors/source-typeform/metadata.yaml
+++ b/airbyte-integrations/connectors/source-typeform/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: e7eff203-90bf-43e5-a240-19ea3056c474
-  dockerImageTag: 1.4.8-rc.3
+  dockerImageTag: 1.4.8-rc.4
   dockerRepository: airbyte/source-typeform
   documentationUrl: https://docs.airbyte.com/integrations/sources/typeform
   externalDocumentationUrls:

--- a/docs/integrations/sources/typeform.md
+++ b/docs/integrations/sources/typeform.md
@@ -106,7 +106,7 @@ The Forms, Responses, and Webhooks streams make separate API calls for each form
 
 | Version | Date       | Pull Request                                             | Subject                                                                                         |
 |:--------|:-----------|:---------------------------------------------------------|:------------------------------------------------------------------------------------------------|
-| 1.4.8-rc.4 | 2026-04-15 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) | Widen API budget window to 120/60s, add 429 detection |
+| 1.4.8-rc.4 | 2026-04-15 | [76363](https://github.com/airbytehq/airbyte/pull/76363) | Remove API budget, set concurrency to 25 |
 | 1.4.8-rc.3 | 2026-04-14 | [76319](https://github.com/airbytehq/airbyte/pull/76319) | Adjust default_concurrency from 3 to 2 for tuning retry |
 | 1.4.8-rc.2 | 2026-04-13 | [76270](https://github.com/airbytehq/airbyte/pull/76270) | Adjust default_concurrency from 4 to 3 for tuning retry |
 | 1.4.8-rc.1 | 2026-04-09 | [76204](https://github.com/airbytehq/airbyte/pull/76204) | Add concurrency_level and HTTPAPIBudget for concurrent stream reads |

--- a/docs/integrations/sources/typeform.md
+++ b/docs/integrations/sources/typeform.md
@@ -106,8 +106,10 @@ The Forms, Responses, and Webhooks streams make separate API calls for each form
 
 | Version | Date       | Pull Request                                             | Subject                                                                                         |
 |:--------|:-----------|:---------------------------------------------------------|:------------------------------------------------------------------------------------------------|
-| 1.4.8-rc.2 | 2026-04-13 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) | Adjust default_concurrency from 4 to 3 for tuning retry |
-| 1.4.8-rc.1 | 2026-04-09 | [76204](https://github.com/airbytehq/airbyte/pull/76204) | Add concurrency_level for concurrent stream reads |
+| 1.4.8-rc.4 | 2026-04-15 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) | Widen API budget window to 120/60s, add 429 detection |
+| 1.4.8-rc.3 | 2026-04-14 | [76319](https://github.com/airbytehq/airbyte/pull/76319) | Adjust default_concurrency from 3 to 2 for tuning retry |
+| 1.4.8-rc.2 | 2026-04-13 | [76270](https://github.com/airbytehq/airbyte/pull/76270) | Adjust default_concurrency from 4 to 3 for tuning retry |
+| 1.4.8-rc.1 | 2026-04-09 | [76204](https://github.com/airbytehq/airbyte/pull/76204) | Add concurrency_level and HTTPAPIBudget for concurrent stream reads |
 | 1.4.7 | 2026-04-02 | [76030](https://github.com/airbytehq/airbyte/pull/76030) | Promoted release candidate to GA |
 | 1.4.7-rc.2 | 2026-03-31 | [75898](https://github.com/airbytehq/airbyte/pull/75898) | Update CDK to 7.15.0 |
 | 1.4.7-rc.1 | 2026-03-26 | [75506](https://github.com/airbytehq/airbyte/pull/75506) | Upgrade CDK version to 7.13.0 |


### PR DESCRIPTION
## What

Removes the `HTTPAPIBudget` entirely and increases `default_concurrency` to 25 for the next round of concurrency tuning (rc.4).

This is part of the ongoing concurrency tuning for source-typeform ([internal issue](https://github.com/airbytehq/airbyte-internal-issues/issues/15314)). Previous RCs:
- rc.1 (c=4, budget 2/1s): caused regressions on non-heartbeat connections
- rc.2 (c=3, budget 2/1s): stalling syncs, rolled back
- rc.3 (c=2, budget 2/1s): budget itself caused stalling via proactive throttling

The `FixedWindowCallRatePolicy` at 2 req/s with a 1-second window was starving workers even at the lowest concurrency (c=2). Per Sophie's direction: remove the budget entirely and let the CDK handle 429 retries with exponential backoff, and set concurrency to 25.

## How

Two changes to `manifest.yaml`:

1. **Removed `api_budget` block entirely** — no more client-side rate limiting. The connector will rely on Typeform's server-side 429 enforcement + CDK retry logic.
2. **Set `default_concurrency: 25` and `max_concurrency: 25`** (up from 2/8).

Also backfills changelog entries for rc.2 and rc.3 with correct PR numbers.

## Review guide

1. `airbyte-integrations/connectors/source-typeform/manifest.yaml` — budget removal + concurrency change
2. `airbyte-integrations/connectors/source-typeform/metadata.yaml` — version bump to `1.4.8-rc.4`
3. `docs/integrations/sources/typeform.md` — changelog updates

**⚠️ Items for human reviewer to verify:**
- [ ] **c=25 with no budget is intentional** — Typeform's documented rate limit is 2 req/s. This will cause frequent 429s under load, handled by CDK retry/backoff. Confirm this is the desired approach vs. a gentler ramp.
- [ ] **`max_concurrency` = `default_concurrency` = 25** — there is no headroom for the CDK to auto-scale. Is this intentional?

## User Impact

Syncs for source-typeform connections pinned to this RC will run with 25 concurrent workers and no client-side rate limiting. This may cause more 429 responses from the Typeform API, but the CDK handles these with exponential backoff. Syncs should no longer stall due to proactive throttling.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/6dcb0ce3acb04fdaa5d90bad560ac37f
Requested by: @sophiecuiy