### PR TITLE
chore(source-freshdesk): re-enable HTTPAPIBudget, keep c=5 for Full Tier 2 rollout (3.2.14-rc.5)

### DIFF
--- a/airbyte-integrations/connectors/source-freshdesk/manifest.yaml
+++ b/airbyte-integrations/connectors/source-freshdesk/manifest.yaml
@@ -3742,21 +3742,19 @@ concurrency_level:
   default_concurrency: "{{ config.get('num_workers', 5) }}"
   max_concurrency: 16
 
-# api_budget commented out for rc.4 tuning experiment — testing c=5 without rate limit budget
-# to determine if the 50 calls/min budget was throttling performance
-# api_budget:
-#   type: HTTPAPIBudget
-#   policies:
-#     - type: FixedWindowCallRatePolicy
-#       period: "PT1M"
-#       # due to lack for support for interpolated string for the call_limit field, this has been
-#       # hardcoded to 50 which is the default rate for free plan
-#       # in the near term use "{{ config.get('requests_per_minute')}}"
-#       # long term is to utilize the `rate_limit_plan` field in config and specifying for each endpoint
-#       call_limit: 50
-#       matchers:
-#         - method: GET
-#           url_base: "https://{{ config['domain'] }}/api/v2/"
-#   ratelimit_reset_header: Retry-After
-#   ratelimit_remaining_header: X-RateLimit-Remaining
-#   status_codes_for_ratelimit_hit: [429]
+api_budget:
+  type: HTTPAPIBudget
+  policies:
+    - type: FixedWindowCallRatePolicy
+      period: "PT1M"
+      # due to lack for support for interpolated string for the call_limit field, this has been
+      # hardcoded to 50 which is the default rate for free plan
+      # in the near term use "{{ config.get('requests_per_minute')}}"
+      # long term is to utilize the `rate_limit_plan` field in config and specifying for each endpoint
+      call_limit: 50
+      matchers:
+        - method: GET
+          url_base: "https://{{ config['domain'] }}/api/v2/"
+  ratelimit_reset_header: Retry-After
+  ratelimit_remaining_header: X-RateLimit-Remaining
+  status_codes_for_ratelimit_hit: [429]

--- a/airbyte-integrations/connectors/source-freshdesk/metadata.yaml
+++ b/airbyte-integrations/connectors/source-freshdesk/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: ec4b9503-13cb-48ab-a4ab-6ade4be46567
-  dockerImageTag: 3.2.14-rc.4
+  dockerImageTag: 3.2.14-rc.5
   dockerRepository: airbyte/source-freshdesk
   documentationUrl: https://docs.airbyte.com/integrations/sources/freshdesk
   externalDocumentationUrls:

--- a/docs/integrations/sources/freshdesk.md
+++ b/docs/integrations/sources/freshdesk.md
@@ -72,6 +72,7 @@ If you don't use the start date Freshdesk will retrieve only the last 30 days. M
 
 | Version | Date       | Pull Request                                             | Subject                                                                               |
 | :------ | :--------- | :------------------------------------------------------- | :------------------------------------------------------------------------------------ |
+| 3.2.14-rc.5 | 2026-04-22 | | Re-enable HTTPAPIBudget, keep c=5 for Full Tier 2 rollout |
 | 3.2.14-rc.4 | 2026-04-17 | | Revert default_concurrency from 6 to 5 and disable HTTPAPIBudget for tuning experiment |
 | 3.2.14-rc.3 | 2026-04-14 | | Concurrency tuning iteration 3: increase default_concurrency from 5 to 6 |
 | 3.2.14-rc.2 | 2026-04-13 | [76272](https://github.com/airbytehq/airbyte/pull/76272) | Concurrency tuning iteration 2: increase default_concurrency from 4 to 5 |


### PR DESCRIPTION
## What

Re-enables the `HTTPAPIBudget` (50 calls/min) that was temporarily disabled in rc.4 during concurrency tuning. Version bumped to `3.2.14-rc.5` in preparation for Full Tier 2 rollout at `default_concurrency=5`.

**Context:** rc.4 commented out the API budget to test whether the 50 calls/min limit was throttling performance. After 24h monitoring across 7 pinned Tier 2 actors, the budget's effect on sync duration was negligible (−0.8%), confirming it is not a bottleneck. Zero HTTP 429s were observed even without the budget. Re-enabling it restores the rate-limit safety net.

## How

- **manifest.yaml**: Uncomments the `api_budget` block (reverts the commenting-out done in rc.4). No functional changes to the budget configuration itself.
- **metadata.yaml**: Bumps `dockerImageTag` from `3.2.14-rc.4` → `3.2.14-rc.5`.
- **freshdesk.md**: Adds changelog entry for rc.5.

## Review guide

1. `manifest.yaml` — verify the uncommented `api_budget` YAML is structurally identical to the original (pre-rc.4) configuration and that `default_concurrency` remains `5`.
2. `metadata.yaml` — version bump only.
3. `docs/integrations/sources/freshdesk.md` — changelog entry.

## User Impact

No user-facing behavior change compared to rc.2 (which also ran c=5 with the budget enabled). The budget prevents excessive API calls on free-tier Freshdesk accounts.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/f5e7f185cbaf4e49b5d1ff5af45e3749
Requested by: @sophiecuiy