### PR TITLE
fix(cdk): use AIRBYTE_EDITION env var instead of DEPLOYMENT_MODE for cloud feature flag

### DIFF
--- a/airbyte-cdk/bulk/core/base/changelog.md
+++ b/airbyte-cdk/bulk/core/base/changelog.md
@@ -1,3 +1,7 @@
+## Version 1.0.3
+
+Use AIRBYTE_EDITION env var instead of DEPLOYMENT_MODE for the AIRBYTE_CLOUD_DEPLOYMENT feature flag, matching the platform's current environment variable.
+
 ## Version 1.0.2
 
 Improved null handling for array types.

--- a/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/command/FeatureFlag.kt
+++ b/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/command/FeatureFlag.kt
@@ -24,7 +24,7 @@ enum class FeatureFlag(
     /** [AIRBYTE_CLOUD_DEPLOYMENT] is active when the connector is running in Airbyte Cloud. */
     AIRBYTE_CLOUD_DEPLOYMENT(
         micronautEnvironmentName = AIRBYTE_CLOUD_ENV,
-        envVar = EnvVar.DEPLOYMENT_MODE,
+        envVar = EnvVar.AIRBYTE_EDITION,
         requiredEnvVarValue = "CLOUD",
         transformActualValue = { it.trim().uppercase() },
     );
@@ -34,7 +34,7 @@ enum class FeatureFlag(
         get() = "${envVar.name}=$requiredEnvVarValue"
 
     enum class EnvVar(val defaultValue: String = "") {
-        DEPLOYMENT_MODE
+        AIRBYTE_EDITION
     }
 
     companion object {

--- a/airbyte-cdk/bulk/core/base/version.properties
+++ b/airbyte-cdk/bulk/core/base/version.properties
@@ -1,1 +1,1 @@
-version=1.0.2
+version=1.0.3


### PR DESCRIPTION
## What

The `FeatureFlag.AIRBYTE_CLOUD_DEPLOYMENT` flag checks `DEPLOYMENT_MODE=CLOUD` to determine if a connector is running on Airbyte Cloud. The platform has migrated to using `AIRBYTE_EDITION=CLOUD` instead. 

## How

Updated `FeatureFlag.kt` to check `AIRBYTE_EDITION` instead of `DEPLOYMENT_MODE`. The required value (`CLOUD`) and transform logic are unchanged.

## Review guide

1. `airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/command/FeatureFlag.kt` — only file changed

### ⚠️ Human review checklist
- **Breaking change**: Any deployment still setting only `DEPLOYMENT_MODE=CLOUD` (without `AIRBYTE_EDITION=CLOUD`) will lose the feature flag. Confirm that **all** Cloud environments now set `AIRBYTE_EDITION`.
- **`envVarBindingDeclaration` side effect**: This property (used in Docker test fixtures for containerized connector tests) will now produce `AIRBYTE_EDITION=CLOUD` instead of `DEPLOYMENT_MODE=CLOUD`. Verify this is correct for test environments.
- **No direct unit tests** exist for `FeatureFlag` activation logic in this module — this is pre-existing, not introduced here.

## User Impact

Cloud-only connector logic gated behind `FeatureFlag.AIRBYTE_CLOUD_DEPLOYMENT` (such as SSL enforcement in source-postgres) will start activating correctly on Cloud again.

No impact on OSS/self-managed deployments.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Reverting restores the old `DEPLOYMENT_MODE` check. If the platform no longer sets that variable, reverting re-breaks the feature flag on Cloud.

Link to Devin session: https://app.devin.ai/sessions/650f055417ef40459bbf3cd2ba6d9f47
Requested by: @mwbayley