### PR TITLE
feat(source-snapchat-marketing): revert to concurrency 4 without api_budget for tuning iteration 4

### DIFF
--- a/airbyte-integrations/connectors/source-snapchat-marketing/manifest.yaml
+++ b/airbyte-integrations/connectors/source-snapchat-marketing/manifest.yaml
@@ -10693,6 +10693,17 @@ schemas:
           - number
         description: Total time viewers spend on viewing content in milliseconds.
 
+# api_budget:
+#   type: HTTPAPIBudget
+#   policies:
+#     - type: MovingWindowCallRatePolicy
+#       rates:
+#         - limit: 100
+#           interval: PT10S
+#       matchers: []
+#   status_codes_for_ratelimit_hit:
+#     - 429
+
 concurrency_level:
   type: ConcurrencyLevel
   default_concurrency: 4

--- a/airbyte-integrations/connectors/source-snapchat-marketing/manifest.yaml
+++ b/airbyte-integrations/connectors/source-snapchat-marketing/manifest.yaml
@@ -10693,18 +10693,7 @@ schemas:
           - number
         description: Total time viewers spend on viewing content in milliseconds.
 
-api_budget:
-  type: HTTPAPIBudget
-  policies:
-    - type: MovingWindowCallRatePolicy
-      rates:
-        - limit: 100
-          interval: PT10S
-      matchers: []
-  status_codes_for_ratelimit_hit:
-    - 429
-
 concurrency_level:
   type: ConcurrencyLevel
-  default_concurrency: 5
+  default_concurrency: 4
   max_concurrency: 10

--- a/airbyte-integrations/connectors/source-snapchat-marketing/metadata.yaml
+++ b/airbyte-integrations/connectors/source-snapchat-marketing/metadata.yaml
@@ -8,7 +8,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 200330b2-ea62-4d11-ac6d-cfe3e3f8ab2b
-  dockerImageTag: 1.5.33-rc.3
+  dockerImageTag: 1.5.33-rc.4
   dockerRepository: airbyte/source-snapchat-marketing
   githubIssueLabel: source-snapchat-marketing
   icon: snapchat.svg

--- a/docs/integrations/sources/snapchat-marketing.md
+++ b/docs/integrations/sources/snapchat-marketing.md
@@ -143,6 +143,7 @@ Syncing data with an hourly granularity often generates large data volumes and c
 
 | Version    | Date       | Pull Request                                             | Subject                                                                        |
 |:-----------|:-----------|:---------------------------------------------------------|:-------------------------------------------------------------------------------|
+| 1.5.33-rc.4 | 2026-04-21 | [TBD](https://github.com/airbytehq/airbyte/pull/TBD) | Revert to concurrency 4 without api_budget for tuning iteration 4 |
 | 1.5.33-rc.3 | 2026-04-16 | [76416](https://github.com/airbytehq/airbyte/pull/76416) | Increase api_budget from 80 to 100 calls per 10s for tuning iteration 3 |
 | 1.5.33-rc.2 | 2026-04-13 | [76255](https://github.com/airbytehq/airbyte/pull/76255) | Increase default_concurrency to 5 for tuning iteration 2 |
 | 1.5.33-rc.1 | 2026-04-10 | [70866](https://github.com/airbytehq/airbyte/pull/70866) | Add HTTPAPIBudget and concurrency_level for progressive rollout tuning |

--- a/docs/integrations/sources/snapchat-marketing.md
+++ b/docs/integrations/sources/snapchat-marketing.md
@@ -143,7 +143,7 @@ Syncing data with an hourly granularity often generates large data volumes and c
 
 | Version    | Date       | Pull Request                                             | Subject                                                                        |
 |:-----------|:-----------|:---------------------------------------------------------|:-------------------------------------------------------------------------------|
-| 1.5.33-rc.4 | 2026-04-21 | [TBD](https://github.com/airbytehq/airbyte/pull/TBD) | Revert to concurrency 4 without api_budget for tuning iteration 4 |
+| 1.5.33-rc.4 | 2026-04-21 | [76875](https://github.com/airbytehq/airbyte/pull/76875) | Revert to concurrency 4 without api_budget for tuning iteration 4 |
 | 1.5.33-rc.3 | 2026-04-16 | [76416](https://github.com/airbytehq/airbyte/pull/76416) | Increase api_budget from 80 to 100 calls per 10s for tuning iteration 3 |
 | 1.5.33-rc.2 | 2026-04-13 | [76255](https://github.com/airbytehq/airbyte/pull/76255) | Increase default_concurrency to 5 for tuning iteration 2 |
 | 1.5.33-rc.1 | 2026-04-10 | [70866](https://github.com/airbytehq/airbyte/pull/70866) | Add HTTPAPIBudget and concurrency_level for progressive rollout tuning |


### PR DESCRIPTION
## What

Tuning iteration 4 for `source-snapchat-marketing` progressive rollout ([#15313](https://github.com/airbytehq/airbyte-internal-issues/issues/15313)).

The previous RC (rc.3) increased `api_budget` from 80 to 100 calls/10s while holding concurrency at 5. Monitoring showed a **+21.1% duration regression** vs rc.2 (the only change was the budget increase). Sophie directed the next iteration: revert to `default_concurrency=4` and **disable `api_budget`** to isolate concurrency behavior without rate-limit budgeting.

## How

Three config-only changes (no logic changes):

1. **`manifest.yaml`** — Comment out the entire `api_budget` block (HTTPAPIBudget / MovingWindowCallRatePolicy) and set `default_concurrency` from 5 back to 4.
2. **`metadata.yaml`** — Bump `dockerImageTag` from `1.5.33-rc.3` → `1.5.33-rc.4`.
3. **`docs/.../snapchat-marketing.md`** — Add changelog entry for rc.4.

## Review guide

1. `manifest.yaml` — Verify the `api_budget` section is fully commented out (not active) and `default_concurrency` is `4`. The block is preserved as comments so it can be easily re-enabled in a future iteration.
2. `metadata.yaml` — Version bump only.
3. `docs/integrations/sources/snapchat-marketing.md` — Changelog entry with PR link.

**Key review question:** Disabling `api_budget` means the connector will no longer self-throttle against the Snapchat token-level 10 req/s limit. At `default_concurrency=4`, this is likely fine (4 concurrent streams each making sequential requests should stay under 10 req/s), but reviewers should confirm this is acceptable.

## User Impact

No user-facing impact. This is an RC version behind a progressive rollout — only 2 pinned source actors will run this version during the monitoring window.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/9239df45723948cd8dfdb91b65b84593
Requested by: @sophiecuiy