### PR TITLE
chore(source-zendesk-talk): decrease default_concurrency from 6 to 4 and comment out HTTPAPIBudget for tuning iteration 4

### DIFF
--- a/airbyte-integrations/connectors/source-zendesk-talk/manifest.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-talk/manifest.yaml
@@ -562,12 +562,40 @@ streams:
 # highest = 50 req/sec (Talk API all endpoints), initial = floor(50 / 4) = 12
 # Tuning iteration 2: decreased to 9 after Phase 1 showed +6% duration regression
 # Tuning iteration 3: decreased to 6 after rc.2 showed persistent heartbeat_timeout failures on high-volume connections
-# Tuning iteration 4: decreased to 4 and removed HTTPAPIBudget to isolate concurrency effect
+# Tuning iteration 4: decreased to 4 and commented out HTTPAPIBudget to isolate concurrency effect
 # Ref: https://developer.zendesk.com/api-reference/voice/talk-api/rate_limits/
 concurrency_level:
   type: ConcurrencyLevel
   default_concurrency: 4
   max_concurrency: 16
+
+# HTTP API Budget: throttle requests per Zendesk Talk API rate limits
+# Commented out for tuning iteration 4 to isolate whether budget throttling contributes to heartbeat_timeout
+# Ref: https://developer.zendesk.com/api-reference/voice/talk-api/rate_limits/
+# api_budget:
+#   type: HTTPAPIBudget
+#   policies:
+#     # Incremental Exports (calls, call_legs): 10 requests per minute
+#     - type: FixedWindowCallRatePolicy
+#       period: "PT1M"
+#       call_limit: 10
+#       matchers:
+#         - method: GET
+#           url_path_pattern: "/stats/incremental/"
+#     # Current Queue Activity: 2,500 requests per 5 minutes
+#     - type: FixedWindowCallRatePolicy
+#       period: "PT5M"
+#       call_limit: 2500
+#       matchers:
+#         - method: GET
+#           url_path_pattern: "/stats/current_queue_activity"
+#     # All Talk API endpoints (catch-all): 15,000 requests per 5 minutes
+#     - type: FixedWindowCallRatePolicy
+#       period: "PT5M"
+#       call_limit: 15000
+#       matchers: []
+#   ratelimit_reset_header: "Retry-After"
+#   status_codes_for_ratelimit_hit: [429]
 
 spec:
   type: Spec

--- a/airbyte-integrations/connectors/source-zendesk-talk/manifest.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-talk/manifest.yaml
@@ -562,38 +562,12 @@ streams:
 # highest = 50 req/sec (Talk API all endpoints), initial = floor(50 / 4) = 12
 # Tuning iteration 2: decreased to 9 after Phase 1 showed +6% duration regression
 # Tuning iteration 3: decreased to 6 after rc.2 showed persistent heartbeat_timeout failures on high-volume connections
+# Tuning iteration 4: decreased to 4 and removed HTTPAPIBudget to isolate concurrency effect
 # Ref: https://developer.zendesk.com/api-reference/voice/talk-api/rate_limits/
 concurrency_level:
   type: ConcurrencyLevel
-  default_concurrency: 6
-  max_concurrency: 24
-
-# HTTP API Budget: throttle requests per Zendesk Talk API rate limits
-# Ref: https://developer.zendesk.com/api-reference/voice/talk-api/rate_limits/
-api_budget:
-  type: HTTPAPIBudget
-  policies:
-    # Incremental Exports (calls, call_legs): 10 requests per minute
-    - type: FixedWindowCallRatePolicy
-      period: "PT1M"
-      call_limit: 10
-      matchers:
-        - method: GET
-          url_path_pattern: "/stats/incremental/"
-    # Current Queue Activity: 2,500 requests per 5 minutes
-    - type: FixedWindowCallRatePolicy
-      period: "PT5M"
-      call_limit: 2500
-      matchers:
-        - method: GET
-          url_path_pattern: "/stats/current_queue_activity"
-    # All Talk API endpoints (catch-all): 15,000 requests per 5 minutes
-    - type: FixedWindowCallRatePolicy
-      period: "PT5M"
-      call_limit: 15000
-      matchers: []
-  ratelimit_reset_header: "Retry-After"
-  status_codes_for_ratelimit_hit: [429]
+  default_concurrency: 4
+  max_concurrency: 16
 
 spec:
   type: Spec

--- a/airbyte-integrations/connectors/source-zendesk-talk/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-talk/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: c8630570-086d-4a40-99ae-ea5b18673071
-  dockerImageTag: 2.0.11-rc.3
+  dockerImageTag: 2.0.11-rc.4
   dockerRepository: airbyte/source-zendesk-talk
   documentationUrl: https://docs.airbyte.com/integrations/sources/zendesk-talk
   externalDocumentationUrls:

--- a/docs/integrations/sources/zendesk-talk.md
+++ b/docs/integrations/sources/zendesk-talk.md
@@ -79,7 +79,8 @@ The Zendesk connector should not run into Zendesk API limitations under normal u
 
 | Version | Date       | Pull Request                                             | Subject                                                                     |
 |:--------|:-----------|:---------------------------------------------------------|:----------------------------------------------------------------------------|
-| 2.0.11-rc.3 | 2026-04-17 | [](https://github.com/airbytehq/airbyte/pull/) | Decrease default_concurrency from 9 to 6 for tuning iteration 3 |
+| 2.0.11-rc.4 | 2026-04-21 | [](https://github.com/airbytehq/airbyte/pull/) | Decrease default_concurrency from 6 to 4 and remove HTTPAPIBudget for tuning iteration 4 |
+| 2.0.11-rc.3 | 2026-04-17 | [76449](https://github.com/airbytehq/airbyte/pull/76449) | Decrease default_concurrency from 9 to 6 for tuning iteration 3 |
 | 2.0.11-rc.2 | 2026-04-13 | [76266](https://github.com/airbytehq/airbyte/pull/76266) | Decrease default_concurrency from 12 to 9 for tuning iteration 2 |
 | 2.0.11-rc.1 | 2026-04-09 | [76203](https://github.com/airbytehq/airbyte/pull/76203) | Add concurrency support with default_concurrency of 12 |
 | 2.0.10 | 2026-04-06 | [](https://github.com/airbytehq/airbyte/pull/) | Add `token_expiry_date` to `complete_oauth_output_specification` so it is hidden from the UI as an OAuth-managed field |


### PR DESCRIPTION
## What

Concurrency tuning iteration 4 for `source-zendesk-talk` as part of the ongoing progressive rollout ([internal issue](https://github.com/airbytehq/airbyte-internal-issues/issues/15316)).

Previous iterations (rc.1 c=12 → rc.2 c=9 → rc.3 c=6) progressively improved duration metrics but a blocker connection (`dbf5ce4a`) continues to fail with `heartbeat_timeout` under any concurrency > 1. This iteration:
- Reduces `default_concurrency` from 6 → 4 (`max_concurrency` 24 → 16)
- **Comments out the `HTTPAPIBudget`** to isolate whether the budget's throttling behavior is contributing to the heartbeat timeouts

Both changes are requested by the rollout owner to further diagnose the root cause.

## How

- `manifest.yaml`: Lower concurrency values and comment out the full `api_budget` block (3 `FixedWindowCallRatePolicy` entries covering incremental exports, queue activity, and the catch-all endpoint). The block is preserved as comments so it can be easily re-enabled once the tuning loop concludes.
- `metadata.yaml`: Bump `dockerImageTag` to `2.0.11-rc.4`
- `zendesk-talk.md`: Add rc.4 changelog entry, backfill PR link for rc.3

## Review guide

1. `manifest.yaml` — verify concurrency values are correct (4/16) and the `api_budget` block is fully commented out with no partially-active lines
2. `metadata.yaml` — version bump only
3. `docs/integrations/sources/zendesk-talk.md` — changelog entry

> **Important context for reviewers:** Commenting out the HTTPAPIBudget means the connector will no longer self-throttle per Zendesk's per-endpoint rate limits. This is intentional for this RC — the budget will be uncommented once the concurrency tuning loop concludes. This RC is only deployed to ~10 pinned actors via progressive rollout, not to all users.

## User Impact

No user-facing impact. This RC is only deployed to a small set of pinned connections during progressive rollout. General users remain on stable `2.0.10`.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/a8b7ef49ffb0424c93226baac20ab5e3
Requested by: @sophiecuiy