### PR TITLE
chore(source-freshdesk): revert to c=5 and disable HTTPAPIBudget (3.2.14-rc.4)

### DIFF
--- a/airbyte-integrations/connectors/source-freshdesk/manifest.yaml
+++ b/airbyte-integrations/connectors/source-freshdesk/manifest.yaml
@@ -3742,19 +3742,21 @@ concurrency_level:
   default_concurrency: "{{ config.get('num_workers', 5) }}"
   max_concurrency: 16
 
-api_budget:
-  type: HTTPAPIBudget
-  policies:
-    - type: FixedWindowCallRatePolicy
-      period: "PT1M"
-      # due to lack for support for interpolated string for the call_limit field, this has been
-      # hardcoded to 50 which is the default rate for free plan
-      # in the near term use "{{ config.get('requests_per_minute')}}"
-      # long term is to utilize the `rate_limit_plan` field in config and specifying for each endpoint
-      call_limit: 50 
-      matchers:
-        - method: GET
-          url_base: "https://{{ config['domain'] }}/api/v2/"
-  ratelimit_reset_header: Retry-After
-  ratelimit_remaining_header: X-RateLimit-Remaining
-  status_codes_for_ratelimit_hit: [429]
+# api_budget commented out for rc.4 tuning experiment — testing c=5 without rate limit budget
+# to determine if the 50 calls/min budget was throttling performance
+# api_budget:
+#   type: HTTPAPIBudget
+#   policies:
+#     - type: FixedWindowCallRatePolicy
+#       period: "PT1M"
+#       # due to lack for support for interpolated string for the call_limit field, this has been
+#       # hardcoded to 50 which is the default rate for free plan
+#       # in the near term use "{{ config.get('requests_per_minute')}}"
+#       # long term is to utilize the `rate_limit_plan` field in config and specifying for each endpoint
+#       call_limit: 50
+#       matchers:
+#         - method: GET
+#           url_base: "https://{{ config['domain'] }}/api/v2/"
+#   ratelimit_reset_header: Retry-After
+#   ratelimit_remaining_header: X-RateLimit-Remaining
+#   status_codes_for_ratelimit_hit: [429]

--- a/airbyte-integrations/connectors/source-freshdesk/manifest.yaml
+++ b/airbyte-integrations/connectors/source-freshdesk/manifest.yaml
@@ -1692,7 +1692,7 @@ spec:
           Number of concurrent threads for syncing. Higher values can speed up
           syncs but may increase API rate limit usage. Adjust based on your
           Freshdesk API plan.
-        default: 6
+        default: 5
         minimum: 2
         maximum: 16
         order: 5
@@ -3739,7 +3739,7 @@ schemas:
 
 concurrency_level:
   type: ConcurrencyLevel
-  default_concurrency: "{{ config.get('num_workers', 6) }}"
+  default_concurrency: "{{ config.get('num_workers', 5) }}"
   max_concurrency: 16
 
 api_budget:

--- a/airbyte-integrations/connectors/source-freshdesk/metadata.yaml
+++ b/airbyte-integrations/connectors/source-freshdesk/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: ec4b9503-13cb-48ab-a4ab-6ade4be46567
-  dockerImageTag: 3.2.14-rc.3
+  dockerImageTag: 3.2.14-rc.4
   dockerRepository: airbyte/source-freshdesk
   documentationUrl: https://docs.airbyte.com/integrations/sources/freshdesk
   externalDocumentationUrls:

--- a/docs/integrations/sources/freshdesk.md
+++ b/docs/integrations/sources/freshdesk.md
@@ -72,6 +72,7 @@ If you don't use the start date Freshdesk will retrieve only the last 30 days. M
 
 | Version | Date       | Pull Request                                             | Subject                                                                               |
 | :------ | :--------- | :------------------------------------------------------- | :------------------------------------------------------------------------------------ |
+| 3.2.14-rc.4 | 2026-04-17 | | Revert default_concurrency from 6 to 5 for Full Tier 2 rollout |
 | 3.2.14-rc.3 | 2026-04-14 | | Concurrency tuning iteration 3: increase default_concurrency from 5 to 6 |
 | 3.2.14-rc.2 | 2026-04-13 | [76272](https://github.com/airbytehq/airbyte/pull/76272) | Concurrency tuning iteration 2: increase default_concurrency from 4 to 5 |
 | 3.2.14-rc.1 | 2026-04-10 | [76202](https://github.com/airbytehq/airbyte/pull/76202) | Add concurrency_level and num_workers for concurrency tuning |

--- a/docs/integrations/sources/freshdesk.md
+++ b/docs/integrations/sources/freshdesk.md
@@ -72,7 +72,7 @@ If you don't use the start date Freshdesk will retrieve only the last 30 days. M
 
 | Version | Date       | Pull Request                                             | Subject                                                                               |
 | :------ | :--------- | :------------------------------------------------------- | :------------------------------------------------------------------------------------ |
-| 3.2.14-rc.4 | 2026-04-17 | | Revert default_concurrency from 6 to 5 for Full Tier 2 rollout |
+| 3.2.14-rc.4 | 2026-04-17 | | Revert default_concurrency from 6 to 5 and disable HTTPAPIBudget for tuning experiment |
 | 3.2.14-rc.3 | 2026-04-14 | | Concurrency tuning iteration 3: increase default_concurrency from 5 to 6 |
 | 3.2.14-rc.2 | 2026-04-13 | [76272](https://github.com/airbytehq/airbyte/pull/76272) | Concurrency tuning iteration 2: increase default_concurrency from 4 to 5 |
 | 3.2.14-rc.1 | 2026-04-10 | [76202](https://github.com/airbytehq/airbyte/pull/76202) | Add concurrency_level and num_workers for concurrency tuning |


### PR DESCRIPTION
## What

Reverts `default_concurrency` from 6 back to 5 **and comments out the `HTTPAPIBudget`** for source-freshdesk, as a tuning experiment to isolate whether the 50 calls/min budget was artificially throttling sync performance.

Related issue: https://github.com/airbytehq/airbyte-internal-issues/issues/15331

**Context from tuning iterations:**
- rc.1 (c=4): +6.1% vs stable
- rc.2 (c=5): **+0.5% vs stable (PASS)** ← best performing
- rc.3 (c=6): +5.5% vs stable (FAIL, over 5% gate)
- 0% failures across all iterations; no rate limiting observed
- Statistical analysis showed c=4/c=5/c=6 are indistinguishable due to bimodal duration patterns and small sample sizes — disabling the budget tests whether it was the actual bottleneck

## How

- `manifest.yaml`: Reverts `num_workers` default and `default_concurrency` fallback from `6` → `5`
- `manifest.yaml`: **Comments out the entire `api_budget` section** (preserved as YAML comments for easy restoration)
- `metadata.yaml`: Bumps version `3.2.14-rc.3` → `3.2.14-rc.4`
- `freshdesk.md`: Adds changelog entry for rc.4

## Review guide

1. `manifest.yaml` line ~1695 and ~3742 — verify both concurrency references are updated consistently to `5`
2. `manifest.yaml` lines ~3745-3762 — **⚠️ Key change**: the `api_budget` block is commented out, not deleted. Without this budget, the connector will make requests as fast as concurrency allows, with no client-side rate limiting. The connector will still respect server-side 429 responses via built-in CDK retry behavior, but won't proactively throttle
3. `metadata.yaml` — version bump only
4. `freshdesk.md` — changelog entry

### Human review checklist
- [ ] Confirm the commented-out budget is acceptable for an RC rollout scoped to 7 pinned Tier 2 connections
- [ ] Confirm no other references to `api_budget` elsewhere in the manifest that would break without the top-level key

## User Impact

No user-facing impact. This is an RC version that will be progressively rolled out to a small set of Tier 2 connections only. Risk: connections on lower Freshdesk plans (Sprout/Blossom) could hit 429 errors more frequently without the budget, mitigated by limited rollout scope and CDK-level 429 retry handling.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/f5e7f185cbaf4e49b5d1ff5af45e3749
Requested by: @sophiecuiy