### PR TITLE
[ready] chore(source-freshdesk): c=5 with HTTPAPIBudget disabled (3.2.14-rc.5)

### DIFF
--- a/airbyte-integrations/connectors/source-freshdesk/manifest.yaml
+++ b/airbyte-integrations/connectors/source-freshdesk/manifest.yaml
@@ -1692,7 +1692,7 @@ spec:
           Number of concurrent threads for syncing. Higher values can speed up
           syncs but may increase API rate limit usage. Adjust based on your
           Freshdesk API plan.
-        default: 6
+        default: 5
         minimum: 2
         maximum: 16
         order: 5
@@ -3739,22 +3739,24 @@ schemas:
 
 concurrency_level:
   type: ConcurrencyLevel
-  default_concurrency: "{{ config.get('num_workers', 6) }}"
+  default_concurrency: "{{ config.get('num_workers', 5) }}"
   max_concurrency: 16
 
-api_budget:
-  type: HTTPAPIBudget
-  policies:
-    - type: FixedWindowCallRatePolicy
-      period: "PT1M"
-      # due to lack for support for interpolated string for the call_limit field, this has been
-      # hardcoded to 50 which is the default rate for free plan
-      # in the near term use "{{ config.get('requests_per_minute')}}"
-      # long term is to utilize the `rate_limit_plan` field in config and specifying for each endpoint
-      call_limit: 50 
-      matchers:
-        - method: GET
-          url_base: "https://{{ config['domain'] }}/api/v2/"
-  ratelimit_reset_header: Retry-After
-  ratelimit_remaining_header: X-RateLimit-Remaining
-  status_codes_for_ratelimit_hit: [429]
+# api_budget commented out for rc.5 tuning experiment — testing c=5 without rate limit budget
+# to determine if the 50 calls/min budget was throttling performance
+# api_budget:
+#   type: HTTPAPIBudget
+#   policies:
+#     - type: FixedWindowCallRatePolicy
+#       period: "PT1M"
+#       # due to lack for support for interpolated string for the call_limit field, this has been
+#       # hardcoded to 50 which is the default rate for free plan
+#       # in the near term use "{{ config.get('requests_per_minute')}}"
+#       # long term is to utilize the `rate_limit_plan` field in config and specifying for each endpoint
+#       call_limit: 50
+#       matchers:
+#         - method: GET
+#           url_base: "https://{{ config['domain'] }}/api/v2/"
+#   ratelimit_reset_header: Retry-After
+#   ratelimit_remaining_header: X-RateLimit-Remaining
+#   status_codes_for_ratelimit_hit: [429]

--- a/airbyte-integrations/connectors/source-freshdesk/metadata.yaml
+++ b/airbyte-integrations/connectors/source-freshdesk/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: ec4b9503-13cb-48ab-a4ab-6ade4be46567
-  dockerImageTag: 3.2.14-rc.3
+  dockerImageTag: 3.2.14-rc.5
   dockerRepository: airbyte/source-freshdesk
   documentationUrl: https://docs.airbyte.com/integrations/sources/freshdesk
   externalDocumentationUrls:

--- a/docs/integrations/sources/freshdesk.md
+++ b/docs/integrations/sources/freshdesk.md
@@ -72,6 +72,7 @@ If you don't use the start date Freshdesk will retrieve only the last 30 days. M
 
 | Version | Date       | Pull Request                                             | Subject                                                                               |
 | :------ | :--------- | :------------------------------------------------------- | :------------------------------------------------------------------------------------ |
+| 3.2.14-rc.5 | 2026-04-17 | | Concurrency tuning: c=5 with HTTPAPIBudget disabled to test budget impact on performance |
 | 3.2.14-rc.3 | 2026-04-14 | | Concurrency tuning iteration 3: increase default_concurrency from 5 to 6 |
 | 3.2.14-rc.2 | 2026-04-13 | [76272](https://github.com/airbytehq/airbyte/pull/76272) | Concurrency tuning iteration 2: increase default_concurrency from 4 to 5 |
 | 3.2.14-rc.1 | 2026-04-10 | [76202](https://github.com/airbytehq/airbyte/pull/76202) | Add concurrency_level and num_workers for concurrency tuning |


### PR DESCRIPTION
## What

Concurrency tuning experiment for source-freshdesk: tests `default_concurrency=5` with the `HTTPAPIBudget` (50 calls/min) **disabled** to isolate whether the budget was artificially throttling sync performance.

Related issue: https://github.com/airbytehq/airbyte-internal-issues/issues/15331

**Context:** Previous iterations (rc.1 through rc.3) tested c=4, c=5, and c=6 with the budget active. Results showed all three concurrency levels were statistically indistinguishable in duration, with high variance driven by bimodal sync patterns and tiny sample sizes. This experiment removes the budget to determine if it is the actual bottleneck.

## How

- `manifest.yaml`: Reverts `num_workers` default and `default_concurrency` fallback from `6` → `5`, and **comments out** the entire `api_budget` section (preserved for easy restoration)
- `metadata.yaml`: Bumps version `3.2.14-rc.3` → `3.2.14-rc.5`
- `freshdesk.md`: Adds changelog entry for rc.5

## Review guide

1. `manifest.yaml` lines ~1695 and ~3742 — concurrency default reverted to 5 (consistent change in both locations)
2. `manifest.yaml` lines ~3745-3762 — **⚠️ Key change**: the `api_budget` block is commented out, not deleted. Without this budget, the connector will make requests as fast as concurrency allows, with no client-side rate limiting. The connector will still respect server-side 429 responses via built-in CDK retry behavior, but won't proactively throttle.
3. `metadata.yaml` — version bump only (note: rc.4 was a separate unmerged PR, hence the skip)

## User Impact

**This is an RC version for progressive rollout only** — it will be pinned to a small set of Tier 2 test connections. Not released to the general user population.

Risk: connections on lower Freshdesk plans (Sprout/Blossom with limits well below 50 req/min) could hit 429 errors more frequently without the budget. Mitigated by the limited rollout scope and CDK-level 429 retry handling.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/f5e7f185cbaf4e49b5d1ff5af45e3749
Requested by: @sophiecuiy