### PR TITLE
ci(ai-review): disable `APPROVE` review submission

### DIFF
--- a/.github/workflows/pr-ai-review-submit.yml
+++ b/.github/workflows/pr-ai-review-submit.yml
@@ -46,7 +46,10 @@ jobs:
           echo "head_sha=$HEAD_SHA" >> $GITHUB_OUTPUT
 
       - name: Authenticate as GitHub App
-        if: steps.parse-marker.outputs.result == 'FAIL' || steps.parse-marker.outputs.result == 'APPROVE'
+        # NOTE: When re-enabling the commented-out APPROVE flow further down in
+        # this workflow, extend this condition back to:
+        #   result == 'FAIL' || result == 'APPROVE'
+        if: steps.parse-marker.outputs.result == 'FAIL'
         uses: actions/create-github-app-token@v3.0.0
         id: get-app-token
         with:
@@ -166,73 +169,94 @@ jobs:
             echo "Skipped: Duplicate REQUEST_CHANGES review for same HEAD SHA"
           fi
 
-      # APPROVE flow (Phase C)
-      - name: Check for existing APPROVE review
+      - name: Log APPROVE result
         if: steps.parse-marker.outputs.result == 'APPROVE'
-        id: check-existing-approve
-        env:
-          GH_TOKEN: ${{ steps.get-app-token.outputs.token }}
         run: |
-          PR_NUMBER="${{ github.event.issue.number }}"
-          HEAD_SHA="${{ steps.parse-marker.outputs.head_sha }}"
+          echo "APPROVE marker received; no GitHub review submitted (APPROVE review submission is currently disabled)."
+          echo "The APPROVE marker is reported in the gate-report comment for metrics and downstream policy consumption."
 
-          # Get existing reviews
-          REVIEWS=$(curl -sS \
-            -H "Authorization: Bearer $GH_TOKEN" \
-            -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/${{ github.repository }}/pulls/$PR_NUMBER/reviews")
-
-          # Check for existing APPROVED review from bot for same HEAD SHA
-          EXISTING=$(echo "$REVIEWS" | jq -r --arg sha "$HEAD_SHA" \
-            '[.[] | select(.state == "APPROVED" and .commit_id == $sha and (.user.type == "Bot"))] | length')
-
-          if [[ "$EXISTING" -gt 0 ]]; then
-            echo "Existing APPROVE review found for HEAD SHA $HEAD_SHA - skipping duplicate"
-            echo "skip=true" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-
-          echo "No existing APPROVE review for this HEAD SHA"
-          echo "skip=false" >> $GITHUB_OUTPUT
-
-      - name: Submit APPROVE review
-        if: steps.parse-marker.outputs.result == 'APPROVE' && steps.check-existing-approve.outputs.skip != 'true'
-        env:
-          GH_TOKEN: ${{ steps.get-app-token.outputs.token }}
-        run: |
-          PR_NUMBER="${{ github.event.issue.number }}"
-          HEAD_SHA="${{ steps.parse-marker.outputs.head_sha }}"
-
-          echo "Submitting APPROVE review for PR #$PR_NUMBER at HEAD SHA $HEAD_SHA"
-
-          # Submit the review
-          RESPONSE=$(curl -sS -X POST \
-            -H "Authorization: Bearer $GH_TOKEN" \
-            -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/${{ github.repository }}/pulls/$PR_NUMBER/reviews" \
-            -d @- <<EOF
-          {
-            "commit_id": "$HEAD_SHA",
-            "event": "APPROVE",
-            "body": "**AI PR Review: All Gates Pass**\n\nAll 6 gates (CI/Tests, Security, Safety/Reversibility, Operational Risk, Pre-Release Validation, PR Quality) have been evaluated and passed.\n\nSee the gate report comment above for details.\n\n> This review was automatically submitted by the AI PR Review system."
-          }
-          EOF
-          )
-
-          # Check if review was created successfully
-          REVIEW_ID=$(echo "$RESPONSE" | jq -r '.id // empty')
-          if [[ -n "$REVIEW_ID" ]]; then
-            echo "Successfully submitted APPROVE review (ID: $REVIEW_ID)"
-          else
-            echo "Failed to submit review. Response:"
-            echo "$RESPONSE" | jq
-            exit 1
-          fi
-
-      - name: Log APPROVE skip reason
-        if: steps.parse-marker.outputs.result == 'APPROVE' && steps.check-existing-approve.outputs.skip == 'true'
-        run: |
-          echo "Skipped: Duplicate APPROVE review for same HEAD SHA"
+      # ----------------------------------------------------------------------------
+      # APPROVE review submission — CURRENTLY DISABLED.
+      #
+      # The steps below previously submitted a GitHub APPROVE review as the bot
+      # whenever the /ai-review playbook emitted an APPROVE marker. They are
+      # intentionally commented out (rather than deleted) because we plan to
+      # re-enable automatic APPROVE reviews in the future, once the approval
+      # preconditions are agreed — i.e. which gates must pass, what evidence is
+      # required, and how to prevent conflation with auto-merge. Until then, the
+      # APPROVE marker remains purely informational (surfaced in the gate-report
+      # comment); no branch-protection-eligible review is posted by this workflow.
+      #
+      # To re-enable: uncomment the three steps below and ensure the
+      # "Authenticate as GitHub App" step's `if:` condition also covers 'APPROVE'.
+      # ----------------------------------------------------------------------------
+      # # APPROVE flow (Phase C)
+      # - name: Check for existing APPROVE review
+      #   if: steps.parse-marker.outputs.result == 'APPROVE'
+      #   id: check-existing-approve
+      #   env:
+      #     GH_TOKEN: ${{ steps.get-app-token.outputs.token }}
+      #   run: |
+      #     PR_NUMBER="${{ github.event.issue.number }}"
+      #     HEAD_SHA="${{ steps.parse-marker.outputs.head_sha }}"
+      #
+      #     # Get existing reviews
+      #     REVIEWS=$(curl -sS \
+      #       -H "Authorization: Bearer $GH_TOKEN" \
+      #       -H "Accept: application/vnd.github+json" \
+      #       "https://api.github.com/repos/${{ github.repository }}/pulls/$PR_NUMBER/reviews")
+      #
+      #     # Check for existing APPROVED review from bot for same HEAD SHA
+      #     EXISTING=$(echo "$REVIEWS" | jq -r --arg sha "$HEAD_SHA" \
+      #       '[.[] | select(.state == "APPROVED" and .commit_id == $sha and (.user.type == "Bot"))] | length')
+      #
+      #     if [[ "$EXISTING" -gt 0 ]]; then
+      #       echo "Existing APPROVE review found for HEAD SHA $HEAD_SHA - skipping duplicate"
+      #       echo "skip=true" >> $GITHUB_OUTPUT
+      #       exit 0
+      #     fi
+      #
+      #     echo "No existing APPROVE review for this HEAD SHA"
+      #     echo "skip=false" >> $GITHUB_OUTPUT
+      #
+      # - name: Submit APPROVE review
+      #   if: steps.parse-marker.outputs.result == 'APPROVE' && steps.check-existing-approve.outputs.skip != 'true'
+      #   env:
+      #     GH_TOKEN: ${{ steps.get-app-token.outputs.token }}
+      #   run: |
+      #     PR_NUMBER="${{ github.event.issue.number }}"
+      #     HEAD_SHA="${{ steps.parse-marker.outputs.head_sha }}"
+      #
+      #     echo "Submitting APPROVE review for PR #$PR_NUMBER at HEAD SHA $HEAD_SHA"
+      #
+      #     # Submit the review
+      #     RESPONSE=$(curl -sS -X POST \
+      #       -H "Authorization: Bearer $GH_TOKEN" \
+      #       -H "Accept: application/vnd.github+json" \
+      #       "https://api.github.com/repos/${{ github.repository }}/pulls/$PR_NUMBER/reviews" \
+      #       -d @- <<EOF
+      #     {
+      #       "commit_id": "$HEAD_SHA",
+      #       "event": "APPROVE",
+      #       "body": "**AI PR Review: All Gates Pass**\n\nAll 6 gates (CI/Tests, Security, Safety/Reversibility, Operational Risk, Pre-Release Validation, PR Quality) have been evaluated and passed.\n\nSee the gate report comment above for details.\n\n> This review was automatically submitted by the AI PR Review system."
+      #     }
+      #     EOF
+      #     )
+      #
+      #     # Check if review was created successfully
+      #     REVIEW_ID=$(echo "$RESPONSE" | jq -r '.id // empty')
+      #     if [[ -n "$REVIEW_ID" ]]; then
+      #       echo "Successfully submitted APPROVE review (ID: $REVIEW_ID)"
+      #     else
+      #       echo "Failed to submit review. Response:"
+      #       echo "$RESPONSE" | jq
+      #       exit 1
+      #     fi
+      #
+      # - name: Log APPROVE skip reason
+      #   if: steps.parse-marker.outputs.result == 'APPROVE' && steps.check-existing-approve.outputs.skip == 'true'
+      #   run: |
+      #     echo "Skipped: Duplicate APPROVE review for same HEAD SHA"
 
       - name: Log UNKNOWN result
         if: steps.parse-marker.outputs.result == 'UNKNOWN'

--- a/.github/workflows/pr-ai-review-submit.yml
+++ b/.github/workflows/pr-ai-review-submit.yml
@@ -46,9 +46,6 @@ jobs:
           echo "head_sha=$HEAD_SHA" >> $GITHUB_OUTPUT
 
       - name: Authenticate as GitHub App
-        # NOTE: When re-enabling the commented-out APPROVE flow further down in
-        # this workflow, extend this condition back to:
-        #   if: steps.parse-marker.outputs.result == 'FAIL' || steps.parse-marker.outputs.result == 'APPROVE'
         if: steps.parse-marker.outputs.result == 'FAIL'
         uses: actions/create-github-app-token@v3.0.0
         id: get-app-token
@@ -172,91 +169,8 @@ jobs:
       - name: Log APPROVE result
         if: steps.parse-marker.outputs.result == 'APPROVE'
         run: |
-          echo "APPROVE marker received; no GitHub review submitted (APPROVE review submission is currently disabled)."
+          echo "APPROVE marker received; no GitHub review submitted."
           echo "The APPROVE marker is reported in the gate-report comment for metrics and downstream policy consumption."
-
-      # ----------------------------------------------------------------------------
-      # APPROVE review submission — CURRENTLY DISABLED.
-      #
-      # The steps below previously submitted a GitHub APPROVE review as the bot
-      # whenever the /ai-review playbook emitted an APPROVE marker. They are
-      # intentionally commented out (rather than deleted) because we plan to
-      # re-enable automatic APPROVE reviews in the future, once the approval
-      # preconditions are agreed — i.e. which gates must pass, what evidence is
-      # required, and how to prevent conflation with auto-merge. Until then, the
-      # APPROVE marker remains purely informational (surfaced in the gate-report
-      # comment); no branch-protection-eligible review is posted by this workflow.
-      #
-      # To re-enable: uncomment the three steps below and ensure the
-      # "Authenticate as GitHub App" step's `if:` condition also covers 'APPROVE'.
-      # ----------------------------------------------------------------------------
-      # # APPROVE flow (Phase C)
-      # - name: Check for existing APPROVE review
-      #   if: steps.parse-marker.outputs.result == 'APPROVE'
-      #   id: check-existing-approve
-      #   env:
-      #     GH_TOKEN: ${{ steps.get-app-token.outputs.token }}
-      #   run: |
-      #     PR_NUMBER="${{ github.event.issue.number }}"
-      #     HEAD_SHA="${{ steps.parse-marker.outputs.head_sha }}"
-      #
-      #     # Get existing reviews
-      #     REVIEWS=$(curl -sS \
-      #       -H "Authorization: Bearer $GH_TOKEN" \
-      #       -H "Accept: application/vnd.github+json" \
-      #       "https://api.github.com/repos/${{ github.repository }}/pulls/$PR_NUMBER/reviews")
-      #
-      #     # Check for existing APPROVED review from bot for same HEAD SHA
-      #     EXISTING=$(echo "$REVIEWS" | jq -r --arg sha "$HEAD_SHA" \
-      #       '[.[] | select(.state == "APPROVED" and .commit_id == $sha and (.user.type == "Bot"))] | length')
-      #
-      #     if [[ "$EXISTING" -gt 0 ]]; then
-      #       echo "Existing APPROVE review found for HEAD SHA $HEAD_SHA - skipping duplicate"
-      #       echo "skip=true" >> $GITHUB_OUTPUT
-      #       exit 0
-      #     fi
-      #
-      #     echo "No existing APPROVE review for this HEAD SHA"
-      #     echo "skip=false" >> $GITHUB_OUTPUT
-      #
-      # - name: Submit APPROVE review
-      #   if: steps.parse-marker.outputs.result == 'APPROVE' && steps.check-existing-approve.outputs.skip != 'true'
-      #   env:
-      #     GH_TOKEN: ${{ steps.get-app-token.outputs.token }}
-      #   run: |
-      #     PR_NUMBER="${{ github.event.issue.number }}"
-      #     HEAD_SHA="${{ steps.parse-marker.outputs.head_sha }}"
-      #
-      #     echo "Submitting APPROVE review for PR #$PR_NUMBER at HEAD SHA $HEAD_SHA"
-      #
-      #     # Submit the review
-      #     RESPONSE=$(curl -sS -X POST \
-      #       -H "Authorization: Bearer $GH_TOKEN" \
-      #       -H "Accept: application/vnd.github+json" \
-      #       "https://api.github.com/repos/${{ github.repository }}/pulls/$PR_NUMBER/reviews" \
-      #       -d @- <<EOF
-      #     {
-      #       "commit_id": "$HEAD_SHA",
-      #       "event": "APPROVE",
-      #       "body": "**AI PR Review: All Gates Pass**\n\nAll 6 gates (CI/Tests, Security, Safety/Reversibility, Operational Risk, Pre-Release Validation, PR Quality) have been evaluated and passed.\n\nSee the gate report comment above for details.\n\n> This review was automatically submitted by the AI PR Review system."
-      #     }
-      #     EOF
-      #     )
-      #
-      #     # Check if review was created successfully
-      #     REVIEW_ID=$(echo "$RESPONSE" | jq -r '.id // empty')
-      #     if [[ -n "$REVIEW_ID" ]]; then
-      #       echo "Successfully submitted APPROVE review (ID: $REVIEW_ID)"
-      #     else
-      #       echo "Failed to submit review. Response:"
-      #       echo "$RESPONSE" | jq
-      #       exit 1
-      #     fi
-      #
-      # - name: Log APPROVE skip reason
-      #   if: steps.parse-marker.outputs.result == 'APPROVE' && steps.check-existing-approve.outputs.skip == 'true'
-      #   run: |
-      #     echo "Skipped: Duplicate APPROVE review for same HEAD SHA"
 
       - name: Log UNKNOWN result
         if: steps.parse-marker.outputs.result == 'UNKNOWN'

--- a/.github/workflows/pr-ai-review-submit.yml
+++ b/.github/workflows/pr-ai-review-submit.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Authenticate as GitHub App
         # NOTE: When re-enabling the commented-out APPROVE flow further down in
         # this workflow, extend this condition back to:
-        #   result == 'FAIL' || result == 'APPROVE'
+        #   if: steps.parse-marker.outputs.result == 'FAIL' || steps.parse-marker.outputs.result == 'APPROVE'
         if: steps.parse-marker.outputs.result == 'FAIL'
         uses: actions/create-github-app-token@v3.0.0
         id: get-app-token


### PR DESCRIPTION
## What

Removes the step in `.github/workflows/pr-ai-review-submit.yml` that submits an APPROVE GitHub review as `octavia-bot` when the `/ai-review` playbook emits an `APPROVE` marker.

Per direction in [the `#ask-devin-ai` thread](https://airbytehq-team.slack.com/archives/C08BHPUMEPJ/p1776739226909799?thread_ts=1776739226.909799&cid=C08BHPUMEPJ), the `/ai-review` workflow no longer participates in auto-merge decisions — "auto-approve" is being de-conflated from "auto-merge", and the decision this workflow publishes is the gate-report comment + marker, not a committed GitHub review that counts toward branch-protection approval.

The `REQUEST_CHANGES` flow on `FAIL` is unchanged. The `APPROVE` marker is still emitted by the playbook into the gate-report comment for metrics and downstream policy consumption.

## How

- Deletes the `Check for existing APPROVE review` / `Submit APPROVE review` / `Log APPROVE skip reason` steps entirely.
- Replaces them with a single `Log APPROVE result` echo step so workflow logs still show when an `APPROVE` marker arrived with no review submitted.
- Narrows the `Authenticate as GitHub App` condition from `FAIL || APPROVE` to `FAIL` (the bot no longer needs App credentials for the APPROVE path).
- Marker contract (`APPROVE | FAIL | UNKNOWN | SKIP`) is unchanged.

An earlier revision kept the code commented-out in place; per reviewer feedback we're deleting outright and relying on git history if ever needed — a future re-enable would most likely use structured output rather than this shell pipeline anyway.

## Review guide

1. `.github/workflows/pr-ai-review-submit.yml` — two sections of interest: the `Authenticate as GitHub App` condition change (~L48–L49) and the `Log APPROVE result` step (~L169–L173) replacing the deleted APPROVE flow.

## User Impact

- PRs that pass all gates will no longer get an `octavia-bot` APPROVE review posted by this workflow. The gate-report comment is still posted by the playbook and still contains the APPROVE marker.
- PRs that fail gates still get a `REQUEST_CHANGES` review (unless `ai-review-override` or `needs-human-review` label is set). No change to that path.
- No change to the `UNKNOWN` / `SKIP` paths.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌

Link to Devin session: https://app.devin.ai/sessions/9ed7586555084f2b88a18c48a7650935
Requested by: @aaronsteers