### PR TITLE
docs(ai-agents): prefer connector names over IDs in code samples

### DIFF
--- a/docs/ai-agents/interfaces/api/execute.md
+++ b/docs/ai-agents/interfaces/api/execute.md
@@ -14,14 +14,16 @@ Before making API calls, you need an application token. For details on obtaining
 
 ## Find the connector ID
 
-Every execute call targets a specific connector by its `connector_id` in the URL. If you didn't store the ID from the [create response](./add-connector), look it up by workspace and connector type (`definition_id`):
+Every execute call targets a specific connector by its `connector_id` in the URL. If you didn't store the ID from the [create response](./add-connector), look it up by workspace and connector type. Call `GET /api/v1/integrations/connectors` and filter by `workspace_name` and `definition_id`:
 
 ```bash title="Request"
 curl 'https://api.airbyte.ai/api/v1/integrations/connectors?workspace_name=default&definition_id=<hubspot_definition_id>' \
   --header 'Authorization: Bearer <your_application_token>'
 ```
 
-The Airbyte Agent Python SDK can resolve a connector by slug (for example, `"hubspot"`) without the ID. Consider using the [SDK](../sdk/execute) if you want to avoid managing connector IDs in application code.
+`definition_id` is the connector type (HubSpot, GitHub, and so on). See [Find a `definition_id`](./add-connector#find-a-definition_id) for how to look one up. The response includes each matching connector's `id` — use it in the execute URL below.
+
+The Airbyte Agent Python SDK can resolve a connector by its slug (for example, `"hubspot"`) without any IDs. Consider using the [SDK](../sdk/execute) if you want to avoid managing connector IDs in application code.
 
 ## Execute an operation
 

--- a/docs/ai-agents/interfaces/api/execute.md
+++ b/docs/ai-agents/interfaces/api/execute.md
@@ -12,6 +12,17 @@ To execute operations from Python code instead, see [Execute operations](../sdk/
 
 Before making API calls, you need an application token. For details on obtaining tokens, see [Token types](./authentication#token-types).
 
+## Find the connector ID
+
+Every execute call targets a specific connector by its `connector_id` in the URL. If you didn't store the ID from the [create response](./add-connector), look it up by workspace and connector type (`definition_id`):
+
+```bash title="Request"
+curl 'https://api.airbyte.ai/api/v1/integrations/connectors?workspace_name=default&definition_id=<hubspot_definition_id>' \
+  --header 'Authorization: Bearer <your_application_token>'
+```
+
+The Airbyte Agent Python SDK can resolve a connector by slug (for example, `"hubspot"`) without the ID. Consider using the [SDK](../sdk/execute) if you want to avoid managing connector IDs in application code.
+
 ## Execute an operation
 
 To execute an operation against a connector, send a POST request to the execute endpoint with the entity, action, and any required parameters.

--- a/docs/ai-agents/interfaces/sdk/add-connector.md
+++ b/docs/ai-agents/interfaces/sdk/add-connector.md
@@ -4,7 +4,7 @@ sidebar_position: 2
 
 # Add a connector
 
-A **connector** in Airbyte Agents is a stored set of credentials for a third-party service plus everything needed to execute operations against it. You create a connector once, then reuse the returned `connector_id` on every subsequent call.
+A **connector** in Airbyte Agents is a stored set of credentials for a third-party service plus everything needed to execute operations against it. You create a connector once, then reference it on every subsequent call — by its slug (preferred) when the workspace has one connector of that type, or by its `connector_id` when you need to disambiguate.
 
 The `Workspace` class covers every connector operation: create, list, get, and delete.
 
@@ -12,7 +12,7 @@ The `Workspace` class covers every connector operation: create, list, get, and d
 
 Call `create_connector` on an open `Workspace`. Pass the `definition_id` for the connector type (GitHub, HubSpot, and so on) and the credentials in the shape that connector expects.
 
-`create_connector` returns a string `connector_id`. Store it somewhere you can retrieve it later.
+`create_connector` returns a string `connector_id`. You can ignore it if the workspace only ever has one connector of this type — later calls can resolve the connector by slug. Store the ID if you plan to run multiple connectors of the same type in the same workspace.
 
 ### API token connectors
 
@@ -24,14 +24,13 @@ from airbyte_agent_sdk import Workspace
 
 async def main():
     async with Workspace() as ws:
-        connector_id = await ws.create_connector(
+        await ws.create_connector(
             definition_id="<github_definition_id>",
             name="My GitHub Connector",
             credentials={
                 "token": "<github_personal_access_token>",
             },
         )
-        print(connector_id)
 
 asyncio.run(main())
 ```
@@ -46,7 +45,7 @@ from airbyte_agent_sdk import Workspace
 
 async def main():
     async with Workspace() as ws:
-        connector_id = await ws.create_connector(
+        await ws.create_connector(
             definition_id="<hubspot_definition_id>",
             name="My HubSpot Connector",
             credentials={
@@ -86,9 +85,7 @@ async with Workspace() as ws:
 
 ## Get a connector
 
-When you already have the `connector_id`, you don't need to list or look it up. Pass it straight to `connect()`. See [Execute operations](./execute).
-
-When you don't have the ID but you know there's exactly one connector of a given type in the workspace, resolve by name:
+When the workspace has exactly one connector of a given type, resolve it by slug. This is the recommended pattern for most apps — you never hard-code a UUID.
 
 ```python title="agent.py"
 async with Workspace() as ws:
@@ -99,9 +96,15 @@ async with Workspace() as ws:
         await stripe.close()
 ```
 
-`get_connector(name=...)` raises `ValueError` if zero or more than one connector of that type exists. Use `connector_id` explicitly when multiple connectors of the same type might exist.
+`get_connector(name=...)` raises `ValueError` if zero or more than one connector of that type exists. When multiple connectors of the same type exist in the workspace — for example, two separate Stripe accounts — pass `connector_id` explicitly:
 
-`get_connector(name=...)` always returns a generic `HostedExecutor` with `.execute(entity, action, params)`. To get a typed connector with IDE autocompletion and structured method shortcuts (for example, `stripe.customers.list(...)`), call `connect(slug, connector_id=...)` with the ID you stored. See [Typed connectors and `HostedExecutor`](./execute#typed-connectors-and-hostedexecutor).
+```python title="agent.py"
+async with Workspace() as ws:
+    stripe_us = await ws.get_connector(connector_id="<us_account_connector_id>")
+    stripe_eu = await ws.get_connector(connector_id="<eu_account_connector_id>")
+```
+
+`get_connector(name=...)` always returns a generic `HostedExecutor` with `.execute(entity, action, params)`. To get a typed connector with IDE autocompletion and structured method shortcuts (for example, `stripe.customers.list(...)`), call `connect(slug)` for slug resolution or `connect(slug, connector_id=...)` when you need to pin a specific connector. See [Typed connectors and `HostedExecutor`](./execute#typed-connectors-and-hostedexecutor).
 
 ## Delete a connector
 

--- a/docs/ai-agents/interfaces/sdk/authenticate.md
+++ b/docs/ai-agents/interfaces/sdk/authenticate.md
@@ -51,7 +51,6 @@ async def main():
         "stripe",
         client_id="<your_client_id>",
         client_secret="<your_client_secret>",
-        connector_id="<connector_id>",
     )
     try:
         result = await stripe.execute("customers", "list", params={"limit": 10})
@@ -75,7 +74,7 @@ configure(
     client_secret="<your_client_secret>",
 )
 
-stripe = connect("stripe", connector_id="<connector_id>")
+stripe = connect("stripe")
 ```
 
 `configure()` accepts the following keyword arguments (all must be passed by name):

--- a/docs/ai-agents/interfaces/sdk/execute.md
+++ b/docs/ai-agents/interfaces/sdk/execute.md
@@ -4,18 +4,18 @@ sidebar_position: 3
 
 # Execute operations
 
-Once you have a `connector_id`, you can run operations against that connector from Python. The SDK offers three execution paths and patterns for exposing a connector as a tool to an AI agent framework.
+Once you've added a connector to your workspace, you can run operations against it from Python. The SDK offers three execution paths and patterns for exposing a connector as a tool to an AI agent framework.
 
 ## Direct execution
 
-The `connect()` factory takes a connector slug and a `connector_id` and returns an execution object. Call its `execute(entity, action, params)` method to run an operation.
+The `connect()` factory takes a connector slug and returns an execution object. Call its `execute(entity, action, params)` method to run an operation. When your workspace has exactly one connector of a given type, you don't need to pass a `connector_id` — the SDK resolves the connector by its slug automatically.
 
 ```python title="agent.py"
 import asyncio
 from airbyte_agent_sdk import connect
 
 async def main():
-    hubspot = connect("hubspot", connector_id="<connector_id>")
+    hubspot = connect("hubspot")
     result = await hubspot.execute("contacts", "list", params={"limit": 10})
     for row in result.data:
         print(row)
@@ -37,9 +37,16 @@ For every other connector in the bundled registry, `connect()` returns a generic
 
 `connect()` raises `ValueError` if the slug isn't in the bundled registry or if no Airbyte credentials are available. It does *not* raise when a typed submodule is missing — YAML-only connectors return a `HostedExecutor`.
 
-### Resolve a connector by name
+### Multiple connectors of the same type
 
-If you have a workspace with exactly one connector of a given type and don't want to pass `connector_id` explicitly, resolve by name. See [Get a connector](./add-connector#get-a-connector).
+If your workspace has more than one connector of a given type — for example, two separate Stripe accounts — slug resolution is ambiguous and raises `ValueError`. Pass an explicit `connector_id` in that case:
+
+```python title="agent.py"
+stripe_us = connect("stripe", connector_id="<us_account_connector_id>")
+stripe_eu = connect("stripe", connector_id="<eu_account_connector_id>")
+```
+
+For patterns that look up a connector ID without hard-coding it, see [Get a connector](./add-connector#get-a-connector).
 
 ## Natural-language queries
 
@@ -62,7 +69,7 @@ Check `result.outcome == "success"` before trusting `result.answer`. The `result
 
 ```python title="Example result.results[0]"
 AskToolCallResult(
-    source_id="<connector_id>",
+    source_id="<resolved_connector_id>",
     entity="customers",
     action="list",
     params={"limit": 5},
@@ -97,7 +104,7 @@ from pydantic_ai import Agent
 from airbyte_agent_sdk import connect
 
 agent = Agent("openai:gpt-4o")
-github = connect("github", connector_id="<connector_id>")
+github = connect("github")
 
 @agent.tool_plain
 async def list_issues(owner: str, repo: str, limit: int = 10) -> str:
@@ -118,7 +125,7 @@ from airbyte_agent_sdk import connect
 from airbyte_agent_sdk.connectors.github import GithubConnector
 
 agent = Agent("openai:gpt-4o")
-github = connect("github", connector_id="<connector_id>")
+github = connect("github")
 
 @agent.tool_plain
 @GithubConnector.tool_utils
@@ -165,10 +172,10 @@ async def github_execute(entity: str, action: str, params: dict | None = None):
 
 Some connectors support a `download` action for binary entities like attachments, audio recordings, and documents. Download responses return a byte stream instead of JSON.
 
-Normally, you first list a parent resource to find the file's ID, then download the file. The examples below assume `zendesk_support = connect("zendesk-support", connector_id="<connector_id>")`. Zendesk Support has a generated typed submodule, so `connect()` returns a typed connector here — YAML-only connectors would return a `HostedExecutor` and use the generic `execute(entity, action, params)` API instead.
+Normally, you first list a parent resource to find the file's ID, then download the file. The examples below assume `zendesk_support = connect("zendesk-support")`. Zendesk Support has a generated typed submodule, so `connect()` returns a typed connector here — YAML-only connectors would return a `HostedExecutor` and use the generic `execute(entity, action, params)` API instead.
 
 ```python title="agent.py"
-zendesk_support = connect("zendesk-support", connector_id="<connector_id>")
+zendesk_support = connect("zendesk-support")
 comments = await zendesk_support.ticket_comments.list(ticket_id="456")
 for comment in comments.data:
     for attachment in comment.attachments or []:
@@ -226,7 +233,7 @@ Most SDK-owned errors inherit from `AirbyteError`, including `HTTPStatusError` (
 import httpx
 from airbyte_agent_sdk import AirbyteError, connect
 
-stripe = connect("stripe", connector_id="<connector_id>")
+stripe = connect("stripe")
 try:
     result = await stripe.execute("customers", "list")
 except (AirbyteError, httpx.HTTPError) as err:

--- a/docs/ai-agents/interfaces/sdk/readme.md
+++ b/docs/ai-agents/interfaces/sdk/readme.md
@@ -35,8 +35,8 @@ async def main():
     # Authenticate. The SDK reads AIRBYTE_CLIENT_ID and AIRBYTE_CLIENT_SECRET
     # from the environment.
     async with Workspace() as ws:
-        # Add a connector and store the returned ID.
-        connector_id = await ws.create_connector(
+        # Add a connector.
+        await ws.create_connector(
             definition_id="<hubspot_definition_id>",
             name="My HubSpot Connector",
             credentials={
@@ -46,8 +46,10 @@ async def main():
             },
         )
 
-        # Execute an operation against the connector.
-        hubspot = connect("hubspot", connector_id=connector_id)
+        # Execute an operation against the connector. `connect()` resolves the
+        # connector by its slug within the current workspace — no ID needed
+        # when the workspace has one connector of this type.
+        hubspot = connect("hubspot")
         try:
             result = await hubspot.execute("contacts", "list", params={"limit": 10})
             for row in result.data:

--- a/docs/ai-agents/interfaces/sdk/workspaces.md
+++ b/docs/ai-agents/interfaces/sdk/workspaces.md
@@ -29,7 +29,7 @@ asyncio.run(main())
 ```python title="agent.py"
 from airbyte_agent_sdk import ask, connect
 
-stripe = connect("stripe", workspace_name="acme_corp", connector_id="<connector_id>")
+stripe = connect("stripe", workspace_name="acme_corp")
 result = await ask("list my 5 most recent customers", workspace_name="acme_corp")
 ```
 


### PR DESCRIPTION
## What

Updates SDK and API interface documentation code samples to prefer passing connector names (slugs) instead of connector IDs wherever possible. Requested by Ian in [#ask-devin-ai](https://airbytehq-team.slack.com/archives/C08BHPUMEPJ/p1776890705784719?thread_ts=1776890705.784719&cid=C08BHPUMEPJ).

## How

### SDK (`docs/ai-agents/interfaces/sdk/`)

- **`readme.md`** (end-to-end example): drop `connector_id=connector_id` capture-and-pass dance in favor of `connect("hubspot")` slug resolution.
- **`authenticate.md`**: remove `connector_id="<connector_id>"` from the explicit-credentials and `configure()` samples — they're about auth, not connector lookup.
- **`execute.md`**:
    - Lead the "Direct execution" example with `connect("hubspot")` (no ID).
    - Replace the old "Resolve a connector by name" pointer with a new "Multiple connectors of the same type" section that shows when `connector_id` is actually necessary.
    - Update the `<connector_id>` placeholders in the tool-exposure, download, and error-handling examples to use bare `connect("slug")` calls.
    - Rename `source_id="<connector_id>"` in the `AskToolCallResult` example to `source_id="<resolved_connector_id>"` to make clear it's returned, not passed.
- **`workspaces.md`**: drop the `connector_id` placeholder from the `connect("stripe", workspace_name="acme_corp")` sample.
- **`add-connector.md`**:
    - Reframe the intro so the slug is the preferred reference, `connector_id` is for disambiguation.
    - "Get a connector" now leads with `ws.get_connector(name="stripe")` as the recommended pattern, with an explicit `connector_id` example for multi-instance workspaces.
    - Drop the unused `connector_id = await ws.create_connector(...)` captures where the ID isn't used afterward.

### API (`docs/ai-agents/interfaces/api/`)

The API's execute endpoint requires `connector_id` in the URL path, so samples inherently need a placeholder. To still steer users toward names-first thinking:

- **`execute.md`**: added a "Find the connector ID" section at the top pointing at `GET /integrations/connectors?workspace_name=...&definition_id=...` for users who didn't store the ID from create, and mentioning the SDK slug-resolution path for users who want to avoid managing IDs in application code.

### Not changed

- Quickstarts (`tutorial-pydantic.md`, `tutorial-langchain.md`, `tutorial-fastmcp.md`) already use `connect("github")` without a `connector_id` — no update needed.
- `docs/ai-agents/connectors/*/AUTH.md` and `REFERENCE.md` are auto-synced from `airbytehq/airbyte-agent-connectors` by `.github/workflows/sync-ai-connector-docs.yml`. Editing them in this repo would be overwritten. The SDK-repo-side AUTH.md template can be updated in a follow-up PR on that repo.
- `docs/ai-agents/reference/sdk/*` is auto-generated from SDK docstrings via pdoc. Those should be updated at the source (SDK repo docstrings) if desired.
- `docs/ai-agents/get-started/skills/lovable.md` uses `connector_id` dynamically from the widget's `sourceCreated` event — not a hardcoded placeholder, so no change needed.

## Review guide

1. `docs/ai-agents/interfaces/sdk/add-connector.md` — biggest reframing; new "Get a connector" section leads with slug lookup.
2. `docs/ai-agents/interfaces/sdk/execute.md` — direct-execution example now slug-only; new "Multiple connectors of the same type" subsection.
3. `docs/ai-agents/interfaces/sdk/readme.md` — end-to-end example.
4. `docs/ai-agents/interfaces/sdk/authenticate.md`, `workspaces.md` — minor placeholder removals.
5. `docs/ai-agents/interfaces/api/execute.md` — new "Find the connector ID" section.

## User Impact

Readers following the SDK docs land on the clean slug pattern first (`connect("stripe")`, `ws.get_connector(name="stripe")`) and only reach for `connector_id` when they genuinely need to disambiguate. API readers get an explicit hand-off to the list endpoint and the SDK for name-based resolution.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

Link to Devin session: https://app.devin.ai/sessions/4753ef2d4d994f20ad1426531539be24
Requested by: @ian-at-airbyte