### PR TITLE
docs(ai-agents): integrate Web app UI section into interfaces and home

### DIFF
--- a/docs/ai-agents/README.md
+++ b/docs/ai-agents/README.md
@@ -100,7 +100,15 @@ It's helpful to think of agent connectors as equivalent to sets of tools. Tools 
 
 <CardWithIcon title="Tutorials" description="Get started with the Airbyte Agents and its connectors. Even if you've never built an AI agent before, you can have one working for you in 15 minutes or less." ctaText="Tutorials" ctaLink="/ai-agents/get-started/tutorials/" icon="fa-cloud" />
 
+<CardWithIcon title="Web app" description="Use the Airbyte Agents web app to talk to an Airbyte-hosted agent in Chats, or define Automations that run on a schedule or webhook." ctaText="Web app docs" ctaLink="/ai-agents/interfaces/ui/" icon="fa-robot" />
+
+</Grid>
+
+<Grid columns="2">
+
 <CardWithIcon title="SDK" description="Use Airbyte's Airbyte Agents to store and manage credentials, run connectors, and power agentic search." ctaText="SDK docs" ctaLink="/ai-agents/interfaces/sdk/" icon="fa-lock" />
+
+<CardWithIcon title="MCP server" description="Connect MCP-capable agents, like Claude, Cursor, and ChatGPT, to your data through the Airbyte-hosted Model Context Protocol server." ctaText="MCP docs" ctaLink="/ai-agents/interfaces/mcp/" icon="fa-plug" />
 
 </Grid>
 

--- a/docs/ai-agents/interfaces/readme.md
+++ b/docs/ai-agents/interfaces/readme.md
@@ -4,8 +4,9 @@ sidebar_position: 4
 
 # Interfaces
 
-Airbyte Agents supports multiple interfaces for connecting AI agents to your data. Choose the interface that best fits how you build and run agents.
+Airbyte Agents supports three interfaces for working with your data and your agents. Choose the interface that best fits how you want to build and run agents.
 
+- [**Web app**](ui): The Airbyte Agents web app at [app.airbyte.ai](https://app.airbyte.ai). Talk to an Airbyte-hosted agent in [Chats](ui/chats), or define [Automations](ui/automations) that run on a schedule or webhook. Best when you want Airbyte itself to be your agent, with no code required.
 - [**MCP server**](mcp): A remote, Airbyte-hosted Model Context Protocol server that connects MCP-capable agents (like Claude, Cursor, and ChatGPT) to your data. Best for conversational agents that use off-the-shelf clients.
 - [**SDK**](sdk): Python SDK and platform APIs for building, authenticating, and executing agent connectors in your own applications. Best for agents you build and host yourself.
 

--- a/docs/ai-agents/interfaces/ui/readme.md
+++ b/docs/ai-agents/interfaces/ui/readme.md
@@ -1,0 +1,31 @@
+---
+sidebar_position: 1
+---
+
+# Web app
+
+The Airbyte Agents web app at [app.airbyte.ai](https://app.airbyte.ai) is the fastest way to use Airbyte Agents without writing code. Describe what you want in natural language, and Airbyte picks the right connectors, makes the necessary tool calls, and replies with an answer grounded in your data.
+
+Use the web app when you want Airbyte itself to be your agent. For agents you build yourself, use the [SDK](../sdk). For agents that already speak Model Context Protocol, use the [MCP server](../mcp).
+
+## Chats and Automations
+
+The web app has two primary surfaces for working with an Airbyte agent.
+
+- [**Chats**](./chats): Interactive conversations with an Airbyte agent. Ask a question, iterate on the answer, and explore your data in natural language. Chats are the fastest way to get a one-off answer or prototype an idea.
+- [**Automations**](./automations): Agent tasks that run without a person in the loop. Trigger an Automation manually, on a schedule, or from a webhook. Use Automations when you need the same work to happen repeatedly and reliably.
+
+Every Chat and Automation runs against the connectors you've authenticated in your workspace. Manage connectors from the **Credentials** page in the sidebar. For the catalog of available connectors, see [Agent connectors](../../connectors).
+
+## Related administration
+
+Other parts of the web app are covered in [Account and administration](../../admin):
+
+- [Profile](../../admin/profile) for account settings.
+- [Sessions](../../admin/sessions) for the run history of every Chat and Automation in your organization.
+- [Review tool calls](../../admin/tool-calls) for inspecting and approving deferred tool calls.
+- [Billing](../../admin/billing) for plans, usage, and invoices.
+
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />


### PR DESCRIPTION
This PR targets the following PR:
- #76447

---

## What

Wires the new `docs/ai-agents/interfaces/ui/` content (Chats + Automations, populated in #76428) into the overall Airbyte Agents docs structure on the `docs-airbyte-agents` integration branch. Requested by @ian-at-airbyte.

Three touchpoints:

1. **`docs/ai-agents/interfaces/ui/readme.md`** — was a zero-byte placeholder. Now a proper landing page for the Web app section: introduces app.airbyte.ai, points at Chats and Automations as the two primary surfaces, and cross-links to SDK / MCP / connectors and the admin pages (profile, sessions, tool-calls, billing) that are also part of the web app but live under `admin/`.
2. **`docs/ai-agents/interfaces/readme.md`** — previously listed only MCP and SDK. Now lists **Web app** as a first-class third interface alongside them, so the Interfaces home reflects all three ways to use Airbyte Agents.
3. **`docs/ai-agents/README.md`** — the Airbyte Agents docs home. Adds a **Web app** card (with Chats/Automations blurb) and an **MCP server** card to the existing Grid so all three interfaces are surfaced from the top-level landing page, not just SDK.

## How

- Wrote `interfaces/ui/readme.md` with `sidebar_position: 1` so Web app sorts before SDK (2) and MCP (6) within the Interfaces category.
- Kept existing MCP/SDK copy in `interfaces/readme.md` verbatim — only added the Web app bullet and adjusted the lede to say "three interfaces".
- Reused `CardWithIcon` with already-registered icons (`fa-robot` for Web app, `fa-plug` for MCP) — confirmed against `docusaurus/src/components/Card/Card.jsx`.
- No sidebar config changes needed; the `ai-agents` docs plugin autogenerates the sidebar from the filesystem (`docusaurus.config.ts` lines 170–218).

## Review guide

1. `docs/ai-agents/interfaces/ui/readme.md` — new landing page content.
2. `docs/ai-agents/interfaces/readme.md` — added Web app to the three-interface list.
3. `docs/ai-agents/README.md` — added Web app + MCP cards to the home-page grid.

## User Impact

Documentation-only change on the `docs-airbyte-agents` integration branch. Readers landing on `/ai-agents/` or `/ai-agents/interfaces/` now see the Web app (Chats, Automations) as an equal peer to the SDK and MCP, instead of the UI section being orphaned behind a blank readme.

Linting:

- `markdownlint-cli2` on the three files: 0 new errors. The two `MD012` hits on `README.md` lines 97–98 are pre-existing blank-line issues on `docs-airbyte-agents`, untouched by this PR.
- `vale --minAlertLevel=warning` on the three files: 0 new alerts on the new/edited content. The two hits on `README.md` line 10 (`Google.Ellipses`, `Google.Exclamation` on the "Plans start as low as... free!" line) are pre-existing.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

Link to Devin session: https://app.devin.ai/sessions/98bec096e90e40e09e83787a5caec65e