### PR TITLE
docs(ai-agents): populate admin/profile content from outline

### DIFF
--- a/docs/ai-agents/admin/profile.md
+++ b/docs/ai-agents/admin/profile.md
@@ -1,7 +1,44 @@
+---
+plan: all
+---
+
 # Manage your user profile
 
-## Personal informaton
+Your Profile page contains your personal account details, your organization's name, and the API credentials Airbyte Agents uses to authenticate programmatic access. Go to the Profile page to review these details or make changes.
+
+## Personal information
+
+The Personal Information card shows the email address associated with your Airbyte Agents account. Airbyte sets this email when you sign up and uses it to identify you, send account notifications, and route support requests.
+
+You can't change your email from the Profile page. It's a read-only field tied to the account you signed in with.
 
 ## Organization information
 
+The Organization card shows the name of the organization you're currently managing. Airbyte displays this name across the app and on invoices.
+
+### Rename your organization
+
+1. On the Profile page, in the Organization card, update the value in **Organization Name**.
+2. Click **Save Changes**.
+
+The name must be between 1 and 256 characters. **Save Changes** stays disabled until you've made a valid change.
+
 ## API credentials
+
+The API Credentials card contains the values you need to authenticate programmatic access to your organization. Use these credentials with the [SDK](../interfaces/sdk/readme.md) or the [MCP server](../interfaces/mcp/readme.md) to run agents outside of the chat UI.
+
+Airbyte displays three values:
+
+- **AIRBYTE_ORGANIZATION_ID**: The unique identifier for your organization.
+- **AIRBYTE_CLIENT_ID**: The client ID for API authentication.
+- **AIRBYTE_CLIENT_SECRET**: The client secret for API authentication.
+
+Airbyte creates these credentials automatically for each organization. The client ID and client secret are sensitive values.
+
+### View and copy credentials
+
+To copy a single value, click the copy icon next to that value. To reveal a hidden value before copying, click the eye icon to toggle visibility on the client ID or client secret.
+
+:::warning
+Treat the client secret like a password. Anyone with your client ID and client secret can access your organization through the API or SDK. Don't commit these values to source control, share them in public channels, or paste them into untrusted tools.
+:::


### PR DESCRIPTION
## What

Fills out `docs/ai-agents/admin/profile.md` from the outline on the `docs-airbyte-agents` branch. Stacked on top of `docs-airbyte-agents`.

Follows the same structure and tone established by the populated `admin/billing.md` page.

## How

Documents the three sections of the Profile page in the Airbyte Agents app, mirroring the actual behavior in the Sonar frontend (`frontend/src/routes/organizations/$organizationId/profile.tsx`):

- **Personal information**: Explains the read-only email field and where it comes from.
- **Organization information**: Documents the editable organization name, including the 1–256 character validation rule and the "Save Changes" button behavior.
- **API credentials**: Describes the three values (`AIRBYTE_ORGANIZATION_ID`, `AIRBYTE_CLIENT_ID`, `AIRBYTE_CLIENT_SECRET`), the copy and show/hide controls, and a warning about treating the client secret as a secret.

Also fixes the `informaton` typo in the outline heading and adds `plan: all` front matter consistent with neighboring pages.

## Review guide

1. `docs/ai-agents/admin/profile.md`

## User Impact

New user-facing documentation for the Profile page. No runtime impact.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌


Link to Devin session: https://app.devin.ai/sessions/287e3b2891de465ebdade0381085b6d4
Requested by: @ian-at-airbyte