### PR TITLE
feat(source-google-analytics-data-api): support yearMonth and yearWeek in custom reports

### DIFF
--- a/airbyte-integrations/connectors/source-google-analytics-data-api/manifest.yaml
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/manifest.yaml
@@ -1,4 +1,4 @@
-version: 6.48.16
+version: 6.48.17
 
 type: DeclarativeSource
 

--- a/airbyte-integrations/connectors/source-google-analytics-data-api/manifest.yaml
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/manifest.yaml
@@ -1102,7 +1102,7 @@ dynamic_streams:
                 - {{ dimension }}
             {% endfor %}
 
-            {% if "date" not in dimensions and not (cohort and cohort.get("enabled") == "true") %}
+            {% if "date" not in dimensions and "yearMonth" not in dimensions and "yearWeek" not in dimensions and not (cohort and cohort.get("enabled") == "true") %}
                 - startDate
                 - endDate
             {% endif %}

--- a/airbyte-integrations/connectors/source-google-analytics-data-api/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/metadata.yaml
@@ -12,7 +12,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 3cc2eafd-84aa-4dca-93af-322d9dfeec1a
-  dockerImageTag: 2.9.32
+  dockerImageTag: 2.9.33
   dockerRepository: airbyte/source-google-analytics-data-api
   documentationUrl: https://docs.airbyte.com/integrations/sources/google-analytics-data-api
   externalDocumentationUrls:

--- a/docs/integrations/sources/google-analytics-data-api.md
+++ b/docs/integrations/sources/google-analytics-data-api.md
@@ -280,6 +280,7 @@ The Google Analytics connector is subject to Google Analytics Data API quotas. P
 
 | Version        | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:---------------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 2.9.33 | 2026-04-22 | [76913](https://github.com/airbytehq/airbyte/pull/76913) | Support `yearMonth` and `yearWeek` dimensions in custom reports |
 | 2.9.32 | 2026-04-21 | [76600](https://github.com/airbytehq/airbyte/pull/76600) | Update dependencies |
 | 2.9.31 | 2026-04-09 | [76185](https://github.com/airbytehq/airbyte/pull/76185) | Improve error messages for HTTP 400/403 responses; use predicate-based 403 handling to distinguish permission errors (config_error) from other 403s (retry) |
 | 2.9.30 | 2026-04-09 | [76190](https://github.com/airbytehq/airbyte/pull/76190) | Add access_token to extract_output and complete_oauth_output_specification to fix OAuth secretId 422 regression |


### PR DESCRIPTION
# source-google-analytics-data-api: fix startDate/endDate injection for weekly and monthly reports

## What
Currently, the connector automatically injects `startDate` and `endDate` metadata fields into records and Primary Keys whenever the specific dimension `date` is missing. 

However, it does not recognize other valid GA4 time-based dimensions such as `yearMonth` and `yearWeek`. This causes the connector to "force-inject" daily date boundaries into monthly or weekly reports, leading to redundant columns and potential primary key bloat in the destination.

This PR ensures that `yearMonth` and `yearWeek` are treated as valid time markers, preventing unnecessary field injection for these granularities.

## How
The Jinja2 conditional logic has been updated in two key areas of the `manifest.yaml`:
1.  **Transformations:** Updated the `AddFields` condition to skip adding `startDate` and `endDate` if `yearMonth` or `yearWeek` are present in the stream's dimensions.
2.  **Primary Key:** Updated the composite primary key logic to exclude `startDate` and `endDate` when these time dimensions are used.

**Updated condition logic:**
`{% if "date" not in dimensions and "yearMonth" not in dimensions and "yearWeek" not in dimensions and not (cohort and cohort.get("enabled") == "true") %}`

## Review guide
1.  `manifest.yaml`: Check the `transformations` section under `google_analytics_stream_template`.
2.  `manifest.yaml`: Check the `primary_key` definition in the same template.

## User Impact
* **Cleaner Data:** Users creating monthly or weekly custom reports will no longer see irrelevant daily `startDate` and `endDate` columns in their final tables.
* **Consistency:** The connector now behaves consistently across all standard GA4 time granularities (`date`, `yearWeek`, `yearMonth`).
* **No breaking changes:** Standard daily reports and Cohort reports remain unaffected.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌