### PR TITLE
fix(docs): replace stale `connector_registry_report.json` with live oss+cloud registries

### DIFF
--- a/docusaurus/src/components/ConnectorRegistry.jsx
+++ b/docusaurus/src/components/ConnectorRegistry.jsx
@@ -2,15 +2,101 @@ import { usePluginData } from "@docusaurus/useGlobalData";
 import TabItem from "@theme/TabItem";
 import Tabs from "@theme/Tabs";
 import { useEffect, useState } from "react";
-import { REGISTRY_URL } from "../constants";
+import { OSS_REGISTRY_URL, CLOUD_REGISTRY_URL } from "../constants";
 import styles from "./ConnectorRegistry.module.css";
 
 const iconStyle = { maxWidth: 25, maxHeight: 25 };
 
-async function fetchCatalog(url, setter) {
-  const response = await fetch(url);
-  const registry = await response.json();
-  setter(registry);
+const GITHUB_REPO_NAME = "airbytehq/airbyte";
+const CONNECTORS_PATH = "airbyte-integrations/connectors";
+
+function buildCompositeEntry(oss, cloud, connectorType, dockerRepository) {
+  const connectorName = dockerRepository.replace("airbyte/", "");
+  const definitionId =
+    oss?.sourceDefinitionId ||
+    oss?.destinationDefinitionId ||
+    cloud?.sourceDefinitionId ||
+    cloud?.destinationDefinitionId ||
+    "";
+
+  const githubUrl = `https://github.com/${GITHUB_REPO_NAME}/blob/master/${CONNECTORS_PATH}/${connectorName}`;
+  const issuesLabel = `connectors/${connectorType}/${connectorName.replace(`${connectorType}-`, "")}`;
+  const issueUrl = `https://github.com/${GITHUB_REPO_NAME}/issues?q=is:open+is:issue+label:${issuesLabel}`;
+
+  return {
+    connector_type: connectorType,
+    definitionId,
+    is_oss: oss != null,
+    is_cloud: cloud != null,
+    github_url: githubUrl,
+    issue_url: issueUrl,
+
+    name_oss: oss?.name || cloud?.name || "",
+    dockerRepository_oss: oss?.dockerRepository || dockerRepository,
+    dockerImageTag_oss: oss?.dockerImageTag || "",
+    supportLevel_oss: oss?.supportLevel || cloud?.supportLevel || "community",
+    iconUrl_oss: oss?.iconUrl || cloud?.iconUrl || "",
+    documentationUrl_oss: oss?.documentationUrl || cloud?.documentationUrl || "",
+
+    name_cloud: cloud?.name || oss?.name || "",
+    dockerRepository_cloud: cloud?.dockerRepository || "",
+    dockerImageTag_cloud: cloud?.dockerImageTag || "",
+    supportLevel_cloud: cloud?.supportLevel || "",
+    documentationUrl_cloud: cloud?.documentationUrl || "",
+  };
+}
+
+function mergeRegistries(ossRegistry, cloudRegistry) {
+  const ossSourcesByRepo = new Map();
+  for (const src of ossRegistry.sources || []) {
+    ossSourcesByRepo.set(src.dockerRepository, src);
+  }
+  const ossDestsByRepo = new Map();
+  for (const dst of ossRegistry.destinations || []) {
+    ossDestsByRepo.set(dst.dockerRepository, dst);
+  }
+  const cloudSourcesByRepo = new Map();
+  for (const src of cloudRegistry.sources || []) {
+    cloudSourcesByRepo.set(src.dockerRepository, src);
+  }
+  const cloudDestsByRepo = new Map();
+  for (const dst of cloudRegistry.destinations || []) {
+    cloudDestsByRepo.set(dst.dockerRepository, dst);
+  }
+
+  const allSourceRepos = new Set([
+    ...ossSourcesByRepo.keys(),
+    ...cloudSourcesByRepo.keys(),
+  ]);
+  const allDestRepos = new Set([
+    ...ossDestsByRepo.keys(),
+    ...cloudDestsByRepo.keys(),
+  ]);
+
+  const merged = [];
+  for (const repo of allSourceRepos) {
+    const oss = ossSourcesByRepo.get(repo) || null;
+    const cloud = cloudSourcesByRepo.get(repo) || null;
+    merged.push(buildCompositeEntry(oss, cloud, "source", repo));
+  }
+  for (const repo of allDestRepos) {
+    const oss = ossDestsByRepo.get(repo) || null;
+    const cloud = cloudDestsByRepo.get(repo) || null;
+    merged.push(buildCompositeEntry(oss, cloud, "destination", repo));
+  }
+  return merged;
+}
+
+async function fetchCatalog(setter) {
+  const [ossResponse, cloudResponse] = await Promise.all([
+    fetch(OSS_REGISTRY_URL),
+    fetch(CLOUD_REGISTRY_URL),
+  ]);
+  const [ossRegistry, cloudRegistry] = await Promise.all([
+    ossResponse.json(),
+    cloudResponse.json(),
+  ]);
+  setter(mergeRegistries(ossRegistry, cloudRegistry));
 }
 
 /*
@@ -122,7 +208,7 @@ export default function ConnectorRegistry({ type }) {
   const [enterpriseConnectors, setEnterpriseConnectors] = useState([]);
 
   useEffect(() => {
-    fetchCatalog(REGISTRY_URL, setRegistry);
+    fetchCatalog(setRegistry);
   }, []);
 
   useEffect(() => {

--- a/docusaurus/src/constants.ts
+++ b/docusaurus/src/constants.ts
@@ -1,2 +1,4 @@
-export const REGISTRY_URL =
-  "https://connectors.airbyte.com/files/generated_reports/connector_registry_report.json";
+export const OSS_REGISTRY_URL =
+  "https://connectors.airbyte.com/files/registries/v0/oss_registry.json";
+export const CLOUD_REGISTRY_URL =
+  "https://connectors.airbyte.com/files/registries/v0/cloud_registry.json";

--- a/docusaurus/src/helpers/clientRegistryUtils.js
+++ b/docusaurus/src/helpers/clientRegistryUtils.js
@@ -1,5 +1,8 @@
 // Client-side registry utilities
 // This works with URLs instead of vfiles and fetches data from the connector registry
+//
+// Fetches both the OSS and Cloud registries and merges them into a single
+// composite list, replacing the legacy connector_registry_report.json dependency.
 
 const connectorPageAlternativeEndings = ["-migrations", "-troubleshooting"];
 const connectorPageAlternativeEndingsRegExp = new RegExp(
@@ -7,16 +10,111 @@ const connectorPageAlternativeEndingsRegExp = new RegExp(
   "gi",
 );
 
-const REGISTRY_URL =
-  "https://connectors.airbyte.com/files/generated_reports/connector_registry_report.json";
+const OSS_REGISTRY_URL =
+  "https://connectors.airbyte.com/files/registries/v0/oss_registry.json";
+const CLOUD_REGISTRY_URL =
+  "https://connectors.airbyte.com/files/registries/v0/cloud_registry.json";
+
+const GITHUB_REPO_NAME = "airbytehq/airbyte";
+const CONNECTORS_PATH = "airbyte-integrations/connectors";
+
+function mergeRegistries(ossRegistry, cloudRegistry) {
+  const ossSourcesByRepo = new Map();
+  for (const src of ossRegistry.sources || []) {
+    ossSourcesByRepo.set(src.dockerRepository, src);
+  }
+  const ossDestsByRepo = new Map();
+  for (const dst of ossRegistry.destinations || []) {
+    ossDestsByRepo.set(dst.dockerRepository, dst);
+  }
+  const cloudSourcesByRepo = new Map();
+  for (const src of cloudRegistry.sources || []) {
+    cloudSourcesByRepo.set(src.dockerRepository, src);
+  }
+  const cloudDestsByRepo = new Map();
+  for (const dst of cloudRegistry.destinations || []) {
+    cloudDestsByRepo.set(dst.dockerRepository, dst);
+  }
+
+  const allSourceRepos = new Set([
+    ...ossSourcesByRepo.keys(),
+    ...cloudSourcesByRepo.keys(),
+  ]);
+  const allDestRepos = new Set([
+    ...ossDestsByRepo.keys(),
+    ...cloudDestsByRepo.keys(),
+  ]);
+
+  const merged = [];
+
+  for (const repo of allSourceRepos) {
+    const oss = ossSourcesByRepo.get(repo) || null;
+    const cloud = cloudSourcesByRepo.get(repo) || null;
+    merged.push(buildCompositeEntry(oss, cloud, "source", repo));
+  }
+
+  for (const repo of allDestRepos) {
+    const oss = ossDestsByRepo.get(repo) || null;
+    const cloud = cloudDestsByRepo.get(repo) || null;
+    merged.push(buildCompositeEntry(oss, cloud, "destination", repo));
+  }
+
+  return merged;
+}
+
+function buildCompositeEntry(oss, cloud, connectorType, dockerRepository) {
+  const connectorName = dockerRepository.replace("airbyte/", "");
+  const definitionId =
+    oss?.sourceDefinitionId ||
+    oss?.destinationDefinitionId ||
+    cloud?.sourceDefinitionId ||
+    cloud?.destinationDefinitionId ||
+    "";
+
+  const githubUrl = `https://github.com/${GITHUB_REPO_NAME}/blob/master/${CONNECTORS_PATH}/${connectorName}`;
+  const issuesLabel = `connectors/${connectorType}/${connectorName.replace(`${connectorType}-`, "")}`;
+  const issueUrl = `https://github.com/${GITHUB_REPO_NAME}/issues?q=is:open+is:issue+label:${issuesLabel}`;
+
+  return {
+    connector_type: connectorType,
+    definitionId,
+    is_oss: oss != null,
+    is_cloud: cloud != null,
+    github_url: githubUrl,
+    issue_url: issueUrl,
+
+    name_oss: oss?.name || cloud?.name || "",
+    dockerRepository_oss: oss?.dockerRepository || dockerRepository,
+    dockerImageTag_oss: oss?.dockerImageTag || "",
+    supportLevel_oss: oss?.supportLevel || cloud?.supportLevel || "community",
+    iconUrl_oss: oss?.iconUrl || cloud?.iconUrl || "",
+    documentationUrl_oss: oss?.documentationUrl || cloud?.documentationUrl || "",
+
+    name_cloud: cloud?.name || oss?.name || "",
+    dockerRepository_cloud: cloud?.dockerRepository || "",
+    dockerImageTag_cloud: cloud?.dockerImageTag || "",
+    supportLevel_cloud: cloud?.supportLevel || "",
+    documentationUrl_cloud: cloud?.documentationUrl || "",
+  };
+}
 
 const fetchRegistry = async () => {
   try {
-    const response = await fetch(REGISTRY_URL);
-    if (!response.ok) {
-      throw new Error(`Failed to fetch registry: ${response.statusText}`);
+    const [ossResponse, cloudResponse] = await Promise.all([
+      fetch(OSS_REGISTRY_URL),
+      fetch(CLOUD_REGISTRY_URL),
+    ]);
+    if (!ossResponse.ok) {
+      throw new Error(`Failed to fetch OSS registry: ${ossResponse.statusText}`);
     }
-    return await response.json();
+    if (!cloudResponse.ok) {
+      throw new Error(`Failed to fetch Cloud registry: ${cloudResponse.statusText}`);
+    }
+    const [ossRegistry, cloudRegistry] = await Promise.all([
+      ossResponse.json(),
+      cloudResponse.json(),
+    ]);
+    return mergeRegistries(ossRegistry, cloudRegistry);
   } catch (error) {
     console.error("Failed to fetch connector registry:", error);
     return [];

--- a/docusaurus/src/scripts/constants.js
+++ b/docusaurus/src/scripts/constants.js
@@ -3,8 +3,10 @@ const path = require("path");
 const DATA_DIR = path.join(__dirname, "..", "data");
 const REGISTRY_CACHE_PATH = path.join(DATA_DIR, "connector_registry_slim.json");
 const AGENT_CONNECTOR_MANIFEST_PATH = path.join(DATA_DIR, "agent_connectors.json");
-const REGISTRY_URL =
-  "https://connectors.airbyte.com/files/generated_reports/connector_registry_report.json";
+const OSS_REGISTRY_URL =
+  "https://connectors.airbyte.com/files/registries/v0/oss_registry.json";
+const CLOUD_REGISTRY_URL =
+  "https://connectors.airbyte.com/files/registries/v0/cloud_registry.json";
 
 // Connector documentation paths
 const CONNECTORS_DOCS_ROOT = "../docs/integrations";
@@ -16,7 +18,8 @@ module.exports = {
   DATA_DIR,
   REGISTRY_CACHE_PATH,
   AGENT_CONNECTOR_MANIFEST_PATH,
-  REGISTRY_URL,
+  OSS_REGISTRY_URL,
+  CLOUD_REGISTRY_URL,
   CONNECTORS_DOCS_ROOT,
   SOURCES_DOCS,
   DESTINATIONS_DOCS,

--- a/docusaurus/src/scripts/fetch-registry.js
+++ b/docusaurus/src/scripts/fetch-registry.js
@@ -152,7 +152,7 @@ async function fetchConnectorRegistriesFromRemote() {
 
 function extractMinimalRegistryData(fullRegistry) {
   return fullRegistry.map((connector) => ({
-    id: connector.name_oss || connector.name_cloud
+    id: (connector.name_oss || connector.name_cloud)
       ?.toLowerCase()
       .replace(/\s+/g, "-")
       .replace(/[^a-z0-9-]/g, ""),

--- a/docusaurus/src/scripts/fetch-registry.js
+++ b/docusaurus/src/scripts/fetch-registry.js
@@ -1,19 +1,24 @@
 /**
  * Utility to manage connector registry - fetching, caching, and extracting minimal data.
- * This is a separate utility so it can be reused by multiple scripts.
+ *
+ * Fetches both the OSS and Cloud registries from the CDN and merges them
+ * into a single composite list with `_oss` / `_cloud` suffixed fields.
+ * This replaces the previous dependency on the legacy
+ * `connector_registry_report.json` (which is no longer regenerated).
  */
 const fs = require("fs");
 const https = require("https");
-const { DATA_DIR, REGISTRY_CACHE_PATH, REGISTRY_URL } = require("./constants");
+const { DATA_DIR, REGISTRY_CACHE_PATH, OSS_REGISTRY_URL, CLOUD_REGISTRY_URL } = require("./constants");
 
-function fetchConnectorRegistryFromRemote() {
+const GITHUB_REPO_NAME = "airbytehq/airbyte";
+const CONNECTORS_PATH = "airbyte-integrations/connectors";
+
+function fetchJsonFromUrl(url) {
   return new Promise((resolve, reject) => {
-    console.log("Fetching connector registry data...");
-
     https
-      .get(REGISTRY_URL, (response) => {
+      .get(url, (response) => {
         if (response.statusCode !== 200) {
-          reject(new Error(`Failed to fetch registry: ${response.statusCode}`));
+          reject(new Error(`Failed to fetch ${url}: ${response.statusCode}`));
           return;
         }
 
@@ -25,25 +30,130 @@ function fetchConnectorRegistryFromRemote() {
 
         response.on("end", () => {
           try {
-            const registry = JSON.parse(data);
-            resolve(registry);
+            resolve(JSON.parse(data));
           } catch (error) {
             reject(
-              new Error(`Failed to parse registry data: ${error.message}`),
+              new Error(`Failed to parse data from ${url}: ${error.message}`),
             );
           }
         });
       })
       .on("error", (error) => {
-        reject(new Error(`Network error: ${error.message}`));
+        reject(new Error(`Network error fetching ${url}: ${error.message}`));
       });
   });
+}
+
+/**
+ * Merge the OSS and Cloud registries into a single flat list of connectors,
+ * with `_oss` / `_cloud` suffixed fields matching the shape that downstream
+ * consumers (remark plugins, sidebar, ConnectorRegistry.jsx) expect.
+ */
+function mergeRegistries(ossRegistry, cloudRegistry) {
+  const ossSourcesByRepo = new Map();
+  for (const src of ossRegistry.sources || []) {
+    ossSourcesByRepo.set(src.dockerRepository, src);
+  }
+  const ossDestsByRepo = new Map();
+  for (const dst of ossRegistry.destinations || []) {
+    ossDestsByRepo.set(dst.dockerRepository, dst);
+  }
+  const cloudSourcesByRepo = new Map();
+  for (const src of cloudRegistry.sources || []) {
+    cloudSourcesByRepo.set(src.dockerRepository, src);
+  }
+  const cloudDestsByRepo = new Map();
+  for (const dst of cloudRegistry.destinations || []) {
+    cloudDestsByRepo.set(dst.dockerRepository, dst);
+  }
+
+  const allSourceRepos = new Set([
+    ...ossSourcesByRepo.keys(),
+    ...cloudSourcesByRepo.keys(),
+  ]);
+  const allDestRepos = new Set([
+    ...ossDestsByRepo.keys(),
+    ...cloudDestsByRepo.keys(),
+  ]);
+
+  const merged = [];
+
+  for (const repo of allSourceRepos) {
+    const oss = ossSourcesByRepo.get(repo) || null;
+    const cloud = cloudSourcesByRepo.get(repo) || null;
+    merged.push(buildCompositeEntry(oss, cloud, "source", repo));
+  }
+
+  for (const repo of allDestRepos) {
+    const oss = ossDestsByRepo.get(repo) || null;
+    const cloud = cloudDestsByRepo.get(repo) || null;
+    merged.push(buildCompositeEntry(oss, cloud, "destination", repo));
+  }
+
+  return merged;
+}
+
+function buildCompositeEntry(oss, cloud, connectorType, dockerRepository) {
+  const connectorName = dockerRepository.replace("airbyte/", "");
+  const definitionId =
+    oss?.sourceDefinitionId ||
+    oss?.destinationDefinitionId ||
+    cloud?.sourceDefinitionId ||
+    cloud?.destinationDefinitionId ||
+    "";
+
+  const githubUrl = `https://github.com/${GITHUB_REPO_NAME}/blob/master/${CONNECTORS_PATH}/${connectorName}`;
+  const issuesLabel = `connectors/${connectorType}/${connectorName.replace(`${connectorType}-`, "")}`;
+  const issueUrl = `https://github.com/${GITHUB_REPO_NAME}/issues?q=is:open+is:issue+label:${issuesLabel}`;
+
+  return {
+    connector_type: connectorType,
+    definitionId,
+    is_oss: oss != null,
+    is_cloud: cloud != null,
+    github_url: githubUrl,
+    issue_url: issueUrl,
+
+    // OSS fields
+    name_oss: oss?.name || cloud?.name || "",
+    dockerRepository_oss: oss?.dockerRepository || dockerRepository,
+    dockerImageTag_oss: oss?.dockerImageTag || "",
+    supportLevel_oss: oss?.supportLevel || cloud?.supportLevel || "community",
+    iconUrl_oss: oss?.iconUrl || cloud?.iconUrl || "",
+    documentationUrl_oss: oss?.documentationUrl || cloud?.documentationUrl || "",
+    spec_oss: oss?.spec || null,
+    remoteRegistries_oss: oss?.remoteRegistries || {},
+    packageInfo_oss: oss?.packageInfo || null,
+    generated_oss: oss?.generated || null,
+
+    // Cloud fields
+    name_cloud: cloud?.name || oss?.name || "",
+    dockerRepository_cloud: cloud?.dockerRepository || "",
+    dockerImageTag_cloud: cloud?.dockerImageTag || "",
+    supportLevel_cloud: cloud?.supportLevel || "",
+    documentationUrl_cloud: cloud?.documentationUrl || "",
+    packageInfo_cloud: cloud?.packageInfo || null,
+    generated_cloud: cloud?.generated || null,
+  };
+}
+
+async function fetchConnectorRegistriesFromRemote() {
+  console.log("Fetching OSS and Cloud connector registries...");
+  const [ossRegistry, cloudRegistry] = await Promise.all([
+    fetchJsonFromUrl(OSS_REGISTRY_URL),
+    fetchJsonFromUrl(CLOUD_REGISTRY_URL),
+  ]);
+  console.log(
+    `Fetched ${(ossRegistry.sources || []).length + (ossRegistry.destinations || []).length} OSS connectors, ` +
+    `${(cloudRegistry.sources || []).length + (cloudRegistry.destinations || []).length} Cloud connectors`,
+  );
+  return mergeRegistries(ossRegistry, cloudRegistry);
 }
 
 function extractMinimalRegistryData(fullRegistry) {
   return fullRegistry.map((connector) => ({
     id: connector.name_oss || connector.name_cloud
-      .toLowerCase()
+      ?.toLowerCase()
       .replace(/\s+/g, "-")
       .replace(/[^a-z0-9-]/g, ""),
     // Properties used by sidebar-connectors.js
@@ -76,6 +186,13 @@ function extractMinimalRegistryData(fullRegistry) {
     packageInfo_cloud: connector.packageInfo_cloud || null,
     generated_oss: connector.generated_oss || null,
     generated_cloud: connector.generated_cloud || null,
+    // Properties used by ConnectorRegistry.jsx (client-side catalog page)
+    connector_type: connector.connector_type || "",
+    dockerRepository_cloud: connector.dockerRepository_cloud || "",
+    dockerImageTag_cloud: connector.dockerImageTag_cloud || "",
+    supportLevel_cloud: connector.supportLevel_cloud || "",
+    documentationUrl_cloud: connector.documentationUrl_cloud || "",
+    name_cloud: connector.name_cloud || "",
   }));
 }
 
@@ -87,8 +204,8 @@ async function fetchRegistry() {
     return minimalRegistry;
   }
 
-  // Fetch if cache doesn't exist
-  const fullRegistry = await fetchConnectorRegistryFromRemote();
+  // Fetch both registries and merge if cache doesn't exist
+  const fullRegistry = await fetchConnectorRegistriesFromRemote();
   const minimalRegistry = extractMinimalRegistryData(fullRegistry);
 
   // Ensure data directory exists
@@ -108,6 +225,6 @@ async function fetchRegistry() {
 
 module.exports = {
   fetchRegistry,
-  fetchConnectorRegistryFromRemote,
+  fetchConnectorRegistriesFromRemote,
   extractMinimalRegistryData,
 };


### PR DESCRIPTION
## What

After the registry 2.0 migration to the ops repo, `connector_registry_report.json` is no longer regenerated. The docs site depended on this file for all connector metadata — any connector published after the migration (e.g. `source-devin-ai`) was missing from it and defaulted to `supportLevel_oss: "archived"` via `buildArchivedRegistryEntry()`.

This PR replaces the single stale `connector_registry_report.json` dependency with live fetches from `oss_registry.json` + `cloud_registry.json`, merging them into the composite `_oss`/`_cloud` suffixed format that all downstream consumers expect.

## How

All 4 active consumers of the legacy report URL are updated:

1. **`scripts/constants.js`** — Replaces `REGISTRY_URL` with `OSS_REGISTRY_URL` + `CLOUD_REGISTRY_URL`
2. **`scripts/fetch-registry.js`** (build-time) — New `fetchJsonFromUrl()`, `mergeRegistries()`, and `buildCompositeEntry()` functions fetch both registries in parallel and merge by `dockerRepository` key. `extractMinimalRegistryData()` gains additional fields needed by the client-side catalog page.
3. **`constants.ts`** — TypeScript exports updated to match
4. **`helpers/clientRegistryUtils.js`** (client-side, per-page) — Same merge logic for runtime use on individual connector doc pages
5. **`components/ConnectorRegistry.jsx`** (client-side, catalog page) — Same merge logic for the full connector catalog component

### Updates since last revision

- **Fixed `id` field operator precedence bug** in `extractMinimalRegistryData`: wrapped `(connector.name_oss || connector.name_cloud)` in parentheses so the entire fallback gets lowercased and slug-normalized. Previously `name_oss` was used raw (e.g. `"MySQL"` instead of `"mysql"`). This was a pre-existing bug, not introduced by this PR.

## Review guide

> **⚠️ Key concern: code duplication.** The `mergeRegistries` / `buildCompositeEntry` logic is duplicated across three files (`fetch-registry.js`, `clientRegistryUtils.js`, `ConnectorRegistry.jsx`) due to the CJS/ESM boundary. Reviewers should decide if this is acceptable or if a shared module should be extracted.

1. `docusaurus/src/scripts/fetch-registry.js` — Core merge logic + build-time fetch. This is the canonical implementation.
2. `docusaurus/src/helpers/clientRegistryUtils.js` — Client-side duplicate of merge logic for per-page registry lookups.
3. `docusaurus/src/components/ConnectorRegistry.jsx` — Client-side duplicate for the catalog page. **Note: `fetchCatalog()` has no error handling unlike `clientRegistryUtils.js`.**
4. `docusaurus/src/scripts/constants.js` + `docusaurus/src/constants.ts` — URL changes (straightforward).

### Items for human review

- [ ] **`id` normalization change**: The parenthesization fix means all connector `id` values will now be slug-normalized (e.g. `"mysql"` instead of `"MySQL"`). Verify nothing downstream relies on the old un-normalized `id` format.
- [ ] **`supportLevel_oss` default for cloud-only connectors**: `buildCompositeEntry` defaults `supportLevel_oss` to `cloud?.supportLevel || "community"` when `oss` is null. The old `buildArchivedRegistryEntry` used `"archived"`. Confirm this is the desired behavior.
- [ ] **Client-side performance**: Previously one HTTP request; now two parallel requests per page load. The registry JSON files are large (~600 connectors each with specs). Consider whether the build-time cache should also serve the client-side catalog page.
- [ ] **Missing error handling**: `ConnectorRegistry.jsx`'s `fetchCatalog()` lacks try/catch — a network error will propagate as an unhandled rejection. `clientRegistryUtils.js` handles this correctly.

## User Impact

Connectors published via the new registry 2.0 pipeline will now correctly appear with their actual `supportLevel` on docs.airbyte.com instead of incorrectly showing as "Archived". Specifically, `source-devin-ai` will show as "Marketplace" (community) rather than "Archived".

No connectors that previously displayed correctly should be affected — the merged output produces the same `_oss`/`_cloud` field shape as the legacy report.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Reverting would restore the legacy `connector_registry_report.json` dependency. Existing connectors that were already in that file would continue to display correctly; only newly published connectors would revert to showing as "Archived".

Link to Devin session: https://app.devin.ai/sessions/ced46ff2da3f4dc8828c60b949c4eafe
Requested by: @aaronsteers