### PR TITLE
chore: bump cdk fix coercer injection.

### DIFF
--- a/airbyte-integrations/connectors/destination-gcs-data-lake/gradle.properties
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/gradle.properties
@@ -1,3 +1,3 @@
 testExecutionConcurrency=1
-cdkVersion=1.0.7
+cdkVersion=1.0.9
 JunitMethodExecutionTimeout=10m

--- a/airbyte-integrations/connectors/destination-gcs-data-lake/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/metadata.yaml
@@ -21,7 +21,7 @@ data:
             alias: airbyte-connector-testing-secret-store
   connectorType: destination
   definitionId: 8c8a2d3e-1b4f-4a9c-9e7d-6f5a4b3c2d1e
-  dockerImageTag: 1.0.8
+  dockerImageTag: 1.0.9
   dockerRepository: airbyte/destination-gcs-data-lake
   documentationUrl: https://docs.airbyte.com/integrations/destinations/gcs-data-lake
   githubIssueLabel: destination-gcs-data-lake

--- a/airbyte-integrations/connectors/destination-gcs-data-lake/src/test-integration/kotlin/io/airbyte/integrations/destination/gcs_data_lake/GcsDataLakeTestUtil.kt
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/src/test-integration/kotlin/io/airbyte/integrations/destination/gcs_data_lake/GcsDataLakeTestUtil.kt
@@ -6,6 +6,7 @@ package io.airbyte.integrations.destination.gcs_data_lake
 
 import io.airbyte.cdk.command.ConfigurationSpecification
 import io.airbyte.cdk.command.ValidatedJsonUtils
+import io.airbyte.cdk.load.data.AirbyteValueCoercer
 import io.airbyte.cdk.load.toolkits.iceberg.parquet.SimpleTableIdGenerator
 import io.airbyte.cdk.load.toolkits.iceberg.parquet.TableIdGenerator
 import io.airbyte.cdk.load.toolkits.iceberg.parquet.io.IcebergUtil
@@ -37,7 +38,8 @@ object GcsDataLakeTestUtil {
         tableIdGenerator: TableIdGenerator = SimpleTableIdGenerator(config.namespace),
     ): Catalog {
         // Create utility instances for test
-        val icebergUtil = IcebergUtil(tableIdGenerator)
+        val icebergUtil =
+            IcebergUtil(tableIdGenerator, AirbyteValueCoercer(useFastTimestampParsing = true))
         val gcsDataLakeCatalogUtil = GcsDataLakeCatalogUtil(icebergUtil)
 
         val properties = gcsDataLakeCatalogUtil.toCatalogProperties(config)

--- a/docs/integrations/destinations/gcs-data-lake.md
+++ b/docs/integrations/destinations/gcs-data-lake.md
@@ -218,6 +218,7 @@ This destination supports [namespaces](https://docs.airbyte.com/platform/using-a
 
 | Version | Date       | Pull Request                                                 | Subject                                                                               |
 |:--------|:-----------|:-------------------------------------------------------------|:--------------------------------------------------------------------------------------|
+| 1.0.9   | 2026-04-16 | [76406](https://github.com/airbytehq/airbyte/pull/76406)     | Upgrade CDK to 1.0.9.                                                                 |
 | 1.0.8   | 2026-03-30 | [75630](https://github.com/airbytehq/airbyte/pull/75630)     | Upgrade CDK to 1.0.7: fix sort order handling during schema evolution.                |
 | 1.0.7   | 2026-02-04 | [72855](https://github.com/airbytehq/airbyte/pull/72855)     | Upgrade CDK to 0.2.8                                                                  |
 | 1.0.6   | 2026-01-23 | [72300](https://github.com/airbytehq/airbyte/pull/72300)     | Upgrade CDK to 0.2.0                                                                  |


### PR DESCRIPTION
## What
Upgrade GCS Data Lake to CDK 1.0.9, adapting to the AirbyteValueCoercer singleton refactor.
## How
- Bump CDK to 1.0.9
- Pass explicit AirbyteValueCoercer instance to IcebergUtil in test utilities
## Recommended reading order
1. `GcsDataLakeTestUtil.kt`
## User Impact
No user-facing change.
## Can this PR be safely reverted and rolled back?
- [x] YES
- [ ] NO