### PR TITLE
docs(ai-agents): round-3 SDK and API docs fixes

### DIFF
--- a/docs/ai-agents/interfaces/api/add-connector.md
+++ b/docs/ai-agents/interfaces/api/add-connector.md
@@ -12,11 +12,19 @@ To do the same thing from Python, see [Add a connector](../sdk/add-connector) in
 
 ## Create a connector
 
-Send a `POST` to `/api/v1/integrations/connectors`. Pass the `definition_id` for the connector type and the credentials in the shape that connector expects. The response includes a connector ID. Store it somewhere you can retrieve it later.
+Send a `POST` to `/api/v1/integrations/connectors`. Pass an identifier for the connector type and the credentials in the shape that connector expects. The response includes a connector ID. Store it somewhere you can retrieve it later.
+
+The request body accepts one of three connector-type identifiers:
+
+- `definition_id`: the connector definition UUID (returned as `sourceDefinitionId` from the definitions endpoint). Recommended.
+- `connector_type`: a human-readable slug such as `"linear"` or `"hubspot"`.
+- `source_template_id`: a template UUID. Useful when your organization has published custom source templates. See [Source templates](#source-templates) below.
+
+Exactly one of the three is required. If none is provided, the server responds with `422 "One of connector_type, definition_id, or source_template_id must be provided"`.
 
 ### API token connectors
 
-Connectors that authenticate with an API key or personal access token accept a `token` field inside `credentials`.
+Connectors that authenticate with a single API key or personal access token take one credential field. The exact field name is connector-specific — Linear uses `api_key`, Notion uses `token`, Jira uses `api_token`, and so on. See the connector's page in the [Connectors](../../connectors) reference for the field name the connector expects.
 
 ```bash title="Request"
 curl -X POST 'https://api.airbyte.ai/api/v1/integrations/connectors' \
@@ -24,13 +32,15 @@ curl -X POST 'https://api.airbyte.ai/api/v1/integrations/connectors' \
   --header 'Content-Type: application/json' \
   --data '{
     "workspace_name": "default",
-    "definition_id": "<github_definition_id>",
-    "name": "My GitHub Connector",
+    "definition_id": "<linear_definition_id>",
+    "name": "My Linear Connector",
     "credentials": {
-      "token": "<github_personal_access_token>"
+      "api_key": "<linear_api_key>"
     }
   }'
 ```
+
+Some connectors also require non-credential configuration at the top level of the request body. For example, `source-github` requires a `"repositories": ["<owner>/<repo>", …]` array alongside `credentials` — without it, create fails with `422 "required property 'repositories' not found"`. Check the connector's page for any extra required fields.
 
 ### OAuth connectors
 
@@ -64,15 +74,25 @@ Airbyte doesn't validate credentials at creation time. A `200 OK` response means
 
 The `definition_id` identifies the connector type. You can look it up two ways:
 
-- Call `GET /api/v1/integrations/definitions/sources` to list every available connector type with its definition ID. See [Make your first request](./#make-your-first-request). Recommended.
+- Call `GET /api/v1/integrations/definitions/sources` to list every available connector type. See [Make your first request](./#make-your-first-request). Recommended.
 - Browse the raw [Airbyte Connector Registry](https://connectors.airbyte.com/files/registries/v0/cloud_registry.json) (large file — approximately 100 MB) and copy the `sourceDefinitionId` for the entry you want.
+
+:::note Naming
+The definitions endpoint returns the ID as `sourceDefinitionId`. The connector creation endpoint accepts it as `definition_id`. Both names refer to the same UUID.
+:::
+
+### Source templates
+
+A **source template** is the organization-level catalog entry a connector is provisioned from: a connector definition plus the default configuration, stream selection, and customizations your organization has agreed on for that connector. Every connector instance belongs to exactly one source template, which is why list and get responses carry a nested `summarized_source_template` (the `source_template_id` field of `create`) alongside the underlying `source_definition_id`.
+
+Most apps won't set `source_template_id` explicitly — passing `definition_id` or `connector_type` picks the default template for that connector type. Use `source_template_id` when your organization has more than one template for the same connector type and you need to pin a specific one.
 
 ### About `workspace_name`
 
-The `workspace_name` field identifies which [workspace](./workspaces) the connector belongs to. Most apps use `"default"` and don't think about this again. If you need to isolate credentials across tenants or teams, pass a different value; Airbyte treats that string as the workspace name and creates the workspace on first use. See [Manage workspaces](./workspaces) for the administrative operations on top.
+The `workspace_name` field identifies which [workspace](./workspaces) the connector belongs to. Most apps use `"default"` and don't think about this again. If you need to isolate credentials across tenants or teams, pass a different value. See [Manage workspaces](./workspaces) for the administrative operations on top.
 
-:::note Accepted aliases
-The API also accepts `customer_name` and `external_user_id` in place of `workspace_name` for backward compatibility. Both are deprecated. Use `workspace_name` in new code.
+:::warning The workspace must already exist
+The create-connector endpoint does not autocreate workspaces. If you call it with a `workspace_name` that Airbyte hasn't seen before, the request fails with `404 "Workspace not found for workspace_name '...'"`. To create a new workspace, first mint a scoped or widget token against that `workspace_name` (see [Authentication](./authentication#scoped-token)), which Airbyte autocreates on demand, or add a connector through the Airbyte Agents UI.
 :::
 
 ## List connectors
@@ -91,12 +111,36 @@ curl 'https://api.airbyte.ai/api/v1/integrations/connectors?workspace_name=defau
   --header 'Authorization: Bearer <application_token>'
 ```
 
+```json title="Response"
+{
+  "data": [
+    {
+      "id": "<connector_id>",
+      "name": "My Linear Connector",
+      "summarized_source_template": {
+        "id": "<source_template_id>",
+        "name": "Linear",
+        "actor_definition_id": "<definition_id>",
+        "icon": "https://connectors.airbyte.com/files/metadata/airbyte/source-linear/latest/icon.svg",
+        "mode": "REPLICATION"
+      },
+      "created_at": "2026-04-20T21:57:20.991787Z",
+      "updated_at": "2026-04-20T21:57:20.991787Z"
+    }
+  ]
+}
+```
+
+Each entry's `id` is the connector ID you pass to [Execute operations](./execute) and [Get a connector](#get-a-connector). The nested `summarized_source_template.actor_definition_id` is the connector's definition ID.
+
 ## Get a connector
 
 ```bash title="Request"
 curl 'https://api.airbyte.ai/api/v1/integrations/connectors/<connector_id>' \
   --header 'Authorization: Bearer <application_token>'
 ```
+
+The response mirrors the `create` response: the connector `id` plus its full `source_template` (including the user config spec), any configured `entities`, and timestamps.
 
 ## Delete a connector
 
@@ -106,6 +150,38 @@ Delete a connector when it's no longer in use. Airbyte removes the stored creden
 curl -X DELETE 'https://api.airbyte.ai/api/v1/integrations/connectors/<connector_id>' \
   --header 'Authorization: Bearer <application_token>'
 ```
+
+```json title="Response (202)"
+{
+  "job_id": "<deletion_job_id>"
+}
+```
+
+Deletion is asynchronous: the server returns `202 Accepted` with a `job_id` and removes the connector in the background. If the same connector ID disappears from subsequent [List connectors](#list-connectors) responses, the deletion has completed.
+
+## Errors
+
+Errors from the connector endpoints use the same envelope across the API. The HTTP status code tells you the error family; the body carries a human message plus a machine-readable `errors` list.
+
+```json title="Example 422"
+{
+  "message": "Value error, One of connector_type, definition_id, or source_template_id must be provided",
+  "errors": [
+    {
+      "field": "body",
+      "message": "Value error, One of connector_type, definition_id, or source_template_id must be provided",
+      "error_code": "value_error"
+    }
+  ]
+}
+```
+
+Common codes:
+
+- `400`: the credentials block doesn't match the connector's auth scheme. The `message` typically includes `"Credentials do not match any auth scheme. Provided keys: [...]. Available schemes: ..."`.
+- `401` / `403`: missing or invalid bearer token.
+- `404`: the `workspace_name` doesn't exist, or the connector ID in the URL isn't found.
+- `422`: the request body parsed but failed schema validation — missing required field on the connector spec, unknown property, and so on.
 
 ## Next steps
 

--- a/docs/ai-agents/interfaces/api/authentication-module.md
+++ b/docs/ai-agents/interfaces/api/authentication-module.md
@@ -46,7 +46,7 @@ app.use(express.json());
 
 const AIRBYTE_API = "https://api.airbyte.ai/api/v1";
 
-async function getOperatorToken() {
+async function getApplicationToken() {
   const response = await fetch(`${AIRBYTE_API}/account/applications/token`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -56,7 +56,7 @@ async function getOperatorToken() {
     }),
   });
   if (!response.ok) {
-    throw new Error(`Operator token request failed: ${response.status}`);
+    throw new Error(`Application token request failed: ${response.status}`);
   }
   const data = await response.json();
   return data.access_token;
@@ -65,12 +65,12 @@ async function getOperatorToken() {
 app.post("/api/airbyte/widget-token", async (req, res) => {
   try {
     const { userId } = req.body;
-    const operatorToken = await getOperatorToken();
+    const applicationToken = await getApplicationToken();
 
     const response = await fetch(`${AIRBYTE_API}/account/applications/widget-token`, {
       method: "POST",
       headers: {
-        Authorization: `Bearer ${operatorToken}`,
+        Authorization: `Bearer ${applicationToken}`,
         "Content-Type": "application/json",
       },
       body: JSON.stringify({

--- a/docs/ai-agents/interfaces/api/authentication/readme.md
+++ b/docs/ai-agents/interfaces/api/authentication/readme.md
@@ -48,7 +48,7 @@ The response contains your application token:
 }
 ```
 
-Application tokens expire after 15 minutes. Request a new token when needed.
+Application tokens are short-lived — `expires_in` is 900 seconds (15 minutes) by design, because they carry organization-wide privileges. Request a new token when yours expires. [Scoped tokens](#scoped-token) and [widget tokens](#widget-token) live longer (20 minutes) because they're already limited to a single workspace and their exposure is lower. If you're building a long-running app, cache the current token and refresh it just before `expires_in` elapses.
 
 ### Scoped token
 

--- a/docs/ai-agents/interfaces/api/execute.md
+++ b/docs/ai-agents/interfaces/api/execute.md
@@ -81,7 +81,11 @@ curl -X POST 'https://api.airbyte.ai/api/v1/integrations/connectors/<connector_i
 
 ### Example: Search with filters
 
-This example searches for records using filter conditions. The search action is available when you have the context store enabled.
+This example searches for records using filter conditions.
+
+:::note `search` requires the context store
+The `search` action reads from Airbyte's pre-indexed context store, not the live third-party API. It's only available on connectors where the context store has been enabled. If the context store isn't enabled for the target connector, the execute call returns an error at runtime. Enable it from the connector's page in the Airbyte Agents UI before using `search`.
+:::
 
 ```bash title="Request"
 curl -X POST 'https://api.airbyte.ai/api/v1/integrations/connectors/<connector_id>/execute' \
@@ -103,6 +107,10 @@ Some connectors support a `download` action for entities like attachments and me
 
 :::note Download responses bypass the envelope
 `download` is the one execute response that does not use the `{status, result, connector_metadata, execution_metadata}` envelope described in [Response format](#response-format). The server streams the file bytes directly with an appropriate `Content-Type`, so your client reads the body as bytes instead of parsing JSON.
+:::
+
+:::warning Verify the downloaded file
+If the target attachment ID doesn't exist (or the connector can't fetch it), the server currently returns `200 OK` with a zero-byte body rather than a structured error. Always check `Content-Length > 0` (or inspect the saved file size) before treating a download as successful.
 :::
 
 To find downloadable files, first list the relevant entity to discover IDs. For example, list a ticket's comments to find attachment metadata, then download a specific attachment.
@@ -175,7 +183,7 @@ Every execute response uses the same top-level envelope. The connector's records
     "endCursor": "<cursor_for_next_page>"
   },
   "execution_metadata": {
-    "connector_instance_id": "<connector_id>",
+    "connector_instance_id": "source_id:<connector_id>",
     "execution_time_ms": 1189
   }
 }
@@ -183,11 +191,11 @@ Every execute response uses the same top-level envelope. The connector's records
 
 - `result` is whatever the operation returns — an array for `list` and `search`, a single object for `get`, or a byte stream for `download`.
 - `connector_metadata` surfaces pagination state. The exact key names depend on the connector. Expect `hasNextPage` and `endCursor` on most connectors; some connectors return `has_next_page` and `end_cursor` instead. Both mean the same thing.
-- `execution_metadata` always includes `connector_instance_id` and `execution_time_ms`.
+- `execution_metadata` always includes `connector_instance_id` and `execution_time_ms`. `connector_instance_id` is a typed identifier string — for a connector created through [Add a connector](./add-connector), it currently comes back as `"source_id:<connector_id>"`. Strip the `source_id:` prefix if you need to compare it against the bare `connector_id` you passed in the URL.
 
 ### Paginate through results
 
-When `connector_metadata.hasNextPage` is `true`, pass the cursor from the previous response as `params.cursor` to get the next page.
+When `connector_metadata.hasNextPage` is `true`, pass the cursor from the previous response as `params.cursor` to get the next page. On the request side, `cursor` is the conventional parameter name for pagination across Airbyte connectors, even when the response key is `endCursor` or `end_cursor`. A small number of connectors use different request keys (for example, an offset-based pager might accept `offset` and `limit`); check the connector's reference page if `cursor` is rejected.
 
 ```bash title="Request"
 curl -X POST 'https://api.airbyte.ai/api/v1/integrations/connectors/<connector_id>/execute' \

--- a/docs/ai-agents/interfaces/api/readme.md
+++ b/docs/ai-agents/interfaces/api/readme.md
@@ -74,7 +74,7 @@ curl -X POST https://api.airbyte.ai/api/v1/integrations/connectors/<connector_id
 
 ## Make your first request
 
-A good zero-setup starting point is listing the available source connector definitions. This read-only endpoint returns the catalog of connectors available in Airbyte Agents, so it returns data even if you haven't configured anything yet.
+Once you have an application token, a good starting point is listing the available source connector definitions. This read-only endpoint returns the catalog of connectors available in Airbyte Agents, so it returns data even if you haven't configured anything yet. It requires the bearer token like every other endpoint.
 
 ```bash title="Request"
 curl https://api.airbyte.ai/api/v1/integrations/definitions/sources \

--- a/docs/ai-agents/interfaces/api/workspaces.md
+++ b/docs/ai-agents/interfaces/api/workspaces.md
@@ -10,15 +10,15 @@ Listing every workspace, updating a workspace's status, deleting a workspace, an
 
 A **workspace** is a container inside your Airbyte Agents organization that holds a set of connectors and credentials. Every organization starts with a `default` workspace, and most apps stay there. Create additional workspaces only when you need to isolate credentials across distinct tenants, teams, or environments.
 
-Every request that touches a connector carries the workspace it belongs to in a `workspace_name` field. Airbyte uses the value as the workspace identifier and creates the workspace on first use.
-
-:::note Accepted aliases
-Some endpoints still accept `customer_name` or `external_user_id` in place of `workspace_name` for backward compatibility. Both are deprecated — use `workspace_name` in new code.
-:::
+Every request that touches a connector carries the workspace it belongs to in a `workspace_name` field. Airbyte treats that string as a stable identifier for the workspace — once a workspace exists under a given name, later requests against the same name always resolve to the same workspace. Renaming a workspace (see [Update a workspace](#update-a-workspace)) changes its display name in list responses but does not change the identifier your backend sends in request bodies; keep using the original `workspace_name`.
 
 ## Create a new workspace
 
-You don't create workspaces directly. Airbyte creates one automatically the first time you reference a new `workspace_name` when [creating a connector](./add-connector) or generating a [scoped token](./authentication#scoped-token). Use any stable string that makes sense in your app.
+You don't create workspaces directly. Airbyte creates one automatically the first time you mint a [scoped token](./authentication#scoped-token) or [widget token](./authentication#widget-token) against a new `workspace_name`. Use any stable string that makes sense in your app — for example, an internal tenant ID or team slug.
+
+:::warning Create-connector does not autocreate
+The [create-connector](./add-connector) endpoint does not autocreate workspaces. Calling it with a `workspace_name` Airbyte hasn't seen before fails with `404 "Workspace not found for workspace_name '...'"`. Mint a scoped token (or open the workspace in the Airbyte Agents UI) first.
+:::
 
 ## Manage workspaces
 
@@ -40,6 +40,29 @@ curl 'https://api.airbyte.ai/api/v1/workspaces?name_contains=acme&status=active'
   -H 'Authorization: Bearer <application_token>'
 ```
 
+```json title="Response"
+{
+  "next": null,
+  "data": [
+    {
+      "id": "<workspace_id>",
+      "name": "default",
+      "organization_id": "<organization_id>",
+      "status": "active",
+      "cache_enabled": null,
+      "tombstone": false,
+      "created_at": "2026-04-20T21:57:20.991787Z",
+      "updated_at": "2026-04-20T21:57:20.991787Z"
+    }
+  ]
+}
+```
+
+- `next` is a cursor. Pass its value as a query parameter to page forward; a `null` value means this is the last page.
+- `status` is `"active"` or `"inactive"`.
+- `tombstone: true` indicates a soft-deleted workspace. Workspaces are filtered to `tombstone: false` by default.
+- `cache_enabled` may be `null` if the workspace predates that feature.
+
 ### Get workspace details
 
 Retrieve details for a specific workspace:
@@ -48,6 +71,8 @@ Retrieve details for a specific workspace:
 curl https://api.airbyte.ai/api/v1/workspaces/<workspace_id> \
   -H 'Authorization: Bearer <application_token>'
 ```
+
+The response has the same per-workspace shape as each entry in the [List workspaces](#list-workspaces) response.
 
 ### Get workspace info from a scoped token
 
@@ -82,6 +107,8 @@ Delete a workspace and all associated resources:
 curl -X DELETE https://api.airbyte.ai/api/v1/workspaces/<workspace_id> \
   -H 'Authorization: Bearer <application_token>'
 ```
+
+Deleting a workspace with many connectors and long-lived credentials can take a few seconds. If the server times out with a `504`, retry once — the first call typically finishes in the background.
 
 ## Best practices
 

--- a/docs/ai-agents/interfaces/sdk/add-connector.md
+++ b/docs/ai-agents/interfaces/sdk/add-connector.md
@@ -16,7 +16,7 @@ Call `create_connector` on an open `Workspace`. Pass the `definition_id` for the
 
 ### API token connectors
 
-Connectors that authenticate with an API key or personal access token accept a `token` field.
+Connectors that authenticate with a single API key or personal access token take one credential field. The exact field name is connector-specific — Linear uses `api_key`, Notion uses `token`, Jira uses `api_token`, and so on. See the connector's page in the [Connectors](../../connectors) reference for the exact field name.
 
 ```python title="agent.py"
 import asyncio
@@ -25,15 +25,17 @@ from airbyte_agent_sdk import Workspace
 async def main():
     async with Workspace() as ws:
         await ws.create_connector(
-            definition_id="<github_definition_id>",
-            name="My GitHub Connector",
+            definition_id="<linear_definition_id>",
+            name="My Linear Connector",
             credentials={
-                "token": "<github_personal_access_token>",
+                "api_key": "<linear_api_key>",
             },
         )
 
 asyncio.run(main())
 ```
+
+Some connectors also require non-credential configuration alongside `credentials`. For example, `source-github` requires a `repositories` array of `owner/repo` strings; create fails with a `422` if it's missing. Check the connector's page for any required configuration.
 
 ### OAuth connectors
 
@@ -62,15 +64,29 @@ Each connector defines its own credential shape. See the connector's page in the
 
 ### Find a `definition_id`
 
-The `definition_id` identifies the connector type. The fastest way to look one up is to call the definitions endpoint and filter by connector name:
+The `definition_id` identifies the connector type. The SDK doesn't currently ship a helper for listing definitions, but `Workspace` exposes the `AirbyteCloudClient` it uses under `ws._cloud_client`, and that client already holds a valid bearer token. You can reuse it to hit the definitions endpoint from Python:
 
-```bash
-curl -s 'https://api.airbyte.ai/api/v1/integrations/definitions/sources' \
-  -H 'Authorization: Bearer <application_token>' \
-  | jq '.definitions[] | select(.name | test("hubspot"; "i")) | {name, id: .sourceDefinitionId}'
+```python title="find_definition_id.py"
+import asyncio
+from airbyte_agent_sdk import Workspace
+
+async def main():
+    async with Workspace() as ws:
+        token = await ws._cloud_client.get_bearer_token()
+        response = await ws._cloud_client._http_client.get(
+            f"{ws._cloud_client.API_BASE_URL}/api/v1/integrations/definitions/sources",
+            params={"name": "hubspot"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        for definition in response.json()["definitions"]:
+            print(definition["name"], definition["sourceDefinitionId"])
+
+asyncio.run(main())
 ```
 
-See [Make your first request](../api/#make-your-first-request) for token details.
+The response returns `sourceDefinitionId`. The `create_connector` request expects it as `definition_id` — the two names refer to the same UUID.
+
+If you prefer to avoid private attributes, the same endpoint is documented under [Find a `definition_id`](../api/add-connector#find-a-definition_id) on the API side; it takes an application token you mint with `POST /account/applications/token`.
 
 You can also browse the raw [Airbyte Connector Registry](https://connectors.airbyte.com/files/registries/v0/cloud_registry.json) JSON (large file — approximately 100 MB) and copy `sourceDefinitionId` for the entry you want.
 
@@ -80,31 +96,35 @@ You can also browse the raw [Airbyte Connector Registry](https://connectors.airb
 async with Workspace() as ws:
     connectors = await ws.list_connectors()
     for info in connectors:
-        print(info.id, info.name, info.type)
+        print(info.id, info.name, info.connector_type)
 ```
+
+Each `ConnectorInfo` carries `id`, `name`, `connector_type` (the connector slug, such as `"stripe"` or `"hubspot"`), `created_at`, and `updated_at`.
 
 ## Get a connector
 
-When the workspace has exactly one connector of a given type, resolve it by slug. This is the recommended pattern for most apps — you never hard-code a UUID.
+For most apps, resolve a connector by passing its slug to `connect()`. `connect()` returns a typed connector (when one is generated) or a generic `HostedExecutor`, and handles slug-to-ID resolution for you when the workspace has exactly one connector of that type. You never hard-code a UUID.
 
 ```python title="agent.py"
-async with Workspace() as ws:
-    stripe = await ws.get_connector(name="stripe")
-    try:
-        result = await stripe.execute("customers", "list", params={"limit": 10})
-    finally:
-        await stripe.close()
+from airbyte_agent_sdk import connect
+
+stripe = connect("stripe")
+try:
+    result = await stripe.execute("customers", "list")
+finally:
+    await stripe.close()
 ```
 
-`get_connector(name=...)` raises `ValueError` if zero or more than one connector of that type exists. When multiple connectors of the same type exist in the workspace — for example, two separate Stripe accounts — pass `connector_id` explicitly:
+When multiple connectors of the same type exist in the workspace — for example, two separate Stripe accounts — pass `connector_id` explicitly to `connect()`:
 
 ```python title="agent.py"
-async with Workspace() as ws:
-    stripe_us = await ws.get_connector(connector_id="<us_account_connector_id>")
-    stripe_eu = await ws.get_connector(connector_id="<eu_account_connector_id>")
+stripe_us = connect("stripe", connector_id="<us_account_connector_id>")
+stripe_eu = connect("stripe", connector_id="<eu_account_connector_id>")
 ```
 
-`get_connector(name=...)` always returns a generic `HostedExecutor` with `.execute(entity, action, params)`. To get a typed connector with IDE autocompletion and structured method shortcuts (for example, `stripe.customers.list(...)`), call `connect(slug)` for slug resolution or `connect(slug, connector_id=...)` when you need to pin a specific connector. See [Typed connectors and `HostedExecutor`](./execute#typed-connectors-and-hostedexecutor).
+`Workspace` also exposes a lower-level `get_connector(connector_id=...)` method that returns a `HostedExecutor` for a known connector ID. Prefer `connect(slug, ...)` unless you specifically need to resolve a connector from inside an open `Workspace` session.
+
+For typed-connector shortcuts like `stripe.customers.list(...)` and the distinction between typed connectors and `HostedExecutor`, see [Typed connectors and `HostedExecutor`](./execute#typed-connectors-and-hostedexecutor).
 
 ## Delete a connector
 

--- a/docs/ai-agents/interfaces/sdk/authenticate.md
+++ b/docs/ai-agents/interfaces/sdk/authenticate.md
@@ -6,6 +6,10 @@ sidebar_position: 1
 
 The SDK authenticates with Airbyte Agents using an Airbyte `client_id` and `client_secret`. Once the SDK has these, it handles the rest: fetching tokens, refreshing them before they expire, and attaching them to every request. You never manage tokens yourself.
 
+:::note Two sets of credentials
+The `AIRBYTE_CLIENT_ID` and `AIRBYTE_CLIENT_SECRET` on this page authenticate *your app* with Airbyte Agents. They aren't the same as the per-connector credentials (an OAuth `client_id`/`client_secret`/`refresh_token`, an API key, and so on) that you pass to [`create_connector`](./add-connector) so Airbyte can sign in to each third-party service on your behalf. The two are independent: rotating one doesn't affect the other.
+:::
+
 ## Get your credentials
 
 1. Sign in to [app.airbyte.ai](https://app.airbyte.ai/).

--- a/docs/ai-agents/interfaces/sdk/execute.md
+++ b/docs/ai-agents/interfaces/sdk/execute.md
@@ -16,16 +16,20 @@ from airbyte_agent_sdk import connect
 
 async def main():
     hubspot = connect("hubspot")
-    result = await hubspot.execute("contacts", "list", params={"limit": 10})
-    for row in result.data:
-        print(row)
+    try:
+        result = await hubspot.execute("contacts", "list")
+        for row in result.data:
+            print(row)
+    finally:
+        await hubspot.close()
 
 asyncio.run(main())
 ```
 
 - `entity` is the resource, such as `contacts`, `tickets`, or `issues`.
 - `action` is one of the connector's supported actions, such as `list`, `get`, or `search`.
-- `params` contains action-specific arguments.
+- `params` contains action-specific arguments. The exact keys are connector- and entity-specific — for example, `source-github`'s `issues` list accepts `per_page`, `source-hubspot`'s `contacts` list paginates via `cursor`. Use [`list_entities()`](#introspection) to discover the parameters a connector supports at runtime.
+- Always wrap the call in `try`/`finally` and `await connector.close()` once you're done to release the underlying HTTP client.
 
 See the connector's page in the [Connectors](../../connectors) reference for the entities and actions it supports.
 
@@ -39,7 +43,7 @@ For every other connector in the bundled registry, `connect()` returns a generic
 
 ### Multiple connectors of the same type
 
-If your workspace has more than one connector of a given type — for example, two separate Stripe accounts — slug resolution is ambiguous and raises `ValueError`. Pass an explicit `connector_id` in that case:
+If your workspace has more than one connector of a given type — for example, two separate Stripe accounts — slug resolution is ambiguous. `connect("stripe")` still returns an executor successfully; the `ValueError("Multiple connectors found for workspace_name '...' and connector definition '...'. Expected exactly 1, found N")` is raised on the first `.execute(...)` call, when the SDK actually needs a single connector ID. Pass an explicit `connector_id` up front to avoid it:
 
 ```python title="agent.py"
 stripe_us = connect("stripe", connector_id="<us_account_connector_id>")
@@ -67,7 +71,7 @@ asyncio.run(main())
 
 Check `result.outcome == "success"` before trusting `result.answer`. The `result.results` list contains one entry per tool call the dispatcher made. Each entry is an `AskToolCallResult` with the fields the dispatcher saw end-to-end:
 
-```python title="Example result.results[0]"
+```python title="Example result.results[0] for a routed list call"
 AskToolCallResult(
     source_id="<resolved_connector_id>",
     entity="customers",
@@ -79,6 +83,15 @@ AskToolCallResult(
     execution_time_ms=2635,
 )
 ```
+
+:::note `data` shape depends on the routed action
+`AskToolCallResult.data` mirrors the raw connector response, so the shape varies by action:
+
+- For connector-native reads (`action="list"`, `"get"`, and so on) `data` is a flat list or a single record, and pagination lives in `connector_metadata`.
+- For `action="context_store_search"`, the backend nests records and pagination together: `data={"data": […], "meta": {"has_more": true, "cursor": "…", "took_ms": 123}}`, and `connector_metadata` is `None`.
+
+Check `call.action` before indexing into `call.data` so a routed `context_store_search` call doesn't surprise you with a `dict` where you expected a `list`.
+:::
 
 Use `ask_sync()` in scripts and notebooks where you don't want to manage an event loop:
 

--- a/docs/ai-agents/interfaces/sdk/readme.md
+++ b/docs/ai-agents/interfaces/sdk/readme.md
@@ -23,6 +23,8 @@ Log in or sign up at [app.airbyte.ai](https://app.airbyte.ai/).
 pip install airbyte-agent-sdk
 ```
 
+The install name uses dashes. The Python import name uses underscores: `from airbyte_agent_sdk import Workspace, connect`.
+
 ## End-to-end example
 
 The example below authenticates with Airbyte, adds a HubSpot connector, and executes an operation against it. The pages in this section explain each step in detail.
@@ -51,7 +53,9 @@ async def main():
         # when the workspace has one connector of this type.
         hubspot = connect("hubspot")
         try:
-            result = await hubspot.execute("contacts", "list", params={"limit": 10})
+            # Parameter names are connector- and entity-specific. Call
+            # `hubspot.list_entities()` to see what each entity accepts.
+            result = await hubspot.execute("contacts", "list")
             for row in result.data:
                 print(row)
         finally:

--- a/docs/ai-agents/interfaces/sdk/workspaces.md
+++ b/docs/ai-agents/interfaces/sdk/workspaces.md
@@ -52,9 +52,27 @@ finally:
 
 ## Auto-creation
 
-You don't explicitly create a workspace. The first `create_connector` call against a new `workspace_name` provisions it on the fly.
+You don't explicitly create a workspace. Airbyte provisions one automatically the first time you mint a scoped or widget token for a new `workspace_name` (see [Authentication](../api/authentication#scoped-token) on the API side). Under the hood, `Workspace()` and `connect()` both mint a scoped token on first use, so opening a `Workspace` is enough.
 
-Other operations do not provision the workspace. `list_connectors()`, `get_connector()`, and `ask()` against a `workspace_name` that hasn't been created yet return an empty result or a 404 — they won't implicitly create it for you. If you need to start from an empty workspace, call `create_connector` first (or add a connector in the Airbyte Agents app).
+`list_connectors()`, `get_connector()`, and `ask()` against a `workspace_name` that hasn't been created yet raise `httpx.HTTPStatusError` with a `404` status — they don't return an empty list and they don't implicitly create the workspace. If you want to start from a known-empty workspace, catch the 404 and then call `create_connector` (or open the workspace in the Airbyte Agents app and add a connector there):
+
+```python title="agent.py"
+import httpx
+from airbyte_agent_sdk import Workspace
+
+async with Workspace(workspace_name="tenant-123") as ws:
+    try:
+        connectors = await ws.list_connectors()
+    except httpx.HTTPStatusError as err:
+        if err.response.status_code == 404:
+            connectors = []
+        else:
+            raise
+```
+
+:::note `create_connector` doesn't autocreate a workspace
+Calling `create_connector` against a new `workspace_name` currently fails with `404 "Workspace not found"` unless a scoped token has already been minted against that name. In practice you rarely hit this because `Workspace(...)` mints one on open, but if you skip `Workspace` and call the create-connector API directly, mint a scoped token first.
+:::
 
 ## Operations that require the API
 

--- a/docs/ai-agents/reference/api/readme.md
+++ b/docs/ai-agents/reference/api/readme.md
@@ -6,6 +6,6 @@ sidebar_position: 1
 
 Complete reference for the Airbyte Agent API. For a guided introduction, authentication, and example requests, see the [API interface](/ai-agents/interfaces/api) documentation.
 
-All API requests use the base URL `https://api.airbyte.ai`. If your account belongs to multiple organizations, include the `X-Organization-Id` header to specify which organization you're targeting.
+All API requests use the base URL `https://api.airbyte.ai`. The target organization is resolved from your application token — mint the token from the organization you want to target and you don't need to pass an additional header. See [Authentication](../../interfaces/api/authentication) for details.
 
 Browse the endpoints, request and response schemas, and authentication requirements in the sidebar.

--- a/docs/vale-styles/config/vocabularies/Airbyte/accept.txt
+++ b/docs/vale-styles/config/vocabularies/Airbyte/accept.txt
@@ -98,6 +98,7 @@ Zendesk
 Okta
 Entra
 Slack
+Jira
 Fargate
 MinIO
 Pydantic
@@ -162,3 +163,5 @@ workspace's
 [Dd]ocstring(s)?
 expirations
 httpx
+[Aa]uto-?create(s|d)?
+async


### PR DESCRIPTION
## What

Round-3 QA remediation for the Airbyte Agents SDK and API documentation. Every item below is a documentation-only fix against the authoring-side pages under `docs/ai-agents/interfaces/` and `docs/ai-agents/reference/api/readme.md`. Code-level bugs surfaced during the QA pass (SDK parameter-name mismatch, create-connector autocreate gap, `connector_instance_id` prefix, and others) are tracked separately and not touched here.

## How

Fixes are grouped by page. Each bullet says what changed and why the change belongs in docs rather than in code.

**`docs/ai-agents/interfaces/sdk/readme.md`**

- Added a one-liner noting `pip install airbyte-agent-sdk` installs under the Python import name `airbyte_agent_sdk` (dash → underscore). Users were hitting this immediately after install.
- Dropped the `params={"limit": 10}` from the end-to-end HubSpot example and pointed at `list_entities()` for discovering per-entity parameter names. `limit` isn't a universal HubSpot-read parameter and was misleading copy-paste.

**`docs/ai-agents/interfaces/sdk/authenticate.md`**

- Added a note distinguishing `AIRBYTE_CLIENT_ID` / `AIRBYTE_CLIENT_SECRET` (authenticates *your app* with Airbyte) from per-connector credentials (what Airbyte uses to sign in to third-party services). The two are independently rotated and readers kept conflating them.

**`docs/ai-agents/interfaces/sdk/add-connector.md`**

- Rewrote the API-token example so the credential shape is concrete and correct. The old text claimed all API-token connectors accept `{"token": ...}`; in practice the field is connector-specific (Linear → `api_key`, Notion → `token`, Jira → `api_token`). Switched the example to Linear with `api_key` and added a sentence pointing at the connector's page for the exact field name.
- Noted that some connectors require extra top-level config alongside `credentials` — for example `source-github` needs a `repositories` array and create fails with `422` without it. Documenting this avoids silent 422s at create time.
- Replaced the curl + jq `definition_id` lookup snippet with a Python snippet that reuses the SDK's already-authenticated `ws._cloud_client`. Users on the SDK path shouldn't have to mint a separate application token just to find a definition ID. The old curl flow still works and is linked for readers who prefer it.
- Added a note clarifying that the definitions endpoint returns the ID as `sourceDefinitionId` while `create_connector` accepts it as `definition_id` — same UUID, two names. This had been tripping up first-time integrators.
- Fixed `info.type` → `info.connector_type` in the `list_connectors` example. `ConnectorInfo` exposes `connector_type`, not `type`; the old code raised `AttributeError`. Also enumerated the full `ConnectorInfo` field set for reference.
- Rewrote "Get a connector" to lead with `connect(slug, …)` (the intended high-level entry point) and demoted `Workspace.get_connector(connector_id=…)` to a lower-level note. Also removed the broken `params={"limit": 10}` copy-paste and added an example for passing `connector_id` when the workspace has multiple connectors of the same type. The old text over-indexed on `get_connector(name=…)`, which has a known bug that's being fixed separately.

**`docs/ai-agents/interfaces/sdk/execute.md`**

- Wrapped the direct-execution example in `try`/`finally` with `await hubspot.close()`, and called the pattern out as the recommended lifecycle. Without it, the underlying HTTP client leaks — this was an authoring omission, not an SDK change.
- Added a `data`-shape note to the `ask()` section. `AskToolCallResult.data` is polymorphic in the current SDK: flat list for routed `list`/`get` actions, a nested `{data, meta}` dict for `context_store_search`. Readers who assumed a single shape were hitting `TypeError` when narrowing. The docs now say what to expect and which field to branch on.
- Reworded the "multiple connectors of the same type" paragraph to reflect actual runtime behavior: `connect()` returns successfully and the ambiguity `ValueError` is raised on the first `.execute()`. The old text implied the error was raised earlier.

**`docs/ai-agents/interfaces/sdk/workspaces.md`**

- Rewrote the auto-creation section. Workspace auto-creation actually happens when a scoped (or widget) token is minted, not when a connector is created. Added a concrete `try: list_connectors() except HTTPStatusError` snippet for the "start from an empty workspace" case, since those operations raise 404 rather than return empty.
- Added a warning that `create_connector` against a brand-new `workspace_name` fails with `404 "Workspace not found"` unless a scoped token was minted first. `Workspace()` mints one on open, so the surprise only hits callers who skip the SDK and use the API directly — but users were hitting this.

**`docs/ai-agents/interfaces/api/readme.md`**

- Reframed the "Make your first request" intro so it reads as "once you have an application token" rather than implying that `/api/v1/integrations/definitions/sources` is callable without auth. It isn't — it returns 401 without a bearer token, same as everything else.

**`docs/ai-agents/interfaces/api/add-connector.md`**

- Same API-token clarification as the SDK page: concrete Linear example with `api_key`, a sentence reminding readers the field name is connector-specific, and a note that some connectors require extra top-level config (GitHub / `repositories`). Users coming from the API side hit the same confusion as the SDK side.
- Documented that the create request accepts one of three connector-type identifiers (`definition_id`, `connector_type`, `source_template_id`) and that exactly one is required. Included the `422 "One of connector_type, definition_id, or source_template_id must be provided"` response so readers can recognize the failure mode.
- Added a short Source Templates section explaining what a source template is, why every connector list/get response carries a nested `summarized_source_template`, and when to pass `source_template_id` over `definition_id`. Readers had no definition of "source template" anywhere on the authoring side.
- Added the same `sourceDefinitionId` vs `definition_id` naming note as on the SDK page.
- Rewrote the `workspace_name` subsection. Dropped the `customer_name` / `external_user_id` "deprecated alias" note — those aliases are not part of the documented surface. Added a warning that the create-connector endpoint does not auto-create workspaces, so `workspace_name` must already exist (mint a scoped token first or use the UI).
- Added a canonical 200 response example for `List connectors` that shows the nested `summarized_source_template` shape, and a pointer that `actor_definition_id` inside it is the connector's definition ID. Added a line clarifying that `Get a connector` returns the full `source_template` plus `entities`.
- Added the actual `202 {"job_id": "..."}` delete response and noted deletion is asynchronous. Readers were interpreting the absence of a response body as a failure.
- Added an Errors section with a representative 422 body (showing the `{message, errors: [{field, message, error_code}]}` envelope) and a short inventory of the common status codes.

**`docs/ai-agents/interfaces/api/execute.md`**

- Added a note to the Search example that `search` requires the context store to be enabled for the target connector. Calls to `search` against a connector without the context store fail at runtime with a misleading-looking error.
- Added a note to Download that a nonexistent attachment ID currently returns `200 OK` with a zero-byte body rather than a 4xx. Flagged the need to check `Content-Length > 0` before trusting the file. (The underlying behavior is a platform issue; documenting it prevents silent empty-file writes until that's fixed.)
- Updated the response example so `connector_instance_id` shows the actual `"source_id:<connector_id>"` prefix the server returns, with a note that consumers comparing it against a bare connector ID need to strip the prefix.
- Added a sentence to "Paginate through results" clarifying that `cursor` is the conventional request-param name even when the response key is `endCursor` / `end_cursor`, and that offset-based pagers may use `offset` / `limit` instead.

**`docs/ai-agents/interfaces/api/workspaces.md`**

- Rewrote the `workspace_name` paragraph. Removed the deprecated alias note; added the key points users need day-to-day — that `workspace_name` is a stable identifier and that renaming a workspace through the update endpoint does not change the identifier their backend sends.
- Explicitly called out, in its own warning, that `create-connector` does not autocreate workspaces. This contradicts the scoped/widget token behavior and kept biting people.
- Added a canonical List workspaces response example so readers can see the envelope (`{next, data: [...]}`) and the per-workspace fields (`status`, `tombstone`, `cache_enabled`). Clarified that `Get workspace details` returns the same per-workspace shape.
- Added a one-liner that workspace deletes with many connectors can 504 on the first attempt and usually complete on retry. (The 504 behavior is a platform issue — documenting sets expectations until it's fixed.)

**`docs/ai-agents/interfaces/api/authentication/readme.md`**

- Reworded the "expires after 15 minutes" sentence to explain *why* it's 15 minutes (organization-wide privilege surface) and to contrast with the 20-minute lifetime of scoped and widget tokens. Readers building long-running apps need this framing to decide when to refresh.

**`docs/ai-agents/interfaces/api/authentication-module.md`**

- Renamed every `operatorToken` / "operator token" / "Operator token" in the Node.js backend example to `applicationToken` / "application token". Everywhere else in the docs this is called an application token, including the endpoint (`/account/applications/token`) and the page's own explanatory copy. The term "operator token" existed only here.

**`docs/ai-agents/reference/api/readme.md`**

- Replaced the `X-Organization-Id` sentence. The header isn't part of the supported API contract; the target organization is resolved from the application token you mint. Kept the cross-reference to the authentication page for detail.

**`docs/vale-styles/config/vocabularies/Airbyte/accept.txt`**

- Added `Jira`, `async`, and `[Aa]uto-?create(s|d)?` to the Airbyte vocabulary. These are real product / API terms used in the docs that were being flagged as spelling errors.

## Review guide

1. `docs/ai-agents/interfaces/sdk/add-connector.md` — biggest delta; worth skimming the "Find a `definition_id`" and "Get a connector" sections first.
2. `docs/ai-agents/interfaces/api/add-connector.md` — matches the SDK rewrite plus adds Source Templates.
3. `docs/ai-agents/interfaces/sdk/workspaces.md` and `docs/ai-agents/interfaces/api/workspaces.md` — check the autocreate framing is consistent across the two pages.
4. `docs/ai-agents/interfaces/sdk/execute.md` — the `try/finally/close` pattern and the `AskToolCallResult.data` polymorphism note.
5. `docs/ai-agents/reference/api/readme.md` — the `X-Organization-Id` change.
6. Other files are smaller one-shot fixes.

## User Impact

Documentation-only. No runtime behavior changes.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

---
[Devin session](https://app.devin.ai/sessions/ba0a9f787c0b4a2088a4858f8ada1759)

Requested by: @ian-at-airbyte