### PR TITLE
chore(source-google-drive): Add Drive API release notes URL to externalDocumentationUrls

### DIFF
--- a/airbyte-integrations/connectors/source-google-drive/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-drive/metadata.yaml
@@ -53,6 +53,9 @@ data:
     - title: Google Drive API reference
       url: https://developers.google.com/drive/api/reference/rest/v3
       type: api_reference
+    - title: Google Drive API release notes
+      url: https://developers.google.com/workspace/drive/release-notes
+      type: api_release_history
     - title: Google Drive authentication
       url: https://developers.google.com/drive/api/guides/about-auth
       type: authentication_guide


### PR DESCRIPTION
## What

Adds the Google Drive API release notes URL (`https://developers.google.com/workspace/drive/release-notes`) to the `externalDocumentationUrls` list in `source-google-drive`'s `metadata.yaml`, with `type: api_release_history`.

This URL was identified during API deprecation monitoring for the `google-drive` API family and is the canonical changelog/release notes page Google publishes for the Drive API. It was not previously listed in the connector's external documentation, so future deprecation monitoring runs can discover and prioritize it automatically.

Related oncall issue:
Resolves https://github.com/airbytehq/oncall/issues/12032

- https://github.com/airbytehq/oncall/issues/12032

Requested by: @DanyloGL (parent/bulk session: https://app.devin.ai/sessions/7a27bde58b134091b7164d64270a9cdf)

## How

Adds a single entry to `externalDocumentationUrls` in `airbyte-integrations/connectors/source-google-drive/metadata.yaml`:

```yaml
- title: Google Drive API release notes
  url: https://developers.google.com/workspace/drive/release-notes
  type: api_release_history
```

No runtime code changes. The `api_release_history` type is already used by sibling Google connectors (`source-google-ads`, `source-google-sheets`, `source-google-analytics-data-api`).

## Review guide

1. `airbyte-integrations/connectors/source-google-drive/metadata.yaml` - only a metadata addition; no runtime or CDK changes.

## User Impact

None for end users. This metadata addition improves the connector's discoverability for internal deprecation monitoring tooling (Coral MCP `get_api_docs_urls`).

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌


Link to Devin session: https://app.devin.ai/sessions/6615337e866249b6b1f435ec34fa9084