### PR TITLE
docs: display burst tag image as block instead of inline

### DIFF
--- a/docs/platform/cloud/managing-airbyte-cloud/manage-data-workers.md
+++ b/docs/platform/cloud/managing-airbyte-cloud/manage-data-workers.md
@@ -97,7 +97,9 @@ Once your organization administrator enables on-demand capacity at the organizat
 
 You can also enable on-demand capacity when first creating a connection. The toggle appears in the connection configuration during setup.
 
-When you enable on-demand capacity on a connection, Airbyte automatically applies a "Burst" tag (![Burst](./assets/burst-tag.png)) with an orange gradient background and a star icon. You can filter connections by the Burst tag to see all on-demand connections at a glance. If you disable on-demand capacity, Airbyte removes the Burst tag automatically. For more information about tags, see [Tagging connections](/platform/using-airbyte/tagging).
+When you enable on-demand capacity on a connection, Airbyte automatically applies a "Burst" tag with an orange gradient background and a star icon. You can filter connections by the Burst tag to see all on-demand connections at a glance. If you disable on-demand capacity, Airbyte removes the Burst tag automatically. For more information about tags, see [Tagging connections](/platform/using-airbyte/tagging).
+
+![Burst tag](./assets/burst-tag.png)
 
 ### Identify queued connections
 


### PR DESCRIPTION
## What

Move the Burst tag image on the [data workers docs page](https://docs.airbyte.com/platform/cloud/managing-airbyte-cloud/manage-data-workers) from an inline position within the paragraph to a separate block image below the paragraph for better readability.

Requested by @matteogp.

## How

In `docs/platform/cloud/managing-airbyte-cloud/manage-data-workers.md`, removed the inline `![Burst](./assets/burst-tag.png)` from within the paragraph text and placed it as a standalone block image on its own line after the paragraph.

## Review guide

1. `docs/platform/cloud/managing-airbyte-cloud/manage-data-workers.md`

## User Impact

The Burst tag image now appears as a separate image below the paragraph instead of inline, making it easier to see.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---
[Devin session](https://app.devin.ai/sessions/97d681f531f449759f9487f60c7ce805)