### PR TITLE
docs(ai-agents): add VS Code tab and one-click install guidance to MCP docs

### DIFF
--- a/docs/ai-agents/mcp-server/readme.md
+++ b/docs/ai-agents/mcp-server/readme.md
@@ -71,7 +71,25 @@ Add the MCP server to your Claude Code command line tool.
 </TabItem>
 <TabItem value="cursor" label="Cursor">
 
-Add the MCP server to your Cursor app.
+Add the MCP server to your Cursor app. The fastest way is a one-click install from the Agent Engine web app. Manual setup is available as a fallback.
+
+**Install with one click (recommended).**
+
+1. Open [app.airbyte.ai](https://app.airbyte.ai) and sign in.
+
+2. In the left sidebar, click **MCP Server**.
+
+3. Click **Add to Cursor**. Your browser prompts you to open Cursor.
+
+4. Approve the prompt. Cursor opens and registers the Airbyte MCP server.
+
+5. In Cursor, click **Connect** next to the Airbyte MCP server.
+
+6. If you're not logged into the Agent Engine, log in now, then grant access.
+
+7. Return to Cursor. The MCP server tools are now available.
+
+**Install manually.**
 
 1. Go to **Cursor** > **Settings** > **Cursor Settings** > **Tools and MCP**.
 
@@ -98,6 +116,60 @@ Add the MCP server to your Cursor app.
 7. Grant access to the Agent Engine MCP.
 
 8. Return to Cursor. The MCP server tools are now available.
+
+</TabItem>
+<TabItem value="vscode" label="VS Code">
+
+Add the MCP server to VS Code. The fastest way is a one-click install from the Agent Engine web app. Manual setup is available as a fallback.
+
+:::note GitHub Copilot is required
+VS Code exposes MCP servers through Copilot Chat's agent mode. Install the GitHub Copilot and GitHub Copilot Chat extensions and sign in before you add the server, or the Airbyte tools don't appear.
+:::
+
+**Install with one click (recommended).**
+
+1. Open [app.airbyte.ai](https://app.airbyte.ai) and sign in.
+
+2. In the left sidebar, click **MCP Server**.
+
+3. Click **Add to VS Code**. Your browser prompts you to open VS Code.
+
+4. Approve the prompt. VS Code opens and asks you to confirm the new MCP server.
+
+5. Click **Trust** to start the server.
+
+6. When prompted, log in to the Agent Engine and grant access. The MCP server tools are now available in Copilot Chat.
+
+**Install manually.** If the one-click install doesn't open VS Code, add the server manually.
+
+1. In VS Code, open the Command Palette and run **MCP: Add Server**.
+
+2. Select **HTTP**.
+
+3. Enter the server URL: `https://mcp.airbyte.ai/mcp`
+
+4. Enter the server name: `Airbyte`
+
+5. Choose **User** to install the server in your user profile.
+
+6. When VS Code asks you to trust the server, click **Trust** to start it.
+
+7. Copilot Chat opens a browser window for OAuth. Log in to the Agent Engine and grant access.
+
+8. Return to VS Code. The MCP server tools are now available in Copilot Chat.
+
+You can also edit `mcp.json` directly. Run **MCP: Open User Configuration** from the Command Palette and add the server:
+
+```json
+{
+  "servers": {
+    "Airbyte": {
+      "type": "http",
+      "url": "https://mcp.airbyte.ai/mcp"
+    }
+  }
+}
+```
 
 </TabItem>
 <TabItem value="claude-desktop" label="Claude Desktop">


### PR DESCRIPTION
## What

Closes [AGENTIC-1119](https://linear.app/airbyteio/issue/AGENTIC-1119/add-vs-code-tab-and-install-guidance-to-mcp-docs).

- Adds a new **VS Code** tab to the Agent Engine MCP server setup docs, with a GitHub Copilot prerequisite callout, a one-click install path from the Agent Engine web app, and a manual fallback using `MCP: Add Server` / `mcp.json`.
- Rewrites the **Cursor** tab to lead with one-click install from the web app, keeping the existing manual `mcp.json` steps as a fallback.

## How

Edits `docs/ai-agents/mcp-server/readme.md` only:

- New `<TabItem value="vscode" label="VS Code">` inserted right after the Cursor tab. Uses VS Code's `mcp.json` shape (`servers` with `type: "http"`), not Cursor's `mcpServers` shape.
- Cursor tab restructured into "Install with one click (recommended)" and "Install manually" sections. Content is bold-prose section markers (not subheadings) so `MD001`/`MD024` stay clean across both tabs.
- Scope is docs-only; no webapp/frontend changes.

## Review guide

1. `docs/ai-agents/mcp-server/readme.md` — check the Cursor and new VS Code tabs.

## User Impact

Users get clearer, preferred-path install guidance for both IDE clients on https://docs.airbyte.com/ai-agents/mcp-server, including the "Copilot must be enabled" prerequisite that's easy to miss.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌


Link to Devin session: https://app.devin.ai/sessions/4755359965054e529f78352b285dd45b
Requested by: @ian-at-airbyte