### PR TITLE
docs(ai-agents): document Claude Code and Codex skills from airbyte-agent-sdk

### DIFF
--- a/docs/ai-agents/get-started/skills/claude-code.md
+++ b/docs/ai-agents/get-started/skills/claude-code.md
@@ -1,0 +1,75 @@
+---
+sidebar_position: 2
+sidebar_label: Claude Code
+---
+
+# Claude Code
+
+[Claude Code](https://docs.claude.com/en/docs/claude-code/overview) is the coding agent from Anthropic that runs in your terminal and integrates with editors like VS Code and Cursor. The [airbyte-agent-sdk](https://github.com/airbytehq/airbyte-agent-sdk) repository publishes a set of Claude skills that teach Claude Code how to build agents on top of the Airbyte typed Python SDK. Once you install the skills, Claude Code reads them on demand whenever you ask it to work with Airbyte connectors.
+
+## What the skills cover
+
+The airbyte-agent-sdk repository ships four skills under `.claude/skills/`:
+
+| Skill | What it teaches Claude Code |
+| ----- | --------------------------- |
+| `bootstrapping-agent` | Wiring a single Airbyte connector into a PydanticAI or Claude SDK agent, including `AirbyteAuthConfig`, connector initialization, and the `tool_utils` decorator pattern. |
+| `building-multi-connector-agent` | Scaffolding a complete agent with multiple Airbyte connectors, composing tools, and writing the run loop. |
+| `discovering-connectors` | Enumerating the available Airbyte connectors and exploring a connector's entities, actions, and schemas at runtime. |
+| `airbyte-sdk-reference` | Reference material for the public SDK API, including `configure()`, `connect()`, `Workspace`, `tool_utils`, `list_entities()`, and `entity_schema()`, plus PydanticAI and Claude SDK code patterns. |
+
+Each skill is a `SKILL.md` file with YAML front matter that Claude Code uses to decide when to load it. You don't need to paste these into context yourself. Claude Code pulls them in automatically when a prompt matches the skill's description.
+
+## Install the skills
+
+Pick the approach that matches how you use Claude Code.
+
+### Recommended: install as a Claude Code plugin
+
+This is the native path for Claude Code and the option that needs the least maintenance.
+
+1. In Claude Code, add the marketplace:
+
+   ```text
+   /plugin marketplace add airbytehq/airbyte-agent-sdk
+   ```
+
+2. Install the plugin:
+
+   ```text
+   /plugin install airbyte-agent-sdk@airbyte-agent-sdk
+   ```
+
+Claude Code pulls the skills from the repository's `.claude/skills/` directory. Re-run `/plugin update` to pick up new skills as Airbyte adds them.
+
+### Alternative: install with skills.sh
+
+[skills.sh](https://skills.sh) is a cross-agent installer that works for Claude Code, Codex, Cursor, OpenCode, and 40+ other agents. Use it if you want the same skills available in multiple agents without installing them separately.
+
+```bash
+npx skills add airbytehq/airbyte-agent-sdk
+```
+
+The installer detects the agents it finds on your machine and wires the skills into each one. For Claude Code specifically, it writes the skills into your user-level `~/.claude/skills/` directory.
+
+## Use the skills
+
+Once you install the skills, you don't need any special command to invoke them. Prompt Claude Code the way you normally would. For example:
+
+- _"Build a PydanticAI agent that reads Stripe customers."_
+- _"Add a HubSpot connector to this agent."_
+- _"List the entities available on the Salesforce connector."_
+
+Claude Code matches the prompt against each skill's front matter description, loads the relevant skill, and uses its instructions to generate code that matches the patterns in the Airbyte Agent SDK.
+
+## Credentials
+
+The skills assume you're using the hosted Airbyte platform, which handles credentials, rate limiting, and execution for you. Before Claude Code runs the generated agent, set these environment variables (get the client ID and secret from [app.airbyte.ai](https://app.airbyte.ai)):
+
+```bash
+AIRBYTE_CLIENT_ID=your_client_id
+AIRBYTE_CLIENT_SECRET=your_client_secret
+AIRBYTE_WORKSPACE_NAME=your_workspace_name
+```
+
+See [Manage your user profile](../../admin/profile.md) for where to find these credentials in the Airbyte Agents web app.

--- a/docs/ai-agents/get-started/skills/codex.md
+++ b/docs/ai-agents/get-started/skills/codex.md
@@ -1,0 +1,68 @@
+---
+sidebar_position: 3
+sidebar_label: Codex
+---
+
+# Codex
+
+[Codex](https://developers.openai.com/codex) is the coding agent from OpenAI that runs locally in your terminal and loads skills from `~/.codex/skills/`. The [airbyte-agent-sdk](https://github.com/airbytehq/airbyte-agent-sdk) repository publishes a set of Codex skills that teach Codex how to build agents on top of the Airbyte typed Python SDK. Once you install the skills, Codex reads them on demand whenever you ask it to work with Airbyte connectors.
+
+## What the skills cover
+
+The airbyte-agent-sdk repository ships four skills under `.codex/skills/`:
+
+| Skill | What it teaches Codex |
+| ----- | --------------------- |
+| `bootstrapping-agent` | Wiring a single Airbyte connector into a PydanticAI or Claude SDK agent, including `AirbyteAuthConfig`, connector initialization, and the `tool_utils` decorator pattern. |
+| `building-multi-connector-agent` | Scaffolding a complete agent with multiple Airbyte connectors, composing tools, and writing the run loop. |
+| `discovering-connectors` | Enumerating the available Airbyte connectors and exploring a connector's entities, actions, and schemas at runtime. |
+| `airbyte-sdk-reference` | Reference material for the public SDK API, including `configure()`, `connect()`, `Workspace`, `tool_utils`, `list_entities()`, and `entity_schema()`, plus PydanticAI and Claude SDK code patterns. |
+
+Each skill is a directory that contains a `SKILL.md` file and an `agents/openai.yaml` manifest. You don't need to paste these into context yourself. Codex loads a skill when a prompt matches its description.
+
+## Install the skills
+
+Pick the approach that matches how you use Codex.
+
+### Recommended: install with skills.sh
+
+[skills.sh](https://skills.sh) is a cross-agent installer that works for Codex, Claude Code, Cursor, OpenCode, and 40+ other agents. It's the lowest-friction way to get the Airbyte skills into Codex.
+
+```bash
+npx skills add airbytehq/airbyte-agent-sdk
+```
+
+The installer writes the skills into `~/.codex/skills/` and keeps them up to date when you re-run the command.
+
+### Alternative: clone and symlink
+
+If you'd rather manage the skills directly, clone the repository and symlink the skills into your Codex skills directory:
+
+```bash
+git clone https://github.com/airbytehq/airbyte-agent-sdk ~/.codex/skills/airbyte-agent-sdk-src
+ln -s ~/.codex/skills/airbyte-agent-sdk-src/.codex/skills/* ~/.codex/skills/
+```
+
+To pick up new or updated skills, run `git pull` inside `~/.codex/skills/airbyte-agent-sdk-src`.
+
+## Use the skills
+
+Once you install the skills, prompt Codex the way you normally would. For example:
+
+- _"Build a PydanticAI agent that reads Stripe customers."_
+- _"Add a HubSpot connector to this agent."_
+- _"List the entities available on the Salesforce connector."_
+
+Codex matches the prompt against each skill's description, loads the relevant skill, and uses its instructions to generate code that matches the patterns in the Airbyte Agent SDK.
+
+## Credentials
+
+The skills assume you're using the hosted Airbyte platform, which handles credentials, rate limiting, and execution for you. Before Codex runs the generated agent, set these environment variables (get the client ID and secret from [app.airbyte.ai](https://app.airbyte.ai)):
+
+```bash
+AIRBYTE_CLIENT_ID=your_client_id
+AIRBYTE_CLIENT_SECRET=your_client_secret
+AIRBYTE_WORKSPACE_NAME=your_workspace_name
+```
+
+See [Manage your user profile](../../admin/profile.md) for where to find these credentials in the Airbyte Agents web app.

--- a/docs/ai-agents/get-started/skills/readme.md
+++ b/docs/ai-agents/get-started/skills/readme.md
@@ -7,10 +7,10 @@ import DocCardList from '@theme/DocCardList';
 
 # Skills
 
-Skills are self-contained packages of context and instructions you give to an AI app builder so it can generate working code against Airbyte. A skill teaches the builder's AI agent the architecture, endpoints, authentication flow, and code patterns it needs to integrate Airbyte connectors into the app it's creating for you.
+Skills are self-contained packages of context and instructions you give to an AI agent so it can generate working code against Airbyte. A skill teaches the agent the architecture, endpoints, authentication flow, and code patterns it needs to integrate Airbyte connectors into whatever it's building for you.
 
-Use a skill when you want a builder to scaffold an app that talks to Airbyte without having to explain the API, the widget, or the context store yourself. Paste the skill into the builder's knowledge or context area, then prompt it to build.
+Use a skill when you want an AI app builder like Lovable, or a coding agent like Claude Code or Codex, to scaffold something that talks to Airbyte without having to explain the API, the widget, the SDK, or the context store yourself. Install the skill into the agent, then prompt it to build.
 
-Each skill below targets a specific AI app builder. Pick the one that matches the tool you're using.
+Each page below targets a specific agent. Pick the one that matches the tool you're using.
 
 <DocCardList />


### PR DESCRIPTION
## What

The [airbyte-agent-sdk](https://github.com/airbytehq/airbyte-agent-sdk) repository ships four skills (`bootstrapping-agent`, `building-multi-connector-agent`, `discovering-connectors`, `airbyte-sdk-reference`) packaged for both Claude Code (under `.claude/skills/`) and Codex (under `.codex/skills/`). Their existence wasn't documented publicly. This PR adds user-facing docs for both under **Get started > Skills**.

Stacked on top of `docs-airbyte-agents`.

## How

- New page `docs/ai-agents/get-started/skills/claude-code.md` — covers what each skill teaches, the Claude Code plugin install path (`/plugin marketplace add airbytehq/airbyte-agent-sdk` + `/plugin install airbyte-agent-sdk@airbyte-agent-sdk`) as the recommended path, and the cross-agent [skills.sh](https://skills.sh) installer (`npx skills add airbytehq/airbyte-agent-sdk`) as an alternative. Links to the hosted credentials docs.
- New page `docs/ai-agents/get-started/skills/codex.md` — covers the same four skills, with skills.sh as the recommended install path and a manual `git clone` + `ln -s ... ~/.codex/skills/` path as an alternative (the clone/symlink recipe from the SDK README).
- Light rewrite of `docs/ai-agents/get-started/skills/readme.md` intro so the section covers both AI app builders (Lovable) and AI coding agents (Claude Code, Codex) — previously the intro only mentioned app builders.
- Sidebar wiring is via `sidebar_position` frontmatter: Lovable stays at 1, Claude Code at 2, Codex at 3. The ai-agents instance uses `defaultSidebarItemsGenerator`, so no sidebar config file changes are needed.

Ran `markdownlint-cli2` and `vale` locally against the three files. Markdownlint passes with 0 errors; Vale is clean except for `Google.Headings` warnings about `Claude Code` not being sentence-case (expected — it's a product name).

## Review guide

1. `docs/ai-agents/get-started/skills/claude-code.md`
2. `docs/ai-agents/get-started/skills/codex.md`
3. `docs/ai-agents/get-started/skills/readme.md` (intro rewrite)

Easiest way to review is to wait for the Vercel preview and click into **Get started > Skills** in the AI Agents docs.

## User Impact

New public docs pages telling users that the skills exist and how to install them into Claude Code or Codex. No runtime behavior changes.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

Link to Devin session: https://app.devin.ai/sessions/dceb102cedfb40a28f5738b11f0546b8
Requested by: @ian-at-airbyte