### PR TITLE
chore(source-zendesk-talk): decrease default_concurrency from 9 to 6 for tuning iteration 3

### DIFF
--- a/airbyte-integrations/connectors/source-zendesk-talk/manifest.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-talk/manifest.yaml
@@ -561,11 +561,12 @@ streams:
 # Concurrency calculated using highest rate limit across all endpoints:
 # highest = 50 req/sec (Talk API all endpoints), initial = floor(50 / 4) = 12
 # Tuning iteration 2: decreased to 9 after Phase 1 showed +6% duration regression
+# Tuning iteration 3: decreased to 6 after rc.2 showed persistent heartbeat_timeout failures on high-volume connections
 # Ref: https://developer.zendesk.com/api-reference/voice/talk-api/rate_limits/
 concurrency_level:
   type: ConcurrencyLevel
-  default_concurrency: 9
-  max_concurrency: 36
+  default_concurrency: 6
+  max_concurrency: 24
 
 # HTTP API Budget: throttle requests per Zendesk Talk API rate limits
 # Ref: https://developer.zendesk.com/api-reference/voice/talk-api/rate_limits/

--- a/airbyte-integrations/connectors/source-zendesk-talk/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-talk/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: c8630570-086d-4a40-99ae-ea5b18673071
-  dockerImageTag: 2.0.11-rc.2
+  dockerImageTag: 2.0.11-rc.3
   dockerRepository: airbyte/source-zendesk-talk
   documentationUrl: https://docs.airbyte.com/integrations/sources/zendesk-talk
   externalDocumentationUrls:

--- a/docs/integrations/sources/zendesk-talk.md
+++ b/docs/integrations/sources/zendesk-talk.md
@@ -79,6 +79,7 @@ The Zendesk connector should not run into Zendesk API limitations under normal u
 
 | Version | Date       | Pull Request                                             | Subject                                                                     |
 |:--------|:-----------|:---------------------------------------------------------|:----------------------------------------------------------------------------|
+| 2.0.11-rc.3 | 2026-04-17 | [](https://github.com/airbytehq/airbyte/pull/) | Decrease default_concurrency from 9 to 6 for tuning iteration 3 |
 | 2.0.11-rc.2 | 2026-04-13 | [76266](https://github.com/airbytehq/airbyte/pull/76266) | Decrease default_concurrency from 12 to 9 for tuning iteration 2 |
 | 2.0.11-rc.1 | 2026-04-09 | [76203](https://github.com/airbytehq/airbyte/pull/76203) | Add concurrency support with default_concurrency of 12 |
 | 2.0.10 | 2026-04-06 | [](https://github.com/airbytehq/airbyte/pull/) | Add `token_expiry_date` to `complete_oauth_output_specification` so it is hidden from the UI as an OAuth-managed field |


### PR DESCRIPTION
## What

Concurrency tuning iteration 3 for `source-zendesk-talk`. Decreases `default_concurrency` from 9 → 6 (and `max_concurrency` from 36 → 24) to address persistent `heartbeat_timeout` failures observed on high-volume connections during rc.2 monitoring.

Part of the concurrency tuning epic: https://github.com/airbytehq/airbyte-internal-issues/issues/15316

**Context:** During 24h monitoring of rc.2 (c=9), one high-volume connection (~209k rows/sync) had a 0% success rate across both rc.1 (c=12) and rc.2 (c=9), exhausting all 20 retry attempts with heartbeat timeouts each time. The connection works fine on stable (c=1). Reducing concurrency further to see if the stalling behavior resolves at c=6.

Prior iterations:
- PR #76203: Initial concurrency (c=12) + HTTPAPIBudget → rc.1
- PR #76266: Decreased to c=9 → rc.2

## How

- `manifest.yaml`: `default_concurrency: 9 → 6`, `max_concurrency: 36 → 24`, added tuning iteration 3 comment
- `metadata.yaml`: Bumped `dockerImageTag` to `2.0.11-rc.3`
- `zendesk-talk.md`: Added changelog entry for rc.3

## Review guide

1. `airbyte-integrations/connectors/source-zendesk-talk/manifest.yaml` — concurrency values and comment
2. `airbyte-integrations/connectors/source-zendesk-talk/metadata.yaml` — version bump
3. `docs/integrations/sources/zendesk-talk.md` — changelog entry (PR link placeholder will be backfilled)

## User Impact

No user-facing impact. This RC will only be deployed to pinned progressive rollout actors (50% of Tier 2 connections). If c=6 resolves the heartbeat timeout failures on high-volume connections, we proceed toward GA; if not, further investigation is needed.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/a8b7ef49ffb0424c93226baac20ab5e3
Requested by: @sophiecuiy