### PR TITLE
docs(ai-agents): explain OAuth versus access token trade-offs for adding a connector

### DIFF
--- a/docs/ai-agents/interfaces/ui/add-connector.md
+++ b/docs/ai-agents/interfaces/ui/add-connector.md
@@ -48,6 +48,31 @@ The Credentials page is the primary place to add, view, and manage connectors fo
 
 The new connector appears immediately in the Credentials table and in the **Available context** list on the Chat and Automation landing pages. You don't need to reload other tabs.
 
+## OAuth versus access tokens
+
+Most connectors let you authenticate with either an OAuth flow or an access token you paste into a form. Both options produce a working connector, but they give Airbyte different levels of control over what that connector can reach. If a connector offers both, prefer OAuth.
+
+### OAuth
+
+In an OAuth flow, the third-party service asks you to authorize Airbyte to act on your behalf. For connectors that publish OAuth scope metadata, the entity picker shows **Read** and **Write** columns, and you can select access per entity. Your selections map to the narrowest set of OAuth scopes that covers what you chose, and the third-party service enforces those scopes on every request the connector makes.
+
+The result is granular, read/write scope control. The connector can only reach the entities and operations the service agreed to, and you can see what you consented to in the authorization dialog.
+
+### Access tokens and personal access tokens (PATs)
+
+When you paste an access token, API key, or PAT into the form, you're handing Airbyte a credential that already carries whatever permissions you assigned to it on the third-party side. Airbyte has no way to narrow that credential. The token grants access to data, but Airbyte can't see what data.
+
+In token mode, selecting entities controls what Airbyte replicates into the [Context Store](../../concepts/context-store), not what the token can reach. The entity picker shows a single **Include** column—there are no read/write modes, because the mode isn't Airbyte's to enforce. If you need to keep the connector away from a piece of data, restrict the token itself on the third-party service before you paste it in.
+
+### Why the entity list can differ
+
+The list of entities the picker shows can differ between the two authentication methods:
+
+- In OAuth mode, the picker shows every entity the connector knows about, including write-only ones, because OAuth scopes can express write-only access.
+- In token mode, the picker hides write-only entities, because selecting one wouldn't put anything into the Context Store.
+
+This is by design, not a bug. In token mode the picker only shows entities you can actually replicate, so the options you see match the outcome you get and the UI doesn't imply a level of access control Airbyte can't enforce.
+
 ## Add a connector during a Chat
 
 You don't have to add connectors up front. If you start a Chat and the agent realizes it needs a data source it doesn't have, it can ask you to authenticate one inline without leaving the conversation.


### PR DESCRIPTION
## What

Stacked on top of `docs-airbyte-agents`. Adds a new **OAuth versus access tokens** section to the `interfaces/ui/add-connector` page explaining how the two authentication methods differ in what Airbyte can see and control.

## How

Inserts a new H2 in `docs/ai-agents/interfaces/ui/add-connector.md` (right after the Credentials-page flow, before the Chat flow) covering:

- **OAuth**: grants the connector access through the third-party service, so Airbyte can enforce granular read/write scopes per entity (backed by `x-airbyte-oauth-scopes` metadata and the Read/Write columns in the entity picker).
- **Access tokens / API keys / PATs**: Airbyte receives an opaque bearer credential whose permissions it cannot narrow. Selecting entities only controls what Airbyte replicates into the Context Store — not what the token itself can reach.
- **Why the entity list can differ**: OAuth shows every entity (including write-only); token mode hides write-only entities because there's nothing to replicate. This is a deliberate design choice so the picker doesn't imply scope control Airbyte can't enforce.

Behavior verified against the sonar code:

- `backend/app/api/integrations/connectors/entities.py` (`_has_oauth_scope_mapping` and `get_available_entities_for_connector`) — read/write modes come from `x-airbyte-entity`/`x-airbyte-action` OpenAPI annotations, and `has_scope_mapping` is driven by the presence of `x-airbyte-oauth-scopes` on the OAuth2 security scheme.
- `backend/app/api/integrations/connectors/oauth/scopes.py` (`try_resolve_entities_to_scopes` / `resolve_entities_to_scopes`) — maps selected entities to the minimal OAuth scopes at consent time when scope metadata exists.
- `frontend/src/components/widget/components/EntityPicker.tsx` — `showReadWriteColumns = showModes && hasScopeMapping`; otherwise (API key or OAuth without scope mapping) a single **Include** column is rendered and write-only entities are filtered out.
- `frontend/src/core/locales/en.json` entity-picker tooltips: base `"Controls what data is copied into the Context Store."`, OAuth `"…also controls what data the connector will be allowed to access."`, api token `"…controls what we check, but does not prevent you from accessing other data."`.

## Review guide

1. `docs/ai-agents/interfaces/ui/add-connector.md` — single new `## OAuth versus access tokens` section with three sub-sections.

## User Impact

Docs-only. Readers get an explicit explanation of why the entity picker looks different between OAuth and token auth, and why they should prefer OAuth when both are available.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌


Link to Devin session: https://app.devin.ai/sessions/3becc87e2f8848cf9196a203d25f5d54
Requested by: @ian-at-airbyte