### PR TITLE
ci(docs): bump amondnet/vercel-action to v42.2.0 to fix Vercel Preview deploy

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -101,7 +101,7 @@ jobs:
 
       - name: Deploy to Vercel
         id: deploy-vercel
-        uses: amondnet/vercel-action@888da851026e0573da056b061931bcb765a915c4 # v41.1.4
+        uses: amondnet/vercel-action@4b810e26f7bb2a331c698af186f890cbf20d5f72 # v42.2.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           vercel-token: ${{ secrets.VERCEL_TOKEN }}

--- a/docusaurus/README.md
+++ b/docusaurus/README.md
@@ -1,5 +1,3 @@
 # Documentation and Docusaurus
 
 For instructions, visit [Contribute to Documentation](https://docs.airbyte.com/contributing-to-airbyte/writing-docs).
-
-<!-- no-op touch to trigger Vercel Preview CI validation for workflow bump -->

--- a/docusaurus/README.md
+++ b/docusaurus/README.md
@@ -1,3 +1,5 @@
 # Documentation and Docusaurus
 
 For instructions, visit [Contribute to Documentation](https://docs.airbyte.com/contributing-to-airbyte/writing-docs).
+
+<!-- no-op touch to trigger Vercel Preview CI validation for workflow bump -->


### PR DESCRIPTION
## What

The `Vercel Preview` job in `.github/workflows/docs-build.yml` is failing on all PRs with:

```
Error: Your Vercel CLI version is outdated. This endpoint requires version 47.2.2 or later. Please upgrade by running `npm i -g vercel@latest`.
```

This is because we pin `amondnet/vercel-action@v41.1.4`, which ships Vercel CLI `41.1.4`. Vercel's deployment API now requires CLI `>=47.2.2`.

Example failing job (on #76419): https://github.com/airbytehq/airbyte/actions/runs/24538585473/job/71741241480

## How

Bump `amondnet/vercel-action` to `v42.2.0` (SHA `4b810e26f7bb2a331c698af186f890cbf20d5f72`), which bundles `vercel ^50.0.0` and therefore satisfies the API's version floor. No input changes needed — the action's API is backward compatible.

## Review guide

1. `.github/workflows/docs-build.yml` — one-line SHA/version bump on the `Deploy to Vercel` step.

## User Impact

Restores Vercel Preview deploys for docs PRs. No runtime impact on shipped artifacts.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/719c767c6b9d44f09bd393a2ecf34022
Requested by: @ian-at-airbyte
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/76423" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
