### PR TITLE
docs(ai-agents): fill out Chats and Automations UI pages

### DIFF
--- a/docs/ai-agents/interfaces/ui/automations.md
+++ b/docs/ai-agents/interfaces/ui/automations.md
@@ -28,11 +28,7 @@ The first time you open Automations in a new workspace, the same suggestions app
 
 ### From a chat
 
-Any Chat can become an Automation. Open the chat and click **Automate this** at the top of the conversation. Airbyte:
-
-1. Takes the prompt and tool configuration you iterated on in the chat.
-2. Creates a new Automation seeded with those settings.
-3. Moves you into the Automation Builder to finish configuring it.
+Any Chat can become an Automation. Open the chat and click **Automate this** at the top of the conversation. Airbyte takes the prompt and tool configuration you iterated on in the chat, converts the chat session into a new Automation seeded with those settings, and moves you into the Automation Builder to finish configuring it. The original chat is replaced by the Automation and no longer appears in Recent Chats.
 
 See [Convert a chat to an automation](./chats#convert-a-chat-to-an-automation) for more detail.
 

--- a/docs/ai-agents/interfaces/ui/automations.md
+++ b/docs/ai-agents/interfaces/ui/automations.md
@@ -4,46 +4,162 @@ sidebar_position: 2
 
 # Automations
 
+An Automation is an agent task that runs on its own, without a human in the loop. You describe what you want done once, pick how you want to trigger it—manually, on a schedule, or from a webhook—and Airbyte runs the task every time the trigger fires. Automations are the right choice when you need the same work to happen repeatedly, reliably, and without someone sitting at a keyboard.
+
+To open Automations, click **Automations** in the left sidebar.
+
 ## Create a new automation
+
+You can create an Automation three ways. The first two start from the Automations page; the third converts an existing [Chat](./chats).
 
 ### From scratch
 
+Click **New Automation** at the top of the Automations page. Airbyte opens a prompt dialog. Describe what you want the Automation to do in plain language, then press Enter or click the send button.
+
+Airbyte creates the Automation in draft, seeds the Automation Builder with your prompt, and takes you into the Builder so you can iterate on it, configure a trigger, and try a test run. See [The Automation Builder](#the-automation-builder) for details.
+
 ### From an idea
 
-### From a Chat
+If you're not sure how to phrase your prompt, use a suggestion. The New Automation dialog lists ready-made ideas grouped into categories such as Sales, Support, Marketing, Finance, Security, Product, HR, Ops, and Engineering.
+
+Click a category chip to filter the list, then click an idea to copy it into the prompt box. Edit the prompt if you want to adapt it to your workspace, then send it. Airbyte creates the Automation from the adapted prompt exactly as if you'd written it yourself.
+
+The first time you open Automations in a new workspace, the same suggestions appear on the empty Automations page so you can start building without going through the dialog.
+
+### From a chat
+
+Any Chat can become an Automation. Open the chat and click **Automate this** at the top of the conversation. Airbyte:
+
+1. Takes the prompt and tool configuration you iterated on in the chat.
+2. Creates a new Automation seeded with those settings.
+3. Moves you into the Automation Builder to finish configuring it.
+
+See [Convert a chat to an automation](./chats#convert-a-chat-to-an-automation) for more detail.
 
 ## Open an existing automation
 
 ### From the sidebar
 
+Recent Automations you've opened appear under **Recent Chats** in the sidebar, alongside your recent chats. Automations use a bolt icon so you can distinguish them at a glance. Click an Automation in the list to jump back into its Builder.
+
 ### From the Automations page
 
-Use search and filters to find what you want.
+Click **Automations** in the sidebar to open the full list. Every Automation in the workspace appears in the table, with its status, trigger, tools, and enabled state.
+
+Use search and filters to find what you want:
+
+- **Search**: Type in the search box at the top of the table to filter by Automation name.
+- **Status**: Filter by Running, Active, Paused, Failed, or Draft.
+- **Trigger**: Filter by Manual, Schedule, or Webhook.
+- **Enabled**: Show only enabled Automations, only turned-off Automations, or both.
+
+Click the **Edit** (pencil) icon on a row to open the Automation in the Builder. Automations created before session linking was introduced can't be edited from this button; Airbyte disables the icon and explains why on hover.
 
 ## Delete an automation
 
+To delete an Automation, click the trash icon on its row on the Automations page, or click **Delete** in the Automation Builder header. Airbyte asks you to confirm. Once you confirm, Airbyte permanently removes the Automation and all of its configuration. Deletion can't be undone. Existing run history rows that reference this Automation remain in the Sessions page for auditing.
+
 ## Rename an automation
 
-## Enable or disable an automation
+Open the Automation in the Builder and click **Properties** to open the Properties panel. Edit the **Name** field. Airbyte saves the change automatically when you click out of the field. The header shows a **Saving…** then **Saved** indicator to confirm. The new name appears immediately on the Automations page and in the sidebar.
 
-## The Automation Builder
+## Turn an automation on or off
+
+Scheduled Automations run automatically when their trigger fires. To pause a scheduled Automation without deleting it, turn its **Enabled** toggle off. The next scheduled time is skipped, and the Automation's status changes to Paused. Turn the toggle back on to resume.
+
+You can toggle Enabled from the table on the Automations page or from the Properties panel in the Builder. The toggle is only available for Automations with a Schedule trigger; Manual and Webhook Automations are always "on" in the sense that they run whenever you invoke them, so there's nothing to pause.
+
+## The Automation Builder {#the-automation-builder}
+
+The Automation Builder is where you design, iterate on, and run an Automation. Open it by creating a new Automation, clicking **Edit** on a row in the Automations page, or opening an Automation from the sidebar.
+
+The Builder has two tabs on the left side:
+
+- **Agent**: A chat with the Automation Builder Agent. Describe what you want the Automation to do, correct its approach, and ask it to try again. Each message runs as a test in the same way a Chat does, so you can validate behavior before committing to a schedule.
+- **Run History**: A list of every live and test run, with status, timestamps, and job-level details. See [Run history](#run-history).
+
+The right side of the Builder shows the Properties panel. Click the **Properties** button in the header to show or hide it.
+
+Click **Back to Automations** in the header to return to the Automations page. Airbyte saves your changes automatically as you work; the header shows a **Saving…** then **Saved** indicator to confirm.
 
 ### Tips for chatting with the Automation Builder Agent
 
+- **Treat the Builder chat like a spec-writing conversation**: Describe the outcome, then iterate. Ask the agent to adjust scope, change which connector it queries, or add a step.
+- **Try a test run early**: Click **Run** in the header after the agent proposes an approach. A test run uses the current draft and shows up in Run History tagged **Test run**, so you can check behavior before enabling a schedule.
+- **Use the Context list to confirm connectors**: The Properties panel shows which connectors the Automation uses. If something is missing, tell the agent which connector to use and it updates the context.
+- **Keep prompts specific and self-contained**: Automations don't have a user to answer follow-up questions at run time. Spell out exactly what to check, which fields to return, and where to send the result.
+
 ### Properties
+
+Click **Properties** in the header to open the Properties panel. The panel contains:
+
+- **Name**: The Automation's display name. Shown in the table, sidebar, and run history. Editable inline.
+- **Prompt**: The original prompt the Automation was created from, shown read-only for reference. To change what the Automation does, chat with the Builder Agent.
+- **Context**: The connectors this Automation uses. Managed through the Builder chat; edit connector membership by asking the agent to add or remove a source. Airbyte blocks direct editing here to keep the prompt and context consistent.
+- **Trigger**: How the Automation is invoked. Choose Manual, Schedule, or Webhook. See [Run automations](#run-automations).
+- **Schedule**: Visible when the trigger is Schedule. A builder that lets you pick a frequency (hourly, daily, weekly, monthly, or a raw cron expression) and a timezone.
+- **Result webhook (optional)**: A destination URL where Airbyte posts results after a run finishes. See [Result webhooks](#result-webhooks).
 
 ## Run automations
 
+An Automation runs when its trigger fires. Choose one trigger per Automation.
+
 ### Manually
+
+Manual Automations only run when you explicitly invoke them. Click the **Run** (play) icon on the Automation's row in the Automations page, or click **Run** in the Builder header, to start a run immediately. Airbyte queues the run, shows a confirmation, and records it in Run History. Use manual runs for Automations you want available on demand but not on a clock—for example, an end-of-quarter summary you invoke when you're ready to review it.
 
 ### On a schedule
 
+Scheduled Automations run at times you define. Open the Properties panel, set **Trigger** to Schedule, and use the schedule builder to pick the cadence:
+
+- **Hourly**, **Daily**, **Weekly**, or **Monthly** for common cases. Airbyte shows the equivalent cron expression so you can verify the schedule.
+- **Custom cron** for anything the builder doesn't cover. Provide the raw cron expression and Airbyte translates it into a human-readable summary.
+
+Pick the **Timezone** the schedule should use. Airbyte defaults to your local timezone. Turn the Automation's **Enabled** toggle on to activate the schedule. Each scheduled run appears in Run History tagged **Live run**.
+
 ### From a webhook
+
+Webhook Automations run when an external system posts to a URL Airbyte provides. Open the Properties panel, set **Trigger** to Webhook, and copy the generated webhook URL. Configure the external system to post to that URL when the event you care about happens. Each POST starts one run.
+
+Webhook Automations are useful for event-driven workflows like "when a Salesforce deal closes, create an onboarding ticket and notify the team in Slack."
 
 ### See the status of a running automation
 
+While an Automation is running, its row on the Automations page shows a **Running** status badge, and the Run History tab in the Builder shows a run in state **Running**. The spinner clears when the run finishes; the row's status then reflects the outcome of the most recent run (Active, Paused, or Failed).
+
+For a step-by-step view of what happened during a run, open the run in Run History or open the session from the [Sessions page](../../admin/sessions).
+
 ## Result webhooks
+
+A result webhook is an optional URL where Airbyte posts the result of each run. Set it in the Properties panel under **Result webhook**.
+
+When a run finishes, Airbyte POSTs a JSON payload containing the Automation's output to the URL you provided. Use result webhooks to:
+
+- Forward Automation output to another system, like a message channel, a queue, or a dashboard.
+- Chain Automations together—one Automation's result webhook triggers another system that kicks off the next step.
+- Store results somewhere you control, in addition to Airbyte's own history.
+
+Result webhooks are currently persisted for scheduled Automations. If you leave the field blank, Airbyte still records the result in Run History—it just doesn't forward it anywhere.
 
 ## Run history
 
+The Run History tab in the Builder lists every run of the current Automation, most recent first. Each entry shows:
+
+- A **Test run** or **Live run** badge. Test runs come from the **Run** button in the Builder; live runs come from a schedule or webhook trigger.
+- The run's overall state: **Running**, **Succeeded**, or **Failed**.
+- When the run was created and how many jobs it produced.
+- A per-job breakdown with state (Pending, Created, Ready, Running, Retrying, Cancelled, Failed, or Completed) and the job's result.
+
+Click a run to expand it and see the full job-level detail. Runs page 10 at a time; use the pagination buttons at the bottom to see older runs.
+
+Run History is scoped to one Automation. To audit runs across every Automation in the workspace, along with Chat sessions, open the [Sessions page](../../admin/sessions).
+
 ## Automation versions
+
+Airbyte treats the current state of the Builder as the draft version of the Automation. As you chat with the Builder Agent or edit properties, Airbyte saves your changes automatically, and the header's **Saving…** / **Saved** indicator confirms each save.
+
+- **Test runs** always execute against the current draft. Use them to verify a change before letting a schedule pick it up.
+- **Live runs** (scheduled or webhook) also run against the current saved state. After you edit an Automation, the next live run uses the new version.
+- **Run History** records which version of the Automation produced each run, so you can correlate behavior changes with edits.
+
+Because each edit is saved in place, there isn't a separate "publish" step. If you want to experiment without affecting a live schedule, turn **Enabled** off, iterate with test runs until you're satisfied, and turn Enabled back on.

--- a/docs/ai-agents/interfaces/ui/chats.md
+++ b/docs/ai-agents/interfaces/ui/chats.md
@@ -4,27 +4,75 @@ sidebar_position: 1
 
 # Chats
 
-What are chats
+A Chat is a conversation between you and an Airbyte agent in the web app. You send a prompt, the agent decides which connectors to use and which tool calls to make, and it replies with an answer grounded in your data. Chats are the fastest way to explore data, get a one-off answer, or prototype an idea before turning it into a reusable [Automation](./automations).
+
+To open Chats, click **New chat** in the left sidebar, or click an existing chat under **Recent Chats**.
 
 ## Start a new chat
 
+Click **New chat** in the sidebar to open the Chat landing page. Type a prompt in the text box and press Enter, or click the send button. Airbyte creates a new chat session, opens it, and sends your first message automatically.
+
+Every chat runs against the connectors you've already authenticated in your workspace. You don't need to select connectors up front—the agent picks the right ones based on your prompt and the [context](#context) available to it.
+
 ### Templates
+
+The Chat landing page suggests prompts you can use instead of writing your own. Suggestions are grouped into categories such as Sales, Support, Marketing, Finance, Security, Product, HR, Ops, and Engineering. Click a category chip to filter the suggestions, then click a suggestion to copy it into the prompt box. Edit the prompt if you want to adapt it, then send it.
+
+Suggestions are starting points, not fixed templates. The agent treats the text exactly like any other prompt, so you can freely reword or combine suggestions.
 
 ## Resume an old chat
 
+Every chat you start is saved. To return to a chat, open the sidebar and click the chat under **Recent Chats**. The sidebar shows your five most recent chats by default. Click **Show more** to expand the list, or open the Sessions page from Settings to browse every chat and automation run in your organization.
+
+When you reopen a chat, the full history loads in place and you can continue the conversation by sending another message. Older messages stay available—scroll up or click **Load older messages** to page through the history.
+
+Chats are private to you by default. To share a chat with a teammate, click the **Share** button at the top of the chat to copy a link. Anyone in your organization can open the link to view the chat in read-only mode; they can't send new messages on your behalf.
+
 ## Context
+
+**Context** is the data and connectors the agent can use to answer your prompt. Airbyte uses the context to decide which tool calls to make, which entities to query, and how to interpret your question.
 
 ### What context is available
 
-- When starting a chat
-- From the chat itself
+Two places surface the context the agent has.
+
+- **When starting a chat**: The Chat landing page lists every connector you've already authenticated in the workspace under **Available context**. The agent can use any of these connectors automatically, so you don't need to name them in your prompt.
+- **From the chat itself**: Inside an open chat, click the **Context** dropdown over the message input to see the same list. Each entry shows the connector's name and logo. If a connector doesn't appear in either view, the agent can't use it in this chat.
 
 ### Add new context
 
+To give the agent more to work with, connect another source. Open the **Credentials** page from the sidebar, connect the new source, and authenticate it. The new connector is immediately available in any chat you open afterward.
+
+If you're in the middle of a chat and realize the agent needs a connector it doesn't have, connect the source in another tab, then return to the chat and ask the agent to try again. The agent picks up the new connector automatically on its next message.
+
 ## What you can use Chats for
 
+Chats are best for interactive, one-off work where you want to iterate with the agent. Common use cases include:
+
+- **Exploring data**: Ask natural-language questions about your customers, deals, tickets, or usage data and drill deeper based on the agent's replies.
+- **Summarizing and reporting**: Generate on-demand summaries, such as "What deals closed this quarter?" or "Which accounts have the most open support tickets?"
+- **Cross-system questions**: Ask questions that span multiple connectors. For example, match Salesforce accounts to HubSpot contacts or Zendesk tickets.
+- **Drafting content**: Use replies as a starting point for emails, follow-ups, status updates, or internal notes.
+- **Prototyping an Automation**: Iterate on a prompt in Chat until the agent reliably returns what you want, then convert the chat into an [Automation](./automations) so it can run on a schedule or webhook.
+
+If you want the same work to happen repeatedly, on a schedule, or in response to an event, use an Automation instead.
+
 ## Tips for effective conversations
+
+- **Be specific about the outcome**: Tell the agent what you want back. "List the 10 highest-value open Salesforce deals, sorted by amount, with owner and close date" works better than "Show all deals."
+- **Name the source if you know it**: If you want data from a specific connector, say so. "Pull ticket counts from Zendesk" is clearer than "Pull ticket counts," especially when multiple connectors cover similar data.
+- **Iterate in small steps**: Ask a question, review the answer, then refine. Agents do their best work when you narrow in gradually rather than asking one complex question.
+- **Check tool calls when something looks off**: Expand a tool call in the conversation to see which connector the agent used, which entity it queried, and whether the call succeeded. This is the fastest way to diagnose unexpected results.
+- **Give feedback on replies**: Use the thumbs-up or thumbs-down buttons on any assistant message. Feedback helps Airbyte improve agent quality and helps you remember which replies you trusted.
 
 ## Convert a chat to an automation
 
 As your chat develops, you may want to turn it into an event that can run repeatedly. These are called Automations.
+
+To convert a chat, click **Automate this** at the top of the chat. Airbyte:
+
+1. Takes the prompt and tools you've been iterating on in the chat.
+2. Creates a new Automation seeded with those settings.
+3. Moves you into the Automation Builder so you can add a trigger, fine-tune the prompt, and run it.
+
+Converting a chat doesn't modify the original chat—you can keep using it for follow-up questions. The resulting Automation starts in draft, so it doesn't run until you configure a trigger and enable it. See [Automations](./automations) for the full builder workflow.

--- a/docs/ai-agents/interfaces/ui/chats.md
+++ b/docs/ai-agents/interfaces/ui/chats.md
@@ -26,7 +26,7 @@ Every chat you start is saved. To return to a chat, open the sidebar and click t
 
 When you reopen a chat, the full history loads in place and you can continue the conversation by sending another message. Older messages stay available—scroll up or click **Load older messages** to page through the history.
 
-Chats are private to you by default. To share a chat with a teammate, click the **Share** button at the top of the chat to copy a link. Anyone in your organization can open the link to view the chat in read-only mode; they can't send new messages on your behalf.
+To share a chat with a teammate, click the **Share** button at the top of the chat to copy a link to the session. Only you can send messages in your own chats; other people in your organization who open the link can read the conversation but can't post new messages to it.
 
 ## Context
 
@@ -67,12 +67,8 @@ If you want the same work to happen repeatedly, on a schedule, or in response to
 
 ## Convert a chat to an automation
 
-As your chat develops, you may want to turn it into an event that can run repeatedly. These are called Automations.
+As your chat develops, you may want to turn it into something that can run repeatedly. These are called Automations.
 
-To convert a chat, click **Automate this** at the top of the chat. Airbyte:
+To convert a chat, click **Automate this** at the top of the chat. Airbyte takes the prompt and tools you've been iterating on, converts the existing chat session into a new Automation seeded with those settings, and opens it in the [Automation Builder](./automations#the-automation-builder) so you can add a trigger, fine-tune the prompt, and run it.
 
-1. Takes the prompt and tools you've been iterating on in the chat.
-2. Creates a new Automation seeded with those settings.
-3. Moves you into the Automation Builder so you can add a trigger, fine-tune the prompt, and run it.
-
-Converting a chat doesn't modify the original chat—you can keep using it for follow-up questions. The resulting Automation starts in draft, so it doesn't run until you configure a trigger and enable it. See [Automations](./automations) for the full builder workflow.
+Converting a chat replaces it—the original chat is turned into the Automation and no longer appears as a chat. If you want to keep exploring the same question as a chat after converting, start a new chat. The resulting Automation starts in draft, so it doesn't run until you configure a trigger and enable it. See [Automations](./automations) for the full builder workflow.

--- a/docs/ai-agents/interfaces/ui/chats.md
+++ b/docs/ai-agents/interfaces/ui/chats.md
@@ -26,7 +26,7 @@ Every chat you start is saved. To return to a chat, open the sidebar and click t
 
 When you reopen a chat, the full history loads in place and you can continue the conversation by sending another message. Older messages stay available—scroll up or click **Load older messages** to page through the history.
 
-To share a chat with a teammate, click the **Share** button at the top of the chat to copy a link to the session. Only you can send messages in your own chats; other people in your organization who open the link can read the conversation but can't post new messages to it.
+Only the person who started a chat can send messages in it. If another member of your organization opens the chat (for example, via a link to its URL), they see the full conversation in read-only mode and can't post new messages.
 
 ## Context
 


### PR DESCRIPTION
## What

Fills out the two outline pages under `docs/ai-agents/interfaces/ui/`:

- `chats.md` — what a Chat is, how to start/resume/share chats, context, use cases, tips, and converting a chat into an Automation.
- `automations.md` — how to create (from scratch, from an idea, from a chat), open, delete, rename, and turn Automations on/off; the Automation Builder (tabs, tips, Properties); running manually / on a schedule / from a webhook; run status; result webhooks; run history; and how versions/draft-vs-live behavior work.

Requested by @ian-at-airbyte. Stacked on the `docs-airbyte-agents` branch so it merges into that integration branch rather than `master`.

## How

Behavior was derived from the sonar frontend (`frontend/src/components/chat/*`, `frontend/src/components/automations/*`, `frontend/src/routes/organizations/$organizationId/chat/*`, `.../automations.tsx`, `SonarSideBar.tsx`, locale strings in `frontend/src/core/locales/en.json`). Content mirrors what the UI actually exposes today: category-filtered suggestions, the Context dropdown, recent-chats list, Share/Automate-this buttons, the Builder's Agent + Run History tabs, Properties panel (Name, Prompt, Context, Trigger, Schedule, Result webhook), manual/schedule/webhook triggers, Test vs Live run badges, and auto-save semantics.

Linting:

- `markdownlint-cli2` with the repo's `.markdownlint.jsonc`: passes with 0 errors.
- `vale --minAlertLevel=warning` using `docusaurus/vale.ini`: 0 errors; one remaining warning on the `## The Automation Builder` heading, which is kept because "Automation Builder" is a product name.

## Review guide

1. `docs/ai-agents/interfaces/ui/chats.md`
2. `docs/ai-agents/interfaces/ui/automations.md`

## User Impact

Documentation-only change on an integration branch. No runtime effect. End users landing on these pages now get substantive guidance instead of an outline.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌


Link to Devin session: https://app.devin.ai/sessions/0ca7180b9f5c44e3b053b2b4f9ddd0ba