### PR TITLE
feat(source-gong): scope isPrivate record filter to OAuth 2.0 auth only

### DIFF
--- a/airbyte-integrations/connectors/source-gong/manifest.yaml
+++ b/airbyte-integrations/connectors/source-gong/manifest.yaml
@@ -83,7 +83,11 @@ definitions:
               - calls
           record_filter:
             type: RecordFilter
-            condition: "{{ not record.get('isPrivate', False) }}"
+            # Gong requires calls with `isPrivate: true` to be filtered client-side
+            # when accessing the API via OAuth (hard listing requirement). Under
+            # basic-auth access keys the customer still owns every call returned
+            # by the API, so the filter is scoped to OAuth2.0 only.
+            condition: "{{ config['credentials']['auth_type'] != 'OAuth2.0' or not record.get('isPrivate', False) }}"
         paginator:
           type: DefaultPaginator
           page_token_option:
@@ -175,7 +179,8 @@ definitions:
               - calls
           record_filter:
             type: RecordFilter
-            condition: "{{ not record.get('metaData', {}).get('isPrivate', False) }}"
+            # Scoped to OAuth2.0 only — see `calls` stream above for rationale.
+            condition: "{{ config['credentials']['auth_type'] != 'OAuth2.0' or not record.get('metaData', {}).get('isPrivate', False) }}"
         paginator:
           type: DefaultPaginator
           page_token_option:

--- a/airbyte-integrations/connectors/source-gong/metadata.yaml
+++ b/airbyte-integrations/connectors/source-gong/metadata.yaml
@@ -7,7 +7,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 32382e40-3b49-4b99-9c5c-4076501914e7
-  dockerImageTag: 1.1.0
+  dockerImageTag: 1.2.0
   dockerRepository: airbyte/source-gong
   documentationUrl: https://docs.airbyte.com/integrations/sources/gong
   githubIssueLabel: source-gong

--- a/airbyte-integrations/connectors/source-gong/unit_tests/test_record_filter.py
+++ b/airbyte-integrations/connectors/source-gong/unit_tests/test_record_filter.py
@@ -1,12 +1,19 @@
 # Copyright (c) 2024 Airbyte, Inc., all rights reserved.
 
-"""Unit tests for the `isPrivate` record filter on `source-gong` streams.
+"""Unit tests for the auth-scoped `isPrivate` record filter on `source-gong` streams.
 
-Gong requires any integration that lists calls to drop calls where `isPrivate` is `true`.
+Gong's API listing requirements mandate that any integration using **OAuth 2.0** must
+drop calls where `isPrivate` is `true` client-side (Gong's API does not expose a
+server-side filter). Under **API Key** authentication the customer still owns every
+call returned by the API, so no filtering is required.
+
 The `calls` and `extensiveCalls` streams each declare a `RecordFilter` in `manifest.yaml`
-that enforces this requirement. These tests mock the Gong API responses and assert the
-filter actually drops the private records at sync time.
+whose Jinja `condition` inspects `config.credentials.auth_type` so the filter activates
+only under OAuth. These tests mock the Gong API responses and assert the expected
+behavior under both auth modes.
 """
+
+import copy
 
 import requests_mock
 from _helpers import get_source
@@ -16,7 +23,7 @@ from airbyte_cdk.test.catalog_builder import CatalogBuilder
 from airbyte_cdk.test.entrypoint_wrapper import read
 
 
-_CONFIG = {
+_API_KEY_CONFIG = {
     "credentials": {
         "auth_type": "APIKey",
         "access_key": "test_access_key",
@@ -24,6 +31,31 @@ _CONFIG = {
     },
     "start_date": "2024-01-01T00:00:00Z",
 }
+
+_OAUTH_CONFIG = {
+    "credentials": {
+        "auth_type": "OAuth2.0",
+        "client_id": "test_client_id",
+        "client_secret": "test_client_secret",
+        "refresh_token": "test_refresh_token",
+    },
+    "start_date": "2024-01-01T00:00:00Z",
+}
+
+
+def _api_key_config() -> dict:
+    """Return a fresh copy of the API Key config so tests cannot mutate each other."""
+    return copy.deepcopy(_API_KEY_CONFIG)
+
+
+def _oauth_config() -> dict:
+    """Return a fresh copy of the OAuth config so tests cannot mutate each other.
+
+    The CDK's OAuth authenticator mutates the config in place (writing `access_token` and
+    `token_expiry_date` back to `credentials`), so sharing a single config dict across
+    tests leaks state and can cause spec validation to fail on later tests.
+    """
+    return copy.deepcopy(_OAUTH_CONFIG)
 
 
 def _public_call(call_id: str) -> dict:
@@ -71,14 +103,35 @@ def _private_extensive_call(call_id: str) -> dict:
     return call
 
 
-def _sync(stream_name: str):
-    source = get_source(config=_CONFIG)
+def _sync(stream_name: str, config: dict):
+    source = get_source(config=config)
     catalog = CatalogBuilder().with_stream(stream_name, SyncMode.full_refresh).build()
-    return read(source, _CONFIG, catalog)
+    return read(source, config, catalog)
 
 
-def test_calls_stream_drops_private_calls():
-    """`calls` stream filters out records where `isPrivate` is `true`."""
+def test_calls_stream_drops_private_calls_under_oauth():
+    """Under OAuth 2.0 auth, `calls` filters out records where `isPrivate` is `true`."""
+    response = {
+        "calls": [
+            _public_call("public-1"),
+            _private_call("private-1"),
+            _public_call("public-2"),
+            _private_call("private-2"),
+        ],
+        "records": {"totalRecords": 4, "currentPageSize": 4, "currentPageNumber": 0},
+    }
+
+    with requests_mock.Mocker() as mocker:
+        mocker.post("https://app.gong.io/oauth2/generate-customer-token", json={"access_token": "t", "expires_in": 3600})
+        mocker.get("https://api.gong.io/v2/calls", json=response)
+        output = _sync("calls", _oauth_config())
+
+    emitted_ids = [record.record.data["id"] for record in output.records]
+    assert emitted_ids == ["public-1", "public-2"], f"expected only public calls under OAuth, got {emitted_ids}"
+
+
+def test_calls_stream_keeps_private_calls_under_api_key():
+    """Under API Key auth, the `isPrivate` filter is not applied — all calls pass through."""
     response = {
         "calls": [
             _public_call("public-1"),
@@ -91,18 +144,19 @@ def test_calls_stream_drops_private_calls():
 
     with requests_mock.Mocker() as mocker:
         mocker.get("https://api.gong.io/v2/calls", json=response)
-        output = _sync("calls")
+        output = _sync("calls", _api_key_config())
 
     emitted_ids = [record.record.data["id"] for record in output.records]
-    assert emitted_ids == ["public-1", "public-2"], f"expected only public calls to be emitted, got {emitted_ids}"
-    emitted_is_private = [record.record.data.get("isPrivate") for record in output.records]
-    assert all(
-        value is False for value in emitted_is_private
-    ), f"expected all emitted calls to have isPrivate=False, got {emitted_is_private}"
+    assert emitted_ids == [
+        "public-1",
+        "private-1",
+        "public-2",
+        "private-2",
+    ], f"expected every call to be emitted under API Key auth, got {emitted_ids}"
 
 
-def test_extensive_calls_stream_drops_private_calls():
-    """`extensiveCalls` stream filters out records where `metaData.isPrivate` is `true`."""
+def test_extensive_calls_stream_drops_private_calls_under_oauth():
+    """Under OAuth 2.0, `extensiveCalls` filters out records where `metaData.isPrivate` is `true`."""
     response = {
         "calls": [
             _public_extensive_call("public-1"),
@@ -114,28 +168,47 @@ def test_extensive_calls_stream_drops_private_calls():
     }
 
     with requests_mock.Mocker() as mocker:
+        mocker.post("https://app.gong.io/oauth2/generate-customer-token", json={"access_token": "t", "expires_in": 3600})
         mocker.post("https://api.gong.io/v2/calls/extensive", json=response)
-        output = _sync("extensiveCalls")
+        output = _sync("extensiveCalls", _oauth_config())
 
     emitted_ids = [record.record.data["metaData"]["id"] for record in output.records]
-    assert emitted_ids == ["public-1", "public-2"], f"expected only public extensive calls to be emitted, got {emitted_ids}"
-    emitted_is_private = [record.record.data["metaData"].get("isPrivate") for record in output.records]
-    assert all(
-        value is False for value in emitted_is_private
-    ), f"expected all emitted extensive calls to have isPrivate=False, got {emitted_is_private}"
+    assert emitted_ids == ["public-1", "public-2"], f"expected only public extensive calls under OAuth, got {emitted_ids}"
 
 
-def test_calls_stream_emits_no_records_when_all_private():
-    """When every call in the response has `isPrivate: true`, the stream emits nothing."""
+def test_extensive_calls_stream_keeps_private_calls_under_api_key():
+    """Under API Key auth, `extensiveCalls` emits every record including private ones."""
+    response = {
+        "calls": [
+            _public_extensive_call("public-1"),
+            _private_extensive_call("private-1"),
+        ],
+        "records": {"totalRecords": 2, "currentPageSize": 2, "currentPageNumber": 0},
+    }
+
+    with requests_mock.Mocker() as mocker:
+        mocker.post("https://api.gong.io/v2/calls/extensive", json=response)
+        output = _sync("extensiveCalls", _api_key_config())
+
+    emitted_ids = [record.record.data["metaData"]["id"] for record in output.records]
+    assert emitted_ids == [
+        "public-1",
+        "private-1",
+    ], f"expected every extensive call to be emitted under API Key auth, got {emitted_ids}"
+
+
+def test_calls_stream_emits_no_records_when_all_private_under_oauth():
+    """Under OAuth 2.0, when every call has `isPrivate: true` the stream emits nothing."""
     response = {
         "calls": [_private_call("private-1"), _private_call("private-2")],
         "records": {"totalRecords": 2, "currentPageSize": 2, "currentPageNumber": 0},
     }
 
     with requests_mock.Mocker() as mocker:
+        mocker.post("https://app.gong.io/oauth2/generate-customer-token", json={"access_token": "t", "expires_in": 3600})
         mocker.get("https://api.gong.io/v2/calls", json=response)
-        output = _sync("calls")
+        output = _sync("calls", _oauth_config())
 
     assert (
         output.records == []
-    ), f"expected zero emitted records when all source records are private, got {[r.record.data['id'] for r in output.records]}"
+    ), f"expected zero emitted records under OAuth when all source records are private, got {[r.record.data['id'] for r in output.records]}"

--- a/docs/integrations/sources/gong.md
+++ b/docs/integrations/sources/gong.md
@@ -78,7 +78,8 @@ The call transcripts stream fetches transcripts one call at a time as a substrea
 
 | Version | Date       | Pull Request                                             | Subject                                                                         |
 | :------ | :--------- | :------------------------------------------------------- | :------------------------------------------------------------------------------ |
-| 1.1.0 | 2026-04-16 | [PR_NUMBER](https://github.com/airbytehq/airbyte/pull/PR_NUMBER) | Filter out private calls (`isPrivate: true`) from `calls` and `extensiveCalls` streams per Gong API listing requirements |
+| 1.2.0 | 2026-04-16 | [PR_NUMBER](https://github.com/airbytehq/airbyte/pull/PR_NUMBER) | Scope the `isPrivate` record filter to OAuth 2.0 auth only; API Key users sync private calls unchanged |
+| 1.1.0 | 2026-04-16 | [76454](https://github.com/airbytehq/airbyte/pull/76454) | Filter out private calls (`isPrivate: true`) from `calls` and `extensiveCalls` streams per Gong API listing requirements |
 | 1.0.1 | 2026-04-10 | [76229](https://github.com/airbytehq/airbyte/pull/76229) | Set deadlineAction to auto_upgrade for 1.0.0 breaking change |
 | 1.0.0 | 2026-03-30 | [75248](https://github.com/airbytehq/airbyte/pull/75248) | Fix schema bugs in `extensiveCalls` stream: define `context` as array type and widen `value` field to accept string, number, boolean, object, and array types. This is a breaking change for users syncing the `extensiveCalls` stream. See the [migration guide](https://docs.airbyte.com/integrations/sources/gong-migrations). |
 | 0.6.3 | 2026-03-27 | [75195](https://github.com/airbytehq/airbyte/pull/75195) | Migrate OAuth scope to scopes object array for granular scopes support |


### PR DESCRIPTION
## What

Follow-up to #76454.

Gong's listing/certification process only requires that `isPrivate: true` calls be dropped client-side when the connector is authenticated via **OAuth 2.0**. Under the other supported auth mode — **API Key** (`access_key` + `access_key_secret`) — the customer still owns every call returned by the API, so the filter should not run.

Version 1.1.0 (merged in #76454) applied the filter unconditionally, which incorrectly strips private calls for API-Key users too. This PR scopes the filter to OAuth 2.0 only.

## How

The `calls` and `extensiveCalls` streams already carry a `RecordFilter` whose `condition` is a Jinja expression evaluated with `config` + `record` in scope. The connector's `spec.connection_specification` uses a `oneOf` on `credentials` keyed by `auth_type` (`OAuth2.0` vs `APIKey`), so the active auth mode is available at `config.credentials.auth_type`.

The condition is now short-circuited on that discriminator:

```yaml
# calls stream (line 90)
condition: "{{ config['credentials']['auth_type'] != 'OAuth2.0' or not record.get('isPrivate', False) }}"

# extensiveCalls stream (line 183)
condition: "{{ config['credentials']['auth_type'] != 'OAuth2.0' or not record.get('metaData', {}).get('isPrivate', False) }}"
```

Under API Key auth the left disjunct is `True`, so the filter keeps every record. Under OAuth 2.0 the left disjunct is `False`, so the existing `not isPrivate` check decides the outcome.

### Tests

Rewrote `unit_tests/test_record_filter.py` to cover both auth modes with 5 test cases (no cassettes — inline `requests_mock`):

| Test | Auth | Behavior asserted |
|------|------|-------------------|
| `test_calls_stream_drops_private_calls_under_oauth` | OAuth 2.0 | Private `calls` records filtered |
| `test_calls_stream_keeps_private_calls_under_api_key` | API Key | All `calls` records pass through |
| `test_extensive_calls_stream_drops_private_calls_under_oauth` | OAuth 2.0 | Private `extensiveCalls` records filtered |
| `test_extensive_calls_stream_keeps_private_calls_under_api_key` | API Key | All `extensiveCalls` records pass through |
| `test_calls_stream_emits_no_records_when_all_private_under_oauth` | OAuth 2.0 | All-private response yields zero records |

The OAuth and API Key config dicts are deep-copied per test because the CDK's OAuth authenticator mutates the `credentials` dict in place (writing `access_token` / `token_expiry_date` back to it), which leaks state across tests and can cause `oneOf` spec validation to fail on later tests when `refresh_token` gets nulled out.

### Metadata + docs

- `metadata.yaml`: `dockerImageTag` bumped `1.1.0` → `1.2.0` (behavior change under API-Key auth)
- `docs/integrations/sources/gong.md`: changelog entry added for 1.2.0

## Review guide

1. `airbyte-integrations/connectors/source-gong/manifest.yaml` — two-line `condition:` swap + comments, lines 84–90 (`calls`) and 180–183 (`extensiveCalls`)
2. `airbyte-integrations/connectors/source-gong/unit_tests/test_record_filter.py` — full rewrite with auth-mode split
3. `airbyte-integrations/connectors/source-gong/metadata.yaml` — version bump
4. `docs/integrations/sources/gong.md` — changelog entry

## User Impact

- **API-Key users**: Private calls are no longer silently dropped. Syncs return every call the API returns (restores 1.0.1 behavior for this user segment).
- **OAuth 2.0 users**: No behavior change vs 1.1.0 — private calls continue to be filtered client-side per Gong's listing requirement.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌

Reverting restores 1.1.0 (filter applied unconditionally). No schema/state migration.

Link to Devin session: https://app.devin.ai/sessions/128827e7d4014a7e8bbf4aa6755653fc
Requested by: @aldogonzalez8