### PR TITLE
feat(source-devin-ai): add incremental sync for all streams

### DIFF
--- a/airbyte-integrations/connectors/source-devin-ai/manifest.yaml
+++ b/airbyte-integrations/connectors/source-devin-ai/manifest.yaml
@@ -44,19 +44,45 @@ definitions:
       field_name: after
       inject_into: request_parameter
 
+  incremental_cursor_server_side:
+    type: DatetimeBasedCursor
+    cursor_field: updated_at
+    cursor_datetime_formats:
+      - "%s"
+    datetime_format: "%s"
+    start_datetime:
+      type: MinMaxDatetime
+      datetime: "{{ config.get('start_date') or '1970-01-01T00:00:00Z' }}"
+      datetime_format: "%Y-%m-%dT%H:%M:%SZ"
+    start_time_option:
+      type: RequestOption
+      inject_into: request_parameter
+      field_name: updated_after
+
+  incremental_cursor_client_side:
+    type: DatetimeBasedCursor
+    cursor_field: updated_at
+    cursor_datetime_formats:
+      - "%s"
+    datetime_format: "%s"
+    start_datetime:
+      type: MinMaxDatetime
+      datetime: "{{ config.get('start_date') or '1970-01-01T00:00:00Z' }}"
+      datetime_format: "%Y-%m-%dT%H:%M:%SZ"
+
   sessions_stream:
     type: DeclarativeStream
     name: sessions
     description: "List all Devin sessions for your organization."
     primary_key:
       - session_id
+    incremental_sync:
+      $ref: "#/definitions/incremental_cursor_server_side"
     retriever:
       type: SimpleRetriever
       requester:
         $ref: "#/definitions/base_requester"
         path: "/v3/organizations/{{ config['org_id'] }}/sessions"
-        request_parameters:
-          created_after: "{{ format_datetime(config['start_date'], '%s') if config.get('start_date') else 0 }}"
       record_selector:
         type: RecordSelector
         extractor:
@@ -164,13 +190,13 @@ definitions:
     description: "List all Devin sessions for your organization with aggregate insights (message counts, session size classification, and AI-generated analysis). Analysis fields may be null for sessions where insights have not been generated yet."
     primary_key:
       - session_id
+    incremental_sync:
+      $ref: "#/definitions/incremental_cursor_server_side"
     retriever:
       type: SimpleRetriever
       requester:
         $ref: "#/definitions/base_requester"
         path: "/v3/organizations/{{ config['org_id'] }}/sessions/insights"
-        request_parameters:
-          created_after: "{{ format_datetime(config['start_date'], '%s') if config.get('start_date') else 0 }}"
       record_selector:
         type: RecordSelector
         extractor:
@@ -366,6 +392,16 @@ definitions:
     description: "List all messages in a Devin session conversation."
     primary_key:
       - event_id
+    incremental_sync:
+      type: DatetimeBasedCursor
+      cursor_field: created_at
+      cursor_datetime_formats:
+        - "%s"
+      datetime_format: "%s"
+      start_datetime:
+        type: MinMaxDatetime
+        datetime: "{{ config.get('start_date') or '1970-01-01T00:00:00Z' }}"
+        datetime_format: "%Y-%m-%dT%H:%M:%SZ"
     retriever:
       type: SimpleRetriever
       requester:
@@ -387,6 +423,7 @@ definitions:
               $ref: "#/definitions/sessions_stream"
             parent_key: session_id
             partition_field: session_id
+            incremental_dependency: true
     transformations:
       - type: AddFields
         fields:
@@ -425,6 +462,8 @@ definitions:
     description: "List all team playbooks for the organization."
     primary_key:
       - playbook_id
+    incremental_sync:
+      $ref: "#/definitions/incremental_cursor_client_side"
     retriever:
       type: SimpleRetriever
       requester:
@@ -490,6 +529,8 @@ definitions:
     description: "List metadata for all secrets in your organization. Does not return secret values."
     primary_key:
       - secret_id
+    incremental_sync:
+      $ref: "#/definitions/incremental_cursor_client_side"
     retriever:
       type: SimpleRetriever
       requester:
@@ -555,6 +596,8 @@ definitions:
     description: "List all knowledge notes for the organization."
     primary_key:
       - note_id
+    incremental_sync:
+      $ref: "#/definitions/incremental_cursor_client_side"
     retriever:
       type: SimpleRetriever
       requester:
@@ -662,7 +705,7 @@ spec:
       start_date:
         type: string
         title: Start Date
-        description: "Optional UTC date-time. Only sessions created on or after this instant are returned for the `sessions`, `sessions_insights`, and `session_messages` streams. Leave empty to fetch full history."
+        description: "Optional UTC date-time used as the initial lower bound for the incremental cursor on all streams. On the first sync, only records updated (or created, for `session_messages`) on or after this instant are returned. Subsequent syncs advance the cursor automatically. Leave empty to fetch full history."
         format: date-time
         pattern: "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$"
         examples:

--- a/airbyte-integrations/connectors/source-devin-ai/metadata.yaml
+++ b/airbyte-integrations/connectors/source-devin-ai/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 3bc4954a-9ebe-48f5-b11d-8f52d61b10d5
-  dockerImageTag: 0.2.0
+  dockerImageTag: 0.3.0
   dockerRepository: airbyte/source-devin-ai
   documentationUrl: https://docs.airbyte.com/integrations/sources/devin-ai
   githubIssueLabel: source-devin-ai

--- a/docs/integrations/sources/devin-ai.md
+++ b/docs/integrations/sources/devin-ai.md
@@ -62,14 +62,16 @@ Syncs data from the [Devin AI](https://devin.ai) platform API (v3), providing vi
 
 ## Supported streams
 
-| Stream | Sync Mode | Description |
-|--------|-----------|-------------|
-| [Sessions](https://docs.devin.ai/api-reference/v3/sessions/list-sessions) | Full Refresh | All Devin sessions in your organization |
-| [Sessions Insights](https://docs.devin.ai/api-reference/v3/sessions/organizations-sessions-insights) | Full Refresh | Sessions enriched with message counts, size classification, and AI-generated analysis |
-| [Session Messages](https://docs.devin.ai/api-reference/v3/sessions/get-session-messages) | Full Refresh | Conversation messages for each session |
-| [Playbooks](https://docs.devin.ai/api-reference/v3/playbooks/list-playbooks) | Full Refresh | Team playbooks for the organization |
-| [Secrets](https://docs.devin.ai/api-reference/v3/secrets/list-secrets) | Full Refresh | Secret metadata (no secret values are synced) |
-| [Knowledge Notes](https://docs.devin.ai/api-reference/v3/notes/enterprise-knowledge-notes) | Full Refresh | Knowledge notes for the organization |
+| Stream | Sync Mode | Cursor | Description |
+|--------|-----------|--------|-------------|
+| [Sessions](https://docs.devin.ai/api-reference/v3/sessions/list-sessions) | Full Refresh, Incremental | `updated_at` | All Devin sessions in your organization |
+| [Sessions Insights](https://docs.devin.ai/api-reference/v3/sessions/organizations-sessions-insights) | Full Refresh, Incremental | `updated_at` | Sessions enriched with message counts, size classification, and AI-generated analysis |
+| [Session Messages](https://docs.devin.ai/api-reference/v3/sessions/get-session-messages) | Full Refresh, Incremental | `created_at` | Conversation messages for each session |
+| [Playbooks](https://docs.devin.ai/api-reference/v3/playbooks/list-playbooks) | Full Refresh, Incremental | `updated_at` | Team playbooks for the organization |
+| [Secrets](https://docs.devin.ai/api-reference/v3/secrets/list-secrets) | Full Refresh, Incremental | `updated_at` | Secret metadata (no secret values are synced) |
+| [Knowledge Notes](https://docs.devin.ai/api-reference/v3/notes/enterprise-knowledge-notes) | Full Refresh, Incremental | `updated_at` | Knowledge notes for the organization |
+
+The Devin v3 API exposes `updated_after` / `created_after` query parameters on the `sessions` and `sessions_insights` endpoints, so those streams filter server-side. The `playbooks`, `secrets`, `knowledge_notes`, and `session_messages` endpoints do not accept date filters, so their cursors are tracked in state and records are filtered client-side. This still yields correct incremental behavior but does not reduce API call volume on those endpoints.
 
 ## Configuration reference
 
@@ -77,7 +79,7 @@ Syncs data from the [Devin AI](https://devin.ai) platform API (v3), providing vi
 |-----------|------|----------|---------|-------------|
 | `api_token` | string | Yes | | Devin API key for authentication. Service user tokens use the `cog_*` prefix. |
 | `org_id` | string | Yes | | Your Devin organization ID. Uses the `org_*` prefix. |
-| `start_date` | string (ISO 8601, UTC) | No | (epoch 0, i.e. no filter) | Optional lower bound on `created_at` for the `sessions`, `sessions_insights`, and `session_messages` streams. Sessions created before this instant are excluded. Format: `YYYY-MM-DDTHH:MM:SSZ`. Example: `2026-01-01T00:00:00Z`. |
+| `start_date` | string (ISO 8601, UTC) | No | (epoch 0, i.e. no filter) | Optional lower bound for the incremental cursor on every stream. On the first sync, only records updated (or created, for `session_messages`) on or after this instant are returned; subsequent syncs advance the cursor automatically. Format: `YYYY-MM-DDTHH:MM:SSZ`. Example: `2026-01-01T00:00:00Z`. |
 
 ## Changelog
 
@@ -86,6 +88,7 @@ Syncs data from the [Devin AI](https://devin.ai) platform API (v3), providing vi
 
 | Version | Date | Pull Request | Subject |
 |---------|------|--------------|---------|
+| 0.3.0 | 2026-04-22 | [TBD](https://github.com/airbytehq/airbyte/pull/TBD) | Add incremental sync on every stream (cursor: `updated_at`; `created_at` for `session_messages`). `start_date` is now the initial cursor lower bound rather than a fixed `created_after` filter |
 | 0.2.0 | 2026-04-20 | [76475](https://github.com/airbytehq/airbyte/pull/76475) | Add `sessions_insights` stream for analytics (message counts, session size, AI-generated classification); add optional `start_date` config to filter `sessions`, `sessions_insights`, and `session_messages` by creation time |
 | 0.1.1 | 2026-04-21 | [76504](https://github.com/airbytehq/airbyte/pull/76504) | Update dependencies |
 | 0.1.0 | 2026-03-10 | | Initial release with sessions, session messages, playbooks, secrets, and knowledge notes streams |


### PR DESCRIPTION
## What

Adds incremental sync support to every stream in `source-devin-ai` (v0.2.0 was full-refresh only):

| Stream | Cursor | Filter |
|---|---|---|
| `sessions` | `updated_at` | server-side via `updated_after` |
| `sessions_insights` | `updated_at` | server-side via `updated_after` |
| `session_messages` | `created_at` | client-side (endpoint has no date filter) |
| `playbooks` | `updated_at` | client-side |
| `secrets` | `updated_at` | client-side |
| `knowledge_notes` | `updated_at` | client-side |

Also changes the semantic of the `start_date` config option: it's now the initial lower bound for the incremental cursor on every stream (instead of a fixed `created_after` filter that re-applied on every sync). Subsequent syncs advance the cursor automatically.

Version bumped to **0.3.0** (minor — additive capability, no breaking change to the existing spec).

## How

- Two shared `DatetimeBasedCursor` blocks in `definitions`: `incremental_cursor_server_side` (injects `updated_after` as a request parameter) and `incremental_cursor_client_side` (cursor tracked in state, records filtered post-fetch).
- `sessions` and `sessions_insights` reference the server-side cursor.
- `playbooks`, `secrets`, `knowledge_notes` reference the client-side cursor.
- `session_messages` has its own inline cursor on `created_at` and its parent reference gets `incremental_dependency: true` so only new/updated parent sessions are traversed.
- Unix-epoch cursor values (`%s`) on the wire; ISO-8601 for the config input.

Verified locally that the manifest loads via `YamlDeclarativeSource` and every stream reports the expected `cursor_field`.

## Review guide

1. `airbyte-integrations/connectors/source-devin-ai/manifest.yaml` — the shared cursor blocks and per-stream `incremental_sync` hookups.
2. `airbyte-integrations/connectors/source-devin-ai/metadata.yaml` — version bump.
3. `docs/integrations/sources/devin-ai.md` — updated stream table, `start_date` description, changelog entry.

## User Impact

- Existing full-refresh users are unaffected — incremental is opt-in per connection.
- New incremental mode dramatically reduces load for the `sessions`/`sessions_insights` streams as the session population grows (50x YoY at the org this was built for).
- `start_date` semantics changed: previous behavior was "filter every sync by `created_after`"; new behavior is "seed the initial cursor". Existing configs continue to work; the difference is visible only after the first incremental sync advances the cursor past `start_date`.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Reverting restores 0.2.0 behavior. State already written by incremental syncs becomes inert on the next full-refresh run.

Link to Devin session: https://app.devin.ai/sessions/2c74ba4a16d040c082a6a1320f5417e3
Requested by: @aaronsteers