### PR TITLE
ci(oss-issue-triage): declare structured-output-schema for AI triage

### DIFF
--- a/.github/workflows/oss-issue-triage.yml
+++ b/.github/workflows/oss-issue-triage.yml
@@ -109,6 +109,93 @@ jobs:
           tags: |
             oss-issue-triage
             community-issue
+          structured-output-schema: |
+            type: object
+            additionalProperties: false
+            required: [event_type, classification, escalation, public_response]
+            properties:
+              event_type:
+                type: string
+                enum: [issue, discussion]
+                description: Whether triage was for a GitHub Issue or Discussion.
+              source_url:
+                type: string
+                format: uri
+                description: Link to the original issue or discussion.
+              reporter:
+                type: string
+                description: GitHub username (without @) of the community member who opened the report.
+              classification:
+                type: object
+                additionalProperties: false
+                required: [category]
+                properties:
+                  category:
+                    type: string
+                    enum:
+                      - bug_report
+                      - feature_request
+                      - question
+                      - configuration_issue
+                      - connector_issue
+                      - other
+                  connector_name:
+                    type: string
+                    description: Connector identifier if applicable (e.g. source-postgres, destination-snowflake). Empty string when not connector-related.
+                  connector_version:
+                    type: string
+                    description: Connector version reported by the user, if any. Empty string if not provided.
+                  airbyte_version:
+                    type: string
+                    description: Airbyte OSS or Cloud version reported by the user, if any. Empty string if not provided.
+                  has_sonar_counterpart:
+                    type: boolean
+                    description: True if this connector has an agent-connector counterpart in airbytehq/sonar.
+                  appears_to_be_regression:
+                    type: boolean
+                  likely_affects_multiple_users:
+                    type: boolean
+              escalation:
+                type: object
+                additionalProperties: false
+                required: [decision]
+                properties:
+                  decision:
+                    type: string
+                    enum: [new_oncall_issue, duplicate_oncall_issue, no_escalation]
+                  oncall_issue_url:
+                    type: string
+                    description: URL of the new or existing oncall issue. Empty when decision is no_escalation.
+                  reason:
+                    type: string
+                    description: Short justification for the escalation decision.
+                  suggested_priority:
+                    type: string
+                    enum: ["", P0, P1, P2, P3, P4]
+                    description: Suggested priority for the oncall issue. Empty when decision is no_escalation.
+                  applied_labels:
+                    type: array
+                    items: { type: string }
+                    description: Labels applied to the oncall issue (e.g. connectors/source/postgres, Sonar, bug, P2).
+              public_response:
+                type: object
+                additionalProperties: false
+                required: [posted]
+                properties:
+                  posted:
+                    type: boolean
+                    description: Whether a public comment was posted on the original issue or discussion.
+                  comment_url:
+                    type: string
+                    description: Permalink to the posted comment. Empty if not posted.
+                  asked_clarifying_questions:
+                    type: boolean
+                  provided_workaround_or_docs:
+                    type: boolean
+              followups:
+                type: array
+                description: Remaining actions or observations for human reviewers.
+                items: { type: string }
 
   ai-triage-discussion:
     name: AI Triage for Community Discussion
@@ -173,3 +260,90 @@ jobs:
           tags: |
             oss-issue-triage
             community-discussion
+          structured-output-schema: |
+            type: object
+            additionalProperties: false
+            required: [event_type, classification, escalation, public_response]
+            properties:
+              event_type:
+                type: string
+                enum: [issue, discussion]
+                description: Whether triage was for a GitHub Issue or Discussion.
+              source_url:
+                type: string
+                format: uri
+                description: Link to the original issue or discussion.
+              reporter:
+                type: string
+                description: GitHub username (without @) of the community member who opened the report.
+              classification:
+                type: object
+                additionalProperties: false
+                required: [category]
+                properties:
+                  category:
+                    type: string
+                    enum:
+                      - bug_report
+                      - feature_request
+                      - question
+                      - configuration_issue
+                      - connector_issue
+                      - other
+                  connector_name:
+                    type: string
+                    description: Connector identifier if applicable (e.g. source-postgres, destination-snowflake). Empty string when not connector-related.
+                  connector_version:
+                    type: string
+                    description: Connector version reported by the user, if any. Empty string if not provided.
+                  airbyte_version:
+                    type: string
+                    description: Airbyte OSS or Cloud version reported by the user, if any. Empty string if not provided.
+                  has_sonar_counterpart:
+                    type: boolean
+                    description: True if this connector has an agent-connector counterpart in airbytehq/sonar.
+                  appears_to_be_regression:
+                    type: boolean
+                  likely_affects_multiple_users:
+                    type: boolean
+              escalation:
+                type: object
+                additionalProperties: false
+                required: [decision]
+                properties:
+                  decision:
+                    type: string
+                    enum: [new_oncall_issue, duplicate_oncall_issue, no_escalation]
+                  oncall_issue_url:
+                    type: string
+                    description: URL of the new or existing oncall issue. Empty when decision is no_escalation.
+                  reason:
+                    type: string
+                    description: Short justification for the escalation decision.
+                  suggested_priority:
+                    type: string
+                    enum: ["", P0, P1, P2, P3, P4]
+                    description: Suggested priority for the oncall issue. Empty when decision is no_escalation.
+                  applied_labels:
+                    type: array
+                    items: { type: string }
+                    description: Labels applied to the oncall issue (e.g. connectors/source/postgres, Sonar, bug, P2).
+              public_response:
+                type: object
+                additionalProperties: false
+                required: [posted]
+                properties:
+                  posted:
+                    type: boolean
+                    description: Whether a public comment was posted on the original issue or discussion.
+                  comment_url:
+                    type: string
+                    description: Permalink to the posted comment. Empty if not posted.
+                  asked_clarifying_questions:
+                    type: boolean
+                  provided_workaround_or_docs:
+                    type: boolean
+              followups:
+                type: array
+                description: Remaining actions or observations for human reviewers.
+                items: { type: string }


### PR DESCRIPTION
## What

First test of the new `structured-output-schema` input on [`aaronsteers/devin-action@v0.7.0`](https://github.com/aaronsteers/devin-action/releases/tag/v0.7.0). Declares the expected shape of the AI triage "notepad" for both the issue and discussion jobs in `.github/workflows/oss-issue-triage.yml`, so that future automation/analytics can consume a consistent object instead of free-form text.

No behaviour change to the triage flow itself — the schema just tells Devin what structured output to maintain.

## How

Added `structured-output-schema:` to both `ai-triage-issue` and `ai-triage-discussion` jobs. The schema is expressed inline as YAML (JSON Schema is a superset of JSON, and YAML 1.2 is a superset of JSON, so this parses cleanly on the action side).

Top-level fields captured:

- `event_type` — `issue` or `discussion`
- `source_url`, `reporter`
- `classification` — category (`bug_report` / `feature_request` / `question` / `configuration_issue` / `connector_issue` / `other`), connector name/version, Airbyte version, Sonar-counterpart flag, regression/multi-user signals
- `escalation` — decision (`new_oncall_issue` / `duplicate_oncall_issue` / `no_escalation`), oncall URL, reason, suggested priority (`P0`–`P4`), applied labels
- `public_response` — whether a comment was posted, comment URL, asked-clarifying-questions / provided-workaround flags
- `followups` — free-form notes for human reviewers

The schema mirrors what the [oss_issue_triage playbook](https://github.com/airbytehq/ai-skills/blob/main/devin/playbooks/oss_issue_triage.md) already directs the agent to decide/do, so populating it should not require prompt changes.

## Review guide

1. `.github/workflows/oss-issue-triage.yml` — both `uses: aaronsteers/devin-action@main` steps gain a `structured-output-schema:` block. Schema is duplicated between the two jobs (GitHub Actions workflow YAML does not reliably support YAML anchors); we can extract to a reusable workflow or a shared file in a follow-up once this shape is validated.

## User Impact

None user-facing. Internal: future triage sessions will populate a structured notepad conforming to this schema, which we can pipe into dashboards / reporting without regex-parsing comments.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌


Link to Devin session: https://app.devin.ai/sessions/6b5971ddeebf4a27bbca60eacbc0af40
Requested by: @aaronsteers