### PR TITLE
feat(source-snapchat-marketing): increase api_budget to 100 calls/10s for tuning iteration 3

### DIFF
--- a/airbyte-integrations/connectors/source-snapchat-marketing/manifest.yaml
+++ b/airbyte-integrations/connectors/source-snapchat-marketing/manifest.yaml
@@ -10698,7 +10698,7 @@ api_budget:
   policies:
     - type: MovingWindowCallRatePolicy
       rates:
-        - limit: 80
+        - limit: 100
           interval: PT10S
       matchers: []
   status_codes_for_ratelimit_hit:

--- a/airbyte-integrations/connectors/source-snapchat-marketing/metadata.yaml
+++ b/airbyte-integrations/connectors/source-snapchat-marketing/metadata.yaml
@@ -8,7 +8,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 200330b2-ea62-4d11-ac6d-cfe3e3f8ab2b
-  dockerImageTag: 1.5.33-rc.2
+  dockerImageTag: 1.5.33-rc.3
   dockerRepository: airbyte/source-snapchat-marketing
   githubIssueLabel: source-snapchat-marketing
   icon: snapchat.svg

--- a/docs/integrations/sources/snapchat-marketing.md
+++ b/docs/integrations/sources/snapchat-marketing.md
@@ -143,6 +143,7 @@ Syncing data with an hourly granularity often generates large data volumes and c
 
 | Version    | Date       | Pull Request                                             | Subject                                                                        |
 |:-----------|:-----------|:---------------------------------------------------------|:-------------------------------------------------------------------------------|
+| 1.5.33-rc.3 | 2026-04-16 | [TBD](https://github.com/airbytehq/airbyte/pull/TBD) | Increase api_budget from 80 to 100 calls per 10s for tuning iteration 3 |
 | 1.5.33-rc.2 | 2026-04-13 | [76255](https://github.com/airbytehq/airbyte/pull/76255) | Increase default_concurrency to 5 for tuning iteration 2 |
 | 1.5.33-rc.1 | 2026-04-10 | [70866](https://github.com/airbytehq/airbyte/pull/70866) | Add HTTPAPIBudget and concurrency_level for progressive rollout tuning |
 | 1.5.32 | 2026-03-24 | [75098](https://github.com/airbytehq/airbyte/pull/75098) | Update dependencies |

--- a/docs/integrations/sources/snapchat-marketing.md
+++ b/docs/integrations/sources/snapchat-marketing.md
@@ -143,7 +143,7 @@ Syncing data with an hourly granularity often generates large data volumes and c
 
 | Version    | Date       | Pull Request                                             | Subject                                                                        |
 |:-----------|:-----------|:---------------------------------------------------------|:-------------------------------------------------------------------------------|
-| 1.5.33-rc.3 | 2026-04-16 | [TBD](https://github.com/airbytehq/airbyte/pull/TBD) | Increase api_budget from 80 to 100 calls per 10s for tuning iteration 3 |
+| 1.5.33-rc.3 | 2026-04-16 | [76416](https://github.com/airbytehq/airbyte/pull/76416) | Increase api_budget from 80 to 100 calls per 10s for tuning iteration 3 |
 | 1.5.33-rc.2 | 2026-04-13 | [76255](https://github.com/airbytehq/airbyte/pull/76255) | Increase default_concurrency to 5 for tuning iteration 2 |
 | 1.5.33-rc.1 | 2026-04-10 | [70866](https://github.com/airbytehq/airbyte/pull/70866) | Add HTTPAPIBudget and concurrency_level for progressive rollout tuning |
 | 1.5.32 | 2026-03-24 | [75098](https://github.com/airbytehq/airbyte/pull/75098) | Update dependencies |


### PR DESCRIPTION
## What

Increases the HTTP API budget for `source-snapchat-marketing` from 80 to 100 calls per 10 seconds as part of ongoing concurrency tuning ([internal issue #15313](https://github.com/airbytehq/airbyte-internal-issues/issues/15313)). Bumps the RC version to `1.5.33-rc.3`.

This is tuning iteration 3. Previous iterations:
- rc.1 ([#70866](https://github.com/airbytehq/airbyte/pull/70866)): Added budget (80/10s) + concurrency=4
- rc.2 ([#76255](https://github.com/airbytehq/airbyte/pull/76255)): Increased concurrency to 5

Concurrency remains at 5; only the budget limit changes in this iteration.

## How

- `manifest.yaml`: `api_budget.policies[0].rates[0].limit` changed from `80` → `100`
- `metadata.yaml`: `dockerImageTag` bumped from `1.5.33-rc.2` → `1.5.33-rc.3`
- `snapchat-marketing.md`: Changelog entry added for rc.3

## Review guide

1. `manifest.yaml` — single line change at L10701
2. `metadata.yaml` — version bump at L11
3. `docs/integrations/sources/snapchat-marketing.md` — changelog entry

**Items to verify:**
- [ ] The changelog entry currently has `[TBD]` as the PR number — needs to be updated with the actual PR number after creation.
- [ ] The new budget of 100 calls/10s (10 req/s) matches exactly the Snapchat token-level rate limit with no headroom. The connector has `status_codes_for_ratelimit_hit: [429]` configured, so it will back off if the limit is hit. Confirm this is acceptable.

## User Impact

No user-facing impact. This RC is only deployed to pinned actors during progressive rollout tuning — it does not affect the stable connector version (1.5.32).

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/9239df45723948cd8dfdb91b65b84593
Requested by: @sophiecuiy