### PR TITLE
docs(ai-agents): add Time zones topic to Core concepts

### DIFF
--- a/docs/ai-agents/admin/sessions.md
+++ b/docs/ai-agents/admin/sessions.md
@@ -25,7 +25,7 @@ The Sessions table lists the most recent sessions first. Each row represents one
 - **Input Tokens**: The total tokens the agent received as input, across every turn in the session.
 - **Output Tokens**: The total tokens the agent produced, across every turn in the session.
 - **Tool Calls**: The number of tool calls the agent made during the session. Drill into [tool calls](./tool-calls.md) to see individual calls.
-- **Date**: When the session last updated. Sessions that are still running show the most recent activity time.
+- **Date**: When the session last updated. Sessions that are still running show the most recent activity time. Dates display in your browser's local [time zone](../concepts/time-zones).
 - **Actions**: Per-row buttons to review or resume the session.
     - Click the **View** icon to open the session and see its messages and tool calls.
     - Click the **Open** icon to jump to the chat or automation the session belongs to.

--- a/docs/ai-agents/concepts/time-zones.md
+++ b/docs/ai-agents/concepts/time-zones.md
@@ -1,0 +1,64 @@
+---
+sidebar_position: 3
+---
+
+# Time zones
+
+Airbyte Agents handles dates and times the same way across every interface: display in your local time, store and transport in UTC, and schedule Automations in a time zone you choose. This page explains how that works and what to expect in each interface.
+
+## The short version
+
+- **Display**: The [web app](../interfaces/ui) formats every date and time in the local time zone set in your browser.
+- **Storage**: The backend stores every timestamp in UTC.
+- **Data in transit**: The [API](../interfaces/api), [SDK](../interfaces/sdk), and [MCP server](../interfaces/mcp) read and return timestamps in UTC, formatted as ISO 8601 strings.
+- **Automation schedules**: You pick a time zone per Automation. Airbyte stores it as an [IANA time zone identifier](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) (for example, `America/New_York` or `Asia/Kolkata`).
+
+## Display in the web app
+
+Every timestamp the web app shows—run history, session tables, activity feeds, Automation schedules—renders in the time zone the browser reports. If you travel, change your operating system's time zone, or open the app in a different browser profile, the same timestamp displays in the new local time. The underlying value doesn't change; only the formatting does.
+
+This applies to both absolute times (for example, `Mar 18, 09:32`) and relative times (for example, `2 hours ago`).
+
+## Storage and data in transit
+
+All timestamps are UTC on the backend, and every interface that reads or writes timestamps uses UTC on the wire:
+
+- **API**: Request and response bodies use ISO 8601 UTC strings (for example, `2026-03-18T13:32:00Z`).
+- **SDK**: The Python SDK returns the same UTC ISO 8601 strings through its response models.
+- **MCP server**: Tools that return timestamps return them in UTC. The `current_datetime` tool, which an agent calls to resolve relative dates like "today" or "last week," returns the current UTC time.
+
+If you pass a timestamp into a connector action—for example, as a date filter on a list query—use UTC. The agent doing the calling is responsible for any time zone conversion before it hands the value to the platform.
+
+## Scheduling Automations
+
+Every scheduled [Automation](../interfaces/ui/automations) has its own time zone, stored as an IANA identifier alongside its cron expression. When the schedule fires, Airbyte evaluates the cron in that time zone, so `0 9 * * MON-FRI` means 9 AM local time for the chosen zone, whether that's `America/Los_Angeles` or `Asia/Tokyo`.
+
+The default time zone depends on how you create the Automation:
+
+- **From the web app**: The [schedule builder](../interfaces/ui/automations#the-automation-builder) defaults to your browser's local time zone. Pick a different zone from the dropdown if you want the schedule to fire somewhere else.
+- **From the Automation Builder chat agent**: The agent uses this precedence when it creates or updates a schedule:
+  1. An explicit time zone you state in the prompt (for example, "at 9 AM Tokyo time").
+  2. Your browser's local time zone, which the web app sends with every message.
+  3. UTC, if neither is available.
+
+  The agent only ever passes IANA identifiers. If you say "EST" or "Eastern Time," it translates to `America/New_York` before calling the tool.
+- **From the API or SDK**: The `timezone` field is optional on the automation create and update endpoints. If you omit it, Airbyte stores the schedule as UTC.
+
+### Interpreting times in an Automation's prompt
+
+A scheduled Automation can run for a long time without you watching it. If your prompt includes relative words like "today," "this week," or "last month," the agent resolves them to a concrete date and time when the run starts. It does this by calling `current_datetime` (UTC) and then reasoning about the window. Be explicit about the zone if the result depends on it (for example, "today in US Pacific time").
+
+## Time zones and MCP clients
+
+The MCP server at [`mcp.airbyte.ai`](../interfaces/mcp) is accessed by external AI clients such as Claude, Cursor, and ChatGPT. It authenticates each user with OAuth but doesn't receive the client's local time zone. Two things follow from this:
+
+- **Times on the wire are UTC.** The MCP tools accept and return UTC timestamps.
+- **Time zone reasoning is the client agent's job.** When you ask your agent "what happened today?" or "show me deals closing this month," the agent needs to decide what "today" and "this month" mean. Most clients resolve relative dates using their host environment's time zone. Tell the agent the zone explicitly if you need precision.
+
+The MCP server doesn't currently expose tools for creating, updating, or running Automations. Build and schedule Automations in the web app, API, or SDK.
+
+## Related topics
+
+- [Automations](../interfaces/ui/automations) — Pick a schedule and time zone.
+- [Sessions](../admin/sessions) — Review when Automation runs and chat sessions happened.
+- [MCP server](../interfaces/mcp) — Connect an external agent to Airbyte.

--- a/docs/ai-agents/concepts/time-zones.md
+++ b/docs/ai-agents/concepts/time-zones.md
@@ -55,7 +55,7 @@ The MCP server at [`mcp.airbyte.ai`](../interfaces/mcp) is accessed by external 
 - **Times on the wire are UTC.** The MCP tools accept and return UTC timestamps.
 - **Time zone reasoning is the client agent's job.** When you ask your agent "what happened today?" or "show me deals closing this month," the agent needs to decide what "today" and "this month" mean. Most clients resolve relative dates using their host environment's time zone. Tell the agent the zone explicitly if you need precision.
 
-The MCP server doesn't currently expose tools for creating, updating, or running Automations. Build and schedule Automations in the web app, API, or SDK.
+The MCP server doesn't currently expose tools for creating, updating, or running Automations. However, if you used it with an agent that supports automations, it runs according to the settings that agent is designed to use.
 
 ## Related topics
 

--- a/docs/ai-agents/concepts/time-zones.md
+++ b/docs/ai-agents/concepts/time-zones.md
@@ -35,7 +35,7 @@ Every scheduled [Automation](../interfaces/ui/automations) has its own time zone
 
 The default time zone depends on how you create the Automation:
 
-- **From the web app**: The [schedule builder](../interfaces/ui/automations#the-automation-builder) defaults to your browser's local time zone. Pick a different zone from the dropdown if you want the schedule to fire somewhere else.
+- **From the web app**: The [Automation Builder](../interfaces/ui/automations#the-automation-builder) defaults to your browser's local time zone. Pick a different zone from the dropdown if you want the schedule to fire somewhere else.
 - **From the Automation Builder chat agent**: The agent uses this precedence when it creates or updates a schedule:
   1. An explicit time zone you state in the prompt (for example, "at 9 AM Tokyo time").
   2. Your browser's local time zone, which the web app sends with every message.

--- a/docs/ai-agents/concepts/time-zones.md
+++ b/docs/ai-agents/concepts/time-zones.md
@@ -42,7 +42,6 @@ The default time zone depends on how you create the Automation:
   3. UTC, if neither is available.
 
   The agent only ever passes IANA identifiers. If you say "EST" or "Eastern Time," it translates to `America/New_York` before calling the tool.
-- **From the API or SDK**: The `timezone` field is optional on the automation create and update endpoints. If you omit it, Airbyte stores the schedule as UTC.
 
 ### Interpreting times in an Automation's prompt
 

--- a/docs/ai-agents/interfaces/mcp/readme.md
+++ b/docs/ai-agents/interfaces/mcp/readme.md
@@ -362,4 +362,4 @@ ChatGPT may not realize it has access to data through the MCP server. If ChatGPT
 ### Queries return unexpected results
 
 - Ask the agent to describe the available entities before querying, so it picks the right one.
-- For time-based queries, the agent resolves relative dates like "this week" or "last month" automatically.
+- For time-based queries, the agent resolves relative dates like "this week" or "last month" automatically. The MCP server returns timestamps in UTC; see [Time zones](../../concepts/time-zones) for how this interacts with your local time.

--- a/docs/ai-agents/interfaces/ui/automations.md
+++ b/docs/ai-agents/interfaces/ui/automations.md
@@ -111,7 +111,7 @@ Scheduled Automations run at times you define. Open the Properties panel, set **
 - **Hourly**, **Daily**, **Weekly**, or **Monthly** for common cases. Airbyte shows the equivalent cron expression so you can verify the schedule.
 - **Custom cron** for anything the builder doesn't cover. Provide the raw cron expression and Airbyte translates it into a human-readable summary.
 
-Pick the **Timezone** the schedule should use. Airbyte defaults to your local timezone. Turn the Automation's **Enabled** toggle on to activate the schedule. Each scheduled run appears in Run History tagged **Live run**.
+Pick the **Timezone** the schedule should use. Airbyte defaults to your local timezone. See [Time zones](../../concepts/time-zones) for how Airbyte stores and displays times across interfaces. Turn the Automation's **Enabled** toggle on to activate the schedule. Each scheduled run appears in Run History tagged **Live run**.
 
 ### From a webhook
 


### PR DESCRIPTION
## What

Adds a new "Time zones" topic under ai-agents Core concepts that explains how Airbyte Agents displays, stores, transports, and schedules dates and times across every interface. Cross-links the new topic from the places that currently surface dates/times: the Automations schedule builder, the Sessions table, and MCP troubleshooting.

## How

- New page: `docs/ai-agents/concepts/time-zones.md` (sidebar_position: 3, sibling of Context store).
- Cross-links added from:
  - `interfaces/ui/automations.md` — the Timezone picker paragraph.
  - `admin/sessions.md` — the session Date column.
  - `interfaces/mcp/readme.md` — the "time-based queries" troubleshooting bullet.

## Review guide

1. `docs/ai-agents/concepts/time-zones.md` — full new topic.
2. `docs/ai-agents/interfaces/ui/automations.md` — one-line cross-link in the scheduling section.
3. `docs/ai-agents/admin/sessions.md` — one-line cross-link on the Date column.
4. `docs/ai-agents/interfaces/mcp/readme.md` — one-line cross-link in the MCP troubleshooting bullet.

## User Impact

Customers get a single, discoverable explainer for time zone behavior that reconciles UI display, backend UTC storage, API/SDK/MCP transport, and Automation scheduling, so they don't have to infer it from individual feature pages.

## Verification against platform code

Everything in the new topic was verified against `sonar` and `connector-sdk`:

- *UI displays in browser-local time*: `Intl.DateTimeFormat(undefined, …)` and `toLocaleString()` in `frontend/src/routes/organizations/$organizationId/sessions/index.tsx` and `frontend/src/core/utils/formatTimestamp.ts`.
- *Backend storage is UTC*: automation migration `1774920000_a9d4e8f1b2c3_add_automation_timezone.py` (column defaults to `'UTC'`) and `_coerce_utc_datetime` in `backend/app/core/automations/service.py`.
- *Scheduler uses IANA zones*: `build_apscheduler_cron_trigger` in `backend/app/core/automations/cron.py` uses `ZoneInfo(timezone)`, resolved from `automation.timezone or "UTC"` in `service.py`.
- *UI defaults to browser tz*: `ScheduleBuilder` calls `getLocalTimezone()` which reads `Intl.DateTimeFormat().resolvedOptions().timeZone`. The frontend also sends `client_timezone: getLocalTimezone()` to the Automation Builder chat agent (`frontend/src/components/chat/store/runAgentStream.ts`).
- *Automation Builder agent precedence*: `backend/app/agents/prompts/workflow_builder_agent_system_prompt.md` states: "Resolve schedule times in this order: explicit timezone from the user's request, otherwise the client timezone from Context, otherwise UTC." The prompt also enforces IANA identifiers only.
- *SDK*: `airbyte_agent_sdk/workspace.py` `create_automation`/`update_automation` accept `timezone: str | None` and the server defaults to UTC.
- *MCP*: `agent-engine-mcp/app/tools/utils.py` `current_datetime()` returns `datetime.now(UTC).isoformat()`. The MCP server exposes no automation/schedule tools — only connectors, discovery, execute, and `current_datetime`.

## Discrepancies to file bugs for

These came up while verifying the claims in the spec; flagging for `@ian-at-airbyte` rather than fixing in this PR:

1. *UI timezone picker is a curated list, not "any time zone"*. The Automation schedule builder dropdown (`frontend/src/utils/cronBuilder.ts` `COMMON_TIMEZONES`) offers roughly two dozen common zones. Users who need a non-listed zone (for example, `Europe/Kyiv` or `Pacific/Chatham`) have to ask the Automation Builder chat agent or use the API/SDK. The spec bullet "Automations can be scheduled in any time zone" is only literally true outside the UI dropdown.
2. *Agent precedence isn't strictly browser-local*. The system prompt uses (1) user-stated zone → (2) browser `client_timezone` → (3) UTC. The spec wording "the agent always attempts to schedule them in your local time zone" understates that an explicit user zone wins. The new doc describes the precedence explicitly.
3. *MCP cannot create or schedule Automations*. `agent-engine-mcp` exposes no automation/workflow tools, so the Automation-scheduling guarantees don't apply to external MCP clients. The new doc calls this out.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚


Link to Devin session: https://app.devin.ai/sessions/ae83feae23ad43fe8ad362ab5b1e5ef5