### PR TITLE
feat(source-typeform): increase max_concurrency to 75 for rc.5

### DIFF
--- a/airbyte-integrations/connectors/source-typeform/manifest.yaml
+++ b/airbyte-integrations/connectors/source-typeform/manifest.yaml
@@ -6,13 +6,9 @@ concurrency_level:
   default_concurrency: 25
   max_concurrency: 75
 
-api_budget:
-  type: HTTPAPIBudget
-  policies:
-    - type: FixedWindowCallRatePolicy
-      period: 1S
-      call_limit: 400
-      matchers: []
+# api_budget intentionally omitted — reviewed and explored during concurrency tuning (rc.1–rc.4).
+# Typeform's documented rate limit is 2 req/s, but proactive budgeting caused stalling at low concurrency.
+# The CDK's built-in 429 retry/backoff handles rate limiting reactively, which works well in practice.
 
 check:
   type: CheckStream

--- a/airbyte-integrations/connectors/source-typeform/manifest.yaml
+++ b/airbyte-integrations/connectors/source-typeform/manifest.yaml
@@ -6,6 +6,14 @@ concurrency_level:
   default_concurrency: 25
   max_concurrency: 75
 
+api_budget:
+  type: HTTPAPIBudget
+  policies:
+    - type: FixedWindowCallRatePolicy
+      period: 1S
+      call_limit: 400
+      matchers: []
+
 check:
   type: CheckStream
   stream_names:

--- a/airbyte-integrations/connectors/source-typeform/manifest.yaml
+++ b/airbyte-integrations/connectors/source-typeform/manifest.yaml
@@ -4,7 +4,7 @@ type: DeclarativeSource
 concurrency_level:
   type: ConcurrencyLevel
   default_concurrency: 25
-  max_concurrency: 25
+  max_concurrency: 75
 
 check:
   type: CheckStream

--- a/airbyte-integrations/connectors/source-typeform/metadata.yaml
+++ b/airbyte-integrations/connectors/source-typeform/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: e7eff203-90bf-43e5-a240-19ea3056c474
-  dockerImageTag: 1.4.8-rc.4
+  dockerImageTag: 1.4.8-rc.5
   dockerRepository: airbyte/source-typeform
   documentationUrl: https://docs.airbyte.com/integrations/sources/typeform
   externalDocumentationUrls:

--- a/docs/integrations/sources/typeform.md
+++ b/docs/integrations/sources/typeform.md
@@ -106,6 +106,7 @@ The Forms, Responses, and Webhooks streams make separate API calls for each form
 
 | Version | Date       | Pull Request                                             | Subject                                                                                         |
 |:--------|:-----------|:---------------------------------------------------------|:------------------------------------------------------------------------------------------------|
+| 1.4.8-rc.5 | 2026-04-16 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) | Increase max_concurrency from 25 to 75 |
 | 1.4.8-rc.4 | 2026-04-15 | [76363](https://github.com/airbytehq/airbyte/pull/76363) | Remove API budget, set concurrency to 25 |
 | 1.4.8-rc.3 | 2026-04-14 | [76319](https://github.com/airbytehq/airbyte/pull/76319) | Adjust default_concurrency from 3 to 2 for tuning retry |
 | 1.4.8-rc.2 | 2026-04-13 | [76270](https://github.com/airbytehq/airbyte/pull/76270) | Adjust default_concurrency from 4 to 3 for tuning retry |

--- a/docs/integrations/sources/typeform.md
+++ b/docs/integrations/sources/typeform.md
@@ -106,7 +106,7 @@ The Forms, Responses, and Webhooks streams make separate API calls for each form
 
 | Version | Date       | Pull Request                                             | Subject                                                                                         |
 |:--------|:-----------|:---------------------------------------------------------|:------------------------------------------------------------------------------------------------|
-| 1.4.8-rc.5 | 2026-04-16 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) | Increase max_concurrency from 25 to 75 |
+| 1.4.8-rc.5 | 2026-04-16 | [76418](https://github.com/airbytehq/airbyte/pull/76418) | Increase max_concurrency from 25 to 75 |
 | 1.4.8-rc.4 | 2026-04-15 | [76363](https://github.com/airbytehq/airbyte/pull/76363) | Remove API budget, set concurrency to 25 |
 | 1.4.8-rc.3 | 2026-04-14 | [76319](https://github.com/airbytehq/airbyte/pull/76319) | Adjust default_concurrency from 3 to 2 for tuning retry |
 | 1.4.8-rc.2 | 2026-04-13 | [76270](https://github.com/airbytehq/airbyte/pull/76270) | Adjust default_concurrency from 4 to 3 for tuning retry |

--- a/docs/integrations/sources/typeform.md
+++ b/docs/integrations/sources/typeform.md
@@ -106,7 +106,7 @@ The Forms, Responses, and Webhooks streams make separate API calls for each form
 
 | Version | Date       | Pull Request                                             | Subject                                                                                         |
 |:--------|:-----------|:---------------------------------------------------------|:------------------------------------------------------------------------------------------------|
-| 1.4.8-rc.5 | 2026-04-16 | [76418](https://github.com/airbytehq/airbyte/pull/76418) | Increase max_concurrency to 75, add api_budget 400 req/s |
+| 1.4.8-rc.5 | 2026-04-16 | [76418](https://github.com/airbytehq/airbyte/pull/76418) | Increase max_concurrency to 75, no api_budget (reviewed/explored, relying on CDK 429 backoff) |
 | 1.4.8-rc.4 | 2026-04-15 | [76363](https://github.com/airbytehq/airbyte/pull/76363) | Remove API budget, set concurrency to 25 |
 | 1.4.8-rc.3 | 2026-04-14 | [76319](https://github.com/airbytehq/airbyte/pull/76319) | Adjust default_concurrency from 3 to 2 for tuning retry |
 | 1.4.8-rc.2 | 2026-04-13 | [76270](https://github.com/airbytehq/airbyte/pull/76270) | Adjust default_concurrency from 4 to 3 for tuning retry |

--- a/docs/integrations/sources/typeform.md
+++ b/docs/integrations/sources/typeform.md
@@ -106,7 +106,7 @@ The Forms, Responses, and Webhooks streams make separate API calls for each form
 
 | Version | Date       | Pull Request                                             | Subject                                                                                         |
 |:--------|:-----------|:---------------------------------------------------------|:------------------------------------------------------------------------------------------------|
-| 1.4.8-rc.5 | 2026-04-16 | [76418](https://github.com/airbytehq/airbyte/pull/76418) | Increase max_concurrency from 25 to 75 |
+| 1.4.8-rc.5 | 2026-04-16 | [76418](https://github.com/airbytehq/airbyte/pull/76418) | Increase max_concurrency to 75, add api_budget 400 req/s |
 | 1.4.8-rc.4 | 2026-04-15 | [76363](https://github.com/airbytehq/airbyte/pull/76363) | Remove API budget, set concurrency to 25 |
 | 1.4.8-rc.3 | 2026-04-14 | [76319](https://github.com/airbytehq/airbyte/pull/76319) | Adjust default_concurrency from 3 to 2 for tuning retry |
 | 1.4.8-rc.2 | 2026-04-13 | [76270](https://github.com/airbytehq/airbyte/pull/76270) | Adjust default_concurrency from 4 to 3 for tuning retry |


### PR DESCRIPTION
## What
Updates `source-typeform` rc.5 configuration as part of the ongoing concurrency tuning series (rc.1 → rc.5):
- Increases `max_concurrency` from 25 to 75
- Adds an inline comment documenting the decision to omit `api_budget` (reviewed/explored during rc.1–rc.4)

Prior context: rc.4 (c=25, no api_budget) ran successfully on 17 Tier 2 actors for ~44h with 93% success rate (100% excluding a pre-existing config_error connection), zero 429/rate-limit errors, and no stalling. Speed aggregate report showed 17–20% faster total sync duration and 21–41% faster source read duration vs. stable.

## How
- `manifest.yaml`: `max_concurrency` raised from 25 → 75. `default_concurrency` remains at 25. Added comment explaining why `api_budget` is intentionally omitted (proactive budgeting caused stalling during earlier RC iterations; the CDK's built-in 429 retry/backoff handles rate limiting reactively).
- `metadata.yaml`: Version bump `1.4.8-rc.4` → `1.4.8-rc.5`.
- `typeform.md`: Changelog entry added.

### Updates since last revision
- Removed the `api_budget` block (was briefly added at 400 req/s, then removed per Sophie's direction). Replaced with an inline comment documenting that api_budget was reviewed and intentionally omitted.
- Updated changelog entry to reflect final state.

## Review guide
1. `airbyte-integrations/connectors/source-typeform/manifest.yaml` — `max_concurrency` bump + comment explaining omitted `api_budget`
2. `airbyte-integrations/connectors/source-typeform/metadata.yaml` — version bump
3. `docs/integrations/sources/typeform.md` — changelog entry

**For reviewer:**
- `default_concurrency` stays at 25; the CDK can auto-scale up to 75 if conditions allow.
- No `api_budget` is configured. Typeform's documented limit is 2 req/s, but earlier RC iterations (rc.1–rc.3) showed that proactive budgeting caused stalling. The CDK handles 429s reactively with retry/backoff, which has proven reliable (zero 429 errors observed across rc.4's 44h rollout window).

## User Impact
No user-facing impact yet — this is an RC version that will only be deployed to version-pinned actors during the controlled rollout. Next rollout targets 100% Tier 2 actors. If promoted to GA, connectors with many forms could see improved sync throughput from the higher concurrency ceiling.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/6dcb0ce3acb04fdaa5d90bad560ac37f
Requested by: @sophiecuiy