### PR TITLE
fix(source-google-ads): surface actionable error for UNRECOGNIZED_FIELD in GAQL queries

### DIFF
--- a/airbyte-integrations/connectors/source-google-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-ads/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 253487c0-2246-43ba-a21f-5116b20a2c50
-  dockerImageTag: 4.2.4
+  dockerImageTag: 4.2.5
   dockerRepository: airbyte/source-google-ads
   documentationUrl: https://docs.airbyte.com/integrations/sources/google-ads
   externalDocumentationUrls:

--- a/airbyte-integrations/connectors/source-google-ads/pyproject.toml
+++ b/airbyte-integrations/connectors/source-google-ads/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "4.2.4"
+version = "4.2.5"
 name = "source-google-ads"
 description = "Source implementation for Google Ads."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/manifest.yaml
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/manifest.yaml
@@ -54,7 +54,7 @@ definitions:
         failure_type: config_error
         predicate: "{{ 'UNRECOGNIZED_FIELD' in (response | string) }}"
         error_message: >-
-          {{ response.get('error', {}).get('details', [{}])[0].get('errors', [{}])[0].get('message', 'GAQL query references an unrecognized field.') }}
+          {{ (response[0] if response is not mapping else response).get('error', {}).get('details', [{}])[0].get('errors', [{}])[0].get('message', 'GAQL query references an unrecognized field.') }}
           Verify all fields are valid for the queried resource:
           https://developers.google.com/google-ads/api/fields/v20/query_validator
       - type: HttpResponseFilter

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/manifest.yaml
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/manifest.yaml
@@ -51,6 +51,14 @@ definitions:
     response_filters:
       - type: HttpResponseFilter
         action: FAIL
+        failure_type: config_error
+        predicate: "{{ 'UNRECOGNIZED_FIELD' in (response | string) }}"
+        error_message: >-
+          {{ response.get('error', {}).get('details', [{}])[0].get('errors', [{}])[0].get('message', 'GAQL query references an unrecognized field.') }}
+          Verify all fields are valid for the queried resource:
+          https://developers.google.com/google-ads/api/fields/v20/query_validator
+      - type: HttpResponseFilter
+        action: FAIL
         http_codes:
           - 500
         error_message: >-

--- a/airbyte-integrations/connectors/source-google-ads/unit_tests/test_components.py
+++ b/airbyte-integrations/connectors/source-google-ads/unit_tests/test_components.py
@@ -151,6 +151,106 @@ class TestCustomGAQueryHttpRequester:
         }
 
 
+class TestErrorHandler:
+    """Verify that the manifest's base_error_handler produces actionable error messages."""
+
+    def test_unrecognized_field_error_surfaces_field_name(self, config):
+        """
+        When the Google Ads API returns UNRECOGNIZED_FIELD, the error handler should surface
+        the specific field name from the API response instead of the generic "Bad request" message.
+        """
+        source = get_source(config)
+
+        # Walk the resolved manifest to find the base_error_handler's first response filter
+        error_handler_def = source.resolved_manifest["definitions"]["base_error_handler"]
+        filters = error_handler_def["response_filters"]
+
+        # The UNRECOGNIZED_FIELD filter should be the first one (highest priority)
+        unrecognized_filter = filters[0]
+        assert "UNRECOGNIZED_FIELD" in unrecognized_filter.get("predicate", ""), (
+            "First response filter should match UNRECOGNIZED_FIELD"
+        )
+
+        # Now test the actual error resolution by constructing the error handler component
+        from airbyte_cdk.sources.declarative.requesters.error_handlers.default_error_handler import DefaultErrorHandler
+        from airbyte_cdk.sources.declarative.requesters.error_handlers.http_response_filter import HttpResponseFilter
+        from airbyte_cdk.sources.streams.http.error_handlers.response_models import ResponseAction
+        from unittest.mock import MagicMock
+
+        response_filter = HttpResponseFilter(
+            config=config,
+            parameters={},
+            action=ResponseAction.FAIL,
+            predicate=unrecognized_filter["predicate"],
+            error_message=unrecognized_filter["error_message"],
+        )
+
+        # Simulate a Google Ads API UNRECOGNIZED_FIELD 400 response
+        import requests as req
+
+        mock_response = MagicMock(spec=req.Response)
+        mock_response.status_code = 400
+        mock_response.ok = False
+        mock_response.json.return_value = {
+            "error": {
+                "code": 400,
+                "message": "Request contains an invalid argument.",
+                "status": "INVALID_ARGUMENT",
+                "details": [
+                    {
+                        "errors": [
+                            {
+                                "errorCode": {"queryError": "UNRECOGNIZED_FIELD"},
+                                "message": "Unrecognized field in the query: 'date'.",
+                            }
+                        ]
+                    }
+                ],
+            }
+        }
+        mock_response.headers = {}
+
+        resolution = response_filter.matches(mock_response)
+
+        assert resolution is not None, "Filter should match UNRECOGNIZED_FIELD response"
+        assert resolution.response_action == ResponseAction.FAIL
+        assert "date" in resolution.error_message, (
+            f"Error message should include the unrecognized field name, got: {resolution.error_message}"
+        )
+        assert "query_validator" in resolution.error_message, (
+            f"Error message should include link to query validator, got: {resolution.error_message}"
+        )
+        # Should NOT contain the generic CDK message
+        assert "Bad request" not in resolution.error_message
+
+    def test_non_unrecognized_field_400_not_matched(self, config):
+        """A 400 error without UNRECOGNIZED_FIELD should NOT be caught by this filter."""
+        from airbyte_cdk.sources.declarative.requesters.error_handlers.http_response_filter import HttpResponseFilter
+        from airbyte_cdk.sources.streams.http.error_handlers.response_models import ResponseAction
+        from unittest.mock import MagicMock
+
+        response_filter = HttpResponseFilter(
+            config=config,
+            parameters={},
+            action=ResponseAction.FAIL,
+            predicate="{{ 'UNRECOGNIZED_FIELD' in (response | string) }}",
+            error_message="should not matter",
+        )
+
+        import requests as req
+
+        mock_response = MagicMock(spec=req.Response)
+        mock_response.status_code = 400
+        mock_response.ok = False
+        mock_response.json.return_value = {
+            "error": {"code": 400, "message": "Some other error.", "status": "INVALID_ARGUMENT"}
+        }
+        mock_response.headers = {}
+
+        resolution = response_filter.matches(mock_response)
+        assert resolution is None, "Filter should NOT match non-UNRECOGNIZED_FIELD 400 errors"
+
+
 class TestClickViewHttpRequester:
     def test_click_view_http_requester_returns_expected_request_body(self, config):
         requester = ClickViewHttpRequester(

--- a/airbyte-integrations/connectors/source-google-ads/unit_tests/test_components.py
+++ b/airbyte-integrations/connectors/source-google-ads/unit_tests/test_components.py
@@ -167,15 +167,14 @@ class TestErrorHandler:
 
         # The UNRECOGNIZED_FIELD filter should be the first one (highest priority)
         unrecognized_filter = filters[0]
-        assert "UNRECOGNIZED_FIELD" in unrecognized_filter.get("predicate", ""), (
-            "First response filter should match UNRECOGNIZED_FIELD"
-        )
+        assert "UNRECOGNIZED_FIELD" in unrecognized_filter.get("predicate", ""), "First response filter should match UNRECOGNIZED_FIELD"
 
         # Now test the actual error resolution by constructing the error handler component
+        from unittest.mock import MagicMock
+
         from airbyte_cdk.sources.declarative.requesters.error_handlers.default_error_handler import DefaultErrorHandler
         from airbyte_cdk.sources.declarative.requesters.error_handlers.http_response_filter import HttpResponseFilter
         from airbyte_cdk.sources.streams.http.error_handlers.response_models import ResponseAction
-        from unittest.mock import MagicMock
 
         response_filter = HttpResponseFilter(
             config=config,
@@ -214,20 +213,21 @@ class TestErrorHandler:
 
         assert resolution is not None, "Filter should match UNRECOGNIZED_FIELD response"
         assert resolution.response_action == ResponseAction.FAIL
-        assert "date" in resolution.error_message, (
-            f"Error message should include the unrecognized field name, got: {resolution.error_message}"
-        )
-        assert "query_validator" in resolution.error_message, (
-            f"Error message should include link to query validator, got: {resolution.error_message}"
-        )
+        assert (
+            "date" in resolution.error_message
+        ), f"Error message should include the unrecognized field name, got: {resolution.error_message}"
+        assert (
+            "query_validator" in resolution.error_message
+        ), f"Error message should include link to query validator, got: {resolution.error_message}"
         # Should NOT contain the generic CDK message
         assert "Bad request" not in resolution.error_message
 
     def test_non_unrecognized_field_400_not_matched(self, config):
         """A 400 error without UNRECOGNIZED_FIELD should NOT be caught by this filter."""
+        from unittest.mock import MagicMock
+
         from airbyte_cdk.sources.declarative.requesters.error_handlers.http_response_filter import HttpResponseFilter
         from airbyte_cdk.sources.streams.http.error_handlers.response_models import ResponseAction
-        from unittest.mock import MagicMock
 
         response_filter = HttpResponseFilter(
             config=config,
@@ -242,9 +242,7 @@ class TestErrorHandler:
         mock_response = MagicMock(spec=req.Response)
         mock_response.status_code = 400
         mock_response.ok = False
-        mock_response.json.return_value = {
-            "error": {"code": 400, "message": "Some other error.", "status": "INVALID_ARGUMENT"}
-        }
+        mock_response.json.return_value = {"error": {"code": 400, "message": "Some other error.", "status": "INVALID_ARGUMENT"}}
         mock_response.headers = {}
 
         resolution = response_filter.matches(mock_response)

--- a/airbyte-integrations/connectors/source-google-ads/unit_tests/test_components.py
+++ b/airbyte-integrations/connectors/source-google-ads/unit_tests/test_components.py
@@ -8,6 +8,7 @@ from typing import List
 from unittest.mock import MagicMock, patch
 
 import pytest
+import requests as req
 from requests.exceptions import ChunkedEncodingError, StreamConsumedError
 from source_google_ads.components import (
     ClickViewHttpRequester,
@@ -21,8 +22,10 @@ from source_google_ads.components import (
 
 from airbyte_cdk import AirbyteTracedException
 from airbyte_cdk.sources.declarative.extractors.dpath_extractor import DpathExtractor
+from airbyte_cdk.sources.declarative.requesters.error_handlers.http_response_filter import HttpResponseFilter
 from airbyte_cdk.sources.declarative.retrievers import SimpleRetriever
 from airbyte_cdk.sources.declarative.schema import InlineSchemaLoader
+from airbyte_cdk.sources.streams.http.error_handlers.response_models import ResponseAction
 from airbyte_cdk.sources.types import StreamSlice
 
 from .conftest import Obj, get_source
@@ -154,27 +157,69 @@ class TestCustomGAQueryHttpRequester:
 class TestErrorHandler:
     """Verify that the manifest's base_error_handler produces actionable error messages."""
 
-    def test_unrecognized_field_error_surfaces_field_name(self, config):
+    @pytest.mark.parametrize(
+        "response_body",
+        [
+            pytest.param(
+                [
+                    {
+                        "error": {
+                            "code": 400,
+                            "message": "Request contains an invalid argument.",
+                            "status": "INVALID_ARGUMENT",
+                            "details": [
+                                {
+                                    "errors": [
+                                        {
+                                            "errorCode": {"queryError": "UNRECOGNIZED_FIELD"},
+                                            "message": "Unrecognized field in the query: 'date'.",
+                                        }
+                                    ]
+                                }
+                            ],
+                        }
+                    }
+                ],
+                id="list-wrapped (real searchStream shape)",
+            ),
+            pytest.param(
+                {
+                    "error": {
+                        "code": 400,
+                        "message": "Request contains an invalid argument.",
+                        "status": "INVALID_ARGUMENT",
+                        "details": [
+                            {
+                                "errors": [
+                                    {
+                                        "errorCode": {"queryError": "UNRECOGNIZED_FIELD"},
+                                        "message": "Unrecognized field in the query: 'date'.",
+                                    }
+                                ]
+                            }
+                        ],
+                    }
+                },
+                id="object-wrapped",
+            ),
+        ],
+    )
+    def test_unrecognized_field_error_surfaces_field_name(self, config, response_body):
         """
         When the Google Ads API returns UNRECOGNIZED_FIELD, the error handler should surface
         the specific field name from the API response instead of the generic "Bad request" message.
+
+        The Google Ads `searchStream` endpoint returns errors wrapped in a top-level JSON list
+        (`[{"error": {...}}]`), while other endpoints may return a bare object. The template
+        must handle both.
         """
         source = get_source(config)
 
-        # Walk the resolved manifest to find the base_error_handler's first response filter
         error_handler_def = source.resolved_manifest["definitions"]["base_error_handler"]
         filters = error_handler_def["response_filters"]
 
-        # The UNRECOGNIZED_FIELD filter should be the first one (highest priority)
         unrecognized_filter = filters[0]
         assert "UNRECOGNIZED_FIELD" in unrecognized_filter.get("predicate", ""), "First response filter should match UNRECOGNIZED_FIELD"
-
-        # Now test the actual error resolution by constructing the error handler component
-        from unittest.mock import MagicMock
-
-        from airbyte_cdk.sources.declarative.requesters.error_handlers.default_error_handler import DefaultErrorHandler
-        from airbyte_cdk.sources.declarative.requesters.error_handlers.http_response_filter import HttpResponseFilter
-        from airbyte_cdk.sources.streams.http.error_handlers.response_models import ResponseAction
 
         response_filter = HttpResponseFilter(
             config=config,
@@ -184,29 +229,10 @@ class TestErrorHandler:
             error_message=unrecognized_filter["error_message"],
         )
 
-        # Simulate a Google Ads API UNRECOGNIZED_FIELD 400 response
-        import requests as req
-
         mock_response = MagicMock(spec=req.Response)
         mock_response.status_code = 400
         mock_response.ok = False
-        mock_response.json.return_value = {
-            "error": {
-                "code": 400,
-                "message": "Request contains an invalid argument.",
-                "status": "INVALID_ARGUMENT",
-                "details": [
-                    {
-                        "errors": [
-                            {
-                                "errorCode": {"queryError": "UNRECOGNIZED_FIELD"},
-                                "message": "Unrecognized field in the query: 'date'.",
-                            }
-                        ]
-                    }
-                ],
-            }
-        }
+        mock_response.json.return_value = response_body
         mock_response.headers = {}
 
         resolution = response_filter.matches(mock_response)
@@ -219,16 +245,10 @@ class TestErrorHandler:
         assert (
             "query_validator" in resolution.error_message
         ), f"Error message should include link to query validator, got: {resolution.error_message}"
-        # Should NOT contain the generic CDK message
         assert "Bad request" not in resolution.error_message
 
     def test_non_unrecognized_field_400_not_matched(self, config):
         """A 400 error without UNRECOGNIZED_FIELD should NOT be caught by this filter."""
-        from unittest.mock import MagicMock
-
-        from airbyte_cdk.sources.declarative.requesters.error_handlers.http_response_filter import HttpResponseFilter
-        from airbyte_cdk.sources.streams.http.error_handlers.response_models import ResponseAction
-
         response_filter = HttpResponseFilter(
             config=config,
             parameters={},
@@ -236,8 +256,6 @@ class TestErrorHandler:
             predicate="{{ 'UNRECOGNIZED_FIELD' in (response | string) }}",
             error_message="should not matter",
         )
-
-        import requests as req
 
         mock_response = MagicMock(spec=req.Response)
         mock_response.status_code = 400

--- a/docs/integrations/sources/google-ads.md
+++ b/docs/integrations/sources/google-ads.md
@@ -351,6 +351,7 @@ Due to a limitation in the Google Ads API which does not allow getting performan
 
 | Version     | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:------------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 4.2.5 | 2026-04-20 | [TBD](https://github.com/airbytehq/airbyte/pull/TBD) | Surface actionable error message for UNRECOGNIZED_FIELD errors in GAQL queries |
 | 4.2.4 | 2026-04-16 | [76331](https://github.com/airbytehq/airbyte/pull/76331) | Improve UNRECOGNIZED_FIELD error message for custom GAQL queries |
 | 4.2.3 | 2026-04-16 | [75451](https://github.com/airbytehq/airbyte/pull/75451) | Fix NULL values for MESSAGE-type fields (e.g., change_event.old_resource, change_event.new_resource) in custom GAQL queries |
 | 4.2.2 | 2026-04-13 | [76276](https://github.com/airbytehq/airbyte/pull/76276) | Rename "concurrent workers" to "concurrent threads" in connector spec |

--- a/docs/integrations/sources/google-ads.md
+++ b/docs/integrations/sources/google-ads.md
@@ -351,7 +351,7 @@ Due to a limitation in the Google Ads API which does not allow getting performan
 
 | Version     | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:------------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 4.2.5 | 2026-04-20 | [TBD](https://github.com/airbytehq/airbyte/pull/TBD) | Surface actionable error message for UNRECOGNIZED_FIELD errors in GAQL queries |
+| 4.2.5 | 2026-04-20 | [76470](https://github.com/airbytehq/airbyte/pull/76470) | Surface actionable error message for UNRECOGNIZED_FIELD errors in GAQL queries |
 | 4.2.4 | 2026-04-16 | [76331](https://github.com/airbytehq/airbyte/pull/76331) | Improve UNRECOGNIZED_FIELD error message for custom GAQL queries |
 | 4.2.3 | 2026-04-16 | [75451](https://github.com/airbytehq/airbyte/pull/75451) | Fix NULL values for MESSAGE-type fields (e.g., change_event.old_resource, change_event.new_resource) in custom GAQL queries |
 | 4.2.2 | 2026-04-13 | [76276](https://github.com/airbytehq/airbyte/pull/76276) | Rename "concurrent workers" to "concurrent threads" in connector spec |


### PR DESCRIPTION
## Summary
- Add `HttpResponseFilter` to the manifest's `base_error_handler` that matches `UNRECOGNIZED_FIELD` in the Google Ads API response and surfaces the specific field error with a link to the query validator
- Previous attempt (#76331) modified dead code in `utils.py` — the `traced_exception` function is only called from the old Python stream classes in `streams.py`, which are no longer used since the connector migrated to manifest-based streams

## What changed

**Before** (generic CDK default for any 400):
```
HTTP Status Code: 400. Error: Bad request. Please check your request parameters.
```

**After** (specific, actionable):
```
Unrecognized field in the query: 'date'. Verify all fields are valid for the queried resource: https://developers.google.com/google-ads/api/fields/v20/query_validator
```

## How

Added a response filter with a Jinja predicate that matches `UNRECOGNIZED_FIELD` anywhere in the response body. The `error_message` template extracts the specific error from the nested Google Ads API response (`error.details[0].errors[0].message`) and appends a link to the query validator. The filter is placed before the existing 500/403 filters so it takes priority for matching 400 responses.

Resolves https://github.com/airbytehq/airbyte-internal-issues/issues/16165
Related to airbytehq/oncall#11944

## Test plan
- [x] Unit test: UNRECOGNIZED_FIELD response matched, error message includes field name and validator link
- [x] Unit test: non-UNRECOGNIZED_FIELD 400 response NOT matched by this filter
- [x] Unit test: manifest error handler structure verified via resolved manifest
- [x] Full test suite passes (270 tests)

## Can this PR be safely reverted and rolled back?

- [x] YES

🤖 Generated with [Claude Code](https://claude.com/claude-code)