### PR TITLE
docs(ai-agents): add PlanInformation component and plan front matter support

### DIFF
--- a/docusaurus/docusaurus.config.ts
+++ b/docusaurus/docusaurus.config.ts
@@ -19,6 +19,7 @@ const getRemarkPlugins = () => ({
   addButtonToTitle: require("./src/remark/addButtonToTitle"),
   npm2yarn: require("@docusaurus/remark-plugin-npm2yarn"),
   agentConnectorHeaderDecoration: require("./src/remark/agentConnectorHeaderDecoration"),
+  planInformation: require("./src/remark/planInformation"),
 });
 
 const plugins = getRemarkPlugins();
@@ -185,6 +186,7 @@ const config: Config = {
         },
         remarkPlugins: [
           plugins.agentConnectorHeaderDecoration,
+          plugins.planInformation,
           plugins.addButtonToTitle,
           [plugins.npm2yarn, { sync: true }],
         ],

--- a/docusaurus/src/components/PlanInformation.jsx
+++ b/docusaurus/src/components/PlanInformation.jsx
@@ -1,0 +1,64 @@
+import React from "react";
+import classNames from "classnames";
+
+import styles from "./PlanInformation.module.css";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import {
+  faCheck,
+  faQuestionCircle,
+  faXmark,
+} from "@fortawesome/free-solid-svg-icons";
+
+const Badge = ({ available, children, title }) => {
+  return (
+    <span
+      className={classNames(styles.badge, { [styles.available]: available })}
+      title={title}
+    >
+      <FontAwesomeIcon
+        icon={available ? faCheck : faXmark}
+        title={available ? "Available" : "Not available"}
+      />
+      <span>{children}</span>
+    </span>
+  );
+};
+
+/**
+ * @type {React.FC<{ plans: string }>}
+ */
+export const PlanInformation = ({ plans }) => {
+  const parsed = Object.fromEntries(
+    plans.split(",").map((p) => [p.trim(), true]),
+  );
+
+  const isAll = parsed["all"];
+  const free = isAll || parsed["free"];
+  const individual = isAll || parsed["individual"];
+  const team = isAll || parsed["team"];
+  const custom = isAll || parsed["custom"];
+
+  return (
+    <div className={styles.badges}>
+      <Badge available={free} title="Included in the Free plan">
+        Free
+      </Badge>
+      <Badge available={individual} title="Included in the Individual plan">
+        Individual
+      </Badge>
+      <Badge available={team} title="Included in the Team plan">
+        Team
+      </Badge>
+      <Badge available={custom} title="Included in the Custom plan">
+        Custom
+      </Badge>
+      <a
+        href="https://airbyte.com/product/ai-agents"
+        target="_blank"
+        className={styles.helpIcon}
+      >
+        <FontAwesomeIcon icon={faQuestionCircle} /> Compare plans
+      </a>
+    </div>
+  );
+};

--- a/docusaurus/src/components/PlanInformation.module.css
+++ b/docusaurus/src/components/PlanInformation.module.css
@@ -1,0 +1,54 @@
+.badges {
+  margin-bottom: 1.5rem;
+  display: inline-flex;
+  gap: 8px;
+  align-items: center;
+  max-width: 100%;
+  overflow-x: auto;
+}
+
+.badge {
+  background: var(--color-dark-blue-40);
+  color: var(--color-dark-blue-700);
+  padding: 3px 8px;
+  border: 1px solid var(--color-dark-blue-40);
+  border-radius: 4px;
+  font-size: 0.75rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+html[data-theme="dark"] .badge {
+  background: var(--color-grey-40);
+  color: var(--ifm-color-emphasis-400);
+  border: none;
+}
+
+.badge:hover {
+  text-decoration: none;
+}
+
+.available {
+  background: var(--color-green-40);
+  color: var(--color-green-800);
+  border: 1px solid var(--color-green-800);
+}
+
+html[data-theme="dark"] .available {
+  background: var(--color-grey-40);
+  color: var(--color-gray-40);
+  border: 1px solid var(--color-dark-blue-40);
+}
+
+.helpIcon {
+  color: var(--ifm-font-color-base);
+  transition: color 0.2s ease;
+  font-size: 0.75rem;
+}
+
+.helpIcon:hover {
+  color: var(--ifm-color-primary);
+}

--- a/docusaurus/src/remark/planInformation.js
+++ b/docusaurus/src/remark/planInformation.js
@@ -1,0 +1,41 @@
+const { select } = require("unist-util-select");
+const { u } = require("unist-builder");
+
+const plugin = () => {
+  const transformer = async (ast, vfile) => {
+    // Run only on files that have `plan` set in their frontmatter.
+    if (!vfile.data?.frontMatter?.plan) {
+      return;
+    }
+
+    // Find first header in document
+    const heading = select("root > mdxJsxFlowElement[name='header']", ast);
+    const headingFallback = select("root > heading[depth='1']", ast);
+    const targetHeading = heading || headingFallback;
+
+    const headingIndex = ast.children.findIndex((ch) => ch === targetHeading);
+    if (headingIndex !== -1) {
+      // Create new <PlanInformation plans={frontmatter.plan} /> element
+      const planNode = u(
+        "mdxJsxFlowElement",
+        {
+          name: "PlanInformation",
+          attributes: [
+            {
+              type: "mdxJsxAttribute",
+              name: "plans",
+              value: vfile.data.frontMatter.plan,
+            },
+          ],
+        },
+        [],
+      );
+
+      // Add the PlanInformation JSX node right after the first header node
+      ast.children.splice(headingIndex + 1, 0, planNode);
+    }
+  };
+  return transformer;
+};
+
+module.exports = plugin;

--- a/docusaurus/src/theme/MDXComponents/index.js
+++ b/docusaurus/src/theme/MDXComponents/index.js
@@ -6,6 +6,7 @@ import { FieldAnchor } from "@site/src/components/FieldAnchor";
 import { HeaderDecoration } from "@site/src/components/HeaderDecoration";
 import { HideInUI } from "@site/src/components/HideInUI";
 import { Navattic } from "@site/src/components/Navattic";
+import { PlanInformation } from "@site/src/components/PlanInformation";
 import { ProductInformation } from "@site/src/components/ProductInformation";
 import { PyAirbyteExample } from "@site/src/components/PyAirbyteExample";
 import { SpecSchema } from "@site/src/components/SpecSchema";
@@ -30,6 +31,7 @@ export default {
   Navattic,
   SpecSchema,
   PyAirbyteExample,
+  PlanInformation,
   ProductInformation,
   Details,
   EntityRelationshipDiagram,


### PR DESCRIPTION
## What

Adds plan-tier badges (Free, Individual, Team, Custom) to the ai-agents Docusaurus docs instance, allowing documentation authors to indicate which Airbyte Agent plans a feature applies to. Resolves [AGENTIC-903](https://linear.app/airbyteio/issue/AGENTIC-903/add-plan-component-and-doc-metadata).

Supersedes draft PR #76208 which used incorrect plan names and cascading logic.

## How

1. **New `PlanInformation` component** (`docusaurus/src/components/PlanInformation.jsx` + CSS module) — renders four badge pills with check/cross icons. No inheritance logic: each plan must be explicitly specified. Supports `all` shorthand to enable all four plans.
2. **New `planInformation` remark plugin** (`docusaurus/src/remark/planInformation.js`) — reads `plan` from front matter and injects a `<PlanInformation>` JSX node after the first heading. Mirrors the existing `productInformation` remark plugin pattern, with a fix for the `headingIndex === 0` edge case (`headingIndex !== -1` instead of `if (headingIndex)`).
3. **Registered `PlanInformation` as a global MDX component** in `docusaurus/src/theme/MDXComponents/index.js`.
4. **Wired into the ai-agents docs instance only** in `docusaurus.config.ts`.

### Usage

Add a `plan` key to any ai-agents markdown file's front matter:

```yaml
---
plan: free, team
---
```

Valid values: `free`, `individual`, `team`, `custom`, `all`. If no `plan` key is specified, nothing is displayed.

## Review guide

1. `docusaurus/src/components/PlanInformation.jsx` — component logic and badge rendering
2. `docusaurus/src/components/PlanInformation.module.css` — styling (matches ProductInformation)
3. `docusaurus/src/remark/planInformation.js` — front matter-driven AST injection
4. `docusaurus/src/theme/MDXComponents/index.js` — global component registration (2 lines)
5. `docusaurus/docusaurus.config.ts` — plugin registration (2 lines)

## User Impact

Docs pages in the ai-agents instance can now display plan availability badges by adding a `plan` key to their front matter. No existing pages are affected — this PR only adds the infrastructure.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Requested by: @ian-at-airbyte

Link to Devin session: https://app.devin.ai/sessions/53066e5d7a6143889ba10d436378ebe7