### PR TITLE
chore(cdk): bump extract CDK to use core-base 1.0.3 for AIRBYTE_EDITION feature flag

### DIFF
--- a/airbyte-cdk/bulk/core/extract/build.gradle
+++ b/airbyte-cdk/bulk/core/extract/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    api "io.airbyte.bulk-cdk:bulk-cdk-core-base:1.0.2"
+    api "io.airbyte.bulk-cdk:bulk-cdk-core-base:1.0.3"
     implementation 'org.apache.commons:commons-lang3:3.17.0'
     implementation 'hu.webarticum:tree-printer:3.2.1'
 

--- a/airbyte-cdk/bulk/core/extract/changelog.md
+++ b/airbyte-cdk/bulk/core/extract/changelog.md
@@ -9,7 +9,7 @@ The Extract CDK provides functionality for source connectors including schema di
 
 | Version | Date       | Pull Request                                         | Subject                                                                                                                                            |
 |---------|------------|------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|
-| 1.1.4   | 2026-04-20 | [76478](https://github.com/airbytehq/airbyte/pull/76478) | Bump bulk-cdk-core-base to 1.0.3 to pick up AIRBYTE_EDITION feature flag fix.                                                                     |
+| 1.1.4   | 2026-04-20 | [76481](https://github.com/airbytehq/airbyte/pull/76481) | Bump bulk-cdk-core-base to 1.0.3 to pick up AIRBYTE_EDITION feature flag fix.                                                                     |
 | 1.1.3   | 2026-04-14 | [76320](https://github.com/airbytehq/airbyte/pull/76320) | Catalog validation failures are captured as stream-level sync failures.                                                                            |
 | 1.1.2   | 2026-03-31 | [74124](https://github.com/airbytehq/airbyte/pull/74124) | Change the default implementation of JDBC incremental partition to non splittable                                                                  |
 | 1.1.1   | 2026-04-02 | [76054](https://github.com/airbytehq/airbyte/pull/76054) | Clarified CDC termination condition. Ensure querySingleValue returns one result or throws.                                                         |

--- a/airbyte-cdk/bulk/core/extract/changelog.md
+++ b/airbyte-cdk/bulk/core/extract/changelog.md
@@ -9,6 +9,7 @@ The Extract CDK provides functionality for source connectors including schema di
 
 | Version | Date       | Pull Request                                         | Subject                                                                                                                                            |
 |---------|------------|------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1.1.4   | 2026-04-20 | [76478](https://github.com/airbytehq/airbyte/pull/76478) | Bump bulk-cdk-core-base to 1.0.3 to pick up AIRBYTE_EDITION feature flag fix.                                                                     |
 | 1.1.3   | 2026-04-14 | [76320](https://github.com/airbytehq/airbyte/pull/76320) | Catalog validation failures are captured as stream-level sync failures.                                                                            |
 | 1.1.2   | 2026-03-31 | [74124](https://github.com/airbytehq/airbyte/pull/74124) | Change the default implementation of JDBC incremental partition to non splittable                                                                  |
 | 1.1.1   | 2026-04-02 | [76054](https://github.com/airbytehq/airbyte/pull/76054) | Clarified CDC termination condition. Ensure querySingleValue returns one result or throws.                                                         |

--- a/airbyte-cdk/bulk/core/extract/version.properties
+++ b/airbyte-cdk/bulk/core/extract/version.properties
@@ -1,1 +1,1 @@
-version=1.1.3
+version=1.1.4


### PR DESCRIPTION
## What

Bumps the extract CDK's dependency on `bulk-cdk-core-base` from 1.0.2 → 1.0.3 so that source connectors pick up the `AIRBYTE_EDITION` feature flag fix from [#76478](https://github.com/airbytehq/airbyte/pull/76478).

Without this bump, source connectors using the extract CDK still resolve `FeatureFlag.AIRBYTE_CLOUD_DEPLOYMENT` against the old `DEPLOYMENT_MODE` env var, which the platform no longer sets — causing Cloud-only checks (e.g. SSL enforcement) to silently not fire.

## How

- `build.gradle`: `bulk-cdk-core-base` 1.0.2 → 1.0.3
- `version.properties`: extract CDK 1.1.3 → 1.1.4
- `changelog.md`: new entry for 1.1.4

## Review guide

1. `airbyte-cdk/bulk/core/extract/build.gradle` — single-line version bump

### ⚠️ Human review checklist
- Confirm `bulk-cdk-core-base` 1.0.3 is published (merged in #76478).

## User Impact

Source connectors rebuilt against this extract CDK version will correctly detect Cloud deployments via `AIRBYTE_EDITION=CLOUD`, re-enabling Cloud-only feature flags like SSL enforcement.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/650f055417ef40459bbf3cd2ba6d9f47
Requested by: @mwbayley