### PR TITLE
ci: bump `actions/upload-artifact` v4.6.2 → v7.0.1 (Node 24)

### DIFF
--- a/.github/workflows/connector-ci-checks.yml
+++ b/.github/workflows/connector-ci-checks.yml
@@ -548,7 +548,7 @@ jobs:
 
       - name: Upload Registry CI Artifacts
         if: matrix.connector && steps.connector-metadata.outcome == 'success'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: registry-artifacts-${{ matrix.connector }}-${{ steps.connector-metadata.outputs.connector-version }}
           path: ./registry-artifacts/

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -400,7 +400,7 @@ jobs:
 
       - name: Upload Registry CI Artifacts
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: registry-artifacts-${{ matrix.connector }}-${{ steps.resolve-docker-image-tag.outputs.docker-image-tag }}
           path: ./registry-artifacts/${{ matrix.connector }}/


### PR DESCRIPTION
## What

GitHub has deprecated Node.js 20 on Actions runners ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). Node 20 reaches EOL April 2026; runners will switch to Node 24 by default on June 2, 2026, and drop Node 20 entirely on September 16, 2026.

The SHA `ea165f8d65b6e75b540449e92b4886f43607fa02` pinned in two workflows here corresponds to `actions/upload-artifact@v4.6.2`, which still runs on Node 20 and triggers this deprecation warning.

## How

Bumps the pinned SHA from `v4.6.2` to `v7.0.1` (`043fb46d1a93c77aae656e7c1c64a875d1fc6a0a`) in:

- `.github/workflows/connector-ci-checks.yml`
- `.github/workflows/publish_connectors.yml`

### Version rationale

- `v4.6.2` (current): Node 20 — deprecated.
- `v5.0.0`: still Node 20 by default; bumps internal `@actions/artifact` to v4.0.0 but keeps `node20` runtime.
- `v6.0.0`: first release to run on Node 24 (`runs.using: node24`); requires Actions runner `≥ 2.327.1` (GitHub-hosted runners are well past this).
- `v7.0.x`: latest; adds optional `archive: false` direct single-file upload and ESM packaging. Defaults remain identical to v4/v5, so existing call sites are unaffected.

The immutable artifact format introduced in v4 is shared by v4/v5/v6/v7, so this change stays compatible with any `actions/download-artifact@v4+` consumers. The only `actions/download-artifact` usage in this repo is in `kotlin-bulk-cdk-dokka-publish.yml`, which pairs with its own unpinned `actions/upload-artifact@v4` step and is out of scope for this PR.

Out of scope (intentionally): other `actions/upload-artifact@v4` references that are not pinned to the deprecated SHA.

## Review guide

1. `.github/workflows/connector-ci-checks.yml` — single line change.
2. `.github/workflows/publish_connectors.yml` — single line change.

## User Impact

None for end users. CI workflows that produce artifacts will run the action on Node 24 instead of Node 20, silencing the deprecation warning and future-proofing ahead of GitHub's September 2026 Node 20 removal.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌


Link to Devin session: https://app.devin.ai/sessions/a06dfb169040493d954e065ce38529e5
Requested by: @aaronsteers