### PR TITLE
feat(destination-redshift-v2): add SQL generation layer

### DIFF
--- a/airbyte-integrations/connectors/destination-redshift-v2/src/main/kotlin/io/airbyte/integrations/destination/redshift2/check/RedshiftChecker.kt
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/main/kotlin/io/airbyte/integrations/destination/redshift2/check/RedshiftChecker.kt
@@ -8,6 +8,8 @@ import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model.ObjectMetadata
 import io.airbyte.cdk.load.check.DestinationChecker
 import io.airbyte.cdk.load.command.Append
+import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.command.NamespaceMapper
 import io.airbyte.cdk.load.component.ColumnType
 import io.airbyte.cdk.load.schema.model.ColumnSchema
 import io.airbyte.cdk.load.schema.model.StreamTableSchema
@@ -155,7 +157,7 @@ class RedshiftChecker(
         log.info { "Test 3: Check CREATE access for ${tableName.namespace}.${tableName.name}..." }
         val createSchemaSql = sqlGenerator.createNamespace(tableName.namespace)
         val createTableSql =
-            sqlGenerator.createTableForCheck(tableName, buildCheckTableSchema(tableName))
+            sqlGenerator.createTable(buildCheckStream(tableName), tableName, replace = false)
 
         dataSource.connection.use { conn ->
             conn.createStatement().use { stmt ->
@@ -245,24 +247,34 @@ class RedshiftChecker(
         return "${prefix}_airbyte_check_$testId.csv.gz"
     }
 
-    /** Builds a [StreamTableSchema] for the check table with one user column (`test_key`). */
-    private fun buildCheckTableSchema(tableName: TableName): StreamTableSchema =
-        StreamTableSchema(
-            tableNames =
-                TableNames(
-                    finalTableName = tableName,
-                    tempTableName = tableName,
-                ),
-            columnSchema =
-                ColumnSchema(
-                    inputToFinalColumnNames = mapOf(CHECK_COLUMN_NAME to CHECK_COLUMN_NAME),
-                    finalSchema =
-                        mapOf(
-                            CHECK_COLUMN_NAME to ColumnType(RedshiftDataType.VARCHAR.typeName, true)
+    /** Builds a [DestinationStream] for the check table with one user column (`test_key`). */
+    private fun buildCheckStream(tableName: TableName): DestinationStream =
+        DestinationStream(
+            unmappedNamespace = tableName.namespace,
+            unmappedName = tableName.name,
+            generationId = 0L,
+            minimumGenerationId = 0L,
+            syncId = 0L,
+            namespaceMapper = NamespaceMapper(),
+            tableSchema =
+                StreamTableSchema(
+                    tableNames =
+                        TableNames(
+                            finalTableName = tableName,
+                            tempTableName = tableName,
                         ),
-                    inputSchema = emptyMap(),
+                    columnSchema =
+                        ColumnSchema(
+                            inputToFinalColumnNames = mapOf(CHECK_COLUMN_NAME to CHECK_COLUMN_NAME),
+                            finalSchema =
+                                mapOf(
+                                    CHECK_COLUMN_NAME to
+                                        ColumnType(RedshiftDataType.VARCHAR.typeName, true)
+                                ),
+                            inputSchema = emptyMap(),
+                        ),
+                    importType = Append,
                 ),
-            importType = Append,
         )
 
     /**

--- a/airbyte-integrations/connectors/destination-redshift-v2/src/main/kotlin/io/airbyte/integrations/destination/redshift2/sql/RedshiftSqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/main/kotlin/io/airbyte/integrations/destination/redshift2/sql/RedshiftSqlGenerator.kt
@@ -4,22 +4,28 @@
 
 package io.airbyte.integrations.destination.redshift2.sql
 
+import io.airbyte.cdk.load.command.Dedupe
+import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.component.ColumnType
+import io.airbyte.cdk.load.component.ColumnTypeChange
 import io.airbyte.cdk.load.message.Meta
+import io.airbyte.cdk.load.message.Meta.Companion.COLUMN_NAME_AB_EXTRACTED_AT
+import io.airbyte.cdk.load.message.Meta.Companion.COLUMN_NAME_AB_GENERATION_ID
 import io.airbyte.cdk.load.schema.model.StreamTableSchema
 import io.airbyte.cdk.load.schema.model.TableName
+import io.airbyte.cdk.load.table.CDC_DELETED_AT_COLUMN
 import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.inject.Singleton
 
-/**
- * Generates Redshift-specific SQL strings for table operations. All identifiers are double-quoted
- * per Redshift/PostgreSQL convention.
- */
 @Singleton
 class RedshiftSqlGenerator {
     private val log = KotlinLogging.logger {}
 
     companion object {
+        private const val DEDUPED_TABLE_ALIAS = "deduped_source"
+        private val EXTRACTED_AT_COLUMN_NAME = quoteIdentifier(COLUMN_NAME_AB_EXTRACTED_AT)
+        private val DELETED_AT_COLUMN_NAME = quoteIdentifier(CDC_DELETED_AT_COLUMN)
+
         internal fun quoteIdentifier(identifier: String): String =
             RedshiftSqlEscapeUtils.quoteIdentifier(identifier)
 
@@ -38,6 +44,40 @@ class RedshiftSqlGenerator {
 
     fun createNamespace(namespace: String): String =
         "CREATE SCHEMA IF NOT EXISTS ${quoteIdentifier(namespace)};".andLog()
+
+    fun createTable(
+        stream: DestinationStream,
+        tableName: TableName,
+        replace: Boolean,
+    ): String {
+        val metaColumns = META_COLUMNS
+        val userColumns = getUserColumns(stream)
+
+        val columnDeclarations =
+            buildList {
+                    metaColumns.forEach { (columnName, columnType) ->
+                        val nullability = if (columnType.nullable) "" else " NOT NULL"
+                        add("${quoteIdentifier(columnName)} ${columnType.type}$nullability")
+                    }
+                    userColumns.forEach { (columnName, columnType) ->
+                        val nullability = if (columnType.nullable) "" else " NOT NULL"
+                        add("${quoteIdentifier(columnName)} ${columnType.type}$nullability")
+                    }
+                }
+                .joinToString(",\n    ")
+
+        val dropStatement =
+            if (replace) "DROP TABLE IF EXISTS ${getFullyQualifiedName(tableName)};\n" else ""
+
+        return """
+            |BEGIN TRANSACTION;
+            |${dropStatement}
+            |CREATE TABLE IF NOT EXISTS ${getFullyQualifiedName(tableName)} ($columnDeclarations);
+            |COMMIT;
+        """
+            .trimMargin()
+            .andLog()
+    }
 
     fun dropTable(tableName: TableName): String =
         "DROP TABLE IF EXISTS ${getFullyQualifiedName(tableName)};".andLog()
@@ -69,17 +109,415 @@ class RedshiftSqlGenerator {
             .andLog()
     }
 
-    /** Generates an ALTER TABLE ADD COLUMN statement. */
     fun addColumn(tableName: TableName, columnName: String, columnType: String): String =
         "ALTER TABLE ${getFullyQualifiedName(tableName)} ADD COLUMN ${quoteIdentifier(columnName)} $columnType;".andLog()
 
-    /** Generates `SELECT COUNT(*)` SQL with a fixed alias. */
     fun countTable(tableName: TableName): String =
         "SELECT COUNT(*) AS \"total\" FROM ${getFullyQualifiedName(tableName)};".andLog()
 
-    /** Generates a parameterized `DELETE` by `_airbyte_raw_id`. */
+    fun getGenerationId(tableName: TableName): String =
+        "SELECT ${quoteIdentifier(COLUMN_NAME_AB_GENERATION_ID)} FROM ${
+            getFullyQualifiedName(
+                tableName,
+            )
+        } LIMIT 1;".andLog()
+
     fun deleteByRawId(tableName: TableName): String =
         "DELETE FROM ${getFullyQualifiedName(tableName)} WHERE ${quoteIdentifier("_airbyte_raw_id")} = ?;".andLog()
+
+    /** Generates an `INSERT INTO target SELECT FROM source` to copy data between tables. */
+    fun copyTable(
+        columnNames: List<String>,
+        sourceTableName: TableName,
+        targetTableName: TableName,
+    ): String {
+        val quotedColumnNames = columnNames.joinToString(", ") { quoteIdentifier(it) }
+        return """
+            |INSERT INTO ${getFullyQualifiedName(targetTableName)} ($quotedColumnNames)
+            |SELECT $quotedColumnNames
+            |FROM ${getFullyQualifiedName(sourceTableName)};
+        """
+            .trimMargin()
+            .andLog()
+    }
+
+    /**
+     * Generates a rename-based table swap within a transaction:
+     * 1. DROP the target table
+     * 2. RENAME the source table to the target name
+     * 3. If cross-schema, SET SCHEMA to move the renamed table
+     */
+    fun overwriteTable(sourceTableName: TableName, targetTableName: TableName): String {
+        val moveSchemaSql =
+            if (sourceTableName.namespace != targetTableName.namespace) {
+                "\nALTER TABLE ${getNamespace(sourceTableName)}.${getName(targetTableName)} SET SCHEMA ${
+                    getNamespace(
+                        targetTableName,
+                    )
+                };"
+            } else {
+                ""
+            }
+
+        return """
+            |BEGIN TRANSACTION;
+            |DROP TABLE IF EXISTS ${getFullyQualifiedName(targetTableName)};
+            |ALTER TABLE ${getFullyQualifiedName(sourceTableName)} RENAME TO ${
+            getName(
+                targetTableName,
+            )
+        };
+            |$moveSchemaSql
+            |COMMIT;
+        """
+            .trimMargin()
+            .andLog()
+    }
+
+    /**
+     * Generates a CTE-based upsert statement to performs:
+     * 1. **Deduplication CTE**: Deduplicates source rows by primary key using ROW_NUMBER()
+     * 2. **CDC Delete CTE**: (if enabled) Deletes target rows matching CDC deletion markers
+     * 3. **Update CTE**: Updates existing target rows with newer source data
+     * 4. **Insert**: Inserts new rows that don't exist in the target
+     */
+    fun upsertTable(
+        stream: DestinationStream,
+        sourceTableName: TableName,
+        targetTableName: TableName,
+    ): String {
+        val importType = stream.tableSchema.importType as Dedupe
+
+        if (importType.primaryKey.isEmpty()) {
+            throw IllegalArgumentException("Cannot perform upsert without primary key")
+        }
+
+        val primaryKeyTargetColumns = getPrimaryKeysColumnNamesQuoted(stream)
+        val cursorTargetColumn = getCursorColumnNameQuoted(stream)
+        val allTargetColumns = getTargetColumnNamesForStream(stream)
+
+        val selectDedupedQuery =
+            selectDeduped(
+                primaryKeyTargetColumns,
+                cursorTargetColumn,
+                allTargetColumns,
+                sourceTableName,
+            )
+
+        val cdcHardDeleteEnabled =
+            stream.tableSchema.columnSchema.inputSchema.containsKey(CDC_DELETED_AT_COLUMN)
+
+        val cdcDeleteQuery =
+            cdcDelete(
+                DEDUPED_TABLE_ALIAS,
+                cursorTargetColumn,
+                targetTableName,
+                primaryKeyTargetColumns,
+                cdcHardDeleteEnabled,
+            )
+
+        val updateExistingRowsQuery =
+            updateExistingRows(
+                DEDUPED_TABLE_ALIAS,
+                targetTableName,
+                allTargetColumns,
+                primaryKeyTargetColumns,
+                cursorTargetColumn,
+                cdcHardDeleteEnabled,
+            )
+
+        val insertNewRowsQuery =
+            insertNewRows(
+                DEDUPED_TABLE_ALIAS,
+                targetTableName,
+                allTargetColumns,
+                primaryKeyTargetColumns,
+                cdcHardDeleteEnabled,
+            )
+
+        return """
+            |WITH $DEDUPED_TABLE_ALIAS AS (
+            |$selectDedupedQuery
+            |),
+            |
+            |$cdcDeleteQuery
+            |updates AS (
+            |$updateExistingRowsQuery
+            |)
+            |
+            |$insertNewRowsQuery
+        """
+            .trimMargin()
+            .andLog()
+    }
+
+    /**
+     * Generates a SELECT with ROW_NUMBER() window function for deduplication.
+     *
+     * Partitions by primary key, orders by cursor (DESC NULLS LAST) then extracted_at (DESC), and
+     * keeps only the first row (most recent) per primary key.
+     */
+    internal fun selectDeduped(
+        primaryKeyTargetColumns: List<String>,
+        cursorTargetColumn: String?,
+        allTargetColumns: List<String>,
+        sourceTableName: TableName,
+    ): String {
+        val cursorOrderClause = cursorTargetColumn?.let { "$it DESC NULLS LAST," } ?: ""
+
+        return """
+            |  SELECT ${allTargetColumns.joinToString(", ")}
+            |  FROM (
+            |    SELECT *,
+            |      ROW_NUMBER() OVER (
+            |        PARTITION BY ${primaryKeyTargetColumns.joinToString(", ")}
+            |        ORDER BY
+            |          $cursorOrderClause $EXTRACTED_AT_COLUMN_NAME DESC
+            |      ) AS row_number
+            |    FROM ${getFullyQualifiedName(sourceTableName)}
+            |  ) AS deduplicated
+            |  WHERE row_number = 1
+        """.trimMargin()
+    }
+
+    /**
+     * Generates the CDC hard-delete CTE, or an empty string if CDC hard delete is disabled.
+     *
+     * Deletes target rows where the source has a CDC deletion marker and the deletion is newer than
+     * the target record.
+     */
+    internal fun cdcDelete(
+        dedupTableAlias: String,
+        cursorTargetColumn: String?,
+        targetTableName: TableName,
+        primaryKeyTargetColumns: List<String>,
+        cdcHardDeleteEnabled: Boolean,
+    ): String {
+        if (!cdcHardDeleteEnabled) {
+            return ""
+        }
+
+        val primaryKeysMatchingCondition =
+            primaryKeyTargetColumns.joinToString(" AND ") { pk ->
+                "${getFullyQualifiedName(targetTableName)}.$pk = $dedupTableAlias.$pk"
+            }
+
+        val cursorComparison =
+            buildCursorComparison(cursorTargetColumn, targetTableName, dedupTableAlias)
+
+        return """
+            |deleted AS (
+            |  DELETE FROM ${getFullyQualifiedName(targetTableName)}
+            |  USING $dedupTableAlias
+            |  WHERE $primaryKeysMatchingCondition
+            |    AND $dedupTableAlias.$DELETED_AT_COLUMN_NAME IS NOT NULL
+            |    AND ($cursorComparison)
+            |),
+            |
+        """.trimMargin()
+    }
+
+    /**
+     * Generates an UPDATE statement that updates existing target rows with newer source data.
+     *
+     * Rows are matched by primary key and only updated when the source cursor/extracted_at is
+     * newer. CDC-deleted rows are skipped if CDC hard delete is enabled.
+     */
+    internal fun updateExistingRows(
+        dedupTableAlias: String,
+        targetTableName: TableName,
+        allTargetColumns: List<String>,
+        primaryKeyTargetColumns: List<String>,
+        cursorTargetColumn: String?,
+        cdcHardDeleteEnabled: Boolean,
+    ): String {
+        val primaryKeysMatches =
+            primaryKeyTargetColumns.joinToString(" AND ") { pk ->
+                "${getFullyQualifiedName(targetTableName)}.$pk = $dedupTableAlias.$pk"
+            }
+
+        val cursorComparison =
+            buildCursorComparison(cursorTargetColumn, targetTableName, dedupTableAlias)
+
+        val updateAssignments =
+            allTargetColumns.joinToString(",\n    ") { col -> "$col = $dedupTableAlias.$col" }
+
+        val skipCdcDeletedClause =
+            if (cdcHardDeleteEnabled) {
+                "\n    AND $dedupTableAlias.$DELETED_AT_COLUMN_NAME IS NULL"
+            } else {
+                ""
+            }
+
+        return """
+            |  UPDATE ${getFullyQualifiedName(targetTableName)}
+            |  SET
+            |    $updateAssignments
+            |  FROM $dedupTableAlias
+            |  WHERE $primaryKeysMatches$skipCdcDeletedClause
+            |    AND ($cursorComparison)
+        """.trimMargin()
+    }
+
+    /**
+     * Generates an INSERT statement for new rows from the deduped source that don't exist in the
+     * target.
+     *
+     * Uses `NOT EXISTS` to check for existing records by primary key. CDC-deleted rows are skipped
+     * if CDC hard delete is enabled.
+     */
+    internal fun insertNewRows(
+        dedupTableAlias: String,
+        targetTableName: TableName,
+        allTargetColumns: List<String>,
+        primaryKeyTargetColumns: List<String>,
+        cdcHardDeleteEnabled: Boolean,
+    ): String {
+        val primaryKeysConditions =
+            primaryKeyTargetColumns.joinToString(" AND ") { pk ->
+                "${getFullyQualifiedName(targetTableName)}.$pk = $dedupTableAlias.$pk"
+            }
+
+        val skipCdcDeletedClause =
+            if (cdcHardDeleteEnabled) {
+                "\n  AND $dedupTableAlias.$DELETED_AT_COLUMN_NAME IS NULL"
+            } else {
+                ""
+            }
+
+        return """
+            |INSERT INTO ${getFullyQualifiedName(targetTableName)} (
+            |  ${allTargetColumns.joinToString(",\n  ")}
+            |)
+            |SELECT
+            |  ${allTargetColumns.joinToString(",\n  ")}
+            |FROM $dedupTableAlias
+            |WHERE
+            |  NOT EXISTS (
+            |    SELECT 1
+            |    FROM ${getFullyQualifiedName(targetTableName)}
+            |    WHERE $primaryKeysConditions
+            |  )$skipCdcDeletedClause
+        """.trimMargin()
+    }
+
+    /**
+     * Builds a 4-way NULL-safe cursor comparison expression to determine if source data is newer
+     * than target data.
+     */
+    private fun buildCursorComparison(
+        cursorTargetColumn: String?,
+        targetTableName: TableName,
+        dedupTableAlias: String,
+    ): String {
+        val target = getFullyQualifiedName(targetTableName)
+        val source = dedupTableAlias
+        return if (cursorTargetColumn != null) {
+            """
+            |$target.$cursorTargetColumn < $source.$cursorTargetColumn
+            |    OR ($target.$cursorTargetColumn = $source.$cursorTargetColumn AND $target.$EXTRACTED_AT_COLUMN_NAME < $source.$EXTRACTED_AT_COLUMN_NAME)
+            |    OR ($target.$cursorTargetColumn IS NULL AND $source.$cursorTargetColumn IS NOT NULL)
+            |    OR ($target.$cursorTargetColumn IS NULL AND $source.$cursorTargetColumn IS NULL AND $target.$EXTRACTED_AT_COLUMN_NAME < $source.$EXTRACTED_AT_COLUMN_NAME)
+            """.trimMargin()
+        } else {
+            "$target.$EXTRACTED_AT_COLUMN_NAME < $source.$EXTRACTED_AT_COLUMN_NAME"
+        }
+    }
+
+    /**
+     * Generates SQL to evolve a table's schema:
+     * 1. ADD COLUMN with the new type (temp name)
+     * 2. UPDATE to cast data from the old column to the temp column
+     * 3. DROP the old column
+     * 4. RENAME the temp column to the original name
+     *
+     * For SUPER <-> VARCHAR conversions, uses `JSON_SERIALIZE()` / `JSON_PARSE()` instead of CAST.
+     */
+    fun matchSchemas(
+        tableName: TableName,
+        columnsToAdd: Map<String, ColumnType>,
+        columnsToRemove: Map<String, ColumnType>,
+        columnsToModify: Map<String, ColumnTypeChange>,
+    ): String {
+        val clauses = mutableListOf<String>()
+        val fqn = getFullyQualifiedName(tableName)
+
+        // Add new columns (no NOT NULL -- preexisting rows would have no default)
+        columnsToAdd.forEach { (name, columnType) ->
+            clauses.add("ALTER TABLE $fqn ADD COLUMN ${quoteIdentifier(name)} ${columnType.type};")
+        }
+
+        // Remove columns
+        columnsToRemove.forEach { (name, _) ->
+            clauses.add("ALTER TABLE $fqn DROP COLUMN ${quoteIdentifier(name)};")
+        }
+
+        // Modify column types via 4-step rename pattern
+        columnsToModify.forEach { (name, typeChange) ->
+            clauses.addAll(buildTypeChangeStatements(fqn, name, typeChange))
+        }
+
+        return """
+            |BEGIN TRANSACTION;
+            |${clauses.joinToString("\n")}
+            |COMMIT;
+        """
+            .trimMargin()
+            .andLog()
+    }
+
+    /**
+     * Builds the 4-step ALTER TABLE statements to change a column's type in Redshift.
+     *
+     * For SUPER -> VARCHAR: uses `JSON_SERIALIZE(col)` to preserve JSON structure as a string. For
+     * VARCHAR -> SUPER: uses `JSON_PARSE(col)` to parse the JSON string into a SUPER value. For all
+     * other conversions: uses `CAST(col AS new_type)`.
+     */
+    private fun buildTypeChangeStatements(
+        fullyQualifiedTableName: String,
+        columnName: String,
+        typeChange: ColumnTypeChange,
+    ): List<String> {
+        val quotedName = quoteIdentifier(columnName)
+        val tempColumn = quoteIdentifier("_airbyte_tmp_$columnName")
+        val oldType = typeChange.originalType.type
+        val newType = typeChange.newType.type
+
+        val castExpression =
+            when {
+                // SUPER -> VARCHAR: serialize JSON to string
+                oldType == RedshiftDataType.SUPER.typeName && newType.startsWith("varchar") ->
+                    "JSON_SERIALIZE($quotedName)"
+                // VARCHAR -> SUPER: parse string as JSON
+                oldType.startsWith("varchar") && newType == RedshiftDataType.SUPER.typeName ->
+                    "JSON_PARSE($quotedName)"
+                // All other conversions: standard CAST
+                else -> "CAST($quotedName AS $newType)"
+            }
+
+        return listOf(
+            // Step 1: Add temp column with the new type
+            "ALTER TABLE $fullyQualifiedTableName ADD COLUMN $tempColumn $newType;",
+            // Step 2: Cast data from old column to temp column
+            "UPDATE $fullyQualifiedTableName SET $tempColumn = $castExpression;",
+            // Step 3: Drop the original column
+            "ALTER TABLE $fullyQualifiedTableName DROP COLUMN $quotedName;",
+            // Step 4: Rename temp column to the original name
+            "ALTER TABLE $fullyQualifiedTableName RENAME COLUMN $tempColumn TO $quotedName;",
+        )
+    }
+
+    /** Generates a query to retrieve column metadata from `information_schema.columns` */
+    fun getTableSchema(tableName: TableName): String =
+        """
+            |SELECT column_name, data_type, is_nullable
+            |FROM information_schema.columns
+            |WHERE table_schema = '${RedshiftSqlEscapeUtils.escapeSqlString(tableName.namespace)}'
+            |AND table_name = '${RedshiftSqlEscapeUtils.escapeSqlString(tableName.name)}'
+            |ORDER BY ordinal_position;
+        """
+            .trimMargin()
+            .andLog()
 
     /** Generates a Redshift COPY command to load gzip CSV data from S3 */
     fun copyFromS3(
@@ -100,6 +538,14 @@ class RedshiftSqlGenerator {
             |IGNOREHEADER 1;
         """.trimMargin()
 
+    // ================================================================
+    // Internal helpers
+    // ================================================================
+
+    /** Returns the user columns (non-meta) from the stream's pre-computed table schema. */
+    private fun getUserColumns(stream: DestinationStream): Map<String, ColumnType> =
+        stream.tableSchema.columnSchema.finalSchema
+
     /** Builds the fully qualified table name as `"namespace"."name"`. */
     private fun getFullyQualifiedName(tableName: TableName): String =
         "${getNamespace(tableName)}.${getName(tableName)}"
@@ -108,6 +554,19 @@ class RedshiftSqlGenerator {
         quoteIdentifier(tableName.namespace.ifBlank { "public" })
 
     private fun getName(tableName: TableName): String = quoteIdentifier(tableName.name)
+
+    /** Returns all target column names (meta + user) for a stream, quoted. */
+    private fun getTargetColumnNamesForStream(stream: DestinationStream): List<String> {
+        val metaColumnNames = META_COLUMNS.keys.map { quoteIdentifier(it) }
+        val userColumnNames = getUserColumns(stream).keys.map { quoteIdentifier(it) }
+        return metaColumnNames + userColumnNames
+    }
+
+    private fun getPrimaryKeysColumnNamesQuoted(stream: DestinationStream): List<String> =
+        stream.tableSchema.getPrimaryKey().flatten().map { quoteIdentifier(it) }
+
+    private fun getCursorColumnNameQuoted(stream: DestinationStream): String? =
+        stream.tableSchema.getCursor().firstOrNull()?.let { quoteIdentifier(it) }
 
     /** Logs the SQL string at INFO level and returns it. */
     private fun String.andLog(): String {

--- a/airbyte-integrations/connectors/destination-redshift-v2/src/main/kotlin/io/airbyte/integrations/destination/redshift2/sql/RedshiftSqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/main/kotlin/io/airbyte/integrations/destination/redshift2/sql/RedshiftSqlGenerator.kt
@@ -312,7 +312,9 @@ class RedshiftSqlGenerator {
             buildCursorComparison(cursorTargetColumn, targetTableName, dedupTableAlias)
 
         val updateAssignments =
-            allTargetColumns.joinToString(",\n    ") { col -> "$col = $dedupTableAlias.$col" }
+            allTargetColumns
+                .filter { it !in primaryKeyTargetColumns }
+                .joinToString(",\n    ") { col -> "$col = $dedupTableAlias.$col" }
 
         val skipCdcDeletedClause =
             if (cdcHardDeleteEnabled) {

--- a/airbyte-integrations/connectors/destination-redshift-v2/src/main/kotlin/io/airbyte/integrations/destination/redshift2/sql/RedshiftSqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/main/kotlin/io/airbyte/integrations/destination/redshift2/sql/RedshiftSqlGenerator.kt
@@ -11,7 +11,6 @@ import io.airbyte.cdk.load.component.ColumnTypeChange
 import io.airbyte.cdk.load.message.Meta
 import io.airbyte.cdk.load.message.Meta.Companion.COLUMN_NAME_AB_EXTRACTED_AT
 import io.airbyte.cdk.load.message.Meta.Companion.COLUMN_NAME_AB_GENERATION_ID
-import io.airbyte.cdk.load.schema.model.StreamTableSchema
 import io.airbyte.cdk.load.schema.model.TableName
 import io.airbyte.cdk.load.table.CDC_DELETED_AT_COLUMN
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -81,33 +80,6 @@ class RedshiftSqlGenerator {
 
     fun dropTable(tableName: TableName): String =
         "DROP TABLE IF EXISTS ${getFullyQualifiedName(tableName)};".andLog()
-
-    /** Simplified `CREATE TABLE` for check/test tables that don't have a `DestinationStream` */
-    fun createTableForCheck(tableName: TableName, tableSchema: StreamTableSchema): String {
-        val metaColumns = META_COLUMNS
-        val userColumns = tableSchema.columnSchema.finalSchema
-
-        val columnDeclarations =
-            buildList {
-                    metaColumns.forEach { (columnName, columnType) ->
-                        val nullability = if (columnType.nullable) "" else " NOT NULL"
-                        add("${quoteIdentifier(columnName)} ${columnType.type}$nullability")
-                    }
-                    userColumns.forEach { (columnName, columnType) ->
-                        val nullability = if (columnType.nullable) "" else " NOT NULL"
-                        add("${quoteIdentifier(columnName)} ${columnType.type}$nullability")
-                    }
-                }
-                .joinToString(",\n    ")
-
-        return """
-            |CREATE TABLE IF NOT EXISTS ${getFullyQualifiedName(tableName)} (
-            |    $columnDeclarations
-            |);
-        """
-            .trimMargin()
-            .andLog()
-    }
 
     fun addColumn(tableName: TableName, columnName: String, columnType: String): String =
         "ALTER TABLE ${getFullyQualifiedName(tableName)} ADD COLUMN ${quoteIdentifier(columnName)} $columnType;".andLog()

--- a/airbyte-integrations/connectors/destination-redshift-v2/src/test/kotlin/io/airbyte/integrations/destination/redshift2/check/RedshiftCheckerUnitTest.kt
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/test/kotlin/io/airbyte/integrations/destination/redshift2/check/RedshiftCheckerUnitTest.kt
@@ -73,7 +73,7 @@ class RedshiftCheckerUnitTest {
 
         // SQL generator: return dummy SQL strings
         every { sqlGenerator.createNamespace(any()) } returns "CREATE SCHEMA sql"
-        every { sqlGenerator.createTableForCheck(any(), any()) } returns "CREATE TABLE sql"
+        every { sqlGenerator.createTable(any(), any(), any()) } returns "CREATE TABLE sql"
         every { sqlGenerator.countTable(any()) } returns "SELECT count sql"
         every { sqlGenerator.deleteByRawId(any()) } returns "DELETE sql"
         every { sqlGenerator.dropTable(any()) } returns "DROP TABLE sql"
@@ -99,7 +99,7 @@ class RedshiftCheckerUnitTest {
 
         // Verify DDL (createNamespace + createTable)
         verify { sqlGenerator.createNamespace(any()) }
-        verify { sqlGenerator.createTableForCheck(any(), any()) }
+        verify { sqlGenerator.createTable(any(), any(), any()) }
 
         // Verify count query
         verify { sqlGenerator.countTable(any()) }

--- a/airbyte-integrations/connectors/destination-redshift-v2/src/test/kotlin/io/airbyte/integrations/destination/redshift2/sql/RedshiftSqlGeneratorTest.kt
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/test/kotlin/io/airbyte/integrations/destination/redshift2/sql/RedshiftSqlGeneratorTest.kt
@@ -1,0 +1,685 @@
+/*
+ * Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.redshift2.sql
+
+import io.airbyte.cdk.load.command.Dedupe
+import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.component.ColumnType
+import io.airbyte.cdk.load.component.ColumnTypeChange
+import io.airbyte.cdk.load.data.FieldType
+import io.airbyte.cdk.load.data.TimestampTypeWithTimezone
+import io.airbyte.cdk.load.schema.model.ColumnSchema
+import io.airbyte.cdk.load.schema.model.StreamTableSchema
+import io.airbyte.cdk.load.schema.model.TableName
+import io.airbyte.cdk.load.table.CDC_DELETED_AT_COLUMN
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+internal class RedshiftSqlGeneratorTest {
+
+    private lateinit var sqlGenerator: RedshiftSqlGenerator
+
+    @BeforeEach
+    fun setUp() {
+        sqlGenerator = RedshiftSqlGenerator()
+    }
+
+    // ================================================================
+    // Helpers
+    // ================================================================
+
+    private fun assertEqualsIgnoreWhitespace(expected: String, actual: String) {
+        assertEquals(dropWhitespace(expected), dropWhitespace(actual))
+    }
+
+    private fun dropWhitespace(text: String) =
+        text.lines().map { it.trim() }.filter { it.isNotEmpty() }.joinToString("\n") { it.trim() }
+
+    private fun mockStream(
+        finalSchema: Map<String, ColumnType>,
+        inputSchema: Map<String, FieldType> = emptyMap(),
+        primaryKey: List<List<String>> = emptyList(),
+        cursor: List<String> = emptyList(),
+    ): DestinationStream {
+        val columnSchema = ColumnSchema(inputSchema, emptyMap(), finalSchema)
+        val streamTableSchema =
+            mockk<StreamTableSchema> {
+                every { this@mockk.columnSchema } returns columnSchema
+                every { getPrimaryKey() } returns primaryKey
+                every { getCursor() } returns cursor
+                every { importType } returns Dedupe(primaryKey = primaryKey, cursor = cursor)
+            }
+        return mockk<DestinationStream> { every { tableSchema } returns streamTableSchema }
+    }
+
+    // ================================================================
+    // DDL: Namespace & Table lifecycle
+    // ================================================================
+
+    @Test
+    fun `createNamespace generates CREATE SCHEMA`() {
+        val sql = sqlGenerator.createNamespace("my_schema")
+        assertEquals("""CREATE SCHEMA IF NOT EXISTS "my_schema";""", sql)
+    }
+
+    @Test
+    fun `createTable with replace drops and recreates`() {
+        val finalSchema =
+            mapOf(
+                "id" to ColumnType("bigint", false),
+                "name" to ColumnType("varchar(65535)", true),
+            )
+        val stream = mockStream(finalSchema)
+        val tableName = TableName(namespace = "public", name = "users")
+
+        val sql = sqlGenerator.createTable(stream, tableName, replace = true)
+
+        assertTrue(sql.contains("BEGIN TRANSACTION;"))
+        assertTrue(sql.contains("""DROP TABLE IF EXISTS "public"."users";"""))
+        assertTrue(sql.contains("""CREATE TABLE IF NOT EXISTS "public"."users""""))
+        assertTrue(sql.contains(""""_airbyte_raw_id" varchar(36) NOT NULL"""))
+        assertTrue(sql.contains(""""_airbyte_extracted_at" timestamptz NOT NULL"""))
+        assertTrue(sql.contains(""""_airbyte_meta" super NOT NULL"""))
+        assertTrue(sql.contains(""""_airbyte_generation_id" bigint NOT NULL"""))
+        assertTrue(sql.contains(""""id" bigint NOT NULL"""))
+        assertTrue(sql.contains(""""name" varchar(65535)"""))
+        assertTrue(sql.contains("COMMIT;"))
+    }
+
+    @Test
+    fun `createTable without replace skips drop`() {
+        val finalSchema = mapOf("id" to ColumnType("bigint", false))
+        val stream = mockStream(finalSchema)
+        val tableName = TableName(namespace = "public", name = "users")
+
+        val sql = sqlGenerator.createTable(stream, tableName, replace = false)
+
+        assertFalse(sql.contains("DROP TABLE"))
+        assertTrue(sql.contains("BEGIN TRANSACTION;"))
+        assertTrue(sql.contains("CREATE TABLE IF NOT EXISTS"))
+        assertTrue(sql.contains("COMMIT;"))
+    }
+
+    @Test
+    fun `dropTable generates DROP TABLE IF EXISTS`() {
+        val sql = sqlGenerator.dropTable(TableName(namespace = "ns", name = "tbl"))
+        assertEquals("""DROP TABLE IF EXISTS "ns"."tbl";""", sql)
+    }
+
+    @Test
+    fun `addColumn generates ALTER TABLE ADD COLUMN`() {
+        val sql =
+            sqlGenerator.addColumn(
+                TableName(namespace = "ns", name = "tbl"),
+                "new_col",
+                "varchar(65535)",
+            )
+        assertEquals(
+            """ALTER TABLE "ns"."tbl" ADD COLUMN "new_col" varchar(65535);""",
+            sql,
+        )
+    }
+
+    // ================================================================
+    // DML: Simple queries
+    // ================================================================
+
+    @Test
+    fun `countTable generates SELECT COUNT`() {
+        val sql = sqlGenerator.countTable(TableName(namespace = "ns", name = "tbl"))
+        assertEquals("""SELECT COUNT(*) AS "total" FROM "ns"."tbl";""", sql)
+    }
+
+    @Test
+    fun `getGenerationId generates SELECT with LIMIT 1`() {
+        val sql = sqlGenerator.getGenerationId(TableName(namespace = "ns", name = "tbl"))
+        assertEquals(
+            """SELECT "_airbyte_generation_id" FROM "ns"."tbl" LIMIT 1;""",
+            sql,
+        )
+    }
+
+    @Test
+    fun `deleteByRawId generates parameterized DELETE`() {
+        val sql = sqlGenerator.deleteByRawId(TableName(namespace = "ns", name = "tbl"))
+        assertEquals(
+            """DELETE FROM "ns"."tbl" WHERE "_airbyte_raw_id" = ?;""",
+            sql,
+        )
+    }
+
+    // ================================================================
+    // Table operations: copy, overwrite
+    // ================================================================
+
+    @Test
+    fun `copyTable generates INSERT INTO SELECT`() {
+        val source = TableName(namespace = "ns", name = "src")
+        val target = TableName(namespace = "ns", name = "tgt")
+
+        val sql = sqlGenerator.copyTable(listOf("col_a", "col_b"), source, target)
+
+        val expected =
+            """
+            INSERT INTO "ns"."tgt" ("col_a", "col_b")
+            SELECT "col_a", "col_b"
+            FROM "ns"."src";
+            """
+        assertEqualsIgnoreWhitespace(expected, sql)
+    }
+
+    @Test
+    fun `overwriteTable same schema generates DROP and RENAME`() {
+        val source = TableName(namespace = "ns", name = "tmp")
+        val target = TableName(namespace = "ns", name = "final")
+
+        val sql = sqlGenerator.overwriteTable(source, target)
+
+        assertTrue(sql.contains("BEGIN TRANSACTION;"))
+        assertTrue(sql.contains("""DROP TABLE IF EXISTS "ns"."final""""))
+        assertTrue(sql.contains("""ALTER TABLE "ns"."tmp" RENAME TO "final""""))
+        assertFalse(sql.contains("SET SCHEMA"))
+        assertTrue(sql.contains("COMMIT;"))
+    }
+
+    @Test
+    fun `overwriteTable cross schema includes SET SCHEMA`() {
+        val source = TableName(namespace = "staging", name = "tmp")
+        val target = TableName(namespace = "public", name = "final")
+
+        val sql = sqlGenerator.overwriteTable(source, target)
+
+        assertTrue(sql.contains("""DROP TABLE IF EXISTS "public"."final""""))
+        assertTrue(sql.contains("""ALTER TABLE "staging"."tmp" RENAME TO "final""""))
+        assertTrue(sql.contains("""SET SCHEMA "public""""))
+    }
+
+    // ================================================================
+    // Upsert: internal methods
+    // ================================================================
+
+    @Test
+    fun `selectDeduped with cursor orders by cursor then extracted_at`() {
+        val sql =
+            sqlGenerator.selectDeduped(
+                primaryKeyTargetColumns = listOf(""""id""""),
+                cursorTargetColumn = """"updated_at"""",
+                allTargetColumns = listOf(""""id"""", """"name"""", """"updated_at""""),
+                sourceTableName = TableName(namespace = "ns", name = "staging"),
+            )
+
+        val expected =
+            """
+            SELECT "id", "name", "updated_at"
+            FROM (
+              SELECT *,
+                ROW_NUMBER() OVER (
+                  PARTITION BY "id"
+                  ORDER BY
+                    "updated_at" DESC NULLS LAST, "_airbyte_extracted_at" DESC
+                ) AS row_number
+              FROM "ns"."staging"
+            ) AS deduplicated
+            WHERE row_number = 1
+            """
+        assertEqualsIgnoreWhitespace(expected, sql)
+    }
+
+    @Test
+    fun `selectDeduped without cursor orders by extracted_at only`() {
+        val sql =
+            sqlGenerator.selectDeduped(
+                primaryKeyTargetColumns = listOf(""""id""""),
+                cursorTargetColumn = null,
+                allTargetColumns = listOf(""""id"""", """"name""""),
+                sourceTableName = TableName(namespace = "ns", name = "staging"),
+            )
+
+        assertTrue(sql.contains(""""_airbyte_extracted_at" DESC"""))
+        assertFalse(sql.contains("NULLS LAST"))
+    }
+
+    @Test
+    fun `cdcDelete enabled generates DELETE CTE with cursor comparison`() {
+        val target = TableName(namespace = "ns", name = "final")
+        val sql =
+            sqlGenerator.cdcDelete(
+                dedupTableAlias = "deduped_source",
+                cursorTargetColumn = """"updated_at"""",
+                targetTableName = target,
+                primaryKeyTargetColumns = listOf(""""id""""),
+                cdcHardDeleteEnabled = true,
+            )
+
+        assertTrue(sql.contains("deleted AS ("))
+        assertTrue(sql.contains("""DELETE FROM "ns"."final""""))
+        assertTrue(sql.contains("USING deduped_source"))
+        assertTrue(sql.contains(""""_ab_cdc_deleted_at" IS NOT NULL"""))
+        assertTrue(sql.contains(""""updated_at" < deduped_source."updated_at""""))
+    }
+
+    @Test
+    fun `cdcDelete disabled returns empty string`() {
+        val sql =
+            sqlGenerator.cdcDelete(
+                dedupTableAlias = "deduped_source",
+                cursorTargetColumn = """"updated_at"""",
+                targetTableName = TableName(namespace = "ns", name = "final"),
+                primaryKeyTargetColumns = listOf(""""id""""),
+                cdcHardDeleteEnabled = false,
+            )
+
+        assertEquals("", sql)
+    }
+
+    @Test
+    fun `updateExistingRows excludes PK from SET assignments`() {
+        val target = TableName(namespace = "ns", name = "final")
+        val sql =
+            sqlGenerator.updateExistingRows(
+                dedupTableAlias = "deduped_source",
+                targetTableName = target,
+                allTargetColumns = listOf(""""id"""", """"name"""", """"updated_at""""),
+                primaryKeyTargetColumns = listOf(""""id""""),
+                cursorTargetColumn = """"updated_at"""",
+                cdcHardDeleteEnabled = false,
+            )
+
+        // Extract the SET section (between "SET" and "FROM")
+        val setSection = sql.substringAfter("SET").substringBefore("FROM")
+        // PK should NOT appear in SET assignments
+        assertFalse(setSection.contains(""""id" = deduped_source."id""""))
+        // Non-PK columns should be in SET
+        assertTrue(setSection.contains(""""name" = deduped_source."name""""))
+        assertTrue(setSection.contains(""""updated_at" = deduped_source."updated_at""""))
+        // PK should be in WHERE
+        assertTrue(sql.contains(""""ns"."final"."id" = deduped_source."id""""))
+    }
+
+    @Test
+    fun `updateExistingRows with CDC adds deleted_at IS NULL clause`() {
+        val target = TableName(namespace = "ns", name = "final")
+        val sql =
+            sqlGenerator.updateExistingRows(
+                dedupTableAlias = "deduped_source",
+                targetTableName = target,
+                allTargetColumns = listOf(""""id"""", """"name""""),
+                primaryKeyTargetColumns = listOf(""""id""""),
+                cursorTargetColumn = """"updated_at"""",
+                cdcHardDeleteEnabled = true,
+            )
+
+        assertTrue(sql.contains(""""_ab_cdc_deleted_at" IS NULL"""))
+    }
+
+    @Test
+    fun `updateExistingRows without cursor uses extracted_at comparison only`() {
+        val target = TableName(namespace = "ns", name = "final")
+        val sql =
+            sqlGenerator.updateExistingRows(
+                dedupTableAlias = "deduped_source",
+                targetTableName = target,
+                allTargetColumns = listOf(""""id"""", """"name""""),
+                primaryKeyTargetColumns = listOf(""""id""""),
+                cursorTargetColumn = null,
+                cdcHardDeleteEnabled = false,
+            )
+
+        assertTrue(
+            sql.contains(
+                """"ns"."final"."_airbyte_extracted_at" < deduped_source."_airbyte_extracted_at""""
+            )
+        )
+        // Should NOT have the 4-way cursor comparison
+        assertFalse(sql.contains("IS NULL AND deduped_source."))
+    }
+
+    @Test
+    fun `insertNewRows without CDC has no deleted_at clause`() {
+        val target = TableName(namespace = "ns", name = "final")
+        val sql =
+            sqlGenerator.insertNewRows(
+                dedupTableAlias = "deduped_source",
+                targetTableName = target,
+                allTargetColumns = listOf(""""id"""", """"name""""),
+                primaryKeyTargetColumns = listOf(""""id""""),
+                cdcHardDeleteEnabled = false,
+            )
+
+        assertTrue(sql.contains("INSERT INTO"))
+        assertTrue(sql.contains("NOT EXISTS"))
+        assertFalse(sql.contains("_ab_cdc_deleted_at"))
+    }
+
+    @Test
+    fun `insertNewRows with CDC adds deleted_at IS NULL clause`() {
+        val target = TableName(namespace = "ns", name = "final")
+        val sql =
+            sqlGenerator.insertNewRows(
+                dedupTableAlias = "deduped_source",
+                targetTableName = target,
+                allTargetColumns = listOf(""""id"""", """"name""""),
+                primaryKeyTargetColumns = listOf(""""id""""),
+                cdcHardDeleteEnabled = true,
+            )
+
+        assertTrue(sql.contains(""""_ab_cdc_deleted_at" IS NULL"""))
+    }
+
+    // ================================================================
+    // Upsert: integration-level
+    // ================================================================
+
+    @Test
+    fun `upsertTable with cursor and CDC generates full CTE chain`() {
+        val finalSchema =
+            mapOf(
+                "id" to ColumnType("bigint", false),
+                "name" to ColumnType("varchar(65535)", true),
+                "updated_at" to ColumnType("timestamptz", true),
+                CDC_DELETED_AT_COLUMN to ColumnType("timestamptz", true),
+            )
+        val inputSchema = mapOf(CDC_DELETED_AT_COLUMN to FieldType(TimestampTypeWithTimezone, true))
+        val stream =
+            mockStream(
+                finalSchema = finalSchema,
+                inputSchema = inputSchema,
+                primaryKey = listOf(listOf("id")),
+                cursor = listOf("updated_at"),
+            )
+
+        val source = TableName(namespace = "ns", name = "staging")
+        val target = TableName(namespace = "ns", name = "final")
+
+        val sql = sqlGenerator.upsertTable(stream, source, target)
+
+        val expected =
+            """
+            WITH deduped_source AS (
+              SELECT "_airbyte_raw_id", "_airbyte_extracted_at", "_airbyte_meta", "_airbyte_generation_id", "id", "name", "updated_at", "_ab_cdc_deleted_at"
+              FROM (
+                SELECT *,
+                  ROW_NUMBER() OVER (
+                    PARTITION BY "id"
+                    ORDER BY
+                      "updated_at" DESC NULLS LAST, "_airbyte_extracted_at" DESC
+                  ) AS row_number
+                FROM "ns"."staging"
+              ) AS deduplicated
+              WHERE row_number = 1
+            ),
+
+            deleted AS (
+              DELETE FROM "ns"."final"
+              USING deduped_source
+              WHERE "ns"."final"."id" = deduped_source."id"
+                AND deduped_source."_ab_cdc_deleted_at" IS NOT NULL
+                AND ("ns"."final"."updated_at" < deduped_source."updated_at"
+                OR ("ns"."final"."updated_at" = deduped_source."updated_at" AND "ns"."final"."_airbyte_extracted_at" < deduped_source."_airbyte_extracted_at")
+                OR ("ns"."final"."updated_at" IS NULL AND deduped_source."updated_at" IS NOT NULL)
+                OR ("ns"."final"."updated_at" IS NULL AND deduped_source."updated_at" IS NULL AND "ns"."final"."_airbyte_extracted_at" < deduped_source."_airbyte_extracted_at"))
+            ),
+
+            updates AS (
+              UPDATE "ns"."final"
+              SET
+                "_airbyte_raw_id" = deduped_source."_airbyte_raw_id",
+                "_airbyte_extracted_at" = deduped_source."_airbyte_extracted_at",
+                "_airbyte_meta" = deduped_source."_airbyte_meta",
+                "_airbyte_generation_id" = deduped_source."_airbyte_generation_id",
+                "name" = deduped_source."name",
+                "updated_at" = deduped_source."updated_at",
+                "_ab_cdc_deleted_at" = deduped_source."_ab_cdc_deleted_at"
+              FROM deduped_source
+              WHERE "ns"."final"."id" = deduped_source."id"
+                AND deduped_source."_ab_cdc_deleted_at" IS NULL
+                AND ("ns"."final"."updated_at" < deduped_source."updated_at"
+                OR ("ns"."final"."updated_at" = deduped_source."updated_at" AND "ns"."final"."_airbyte_extracted_at" < deduped_source."_airbyte_extracted_at")
+                OR ("ns"."final"."updated_at" IS NULL AND deduped_source."updated_at" IS NOT NULL)
+                OR ("ns"."final"."updated_at" IS NULL AND deduped_source."updated_at" IS NULL AND "ns"."final"."_airbyte_extracted_at" < deduped_source."_airbyte_extracted_at"))
+            )
+
+            INSERT INTO "ns"."final" (
+              "_airbyte_raw_id",
+              "_airbyte_extracted_at",
+              "_airbyte_meta",
+              "_airbyte_generation_id",
+              "id",
+              "name",
+              "updated_at",
+              "_ab_cdc_deleted_at"
+            )
+            SELECT
+              "_airbyte_raw_id",
+              "_airbyte_extracted_at",
+              "_airbyte_meta",
+              "_airbyte_generation_id",
+              "id",
+              "name",
+              "updated_at",
+              "_ab_cdc_deleted_at"
+            FROM deduped_source
+            WHERE
+              NOT EXISTS (
+                SELECT 1
+                FROM "ns"."final"
+                WHERE "ns"."final"."id" = deduped_source."id"
+              )
+              AND deduped_source."_ab_cdc_deleted_at" IS NULL
+            """
+        assertEqualsIgnoreWhitespace(expected, sql)
+    }
+
+    @Test
+    fun `upsertTable without CDC omits deleted CTE`() {
+        val finalSchema =
+            mapOf(
+                "id" to ColumnType("bigint", false),
+                "name" to ColumnType("varchar(65535)", true),
+                "updated_at" to ColumnType("timestamptz", true),
+            )
+        val stream =
+            mockStream(
+                finalSchema = finalSchema,
+                primaryKey = listOf(listOf("id")),
+                cursor = listOf("updated_at"),
+            )
+
+        val source = TableName(namespace = "ns", name = "staging")
+        val target = TableName(namespace = "ns", name = "final")
+
+        val sql = sqlGenerator.upsertTable(stream, source, target)
+
+        assertTrue(sql.contains("WITH deduped_source AS"))
+        assertFalse(sql.contains("deleted AS"))
+        assertTrue(sql.contains("updates AS"))
+        assertTrue(sql.contains("INSERT INTO"))
+        assertFalse(sql.contains("_ab_cdc_deleted_at"))
+    }
+
+    @Test
+    fun `upsertTable without primary key throws IllegalArgumentException`() {
+        val streamTableSchema =
+            mockk<StreamTableSchema> {
+                every { importType } returns Dedupe(primaryKey = emptyList(), cursor = emptyList())
+            }
+        val stream = mockk<DestinationStream> { every { tableSchema } returns streamTableSchema }
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                sqlGenerator.upsertTable(
+                    stream,
+                    TableName(namespace = "ns", name = "src"),
+                    TableName(namespace = "ns", name = "tgt"),
+                )
+            }
+
+        assertEquals("Cannot perform upsert without primary key", exception.message)
+    }
+
+    // ================================================================
+    // Schema evolution: matchSchemas
+    // ================================================================
+
+    @Test
+    fun `matchSchemas adds columns`() {
+        val tableName = TableName(namespace = "ns", name = "tbl")
+        val sql =
+            sqlGenerator.matchSchemas(
+                tableName,
+                columnsToAdd =
+                    mapOf(
+                        "new_col" to ColumnType("varchar(65535)", true),
+                        "another_col" to ColumnType("bigint", false),
+                    ),
+                columnsToRemove = emptyMap(),
+                columnsToModify = emptyMap(),
+            )
+
+        assertTrue(sql.contains("BEGIN TRANSACTION;"))
+        assertTrue(sql.contains("""ALTER TABLE "ns"."tbl" ADD COLUMN "new_col" varchar(65535);"""))
+        assertTrue(sql.contains("""ALTER TABLE "ns"."tbl" ADD COLUMN "another_col" bigint;"""))
+        assertTrue(sql.contains("COMMIT;"))
+    }
+
+    @Test
+    fun `matchSchemas removes columns`() {
+        val tableName = TableName(namespace = "ns", name = "tbl")
+        val sql =
+            sqlGenerator.matchSchemas(
+                tableName,
+                columnsToAdd = emptyMap(),
+                columnsToRemove = mapOf("old_col" to ColumnType("varchar", true)),
+                columnsToModify = emptyMap(),
+            )
+
+        assertTrue(sql.contains("""ALTER TABLE "ns"."tbl" DROP COLUMN "old_col";"""))
+    }
+
+    @Test
+    fun `matchSchemas SUPER to VARCHAR uses JSON_SERIALIZE`() {
+        val tableName = TableName(namespace = "ns", name = "tbl")
+        val sql =
+            sqlGenerator.matchSchemas(
+                tableName,
+                columnsToAdd = emptyMap(),
+                columnsToRemove = emptyMap(),
+                columnsToModify =
+                    mapOf(
+                        "json_col" to
+                            ColumnTypeChange(
+                                originalType = ColumnType("super", true),
+                                newType = ColumnType("varchar(65535)", true),
+                            )
+                    ),
+            )
+
+        assertTrue(sql.contains("""ADD COLUMN "_airbyte_tmp_json_col" varchar(65535);"""))
+        assertTrue(sql.contains("JSON_SERIALIZE(\"json_col\")"))
+        assertTrue(sql.contains("""DROP COLUMN "json_col";"""))
+        assertTrue(sql.contains("""RENAME COLUMN "_airbyte_tmp_json_col" TO "json_col";"""))
+    }
+
+    @Test
+    fun `matchSchemas VARCHAR to SUPER uses JSON_PARSE`() {
+        val tableName = TableName(namespace = "ns", name = "tbl")
+        val sql =
+            sqlGenerator.matchSchemas(
+                tableName,
+                columnsToAdd = emptyMap(),
+                columnsToRemove = emptyMap(),
+                columnsToModify =
+                    mapOf(
+                        "data_col" to
+                            ColumnTypeChange(
+                                originalType = ColumnType("varchar(65535)", true),
+                                newType = ColumnType("super", true),
+                            )
+                    ),
+            )
+
+        assertTrue(sql.contains("""ADD COLUMN "_airbyte_tmp_data_col" super;"""))
+        assertTrue(sql.contains("JSON_PARSE(\"data_col\")"))
+        assertTrue(sql.contains("""DROP COLUMN "data_col";"""))
+        assertTrue(sql.contains("""RENAME COLUMN "_airbyte_tmp_data_col" TO "data_col";"""))
+    }
+
+    @Test
+    fun `matchSchemas generic type change uses CAST`() {
+        val tableName = TableName(namespace = "ns", name = "tbl")
+        val sql =
+            sqlGenerator.matchSchemas(
+                tableName,
+                columnsToAdd = emptyMap(),
+                columnsToRemove = emptyMap(),
+                columnsToModify =
+                    mapOf(
+                        "num_col" to
+                            ColumnTypeChange(
+                                originalType = ColumnType("bigint", false),
+                                newType = ColumnType("numeric(38,9)", false),
+                            )
+                    ),
+            )
+
+        assertTrue(sql.contains("""ADD COLUMN "_airbyte_tmp_num_col" numeric(38,9);"""))
+        assertTrue(sql.contains("""CAST("num_col" AS numeric(38,9))"""))
+        assertTrue(sql.contains("""DROP COLUMN "num_col";"""))
+        assertTrue(sql.contains("""RENAME COLUMN "_airbyte_tmp_num_col" TO "num_col";"""))
+    }
+
+    // ================================================================
+    // Staging & schema discovery
+    // ================================================================
+
+    @Test
+    fun `copyFromS3 generates COPY command`() {
+        val sql =
+            sqlGenerator.copyFromS3(
+                tableName = TableName(namespace = "ns", name = "tbl"),
+                s3Path = "s3://bucket/path/file.csv.gz",
+                accessKeyId = "AKIATEST",
+                secretAccessKey = "secret123",
+                region = "us-east-1",
+            )
+
+        assertTrue(sql.contains("""COPY "ns"."tbl""""))
+        assertTrue(sql.contains("FROM 's3://bucket/path/file.csv.gz'"))
+        assertTrue(
+            sql.contains("CREDENTIALS 'aws_access_key_id=AKIATEST;aws_secret_access_key=secret123'")
+        )
+        assertTrue(sql.contains("CSV GZIP"))
+        assertTrue(sql.contains("REGION 'us-east-1'"))
+        assertTrue(sql.contains("TIMEFORMAT 'auto'"))
+        assertTrue(sql.contains("IGNOREHEADER 1"))
+    }
+
+    @Test
+    fun `getTableSchema queries information_schema`() {
+        val sql = sqlGenerator.getTableSchema(TableName(namespace = "my_schema", name = "my_table"))
+
+        assertTrue(sql.contains("SELECT column_name, data_type, is_nullable"))
+        assertTrue(sql.contains("FROM information_schema.columns"))
+        assertTrue(sql.contains("table_schema = 'my_schema'"))
+        assertTrue(sql.contains("table_name = 'my_table'"))
+        assertTrue(sql.contains("ORDER BY ordinal_position"))
+    }
+
+    // ================================================================
+    // Edge cases
+    // ================================================================
+
+    @Test
+    fun `blank namespace defaults to public`() {
+        val sql = sqlGenerator.dropTable(TableName(namespace = "", name = "tbl"))
+        assertEquals("""DROP TABLE IF EXISTS "public"."tbl";""", sql)
+    }
+}


### PR DESCRIPTION
## Summary

- **Add full SQL generation** to `RedshiftSqlGenerator`: `createTable`, `upsertTable` (CTE-based dedup with cursor + CDC support), `matchSchemas` (4-step type change with `JSON_SERIALIZE`/`JSON_PARSE` for SUPER<->VARCHAR), `overwriteTable`, `copyTable`, `copyFromS3`, `getTableSchema`, and other DDL/DML helpers
- **Remove `createTableForCheck`** in favor of reusing `createTable` -- the checker now builds a lightweight `DestinationStream` wrapper instead of using a separate code path
- **Exclude PK columns from UPDATE SET** in upsert -- PK columns are matched in WHERE and guaranteed equal, so assigning them was redundant
- **Add 28 unit tests** for `RedshiftSqlGenerator` covering DDL, DML, upsert (with/without cursor, with/without CDC, PK exclusion), schema evolution (add/remove/SUPER<->VARCHAR/generic CAST), staging, and edge cases