### PR TITLE
docs(ai-agents): discuss scheduling dispatch implications in Automations topic

### DIFF
--- a/docs/ai-agents/interfaces/ui/automations.md
+++ b/docs/ai-agents/interfaces/ui/automations.md
@@ -113,6 +113,18 @@ Scheduled Automations run at times you define. Open the Properties panel, set **
 
 Pick the **Timezone** the schedule should use. Airbyte defaults to your local timezone. Turn the Automation's **Enabled** toggle on to activate the schedule. Each scheduled run appears in Run History tagged **Live run**.
 
+#### How scheduled runs are dispatched
+
+Airbyte dispatches scheduled Automations at the exact moment the cron expression matches, in the timezone you selected. The scheduler doesn't apply jitter or a random offset, so every Automation whose schedule matches the same instant is dispatched together. For example, two Automations scheduled for `0 * * * *` in the same timezone both fire at the top of the hour.
+
+Keep this in mind when you design schedules:
+
+- **Avoid stacking many heavy Automations on the same round cadence.** If you have several Automations that each do substantial work, stagger them across different minutes (for example, `5 * * * *`, `15 * * * *`, `25 * * * *`) rather than running them all at `0 * * * *`. This spreads load on your connectors, reduces the chance of hitting upstream rate limits at the same moment, and makes failures easier to diagnose one Automation at a time.
+- **Expect near-simultaneous webhook or connector calls** when multiple Automations share a trigger time and hit the same third-party API. If that API enforces per-minute rate limits, consider splitting the schedules.
+- **Dispatch time isn't execution time.** Airbyte dispatches the run on the dot, but the agent work itself takes as long as it takes. A 9:00 schedule doesn't guarantee results by 9:00—only that the run starts then.
+
+If you need a schedule that's more fine-grained than the builder's presets allow, use **Custom cron** and pick a specific minute offset that isn't shared with your other Automations.
+
 ### From a webhook
 
 Webhook Automations run when an external system posts to a URL Airbyte provides. Open the Properties panel, set **Trigger** to Webhook, and copy the generated webhook URL. Configure the external system to post to that URL when the event you care about happens. Each POST starts one run.

--- a/docs/ai-agents/interfaces/ui/automations.md
+++ b/docs/ai-agents/interfaces/ui/automations.md
@@ -123,7 +123,7 @@ Keep this in mind when you design schedules:
 - **Expect near-simultaneous webhook or connector calls** when multiple Automations share a trigger time and hit the same third-party API. If that API enforces per-minute rate limits, consider splitting the schedules.
 - **Dispatch time isn't execution time.** Airbyte dispatches the run on the dot, but the agent work itself takes as long as it takes. A 9:00 schedule doesn't guarantee results by 9:00—only that the run starts then.
 
-If you need a schedule that's more fine-grained than the builder's presets allow, use **Custom cron** and pick a specific minute offset that isn't shared with your other Automations.
+If you need a schedule that's more fine-grained than the Automation Builder's presets allow, use **Custom cron** and pick a specific minute offset that isn't shared with your other Automations.
 
 ### From a webhook
 


### PR DESCRIPTION
## What

Adds a "How scheduled runs are dispatched" subsection to `docs/ai-agents/interfaces/ui/automations.md` explaining the practical implications of Airbyte's Automation scheduler for users designing schedules.

## How

Scheduled Automations are backed by APScheduler's `CronTrigger` (`backend/app/core/automations/cron.py`, `backend/app/core/automations/service.py`). The scheduler fires jobs at the exact instant the cron expression matches and does not apply jitter or a random offset. That behavior has user-visible consequences worth documenting:

- Automations sharing the same cron in the same timezone are dispatched together.
- This can cause simultaneous load on shared connectors or upstream APIs with per-minute rate limits.
- Dispatch time is not execution time; the agent work itself still takes as long as it takes.

The new subsection covers these points and recommends staggering minute offsets via **Custom cron** for heavy workloads.

## Review guide

1. `docs/ai-agents/interfaces/ui/automations.md` — new "How scheduled runs are dispatched" subsection under "On a schedule".

## User Impact

Docs-only change. Users get clearer guidance on how their cron schedules are executed and how to avoid stacking many heavy Automations on the same round cadence.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

Link to Devin session: https://app.devin.ai/sessions/d2f83d5d61f94a32ad692c9bac69a57b
Requested by: @ian-at-airbyte