### PR TITLE
chore(source-amazon-ads): update stale Authorization external doc URL

### DIFF
--- a/airbyte-integrations/connectors/source-amazon-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-amazon-ads/metadata.yaml
@@ -124,8 +124,8 @@ data:
     - title: All releases
       url: https://advertising.amazon.com/API/docs/en-us/release-notes/index
       type: api_release_history
-    - title: Authorization
-      url: https://advertising.amazon.com/API/docs/en-us/get-started/authorization
+    - title: Authorization (onboarding)
+      url: https://advertising.amazon.com/API/docs/en-us/guides/onboarding/overview
       type: authentication_guide
     - title: Rate limits
       url: https://advertising.amazon.com/API/docs/en-us/get-started/developer-notes#rate-limiting


### PR DESCRIPTION
## What

The `authentication_guide` URL in `airbyte-integrations/connectors/source-amazon-ads/metadata.yaml` points at `https://advertising.amazon.com/API/docs/en-us/get-started/authorization`, which Amazon's Advanced Tools Center now renders as "The requested document was not found." The canonical entry point for the LwA onboarding flow (create LwA client → apply for API access → assign API access) is `https://advertising.amazon.com/API/docs/en-us/guides/onboarding/overview`.

Found as part of an API deprecation monitoring run for the `amazon-ads` API family.

Resolves https://github.com/airbytehq/oncall/issues/12020

- https://github.com/airbytehq/oncall/issues/12020
- https://github.com/airbytehq/oncall/issues/12021 (related Sonar no-op audit log)

## How

Swap the stale `Authorization` entry for an `Authorization (onboarding)` entry pointing to the current onboarding overview page. Type (`authentication_guide`) is unchanged so future deprecation-monitoring runs will continue to pick it up.

## Review guide

1. `airbyte-integrations/connectors/source-amazon-ads/metadata.yaml` — single URL swap under `externalDocumentationUrls`.

## User Impact

No runtime impact. This only changes metadata surfaced by the connector registry/UI; sync behavior, auth flow, and dependencies are unchanged.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

Requested by @DanyloGL.

Link to Devin session: https://app.devin.ai/sessions/3b4baff9340a41598b8dfaea3b174e6f
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/76461" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
