### PR TITLE
chore(source-sendgrid): Increase HTTPAPIBudget rate limit from 50 to 70 req/s (1.3.29-rc.1)

### DIFF
--- a/airbyte-integrations/connectors/source-sendgrid/manifest.yaml
+++ b/airbyte-integrations/connectors/source-sendgrid/manifest.yaml
@@ -684,7 +684,7 @@ api_budget:
   policies:
     - type: MovingWindowCallRatePolicy
       rates:
-        - limit: 50
+        - limit: 70
           interval: PT1S
       matchers: []
   ratelimit_reset_header: X-RateLimit-Reset

--- a/airbyte-integrations/connectors/source-sendgrid/metadata.yaml
+++ b/airbyte-integrations/connectors/source-sendgrid/metadata.yaml
@@ -39,10 +39,8 @@ data:
   registryOverrides:
     cloud:
       enabled: true
-      dockerImageTag: 1.3.28
     oss:
       enabled: true
-      dockerImageTag: 1.3.28
   releaseStage: generally_available
   suggestedStreams:
     streams:

--- a/airbyte-integrations/connectors/source-sendgrid/metadata.yaml
+++ b/airbyte-integrations/connectors/source-sendgrid/metadata.yaml
@@ -10,10 +10,10 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: fbb5fbe2-16ad-4cf4-af7d-ff9d9c316c87
-  dockerImageTag: 1.3.29
+  dockerImageTag: 1.3.30-rc.1
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
     breakingChanges:
       1.0.0:
         message: This release makes several changes that upgrade the Sendgrid connector. The configuration options have been renamed to `api_key` and `start_date`. `start_date` is now required. The `unsubscribe_groups` stream has been removed. It was the same as `suppression_groups`. You can use that and get the same data. The `single_sends` stream has been renamed `singlesend_stats`. This is closer to the data and API. The `segments` stream has been upgraded to use the Sendgrid 2.0 API because the older one has been deprecated. The schema has changed as a result. To ensure a smooth upgrade, please refresh your schemas and reset your data before resuming syncs.
@@ -39,8 +39,10 @@ data:
   registryOverrides:
     cloud:
       enabled: true
+      dockerImageTag: 1.3.28
     oss:
       enabled: true
+      dockerImageTag: 1.3.28
   releaseStage: generally_available
   suggestedStreams:
     streams:

--- a/airbyte-integrations/connectors/source-sendgrid/metadata.yaml
+++ b/airbyte-integrations/connectors/source-sendgrid/metadata.yaml
@@ -10,10 +10,10 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: fbb5fbe2-16ad-4cf4-af7d-ff9d9c316c87
-  dockerImageTag: 1.3.28
+  dockerImageTag: 1.3.29-rc.1
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
     breakingChanges:
       1.0.0:
         message: This release makes several changes that upgrade the Sendgrid connector. The configuration options have been renamed to `api_key` and `start_date`. `start_date` is now required. The `unsubscribe_groups` stream has been removed. It was the same as `suppression_groups`. You can use that and get the same data. The `single_sends` stream has been renamed `singlesend_stats`. This is closer to the data and API. The `segments` stream has been upgraded to use the Sendgrid 2.0 API because the older one has been deprecated. The schema has changed as a result. To ensure a smooth upgrade, please refresh your schemas and reset your data before resuming syncs.
@@ -39,8 +39,10 @@ data:
   registryOverrides:
     cloud:
       enabled: true
+      dockerImageTag: 1.3.28
     oss:
       enabled: true
+      dockerImageTag: 1.3.28
   releaseStage: generally_available
   suggestedStreams:
     streams:

--- a/docs/integrations/sources/sendgrid.md
+++ b/docs/integrations/sources/sendgrid.md
@@ -105,6 +105,7 @@ If you encounter 403 errors, check the following:
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                                                                                                                           |
 |:--------|:-----------| :------------------------------------------------------- |:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1.3.30-rc.1 | 2026-04-16 | [76407](https://github.com/airbytehq/airbyte/pull/76407) | Increase HTTPAPIBudget rate limit from 50 to 70 req/s |
 | 1.3.29 | 2026-04-21 | [75796](https://github.com/airbytehq/airbyte/pull/75796) | Update dependencies |
 | 1.3.28 | 2026-04-14 | [76335](https://github.com/airbytehq/airbyte/pull/76335) | Promoted release candidate to GA |
 | 1.3.28-rc.5 | 2026-04-13 | [74713](https://github.com/airbytehq/airbyte/pull/74713) | Add HTTPAPIBudget rate limiting (Phase 2) with concurrency=6 |

--- a/docs/integrations/sources/sendgrid.md
+++ b/docs/integrations/sources/sendgrid.md
@@ -105,6 +105,7 @@ If you encounter 403 errors, check the following:
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                                                                                                                           |
 |:--------|:-----------| :------------------------------------------------------- |:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1.3.29-rc.1 | 2026-04-16 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Increase HTTPAPIBudget rate limit from 50 to 70 req/s |
 | 1.3.28 | 2026-04-14 | [76335](https://github.com/airbytehq/airbyte/pull/76335) | Promoted release candidate to GA |
 | 1.3.28-rc.5 | 2026-04-13 | [74713](https://github.com/airbytehq/airbyte/pull/74713) | Add HTTPAPIBudget rate limiting (Phase 2) with concurrency=6 |
 | 1.3.28-rc.4 | 2026-04-12 | [74713](https://github.com/airbytehq/airbyte/pull/74713) | Add concurrency_level for parallel stream processing (concurrency=6) |


### PR DESCRIPTION
## What

Increases the source-sendgrid `HTTPAPIBudget` rate limit from 50 req/s to 70 req/s.

After promoting 1.3.28 (concurrency=6 + HTTPAPIBudget@50 req/s) to GA, analysis of RC.4 vs GA sync performance across 12 Tier 2 connections revealed that the 50 req/s budget was throttling source reads for higher-volume connections. Specifically, one BigQuery-destined connection syncing ~17K rows saw its `source_read_duration_seconds` double from ~71s to ~147s, indicating the budget was the bottleneck.

Raising the limit to 70 req/s should reduce unnecessary throttling for these connections while still providing rate limit protection.

## How

- Updated `manifest.yaml`: Changed `api_budget.policies[0].rates[0].limit` from 50 to 70
- Bumped version to `1.3.29-rc.1` via ops-mcp `bump_version_in_repo`
- Progressive rollout enabled for validation

## Review guide

1. `airbyte-integrations/connectors/source-sendgrid/manifest.yaml` — single line change (50 → 70)
2. `airbyte-integrations/connectors/source-sendgrid/metadata.yaml` — version bump + rollout config
3. `docs/integrations/sources/sendgrid.md` — changelog entry

## User Impact

Higher-volume SendGrid connections should see reduced sync duration as the source-side rate limiter is less likely to be the bottleneck. No negative user impact expected — 70 req/s is still well below SendGrid's general API ceiling (~100 req/s).

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/ae769e947058475ca43bea39b1ad318a
Requested by: @sophiecuiy