### PR TITLE
docs(ai-agents): drop per-end-user framing from SDK section

### DIFF
--- a/docs/ai-agents/interfaces/sdk/add-connector.md
+++ b/docs/ai-agents/interfaces/sdk/add-connector.md
@@ -4,15 +4,15 @@ sidebar_position: 2
 
 # Add a connector
 
-A **connector** in Airbyte Agents is a per-end-user instance that stores one set of credentials for a third-party service and executes operations against it. You create a connector the first time an end user connects their account, then reuse the returned `connector_id` on every subsequent call.
+A **connector** in Airbyte Agents is a stored set of credentials for a third-party service plus everything needed to execute operations against it. You create a connector once, then reuse the returned `connector_id` on every subsequent call.
 
 The `Workspace` class covers every connector operation: create, list, get, and delete.
 
 ## Create a connector
 
-Call `create_connector` on an open `Workspace`. Pass the `definition_id` for the connector type (GitHub, HubSpot, and so on) and the end user's credentials in the shape that connector expects.
+Call `create_connector` on an open `Workspace`. Pass the `definition_id` for the connector type (GitHub, HubSpot, and so on) and the credentials in the shape that connector expects.
 
-`create_connector` returns a string `connector_id`. Store it in your app database, keyed by your end user.
+`create_connector` returns a string `connector_id`. Store it somewhere you can retrieve it later.
 
 ### API token connectors
 
@@ -28,7 +28,7 @@ async def main():
             definition_id="<github_definition_id>",
             name="My GitHub Connector",
             credentials={
-                "token": "<user_github_personal_access_token>",
+                "token": "<github_personal_access_token>",
             },
         )
         print(connector_id)
@@ -103,4 +103,4 @@ async with Workspace() as ws:
     await ws.delete_connector("<connector_id>")
 ```
 
-Delete a connector when an end user disconnects their account. Airbyte removes the stored credentials.
+Delete a connector when you no longer need it. Airbyte removes the stored credentials.

--- a/docs/ai-agents/interfaces/sdk/execute.md
+++ b/docs/ai-agents/interfaces/sdk/execute.md
@@ -67,7 +67,7 @@ result = ask_sync("list my 5 most recent Stripe customers")
 print(result.answer)
 ```
 
-Prefer `connect()` plus `execute()` when you know exactly which entity and action to call. Prefer `ask()` when you want the platform to pick the right operation based on an end user's intent.
+Prefer `connect()` plus `execute()` when you know exactly which entity and action to call. Prefer `ask()` when you want the platform to pick the right operation based on a natural-language request.
 
 ## Expose a connector as an agent tool
 

--- a/docs/ai-agents/interfaces/sdk/readme.md
+++ b/docs/ai-agents/interfaces/sdk/readme.md
@@ -25,7 +25,7 @@ pip install airbyte-agent-sdk
 
 ## End-to-end example
 
-The example below authenticates with Airbyte, adds a HubSpot connector for an end user, and executes an operation against it. The pages in this section explain each step in detail.
+The example below authenticates with Airbyte, adds a HubSpot connector, and executes an operation against it. The pages in this section explain each step in detail.
 
 ```python title="agent.py"
 import asyncio
@@ -35,7 +35,7 @@ async def main():
     # Authenticate. The SDK reads AIRBYTE_CLIENT_ID and AIRBYTE_CLIENT_SECRET
     # from the environment.
     async with Workspace() as ws:
-        # Add a connector for the end user and store the returned ID.
+        # Add a connector and store the returned ID.
         connector_id = await ws.create_connector(
             definition_id="<hubspot_definition_id>",
             name="My HubSpot Connector",

--- a/docs/ai-agents/interfaces/sdk/workspaces.md
+++ b/docs/ai-agents/interfaces/sdk/workspaces.md
@@ -4,13 +4,13 @@ sidebar_position: 4
 
 # Manage workspaces
 
-A **workspace** is an end user's isolated container inside your Airbyte Agents organization. Each workspace has its own connectors and credentials. A token scoped to one workspace can't reach another, which is how Airbyte Agents keeps each end user's data separate in multi-tenant apps.
+A **workspace** is a container inside your Airbyte Agents organization that holds a set of connectors and credentials. A token scoped to one workspace can't reach another.
 
-Most apps use the `default` workspace and never think about this again. The `Workspace` class, `connect()`, and `ask()` all default to `workspace_name="default"`. Only split into multiple workspaces when you actively need per-end-user isolation inside a single Airbyte Agents organization.
+Most apps use the `default` workspace and never think about this again. The `Workspace` class, `connect()`, and `ask()` all default to `workspace_name="default"`. Reach for multiple workspaces only when you actively need to isolate credentials across distinct tenants, teams, or environments.
 
 ## Use a specific workspace
 
-To target a workspace other than `default`, pass `workspace_name`. Use a stable identifier for your end user, such as your internal user ID or company slug.
+To target a workspace other than `default`, pass `workspace_name`. Use a stable identifier that makes sense in your app, such as an internal tenant ID or team slug.
 
 ```python title="agent.py"
 import asyncio


### PR DESCRIPTION
## What

Follow-up to #76881. The API section now presumes the `default` workspace and keeps workspaces as a "thing that exists for multi-tenant apps" rather than the general narrative. This PR applies the same treatment to the SDK section so the two interfaces tell the same story.

## How

- `sdk/add-connector.md`: intro reframed from "per-end-user instance… first time an end user connects their account" to "a stored set of credentials for a third-party service"; dropped "the end user's credentials", "keyed by your end user", "when an end user disconnects their account". Renamed a sample credential variable from `<user_github_personal_access_token>` to `<github_personal_access_token>`.
- `sdk/workspaces.md`: intro changed from "an end user's isolated container… keeps each end user's data separate in multi-tenant apps" to "a container inside your Airbyte Agents organization that holds a set of connectors and credentials"; guidance to split into multiple workspaces no longer frames it as "per-end-user isolation".
- `sdk/readme.md`: end-to-end example text changed from "adds a HubSpot connector for an end user" to "adds a HubSpot connector"; removed "for the end user" from a code comment.
- `sdk/execute.md`: `ask()` guidance changed from "based on an end user's intent" to "based on a natural-language request".

## Review guide

1. `docs/ai-agents/interfaces/sdk/add-connector.md`
2. `docs/ai-agents/interfaces/sdk/workspaces.md`
3. `docs/ai-agents/interfaces/sdk/readme.md`
4. `docs/ai-agents/interfaces/sdk/execute.md`

## User Impact

Documentation-only. SDK narrative now mirrors the API narrative: default workspace first, multi-tenant isolation presented as an opt-in use case instead of the baseline story.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

cc @ian-at-airbyte (substantive documentation content change).

Link to Devin session: https://app.devin.ai/sessions/f48c1bbc03ad4c5bb182aa935a8a5a12