### PR TITLE
feat(source-justcall): chunk calls/sms backfills into 30-day windows

### DIFF
--- a/airbyte-integrations/connectors/source-justcall/manifest.yaml
+++ b/airbyte-integrations/connectors/source-justcall/manifest.yaml
@@ -91,6 +91,11 @@ definitions:
         cursor_datetime_formats:
           - "%Y-%m-%d"
         datetime_format: "%Y-%m-%d"
+        # JustCall's /v2.1/calls endpoint caps (to_datetime - from_datetime) at 90 days.
+        # Without a step, the cursor emits a single slice for the full backfill and the
+        # API rejects it. Chunk into 30-day windows instead.
+        step: P30D
+        cursor_granularity: P1D
         start_datetime:
           type: MinMaxDatetime
           datetime: "{{ config[\"start_date\"] }}"
@@ -151,6 +156,11 @@ definitions:
         cursor_datetime_formats:
           - "%Y-%m-%d"
         datetime_format: "%Y-%m-%d"
+        # JustCall's /v2.1/texts endpoint caps (to_datetime - from_datetime) at 90 days.
+        # Without a step, the cursor emits a single slice for the full backfill and the
+        # API rejects it. Chunk into 30-day windows instead.
+        step: P30D
+        cursor_granularity: P1D
         start_datetime:
           type: MinMaxDatetime
           datetime: "{{ config[\"start_date\"] }}"

--- a/airbyte-integrations/connectors/source-justcall/metadata.yaml
+++ b/airbyte-integrations/connectors/source-justcall/metadata.yaml
@@ -17,7 +17,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 488cdc64-36cd-451d-bcfa-c6478b461e94
-  dockerImageTag: 0.0.47
+  dockerImageTag: 0.0.48
   dockerRepository: airbyte/source-justcall
   githubIssueLabel: source-justcall
   icon: icon.svg

--- a/docs/integrations/sources/justcall.md
+++ b/docs/integrations/sources/justcall.md
@@ -25,6 +25,7 @@ JustCall connector enables seamless data integration by syncing call logs, conta
 
 | Version          | Date              | Pull Request | Subject        |
 |------------------|-------------------|--------------|----------------|
+| 0.0.48 | 2026-04-17 | [76435](https://github.com/airbytehq/airbyte/pull/76435) | Chunk calls/sms backfills into 30-day windows (JustCall API caps `to_datetime - from_datetime` at 90 days) |
 | 0.0.47 | 2026-03-31 | [75726](https://github.com/airbytehq/airbyte/pull/75726) | Update dependencies |
 | 0.0.46 | 2026-03-24 | [75034](https://github.com/airbytehq/airbyte/pull/75034) | Update dependencies |
 | 0.0.45 | 2026-02-24 | [73952](https://github.com/airbytehq/airbyte/pull/73952) | Update dependencies |


### PR DESCRIPTION
## What

Adds `step: P30D` and `cursor_granularity: P1D` to the `DatetimeBasedCursor` for both incremental streams (`calls`, `sms`) in the JustCall source-connector manifest.

## Why

JustCall's `/v2.1/calls` and `/v2.1/texts` endpoints reject requests whose `(to_datetime - from_datetime)` exceeds **90 days** (see https://developer.justcall.io/reference/call_list_v21). The current manifest defines an `incremental_sync` block with `start_datetime` / `end_datetime` but no `step` or `cursor_granularity`, so the cursor emits a **single slice** spanning `start_date..now()` and passes it directly to the API.

In practice, this means any sync spanning more than ~90 days — whether a long backfill or a large gap in incremental runs after an outage — gets a hard 400 on every attempt and never recovers on its own.

## ⚠️ Note on a separate JustCall age limit (discovered during deployment)

After deploying this fix to our preview image and running it against JustCall's production API, I confirmed the connector correctly emits 30-day chunked requests to `/v2.1/texts`. However, JustCall's API enforces a **second, independent restriction** not covered by this PR: every request's date range must fall entirely **within the most recent 3 months**. Any request for older data — regardless of its width — returns:

> `400: "The selected datetime range must be within the most recent 3 month(s)."`

This absolute-age cap is server-side and cannot be worked around from the connector. So while this PR's fix is necessary for any sync spanning >90 days, **it does not by itself enable long historical backfills** (e.g. from 18 months ago). Backfills beyond ~3 months require vendor-provided bulk export or an alternative data source for the pre-3-month window.

**Where this PR still has clear value**: protecting against large incremental-sync gaps. If Airbyte is offline (or a connection is paused) for ≥90 days, the next run's cursor → `now()` window exceeds the width cap without this fix — a previously-healthy connection would break permanently until manual intervention. With chunking, the catch-up sync issues sequential 30-day requests that all stay within the width cap. Any date ranges that also fall within the last 3 months will succeed; older ones still hit the separate age cap, but the connector handles them as individual slice failures rather than a total failure.

## Fix

Chunk the date range into 30-day windows (comfortably under the 90-day cap) with daily cursor granularity:

```yaml
incremental_sync:
  type: DatetimeBasedCursor
  cursor_field: call_date   # (and sms_date for the sms stream)
  cursor_datetime_formats:
    - "%Y-%m-%d"
  datetime_format: "%Y-%m-%d"
  step: P30D
  cursor_granularity: P1D
  ...
```

Steady-state incremental syncs aren't affected — once the cursor has advanced past `now - 30d`, each run issues a single in-window request. The only behavior change is in the multi-window case.

## Testing

**CI (passing):** `Test source-justcall Connector (No Creds)`, `Lint source-justcall Connector`, `Check Changelog Updated`, `Format Check`, `Docs / MarkDownLint`, `Docs / Vale`, PR-structure/title checks.

**Real-world verification against JustCall's production API**:
- Built a preview image from this branch (`0.0.48-preview.e575b33`) and deployed it to our Airbyte OSS installation using a custom `source_definition` pinned to that tag.
- Ran a sync against a real JustCall tenant. Observed in orchestrator logs that the `sms` stream issued sequential 30-day chunked requests against `/v2.1/texts` exactly as designed, e.g.:
  ```
  from_datetime=2025-07-28&to_datetime=2025-08-26
  from_datetime=2025-08-27&to_datetime=2025-09-25
  from_datetime=2025-09-26&to_datetime=2025-10-25
  ...
  ```
- **Chunking mechanism works as designed.** Each request stays within JustCall's 90-day width cap. Requests for ranges within the last 3 months succeed; ranges older than that hit the separate age-limit 400 described above (not a chunking issue).
- The non-incremental streams (`users`, `contacts`, `phone_numbers`, `agent_analytics`) continue to sync normally and were unaffected by this change.
- Did not separately exercise the `calls` stream end-to-end in this test, but it uses the same `DatetimeBasedCursor` mechanism as `sms` and the manifest change is symmetric across both streams.

## Files changed

- `airbyte-integrations/connectors/source-justcall/manifest.yaml` — `step` + `cursor_granularity` on `calls` and `sms`
- `airbyte-integrations/connectors/source-justcall/metadata.yaml` — `dockerImageTag: 0.0.47 → 0.0.48`
- `docs/integrations/sources/justcall.md` — changelog entry
