### PR TITLE
chore: bump cdk fix coercer injection.

### DIFF
--- a/airbyte-integrations/connectors/destination-postgres/gradle.properties
+++ b/airbyte-integrations/connectors/destination-postgres/gradle.properties
@@ -1,4 +1,4 @@
-cdkVersion=1.0.6
+cdkVersion=1.0.9
 # our testcontainer has issues with too much concurrency.
 # 4 threads seems to be the sweet spot.
 testExecutionConcurrency=4

--- a/airbyte-integrations/connectors/destination-postgres/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-postgres/metadata.yaml
@@ -6,7 +6,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 25c5221d-dce2-4163-ade9-739ef790f503
-  dockerImageTag: 3.0.12
+  dockerImageTag: 3.0.13
   dockerRepository: airbyte/destination-postgres
   documentationUrl: https://docs.airbyte.com/integrations/destinations/postgres
   githubIssueLabel: destination-postgres

--- a/airbyte-integrations/connectors/destination-postgres/src/test-integration/kotlin/io/airbyte/integrations/destination/postgres/write/PostgresRawDataDumper.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/test-integration/kotlin/io/airbyte/integrations/destination/postgres/write/PostgresRawDataDumper.kt
@@ -50,6 +50,7 @@ import java.time.temporal.ChronoField
 class PostgresRawDataDumper(
     private val configProvider: (ConfigurationSpecification) -> PostgresConfiguration
 ) : DestinationDataDumper {
+    private val coercer = AirbyteValueCoercer(useFastTimestampParsing = true)
     companion object {
         // Lenient formatters that handle PostgreSQL's JSONB serialization quirks
         // (e.g., dropping :00 seconds)
@@ -161,7 +162,7 @@ class PostgresRawDataDumper(
                     )
                 } catch (e: Exception) {
                     // Fall back to standard coercer
-                    AirbyteValueCoercer.coerce(value, type) ?: value
+                    coercer.coerce(value, type) ?: value
                 }
             }
             TimestampTypeWithoutTimezone -> {
@@ -171,7 +172,7 @@ class PostgresRawDataDumper(
                         LocalDateTime.parse(value.value, TIMESTAMP_NO_TZ_FORMATTER)
                     )
                 } catch (e: Exception) {
-                    AirbyteValueCoercer.coerce(value, type) ?: value
+                    coercer.coerce(value, type) ?: value
                 }
             }
             TimeTypeWithTimezone -> {
@@ -179,7 +180,7 @@ class PostgresRawDataDumper(
                 try {
                     TimeWithTimezoneValue(OffsetTime.parse(value.value, TIME_FORMATTER))
                 } catch (e: Exception) {
-                    AirbyteValueCoercer.coerce(value, type) ?: value
+                    coercer.coerce(value, type) ?: value
                 }
             }
             TimeTypeWithoutTimezone -> {
@@ -187,7 +188,7 @@ class PostgresRawDataDumper(
                 try {
                     TimeWithoutTimezoneValue(LocalTime.parse(value.value, TIME_NO_TZ_FORMATTER))
                 } catch (e: Exception) {
-                    AirbyteValueCoercer.coerce(value, type) ?: value
+                    coercer.coerce(value, type) ?: value
                 }
             }
             DateType -> {
@@ -195,7 +196,7 @@ class PostgresRawDataDumper(
                 try {
                     DateValue(LocalDate.parse(value.value, DATE_FORMATTER))
                 } catch (e: Exception) {
-                    AirbyteValueCoercer.coerce(value, type) ?: value
+                    coercer.coerce(value, type) ?: value
                 }
             }
             // For UnknownType with PASS_THROUGH behavior, unwrap double-serialized strings
@@ -223,7 +224,7 @@ class PostgresRawDataDumper(
             }
             // For other primitive types, use the standard coercer
             else -> {
-                val coerced = AirbyteValueCoercer.coerce(value, type)
+                val coerced = coercer.coerce(value, type)
                 // If coercion returns null, it means the value couldn't be coerced to the expected
                 // type.
                 // In test scenarios, we want to preserve the original value to see what went wrong.

--- a/docs/integrations/destinations/postgres.md
+++ b/docs/integrations/destinations/postgres.md
@@ -298,6 +298,7 @@ This destination supports [namespaces](https://docs.airbyte.com/platform/using-a
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                                                                                                |
 |:--------|:-----------|:-----------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 3.0.13  | 2026-04-16 | [76409](https://github.com/airbytehq/airbyte/pull/76409)   | Upgrade CDK to 1.0.9.                                                                                                                                                                  |
 | 3.0.12  | 2026-03-25 | | Upgrade CDK to 1.0.6; fix duplicate records in dedup+truncate mode by dropping temp tables after successful upsert |
 | 3.0.11  | 2026-02-25 | | Upgrade CDK to 1.0.2 and base image to 2.0.4 for CVE patches |
 | 3.0.10  | 2026-02-04 | [72858](https://github.com/airbytehq/airbyte/pull/72858)   | Upgrade CDK to 0.2.8                                                                                                                                                                   |


### PR DESCRIPTION
## What
Upgrade Postgres to CDK 1.0.9, adapting to the AirbyteValueCoercer singleton refactor.
## How
- Bump CDK to 1.0.9
- Pass explicit AirbyteValueCoercer instance in PostgresRawDataDumper (test-integration)
## Recommended reading order
1. `PostgresRawDataDumper.kt`
## User Impact
No user-facing change.
## Can this PR be safely reverted and rolled back?
- [x] YES
- [ ] NO