### PR TITLE
docs(ai-agents): populate admin/billing content from mockup

### DIFF
--- a/docs/ai-agents/admin/billing.md
+++ b/docs/ai-agents/admin/billing.md
@@ -29,7 +29,7 @@ A plan to explore Airbyte Agents and prototype agents.
 
 ### Individual
 
-A plan for personal use and daily workflows.
+A plan for personal use and daily work.
 
 - $29 per month.
 - 1,000 AOs per month.

--- a/docs/ai-agents/admin/billing.md
+++ b/docs/ai-agents/admin/billing.md
@@ -12,10 +12,6 @@ Each time your agent works for you, it consumes AOs. Your plan determines:
 - Whether you can exceed that limit and how much overage costs.
 - How often Airbyte refreshes data in your Context Store.
 
-:::note
-Airbyte is iterating on how it meters AOs. The relative cost of different operations can change. Use the [Usage panel](#monitor-usage) to see how your activity translates to AOs in practice.
-:::
-
 ## Plans you can choose from
 
 Airbyte Agents offers four plans. Free and Individual are self-serve. You can upgrade to them directly from the Billing page. Team and Custom plans are sales-assisted. Contact [Airbyte Sales](https://airbyte.com/company/talk-to-sales) to sign up for these plans.

--- a/docs/ai-agents/admin/billing.md
+++ b/docs/ai-agents/admin/billing.md
@@ -18,7 +18,7 @@ Airbyte Agents offers four plans. Free and Individual are self-serve. You can up
 
 ### Free
 
-A plan to explore Agent Engine and prototype agents.
+A plan to explore Airbyte Agents and prototype agents.
 
 - $0 per month.
 - 1,000 AOs per month.

--- a/docs/ai-agents/admin/billing.md
+++ b/docs/ai-agents/admin/billing.md
@@ -4,43 +4,194 @@ Airbyte Agents bills you based on a unit of measurement called agentic operation
 
 ## What's an agentic operation?
 
-Agentic operations represent the processing intensity of a prompt and how much work the agent needs to do to answer the prompt. AOs are derived through a combination of tool calls and token usage. Simple tasks typically make fewer tool calls and use fewer tokens, so they use fewer AOs. Complex reasoning tasks typically make more tool calls and use more tokens, so they use more AOs.
+An agentic operation represents the processing intensity of a prompt and how much work the agent does to answer it. Airbyte derives AOs from a combination of tool calls and token usage. Simple tasks typically make fewer tool calls and use fewer tokens, so they consume fewer AOs. Complex reasoning tasks typically make more tool calls and use more tokens, so they consume more AOs.
 
-Each time your agent works for you, it consumes AOs.
+Each time your agent works for you, it consumes AOs. Your plan determines:
 
-### Your plan determines your AOs
+- How many free AOs you have each month.
+- Whether you can exceed that limit and how much overage costs.
+- How often Airbyte refreshes data in your Context Store.
 
-- How many free AOs you have
-- How much AO overage costs
+:::note
+Airbyte is iterating on how it meters AOs. The relative cost of different operations can change. Use the [Usage panel](#monitor-usage) to see how your activity translates to AOs in practice.
+:::
 
 ## Plans you can choose from
 
-- Free
-- Individual
-- Team
-- Custom
+Airbyte Agents offers four plans. Free and Individual are self-serve. You can upgrade to them directly from the Billing page. Team and Custom plans are sales-assisted. Contact [Airbyte Sales](https://airbyte.com/company/talk-to-sales) to sign up for these plans.
+
+### Free
+
+A plan to explore Agent Engine and prototype agents.
+
+- $0 per month.
+- 1,000 AOs per month.
+- Daily limit of 500 AOs. When you reach the daily limit, agent operations pause until the next day.
+- Overage isn't available. When you reach your monthly limit, agent operations pause until the next billing period.
+- Context Store refreshes hourly during your first month, then daily.
+- AI and community support.
+
+### Individual
+
+A plan for personal use and daily workflows.
+
+- $29 per month.
+- 1,000 AOs per month.
+- No daily limit.
+- Overage AOs are available.
+- Context Store refreshes hourly.
+- Standard human support, in addition to AI and community support.
+
+You must [add a payment method](#add-a-payment-method) before you upgrade to the Individual plan.
+
+### Team
+
+A plan for teams running more automations.
+
+- $299 per month.
+- 10,000 AOs per month.
+- No daily limit.
+- Overage AOs are available.
+- Context Store refreshes hourly.
+- Multiple workspaces and an authentication module.
+- Single sign-on and SAML.
+- Standard human support, in addition to AI and community support.
+
+### Custom
+
+A plan for large companies and embedded products. Airbyte tailors pricing, usage limits, and feature access to your needs. Custom plans include:
+
+- A dedicated account manager.
+- Service level agreements.
+- Dedicated human support.
+- Everything included in the Team plan.
 
 ## Manage payments
 
+Manage payment methods, billing information, and your maximum bill from the Billing page.
+
 ### Add a payment method
+
+If you don't have a payment method on file, the Payment Method card shows **No payment method on file**.
+
+1. On the Billing page, in the Payment Method card, click **Add payment method**.
+2. Enter your card details and billing address.
+3. Click **Save**.
+
+Adding a payment method is a prerequisite for upgrading to the Individual plan. Team and Custom plans are sales-assisted, and Airbyte configures billing as part of your contract.
 
 ### Update your payment method
 
-### Set a maximum bill
+To replace the card on file:
+
+1. On the Billing page, in the Payment Method card, click **Update**.
+2. Enter the new card details.
+3. Click **Save**.
+
+### Update your billing information
+
+Your billing information is the email address and mailing address Airbyte uses on invoices and receipts.
+
+1. On the Billing page, in the Billing Information card, click **Update**.
+2. Update the contact email or address.
+3. Click **Save**.
+
+### Set a maximum bill {#maximum-bill}
+
+A maximum bill is a spending cap for a single billing period. If your bill reaches the amount you set, Airbyte pauses all agent operations and stops adding charges until the next billing period begins.
+
+1. On the Billing page, in the Maximum Bill card, click **Edit**.
+2. Enter an amount in U.S. dollars.
+3. Click **Save**.
+
+To remove your maximum bill, click **Edit**, clear the value, and click **Save**. The card shows **No limit set** when no cap is in place.
+
+:::tip
+Set a maximum bill even if you don't expect to exceed your included AOs. This protects you from unexpected charges caused by unintended automations, stuck loops, or mistakes in an agent configuration.
+:::
 
 ## Monitor usage
 
+The Usage panel on the Billing page shows how your activity consumes AOs and tool calls over time.
+
+### View usage
+
+Use the toggle to switch between a table view and a chart view.
+
+- **Chart**: A stacked bar chart of included AOs and overage AOs over the selected time range. Click a legend item to hide or show that series. Hover over a bar to see the AO and tool call breakdown for that bucket.
+- **Table**: Individual entries for each session or invocation, with the date, source, AO count, and tool call count. Entries that exceed your monthly included AOs display an **Overage** badge.
+
+### Filter usage
+
+Filter the Usage panel to focus on a specific source or time range:
+
+- **Source**: Filter by where the activity originated. Sources include Chat, Automation, Automation Builder Chat, MCP, API, and SDK.
+- **Billing period**: Choose the current billing period or one of the last five billing periods.
+- **Custom range**: Pick any start and end date to view usage across an arbitrary window.
+
+Rows from Chat, Automation, and Automation Builder Chat link to the originating session, so you can investigate what drove a particular spike.
+
+### Understand included and overage AOs
+
+Airbyte splits your usage into two buckets:
+
+- **Included AOs**: AOs that fit within your monthly included allowance.
+- **Overage AOs**: AOs that exceed your monthly allowance, billed at your plan's overage rate.
+
+The Usage panel summary shows the totals for both. The Free plan can't exceed its monthly allowance, so it never accrues overage AOs.
+
 ## Invoices
 
-Airbyte bills the payment method on file once per month.
+Airbyte bills the payment method on file once per month. Find past invoices on the Billing page in the Invoices panel.
+
+Each row shows the invoice date, amount, status, and actions.
+
+- **Paid**: Airbyte successfully charged your payment method.
+- **Not Paid**: Airbyte couldn't charge your payment method, or the invoice isn't paid yet.
 
 ### Pay an invoice
 
-### Automatic invoice at $2000
+If an invoice is Not Paid, the Payment Method card displays a banner that tells you how many unpaid invoices you have and their total amount.
+
+To pay an unpaid invoice:
+
+1. On the Billing page, find the invoice in the Invoices panel.
+2. Click **Pay now**.
+3. Confirm the payment method and complete the charge.
+
+If you can't pay with the card on file, [update your payment method](#update-your-payment-method) first, then retry.
+
+### Download an invoice
+
+In the Invoices panel, click the download icon next to an invoice to save a copy.
+
+### Automatic invoice at $2,000 {#auto-bill}
+
+If your charges for a billing period reach $2,000, Airbyte automatically issues an invoice and bills the payment method on file. This is in addition to your regular monthly invoice. After the automatic invoice, charges continue to accrue normally for the rest of the billing period.
+
+The $2,000 automatic invoice is independent of your [maximum bill](#maximum-bill). The automatic invoice is how Airbyte collects what you already owe. The maximum bill is how you tell Airbyte to stop adding charges.
 
 ## Avoid billing surprises
 
-To avoid billing surprises, Airbyte offers two capabilities. We strongly encourage you to rely on these tools to avoid unexpected charges.
+To avoid billing surprises, Airbyte offers two capabilities. Airbyte strongly encourages you to rely on these tools to avoid unexpected charges.
 
-- If you reach $2000 in a given billing period, we [automatically generate an invoice and bill you](#auto-bill).
-- You can set a [maximum bill](#maximum-bill) to ensure you're never charged more than you're willing to pay.
+- If your charges reach $2,000 in a billing period, Airbyte [automatically generates an invoice and bills you](#auto-bill).
+- You can set a [maximum bill](#maximum-bill) so you're never charged more than you're willing to pay in a billing period.
+
+## Cancel your subscription
+
+You can cancel a paid subscription from the Billing page. When you cancel:
+
+- Active syncs stop running.
+- Airbyte permanently deletes cached data in the Context Store.
+- Airbyte removes your connector configurations.
+- Airbyte revokes your API keys.
+- Human support access ends.
+
+Your subscription stays active until the end of your current billing period, and Airbyte won't charge you for the following period.
+
+To cancel:
+
+1. On the Billing page, in the Subscription card, click **Change your plan**.
+2. Select the Free plan, or contact Airbyte to cancel a Custom plan.
+3. Review what you'll lose access to, and confirm the cancellation.

--- a/docs/ai-agents/admin/readme.md
+++ b/docs/ai-agents/admin/readme.md
@@ -1,1 +1,3 @@
-# Acount and administration
+# Account and administration
+
+Manage your Airbyte Agents account. This section covers [billing](./billing.md), including plans, payments, usage monitoring, invoices, and subscription changes.

--- a/docs/vale-styles/config/vocabularies/Airbyte/accept.txt
+++ b/docs/vale-styles/config/vocabularies/Airbyte/accept.txt
@@ -25,6 +25,11 @@ Elastic License 2.0
 ELv2
 MIT
 Agent Engine
+[Aa]gent(ic)? [Oo]peration(s)?
+AO
+AOs
+[Aa]utomation(s)?
+SAML
 
 #
 # Common terms Airbyte uses


### PR DESCRIPTION
## What

Fills in the `docs/ai-agents/admin/billing.md` outline on the `docs-airbyte-agents` branch with content derived from the Lovable mockup in `airbyte-agent-engine` (`src/pages/dashboard/Billing.tsx` and `Plans.tsx`).

Stacked on `docs-airbyte-agents` so it merges into the outline PR first, not directly into master.

## How

- Expanded every outline section in `billing.md`: AO explainer, four plans (Free, Individual, Team, Custom), payment management, maximum bill, usage monitoring (chart/table + filters), invoices (pay / download / $2,000 auto-invoice), avoid-surprises cross-links, and a new Cancel-subscription section based on the cancellation dialog copy.
- Fixed the typo in `docs/ai-agents/admin/readme.md` ("Acount" → "Account") and added a one-line section intro linking to billing.
- Added `AOs`, agentic operation(s), automation(s), and `SAML` to `docs/vale-styles/config/vocabularies/Airbyte/accept.txt` so the new doc passes Vale spellcheck.
- Followed the style guide: sentence-case headings, imperative voice, numbered steps, `:::note` / `:::tip` admonitions, and explicit anchor IDs (`#maximum-bill`, `#auto-bill`) that match existing cross-links.
- Per reviewer guidance, deliberately avoided specific AO calculation formulas (pricing/metering is in flux) and marked Team/Custom as strictly sales-assisted. No external "How we bill" link — the canonical URL will be this page itself.
- Linting: `markdownlint-cli2` passes with 0 errors. `vale` passes with 0 errors (1 warning for "sign-on" inside the phrase "Single sign-on" and 1 suggestion about the literal UI label "Not Paid" — both safe to ignore).

## Review guide

1. `docs/ai-agents/admin/billing.md` — the bulk of the change. Please sanity-check the factual claims sourced from the mockup, especially:
    - Plan prices ($0 / $29 / $299), monthly AO limits (1,000 / 1,000 / 10,000), Free daily cap of 500, overage rates ($0.004 / $0.005) — these come from `Plans.tsx` and may need to match final pricing.
    - Context Store refresh cadence (hourly for first month then daily on Free; hourly on paid).
    - $2,000 automatic invoice threshold and its interaction with Maximum Bill.
    - Cancellation consequences list (syncs stop, Context Store deleted, connector configs removed, API keys revoked, human support access ends) — paraphrased from the cancel dialog.
2. `docs/ai-agents/admin/readme.md` — typo fix + one-line intro.
3. `docs/vale-styles/config/vocabularies/Airbyte/accept.txt` — new accepted vocabulary. Global effect on Vale across the repo; the additions are narrow (AO/AOs, automations, SAML, "agent(ic) operation(s)").

## User Impact

Readers of the Agent Engine docs get a complete Billing page with real guidance on plans, payments, usage monitoring, invoices, and cancellation, instead of an outline of empty headings. No code impact.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

Link to Devin session: https://app.devin.ai/sessions/6fedaad169ef4768916d27c13cb9ee44
Requested by: @ian-at-airbyte