### PR TITLE
docs(ai-agents): correct API reference drift and gaps

### DIFF
--- a/docs/ai-agents/interfaces/api/add-connector.md
+++ b/docs/ai-agents/interfaces/api/add-connector.md
@@ -23,7 +23,7 @@ curl -X POST 'https://api.airbyte.ai/api/v1/integrations/connectors' \
   --header 'Authorization: Bearer <application_token>' \
   --header 'Content-Type: application/json' \
   --data '{
-    "customer_name": "default",
+    "workspace_name": "default",
     "definition_id": "<github_definition_id>",
     "name": "My GitHub Connector",
     "credentials": {
@@ -41,7 +41,7 @@ curl -X POST 'https://api.airbyte.ai/api/v1/integrations/connectors' \
   --header 'Authorization: Bearer <application_token>' \
   --header 'Content-Type: application/json' \
   --data '{
-    "customer_name": "default",
+    "workspace_name": "default",
     "definition_id": "<hubspot_definition_id>",
     "name": "My HubSpot Connector",
     "credentials": {
@@ -56,6 +56,10 @@ Each connector defines its own credential shape. See the connector's page in the
 
 If you need to drive the OAuth consent screen yourself with your own branding, see [Build your own OAuth flow](./authentication/build-your-own). The final step of that flow calls this same endpoint with a `server_side_oauth_secret_id` in place of `credentials`.
 
+:::note Credentials aren't validated until first execute
+Airbyte doesn't validate credentials at creation time. A `200 OK` response means the request body parsed, not that the credentials work. Expect an authentication error at the first [execute](./execute) call if any credential is wrong.
+:::
+
 ### Find a `definition_id`
 
 The `definition_id` identifies the connector type. You can look it up two ways:
@@ -63,18 +67,29 @@ The `definition_id` identifies the connector type. You can look it up two ways:
 - Browse the [Airbyte Connector Registry](https://connectors.airbyte.com/files/registries/v0/cloud_registry.json) and copy the `sourceDefinitionId` for your connector.
 - Call `GET /api/v1/integrations/definitions/sources` to list every available connector type with its definition ID. See [Make your first request](./#make-your-first-request).
 
-### About `customer_name`
+### About `workspace_name`
 
-The `customer_name` field identifies which [workspace](./workspaces) the connector belongs to. Most apps use `"default"` and don't think about this again. If you need to isolate credentials across tenants or teams, pass a different value; Airbyte treats that string as the workspace name and creates the workspace on first use. See [Manage workspaces](./workspaces) for the administrative operations on top.
+The `workspace_name` field identifies which [workspace](./workspaces) the connector belongs to. Most apps use `"default"` and don't think about this again. If you need to isolate credentials across tenants or teams, pass a different value; Airbyte treats that string as the workspace name and creates the workspace on first use. See [Manage workspaces](./workspaces) for the administrative operations on top.
+
+:::note Accepted aliases
+The API also accepts `customer_name` and `external_user_id` in place of `workspace_name` for backward compatibility. Both are deprecated. Use `workspace_name` in new code.
+:::
 
 ## List connectors
 
+List the connectors in a workspace. A workspace identifier is required — pass `workspace_name` (or `workspace_id`) as a query parameter.
+
 ```bash title="Request"
-curl 'https://api.airbyte.ai/api/v1/integrations/connectors' \
+curl 'https://api.airbyte.ai/api/v1/integrations/connectors?workspace_name=default' \
   --header 'Authorization: Bearer <application_token>'
 ```
 
-Filter by `customer_name` or `definition_id` with query parameters to narrow the result set.
+Add `definition_id` to narrow results to a single connector type.
+
+```bash title="Request"
+curl 'https://api.airbyte.ai/api/v1/integrations/connectors?workspace_name=default&definition_id=<hubspot_definition_id>' \
+  --header 'Authorization: Bearer <application_token>'
+```
 
 ## Get a connector
 

--- a/docs/ai-agents/interfaces/api/authentication/build-your-own.md
+++ b/docs/ai-agents/interfaces/api/authentication/build-your-own.md
@@ -173,6 +173,43 @@ curl -X DELETE "https://api.airbyte.ai/api/v1/oauth/credentials/connector_type/h
 
 When your user wants to connect a third-party service, initiate the OAuth flow to get a consent URL.
 
+### Prerequisite: enable the connector for your organization
+
+Initiate requires an organization-specific source template for the connector type. Without one, the call returns `400` with `"No organization-specific source template configured for this connector type."` (This differs from [Add a connector](../add-connector), which falls back to Airbyte-managed defaults when no org template exists.)
+
+The easiest way to enable a connector is in the Airbyte Agents app — it's a one-time setup and anyone on your team can do it.
+
+<Tabs>
+<TabItem value="ui" label="Airbyte Agents app" default>
+
+Open the Airbyte Agents app and add the connector once for your organization. See [Add a connector](../../ui/add-connector) for the full walkthrough. The app handles enabling the connector type and configuring the OAuth client in one flow.
+
+</TabItem>
+<TabItem value="api" label="API">
+
+Clone one of Airbyte's global source template stubs into your organization:
+
+```bash title="1. Find the global template for your connector type"
+curl 'https://api.airbyte.ai/api/v1/integrations/templates/sources/global' \
+  -H 'Authorization: Bearer <application_token>'
+```
+
+Pick the entry whose `actor_definition_id` matches the connector type you want to enable.
+
+```bash title="2. Clone it into your organization"
+curl -X POST 'https://api.airbyte.ai/api/v1/integrations/templates/sources' \
+  -H 'Authorization: Bearer <application_token>' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "original_source_template_id": "<global_template_id_from_step_1>"
+  }'
+```
+
+After the clone succeeds, initiate calls for that connector type will resolve to the new org-specific template.
+
+</TabItem>
+</Tabs>
+
 ### Endpoint
 
 ```text
@@ -376,6 +413,10 @@ app.listen(3000);
 **"Workspace not found" error:**
 
 - Ensure the `workspace_name` you provide in the initiate step is correct. Airbyte creates the workspace automatically on first use.
+
+**`"No organization-specific source template configured for this connector type."`:**
+
+- This connector type isn't enabled for your organization yet. Enable it once from the Airbyte Agents app ([Add a connector](../../ui/add-connector)), or clone the global template via the API (see the Prerequisite section above). Initiate only resolves against org-specific templates; Airbyte-managed defaults don't apply to this endpoint.
 
 **OAuth consent URL returns an error:**
 

--- a/docs/ai-agents/interfaces/api/execute.md
+++ b/docs/ai-agents/interfaces/api/execute.md
@@ -144,23 +144,33 @@ const url = URL.createObjectURL(blob);
 
 ## Response format
 
-Responses include the requested data along with pagination information when applicable.
+Every execute response uses the same top-level envelope. The connector's records land in `result`, pagination details land in `connector_metadata`, and timing and identity land in `execution_metadata`.
 
 ```json title="Response"
 {
-  "data": [...],
-  "meta": {
-    "pagination": {
-      "totalRecords": 150,
-      "currentPageSize": 50,
-      "currentPageNumber": 1,
-      "cursor": "<cursor_for_next_page>"
-    }
+  "status": "success",
+  "result": [
+    { "id": "1", "name": "Ada Lovelace" },
+    { "id": "2", "name": "Grace Hopper" }
+  ],
+  "connector_metadata": {
+    "hasNextPage": true,
+    "endCursor": "<cursor_for_next_page>"
+  },
+  "execution_metadata": {
+    "connector_instance_id": "<connector_id>",
+    "execution_time_ms": 1189
   }
 }
 ```
 
-To retrieve additional pages, include the cursor in subsequent requests.
+- `result` is whatever the operation returns — an array for `list` and `search`, a single object for `get`, or a byte stream for `download`.
+- `connector_metadata` surfaces pagination state. The exact key names depend on the connector. Expect `hasNextPage` and `endCursor` on most connectors; some connectors return `has_next_page` and `end_cursor` instead. Both mean the same thing.
+- `execution_metadata` always includes `connector_instance_id` and `execution_time_ms`.
+
+### Paginate through results
+
+When `connector_metadata.hasNextPage` is `true`, pass the cursor from the previous response as `params.cursor` to get the next page.
 
 ```bash title="Request"
 curl -X POST 'https://api.airbyte.ai/api/v1/integrations/connectors/<connector_id>/execute' \
@@ -170,10 +180,12 @@ curl -X POST 'https://api.airbyte.ai/api/v1/integrations/connectors/<connector_i
     "entity": "users",
     "action": "list",
     "params": {
-      "cursor": "<cursor_from_previous_response>"
+      "cursor": "<endCursor_from_previous_response>"
     }
   }'
 ```
+
+Keep requesting pages until `hasNextPage` is `false`.
 
 ## Next steps
 

--- a/docs/ai-agents/interfaces/api/readme.md
+++ b/docs/ai-agents/interfaces/api/readme.md
@@ -50,7 +50,7 @@ curl -X POST https://api.airbyte.ai/api/v1/integrations/connectors \
   -H 'Authorization: Bearer <application_token>' \
   -H 'Content-Type: application/json' \
   -d '{
-    "customer_name": "default",
+    "workspace_name": "default",
     "definition_id": "<hubspot_definition_id>",
     "name": "My HubSpot Connector",
     "credentials": {

--- a/docs/ai-agents/interfaces/api/workspaces.md
+++ b/docs/ai-agents/interfaces/api/workspaces.md
@@ -10,11 +10,15 @@ Listing every workspace, updating a workspace's status, deleting a workspace, an
 
 A **workspace** is a container inside your Airbyte Agents organization that holds a set of connectors and credentials. Every organization starts with a `default` workspace, and most apps stay there. Create additional workspaces only when you need to isolate credentials across distinct tenants, teams, or environments.
 
-Every request that touches a connector carries the workspace it belongs to. In the REST body that's `customer_name`; in a scoped or widget token request it's `workspace_name`. Airbyte uses the value as the workspace identifier and creates the workspace on first use.
+Every request that touches a connector carries the workspace it belongs to in a `workspace_name` field. Airbyte uses the value as the workspace identifier and creates the workspace on first use.
+
+:::note Accepted aliases
+Some endpoints still accept `customer_name` or `external_user_id` in place of `workspace_name` for backward compatibility. Both are deprecated — use `workspace_name` in new code.
+:::
 
 ## Create a new workspace
 
-You don't create workspaces directly. Airbyte creates one automatically the first time you reference a new `workspace_name` when generating a [scoped token](./authentication#scoped-token), or a new `customer_name` when creating a connector. Use any stable string that makes sense in your app.
+You don't create workspaces directly. Airbyte creates one automatically the first time you reference a new `workspace_name` when [creating a connector](./add-connector) or generating a [scoped token](./authentication#scoped-token). Use any stable string that makes sense in your app.
 
 ## Manage workspaces
 


### PR DESCRIPTION
## What

Fixes drift between the Airbyte Agents API reference and the live API, discovered during a walkthrough of the docs against the hosted service. Doc-only change.

Covers five findings in `docs/ai-agents/interfaces/api/`:

1. **`execute.md` — response format.** The documented envelope (`data`/`meta.pagination.totalRecords`/`currentPageSize`/…) doesn't exist. The real envelope is `status` / `result` / `connector_metadata` / `execution_metadata`, and pagination surfaces as `connector_metadata.hasNextPage` + `endCursor`. Verified against `sonar: app/api/integrations/connectors/schemas.py:290` (`ConnectorExecuteResponse`). Updated the Response format section to match reality, added a Paginate subsection, and noted the `hasNextPage`/`has_next_page` casing inconsistency that some connectors return.

2. **`add-connector.md` — List connectors requires a workspace.** The curl example omitted `?workspace_name=`, which 400s. Added the query parameter to the example and a second example that also narrows by `definition_id`. Matches the validation in `sonar: app/api/integrations/connectors/controllers.py`.

3. **`add-connector.md`, `readme.md`, `workspaces.md` — use `workspace_name`, not `customer_name`.** `customer_name` is a deprecated alias (`routers.py:128` marks it `deprecated=True`). Swapped every user-facing example to `workspace_name`, reworded the "About customer_name" section, removed the artificial `customer_name` vs `workspace_name` split from `workspaces.md`, and added matching "Accepted aliases" callouts so readers with old code still understand what they're seeing.

4. **`add-connector.md` — credentials aren't validated until first execute.** Added a note so readers don't mistake `200 OK` on create for a working credential. Any authentication error shows up on the first `execute` call instead.

5. **`authentication/build-your-own.md` — OAuth initiate prerequisite.** Initiate returns 400 (`"No organization-specific source template configured for this connector type."`) on a fresh org because the endpoint explicitly forbids global templates (`sonar: connectors/oauth/controllers.py:136-140`), while `create_connector` falls back to global templates (`sources/config_mapper.py:269-282`). Added a Prerequisite subsection with Tabs — UI (default, links to `../../ui/add-connector`) and API (shows the `GET /templates/sources/global` → `POST /templates/sources` clone sequence). Reworded the matching troubleshooting entry.

## How

Edits in:

- `docs/ai-agents/interfaces/api/execute.md`
- `docs/ai-agents/interfaces/api/add-connector.md`
- `docs/ai-agents/interfaces/api/readme.md`
- `docs/ai-agents/interfaces/api/workspaces.md`
- `docs/ai-agents/interfaces/api/authentication/build-your-own.md`

No code changes; no new pages. `markdownlint-cli2` error count on `docs/ai-agents/interfaces/api/**/*.md` is unchanged (28 before, 28 after) — all pre-existing MD060 table-column-style issues.

## Review guide

1. `docs/ai-agents/interfaces/api/execute.md` — Response format section is the biggest single change. Double-check the example `connector_metadata` fields against what a real list response returns for a connector you've used.
2. `docs/ai-agents/interfaces/api/authentication/build-your-own.md` — Part 2 opens with the new Prerequisite + Tabs block. Confirm the UI tab link (`../../ui/add-connector`) is the right target, and that the API tab curl sequence is how you'd want developers to self-serve.
3. Everything else is mechanical `customer_name` → `workspace_name` and alias callouts.

## User Impact

Developers following the API reference end-to-end no longer hit the `customer_name`/`workspace_name` and list-connectors 400s, and no longer get surprised by the mismatched execute response envelope or the OAuth initiate 400 on a fresh org.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌


Link to Devin session: https://app.devin.ai/sessions/0b5975b7693a42c38b2965137d5e230f
Requested by: @ian-at-airbyte