### PR TITLE
docs(ai-agents): correct SDK reference drift and gaps

### DIFF
--- a/docs/ai-agents/interfaces/sdk/add-connector.md
+++ b/docs/ai-agents/interfaces/sdk/add-connector.md
@@ -63,10 +63,17 @@ Each connector defines its own credential shape. See the connector's page in the
 
 ### Find a `definition_id`
 
-The `definition_id` identifies the connector type. You can look it up two ways:
+The `definition_id` identifies the connector type. The fastest way to look one up is to call the definitions endpoint and filter by connector name:
 
-- Browse the [Airbyte Connector Registry](https://connectors.airbyte.com/files/registries/v0/cloud_registry.json) and copy the `sourceDefinitionId` for your connector.
-- Call the API `GET /api/v1/integrations/definitions/sources` to list every available connector type with its definition ID.
+```bash
+curl -s 'https://api.airbyte.ai/api/v1/integrations/definitions/sources' \
+  -H 'Authorization: Bearer <application_token>' \
+  | jq '.data[] | select(.name | test("hubspot"; "i")) | {name, id: .sourceDefinitionId}'
+```
+
+See [Make your first request](../api/#make-your-first-request) for token details.
+
+You can also browse the raw [Airbyte Connector Registry](https://connectors.airbyte.com/files/registries/v0/cloud_registry.json) JSON and copy `sourceDefinitionId` for the entry you want.
 
 ## List connectors
 

--- a/docs/ai-agents/interfaces/sdk/execute.md
+++ b/docs/ai-agents/interfaces/sdk/execute.md
@@ -33,7 +33,9 @@ See the connector's page in the [Connectors](../../connectors) reference for the
 
 For connectors with a generated typed submodule, `connect()` returns a typed connector with IDE autocompletion, method-level docstrings, and structured call shortcuts. For example: `await hubspot.contacts.list(limit=10)`. For the full list of typed connectors, see the [SDK reference](../../reference/sdk).
 
-For every other connector, `connect()` returns a generic `HostedExecutor` with the same `execute(entity, action, params)` method but without typed shortcuts. The execution behavior is otherwise identical.
+For every other connector in the bundled registry, `connect()` returns a generic `HostedExecutor` with the same `execute(entity, action, params)` method but without typed shortcuts. The execution behavior is otherwise identical.
+
+`connect()` raises `ValueError` if the slug isn't in the bundled registry or if no Airbyte credentials are available. It does *not* raise when a typed submodule is missing — YAML-only connectors return a `HostedExecutor`.
 
 ### Resolve a connector by name
 
@@ -193,11 +195,14 @@ for entity in entities:
     # contacts: ['list', 'get', 'search']
 ```
 
-`entity_schema(entity)` returns the JSON schema for records of that entity.
+`entity_schema(entity)` returns the JSON schema for records of that entity, or `None` if the connector doesn't ship one for that entity. Always guard the result:
 
 ```python title="agent.py"
 schema = hubspot.entity_schema("contacts")
-print(list(schema.get("properties", {}).keys()))
+if schema is None:
+    print("No schema available for contacts")
+else:
+    print(list(schema.get("properties", {}).keys()))
 ```
 
 ## Handle errors

--- a/docs/ai-agents/interfaces/sdk/workspaces.md
+++ b/docs/ai-agents/interfaces/sdk/workspaces.md
@@ -35,7 +35,9 @@ result = await ask("list my 5 most recent customers", workspace_name="acme_corp"
 
 ## Auto-creation
 
-The SDK creates a workspace on first reference. You don't explicitly create one. The first `create_connector` or `ask()` call against a new `workspace_name` provisions it on the fly.
+You don't explicitly create a workspace. The first `create_connector` call against a new `workspace_name` provisions it on the fly.
+
+Other operations do not provision the workspace. `list_connectors()`, `get_connector()`, and `ask()` against a `workspace_name` that hasn't been created yet return an empty result or a 404 — they won't implicitly create it for you. If you need to start from an empty workspace, call `create_connector` first (or add a connector in the Airbyte Agents app).
 
 ## Operations that require the API
 


### PR DESCRIPTION
## What

Fixes drift between the Airbyte Agents SDK reference and the installed `airbyte-agent-sdk` package, discovered during a walkthrough of the docs against the hosted service. Doc-only change.

Covers four findings in `docs/ai-agents/interfaces/sdk/`:

1. **`workspaces.md` — auto-creation semantics.** The Auto-creation section claimed `ask()` and "first reference" provision a workspace. Only `create_connector` does. `list_connectors`, `get_connector`, and `ask()` return empty or 404 against a workspace that was never populated. Verified against `sonar: connector-sdk/airbyte_agent_sdk/workspace.py:85-158` — `list_workspace_connectors` and `ask_workspace` call through to the cloud client without any upsert, while `create_connector` lands on `create_source` which falls back to workspace creation.

2. **`add-connector.md` — `definition_id` lookup.** "Browse the 25k-line JSON registry" isn't actionable. Replaced with a `curl | jq` example against `GET /api/v1/integrations/definitions/sources`, filtered by connector name. The raw-registry link is kept as a fallback for readers who want to spelunk.

3. **`execute.md` — `connect()` failure modes.** The Typed connectors / `HostedExecutor` section glossed over when `connect()` errors. Added one sentence clarifying it raises `ValueError` for unknown slugs or missing credentials, and *does not* raise when the typed submodule is missing — YAML-only connectors fall back to `HostedExecutor`. Matches `sonar: connector-sdk/airbyte_agent_sdk/connect.py:115-158`.

4. **`execute.md` — `entity_schema` can return `None`.** The Introspection example printed `.get("properties", {})` against a value that is typed `dict | None`. Added a `None` guard so the example doesn't AttributeError when you hit an entity without a shipped schema. Matches `sonar: connector-sdk/airbyte_agent_sdk/types.py:354`.

## How

Edits in:

- `docs/ai-agents/interfaces/sdk/workspaces.md`
- `docs/ai-agents/interfaces/sdk/add-connector.md`
- `docs/ai-agents/interfaces/sdk/execute.md`

No code changes, no new pages, no structural reshuffling. `markdownlint-cli2` on `docs/ai-agents/interfaces/sdk/**/*.md` is clean before and after.

## Review guide

1. `docs/ai-agents/interfaces/sdk/workspaces.md` — confirm the Auto-creation rewording matches your mental model: only `create_connector` provisions; other ops are read-only and 404 on missing workspaces.
2. `docs/ai-agents/interfaces/sdk/add-connector.md` — the new `curl | jq` example requires `jq`. If you'd rather point at something that works out of the box, let me know.
3. `docs/ai-agents/interfaces/sdk/execute.md` — the `connect()` clarification and `entity_schema` None guard are both small, mechanical fixes.

## User Impact

Developers following the SDK reference stop hitting "I called `list_connectors` on a new workspace and got 404" and "I called `entity_schema` and got an AttributeError because the example didn't guard None" as surprises.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌


Link to Devin session: https://app.devin.ai/sessions/0b5975b7693a42c38b2965137d5e230f
Requested by: @ian-at-airbyte