### PR TITLE
docs(ai-agents): apply Context Store and Automation Builder proper nouns

### DIFF
--- a/docs/ai-agents/concepts/context-store.md
+++ b/docs/ai-agents/concepts/context-store.md
@@ -2,11 +2,11 @@
 sidebar_position: 2
 ---
 
-# Context store
+# Context Store
 
-The context store is a managed, searchable replica of select entities from all your connected data sources. Airbyte populates it from the connectors in your workspace and gives agents a fast, consistent way to search your business data in natural language, without hitting the underlying APIs for every request.
+The Context Store is a managed, searchable replica of select entities from all your connected data sources. Airbyte populates it from the connectors in your workspace and gives agents a fast, consistent way to search your business data in natural language, without hitting the underlying APIs for every request.
 
-Some third-party APIs have search endpoints, but many don't. Without the context store, prompts like these force your agent to list, page through, and filter records from the API in real time:
+Some third-party APIs have search endpoints, but many don't. Without the Context Store, prompts like these force your agent to list, page through, and filter records from the API in real time:
 
 - `List all customers closing this month with deal sizes greater than $5000.`
 - `Search all dresses and find the ones with a color option of red.`
@@ -20,9 +20,9 @@ Working this way causes a variety of problems:
 
 The result is a query that takes substantial time and resources to process, a degraded experience, and inflated costs.
 
-The context store solves this problem by making key fields available to your agents in Airbyte-managed storage. When you turn it on, Airbyte replicates a curated subset of the entities in your agent connectors into the store and keeps it up to date. Agents then answer these kinds of questions with fast, indexed searches instead of live API crawls.
+The Context Store solves this problem by making key fields available to your agents in Airbyte-managed storage. When you turn it on, Airbyte replicates a curated subset of the entities in your agent connectors into the store and keeps it up to date. Agents then answer these kinds of questions with fast, indexed searches instead of live API crawls.
 
-## What's in the context store
+## What's in the Context Store
 
 Each connected source has its own isolated store. Airbyte curates the store for search, not archival.
 
@@ -32,11 +32,11 @@ Each connected source has its own isolated store. Airbyte curates the store for 
 
 For the list of entities each connector contributes, see [Agent connectors](../connectors).
 
-## Who can configure the context store
+## Who can configure the Context Store
 
-The context store is an organization-level setting. Only organization administrators see the **Manage Context Store** button and can turn the store on or off. End users who run Chats and Automations see the benefits of the store but don't configure it.
+The Context Store is an organization-level setting. Only organization administrators see the **Manage Context Store** button and can turn the store on or off. End users who run Chats and Automations see the benefits of the store but don't configure it.
 
-## Turn on the context store
+## Turn on the Context Store
 
 1. In the Airbyte Agents web app, click **Credentials** in the left sidebar.
 
@@ -44,20 +44,20 @@ The context store is an organization-level setting. Only organization administra
 
 3. In the slide-out, turn on **Enable Context Store**.
 
-When you turn on the context store:
+When you turn on the Context Store:
 
 - **Storage begins automatically.** Airbyte starts copying data from each agent connector in your workspace into the store.
 - **Search becomes available.** As soon as a connector has enough data, its entities are available to agents through the search action.
 
 You can continue using Airbyte while the store populates. First-time population takes longer for connectors with large datasets.
 
-## Check context store status
+## Check Context Store status
 
-You can check context store status in two places on the **Credentials** page: per connector and per entity.
+You can check Context Store status in two places on the **Credentials** page: per connector and per entity.
 
 ### Per-connector status
 
-Each credential in the Credentials list shows a status badge when the context store is on for its workspace.
+Each credential in the Credentials list shows a status badge when the Context Store is on for its workspace.
 
 - **Ready.** The store is populated and fully available for search.
 - **Preview.** The first population is still in progress, but some data is already searchable.
@@ -77,7 +77,7 @@ Click the status badge on a credential to open a detailed view for that connecto
 
 Use this view to confirm which entities are ready to query and which are still populating.
 
-## Turn off the context store
+## Turn off the Context Store
 
 1. In the Airbyte Agents web app, click **Credentials** in the left sidebar.
 
@@ -85,17 +85,17 @@ Use this view to confirm which entities are ready to query and which are still p
 
 3. In the slide-out, turn off **Enable Context Store**.
 
-When you turn off the context store, Airbyte removes the replicated data from the store. Agents can no longer use the search action until you turn the store back on and Airbyte repopulates it.
+When you turn off the Context Store, Airbyte removes the replicated data from the store. Agents can no longer use the search action until you turn the store back on and Airbyte repopulates it.
 
-## When to use the context store
+## When to use the Context Store
 
-Turn the context store on when:
+Turn the Context Store on when:
 
 - You want agents to search across large amounts of connector data with predictable latency.
 - You want prompts like "find all X where Y" to run as a single search instead of a live API crawl.
 - You want consistent search behavior across connectors, including connectors whose APIs don't offer their own search endpoint.
 
-You may want to skip the context store when:
+You may want to skip the Context Store when:
 
 - You already maintain your own copy of the relevant data and prefer to expose it through your own tools.
 - You only need to read or write a small number of records at a time and don't need to search across a dataset.
@@ -103,5 +103,5 @@ You may want to skip the context store when:
 ## Limitations
 
 - The refresh rate isn't user-configurable.
-- All agent connectors can use the context store. Limited, temporary exceptions are possible.
+- All agent connectors can use the Context Store. Limited, temporary exceptions are possible.
 - Turning the store off and on again triggers a fresh population. Plan for this if you rely on search-heavy prompts.

--- a/docs/ai-agents/get-started/skills/readme.md
+++ b/docs/ai-agents/get-started/skills/readme.md
@@ -9,7 +9,7 @@ import DocCardList from '@theme/DocCardList';
 
 Skills are self-contained packages of context and instructions you give to an AI agent so it can generate working code against Airbyte. A skill teaches the agent the architecture, endpoints, authentication flow, and code patterns it needs to integrate Airbyte connectors into whatever it's building for you.
 
-Use a skill when you want an AI app builder like Lovable, or a coding agent like Claude Code or Codex, to scaffold something that talks to Airbyte without having to explain the API, the widget, the SDK, or the context store yourself. Install the skill into the agent, then prompt it to build.
+Use a skill when you want an AI app builder like Lovable, or a coding agent like Claude Code or Codex, to scaffold something that talks to Airbyte without having to explain the API, the widget, the SDK, or the Context Store yourself. Install the skill into the agent, then prompt it to build.
 
 Each page below targets a specific agent. Pick the one that matches the tool you're using.
 

--- a/docs/ai-agents/interfaces/api/execute.md
+++ b/docs/ai-agents/interfaces/api/execute.md
@@ -83,8 +83,8 @@ curl -X POST 'https://api.airbyte.ai/api/v1/integrations/connectors/<connector_i
 
 This example searches for records using filter conditions.
 
-:::note `search` reads from the [context store](../../concepts/context-store)
-The `search` action reads from Airbyte's pre-indexed context store, not the live third-party API. The store is enabled by default in new organizations, and Airbyte populates it per connector after the connector is created. If you call `search` while the connector's context store still shows `Loading` or `Building Preview` on the Credentials page, the call returns an error at runtime. Wait for the status to reach `Preview` or `Ready`, or use `list`/`get` against the live API until it does.
+:::note `search` reads from the [Context Store](../../concepts/context-store)
+The `search` action reads from Airbyte's pre-indexed Context Store, not the live third-party API. The store is enabled by default in new organizations, and Airbyte populates it per connector after the connector is created. If you call `search` while the connector's Context Store still shows `Loading` or `Building Preview` on the Credentials page, the call returns an error at runtime. Wait for the status to reach `Preview` or `Ready`, or use `list`/`get` against the live API until it does.
 :::
 
 ```bash title="Request"

--- a/docs/ai-agents/interfaces/mcp/readme.md
+++ b/docs/ai-agents/interfaces/mcp/readme.md
@@ -319,7 +319,7 @@ For example:
 
 Connectors handle authentication, pagination, schema validation, and error handling so the agent can focus on answering questions and performing tasks. The agent automatically discovers which entities and actions are available for each connector you've added, so you only need to describe what you want in natural language.
 
-When you connect a service through the MCP server, the Airbyte Agents can copy key data from that connector into a [context store](../../concepts/context-store). The context store is a managed, searchable replica of select entities from all your connected data sources. This improves search speed and reduces token consumption compared to querying third-party APIs directly, especially for prompts that involve filtering or searching large datasets.
+When you connect a service through the MCP server, the Airbyte Agents can copy key data from that connector into a [Context Store](../../concepts/context-store). The Context Store is a managed, searchable replica of select entities from all your connected data sources. This improves search speed and reduces token consumption compared to querying third-party APIs directly, especially for prompts that involve filtering or searching large datasets.
 
 For the complete list of connectors and their supported entities, see [Agent connectors](../../connectors).
 

--- a/docs/ai-agents/interfaces/ui/add-connector.md
+++ b/docs/ai-agents/interfaces/ui/add-connector.md
@@ -97,7 +97,7 @@ Automations run without a person sitting in the loop, so every connector an auto
 
 The fastest path is to tell the Automation Builder Agent what you want and let it flag missing connectors. Describe the automation in plain language. If a required data source isn't authenticated yet, the agent says so—often with connector tiles right in the chat—exactly like in a regular Chat. Click a tile, authenticate, and continue iterating on the automation. The agent re-reads the workspace context and adjusts its plan once the new connector is available.
 
-You can also ask the Builder Agent to change which connectors the automation uses. Sending a message like "use the Salesforce connector instead" or "add HubSpot" tells it to update the automation's [**Context**](./automations#properties) to match. Airbyte blocks direct edits to the Context list in the Properties panel on purpose, so that the prompt and the connectors it relies on stay in sync.
+You can also ask the Automation Builder Agent to change which connectors the automation uses. Sending a message like "use the Salesforce connector instead" or "add HubSpot" tells it to update the automation's [**Context**](./automations#properties) to match. Airbyte blocks direct edits to the Context list in the Properties panel on purpose, so that the prompt and the connectors it relies on stay in sync.
 
 If you prefer, you can still pre-authenticate everything from the Credentials page first, then open the Automation Builder with the connectors already in place. That path is often faster when you already know exactly which sources the automation needs.
 

--- a/docs/ai-agents/interfaces/ui/automations.md
+++ b/docs/ai-agents/interfaces/ui/automations.md
@@ -16,7 +16,7 @@ You can create an Automation three ways. The first two start from the Automation
 
 Click **New Automation** at the top of the Automations page. Airbyte opens a prompt dialog. Describe what you want the Automation to do in plain language, then press Enter or click the send button.
 
-Airbyte creates the Automation in draft, seeds the Automation Builder with your prompt, and takes you into the Builder so you can iterate on it, configure a trigger, and try a test run. See [The Automation Builder](#the-automation-builder) for details.
+Airbyte creates the Automation in draft, seeds the Automation Builder with your prompt, and takes you into the Automation Builder so you can iterate on it, configure a trigger, and try a test run. See [The Automation Builder](#the-automation-builder) for details.
 
 ### From an idea
 
@@ -36,7 +36,7 @@ See [Convert a chat to an automation](./chats#convert-a-chat-to-an-automation) f
 
 ### From the sidebar
 
-Recent Automations you've opened appear under **Recent Chats** in the sidebar, alongside your recent chats. Automations use a bolt icon so you can distinguish them at a glance. Click an Automation in the list to jump back into its Builder.
+Recent Automations you've opened appear under **Recent Chats** in the sidebar, alongside your recent chats. Automations use a bolt icon so you can distinguish them at a glance. Click an Automation in the list to jump back into its Automation Builder.
 
 ### From the Automations page
 
@@ -49,7 +49,7 @@ Use search and filters to find what you want:
 - **Trigger**: Filter by Manual, Schedule, or Webhook.
 - **Enabled**: Show only enabled Automations, only turned-off Automations, or both.
 
-Click the **Edit** (pencil) icon on a row to open the Automation in the Builder. Automations created before session linking was introduced can't be edited from this button; Airbyte disables the icon and explains why on hover.
+Click the **Edit** (pencil) icon on a row to open the Automation in the Automation Builder. Automations created before session linking was introduced can't be edited from this button; Airbyte disables the icon and explains why on hover.
 
 ## Delete an automation
 
@@ -57,30 +57,30 @@ To delete an Automation, click the trash icon on its row on the Automations page
 
 ## Rename an automation
 
-Open the Automation in the Builder and click **Properties** to open the Properties panel. Edit the **Name** field. Airbyte saves the change automatically when you click out of the field. The header shows a **Saving…** then **Saved** indicator to confirm. The new name appears immediately on the Automations page and in the sidebar.
+Open the Automation in the Automation Builder and click **Properties** to open the Properties panel. Edit the **Name** field. Airbyte saves the change automatically when you click out of the field. The header shows a **Saving…** then **Saved** indicator to confirm. The new name appears immediately on the Automations page and in the sidebar.
 
 ## Turn an automation on or off
 
 Scheduled Automations run automatically when their trigger fires. To pause a scheduled Automation without deleting it, turn its **Enabled** toggle off. The next scheduled time is skipped, and the Automation's status changes to Paused. Turn the toggle back on to resume.
 
-You can toggle Enabled from the table on the Automations page or from the Properties panel in the Builder. The toggle is only available for Automations with a Schedule trigger; Manual and Webhook Automations are always "on" in the sense that they run whenever you invoke them, so there's nothing to pause.
+You can toggle Enabled from the table on the Automations page or from the Properties panel in the Automation Builder. The toggle is only available for Automations with a Schedule trigger; Manual and Webhook Automations are always "on" in the sense that they run whenever you invoke them, so there's nothing to pause.
 
 ## The Automation Builder {#the-automation-builder}
 
 The Automation Builder is where you design, iterate on, and run an Automation. Open it by creating a new Automation, clicking **Edit** on a row in the Automations page, or opening an Automation from the sidebar.
 
-The Builder has two tabs on the left side:
+The Automation Builder has two tabs on the left side:
 
 - **Agent**: A chat with the Automation Builder Agent. Describe what you want the Automation to do, correct its approach, and ask it to try again. Each message runs as a test in the same way a Chat does, so you can validate behavior before committing to a schedule.
 - **Run History**: A list of every live and test run, with status, timestamps, and job-level details. See [Run history](#run-history).
 
-The right side of the Builder shows the Properties panel. Click the **Properties** button in the header to show or hide it.
+The right side of the Automation Builder shows the Properties panel. Click the **Properties** button in the header to show or hide it.
 
 Click **Back to Automations** in the header to return to the Automations page. Airbyte saves your changes automatically as you work; the header shows a **Saving…** then **Saved** indicator to confirm.
 
 ### Tips for chatting with the Automation Builder Agent
 
-- **Treat the Builder chat like a spec-writing conversation**: Describe the outcome, then iterate. Ask the agent to adjust scope, change which connector it queries, or add a step.
+- **Treat the Automation Builder chat like a spec-writing conversation**: Describe the outcome, then iterate. Ask the agent to adjust scope, change which connector it queries, or add a step.
 - **Try a test run early**: Click **Run** in the header after the agent proposes an approach. A test run uses the current draft and shows up in Run History tagged **Test run**, so you can check behavior before enabling a schedule.
 - **Use the Context list to confirm connectors**: The Properties panel shows which connectors the Automation uses. If something is missing, tell the agent which connector to use and it updates the context.
 - **Keep prompts specific and self-contained**: Automations don't have a user to answer follow-up questions at run time. Spell out exactly what to check, which fields to return, and where to send the result.
@@ -90,8 +90,8 @@ Click **Back to Automations** in the header to return to the Automations page. A
 Click **Properties** in the header to open the Properties panel. The panel contains:
 
 - **Name**: The Automation's display name. Shown in the table, sidebar, and run history. Editable inline.
-- **Prompt**: The original prompt the Automation was created from, shown read-only for reference. To change what the Automation does, chat with the Builder Agent.
-- **Context**: The connectors this Automation uses. Managed through the Builder chat; edit connector membership by asking the agent to add or remove a source. Airbyte blocks direct editing here to keep the prompt and context consistent.
+- **Prompt**: The original prompt the Automation was created from, shown read-only for reference. To change what the Automation does, chat with the Automation Builder Agent.
+- **Context**: The connectors this Automation uses. Managed through the Automation Builder chat; edit connector membership by asking the agent to add or remove a source. Airbyte blocks direct editing here to keep the prompt and context consistent.
 - **Trigger**: How the Automation is invoked. Choose Manual, Schedule, or Webhook. See [Run automations](#run-automations).
 - **Schedule**: Visible when the trigger is Schedule. A builder that lets you pick a frequency (hourly, daily, weekly, monthly, or a raw cron expression) and a timezone.
 - **Result webhook (optional)**: A destination URL where Airbyte posts results after a run finishes. See [Result webhooks](#result-webhooks).
@@ -102,7 +102,7 @@ An Automation runs when its trigger fires. Choose one trigger per Automation.
 
 ### Manually
 
-Manual Automations only run when you explicitly invoke them. Click the **Run** (play) icon on the Automation's row in the Automations page, or click **Run** in the Builder header, to start a run immediately. Airbyte queues the run, shows a confirmation, and records it in Run History. Use manual runs for Automations you want available on demand but not on a clock—for example, an end-of-quarter summary you invoke when you're ready to review it.
+Manual Automations only run when you explicitly invoke them. Click the **Run** (play) icon on the Automation's row in the Automations page, or click **Run** in the Automation Builder header, to start a run immediately. Airbyte queues the run, shows a confirmation, and records it in Run History. Use manual runs for Automations you want available on demand but not on a clock—for example, an end-of-quarter summary you invoke when you're ready to review it.
 
 ### On a schedule
 
@@ -121,7 +121,7 @@ Webhook Automations are useful for event-driven workflows like "when a Salesforc
 
 ### See the status of a running automation
 
-While an Automation is running, its row on the Automations page shows a **Running** status badge, and the Run History tab in the Builder shows a run in state **Running**. The spinner clears when the run finishes; the row's status then reflects the outcome of the most recent run (Active, Paused, or Failed).
+While an Automation is running, its row on the Automations page shows a **Running** status badge, and the Run History tab in the Automation Builder shows a run in state **Running**. The spinner clears when the run finishes; the row's status then reflects the outcome of the most recent run (Active, Paused, or Failed).
 
 For a step-by-step view of what happened during a run, open the run in Run History or open the session from the [Sessions page](../../admin/sessions).
 
@@ -139,9 +139,9 @@ Result webhooks are currently persisted for scheduled Automations. If you leave 
 
 ## Run history
 
-The Run History tab in the Builder lists every run of the current Automation, most recent first. Each entry shows:
+The Run History tab in the Automation Builder lists every run of the current Automation, most recent first. Each entry shows:
 
-- A **Test run** or **Live run** badge. Test runs come from the **Run** button in the Builder; live runs come from a schedule or webhook trigger.
+- A **Test run** or **Live run** badge. Test runs come from the **Run** button in the Automation Builder; live runs come from a schedule or webhook trigger.
 - The run's overall state: **Running**, **Succeeded**, or **Failed**.
 - When the run was created and how many jobs it produced.
 - A per-job breakdown with state (Pending, Created, Ready, Running, Retrying, Cancelled, Failed, or Completed) and the job's result.
@@ -152,7 +152,7 @@ Run History is scoped to one Automation. To audit runs across every Automation i
 
 ## Automation versions
 
-Airbyte treats the current state of the Builder as the draft version of the Automation. As you chat with the Builder Agent or edit properties, Airbyte saves your changes automatically, and the header's **Saving…** / **Saved** indicator confirms each save.
+Airbyte treats the current state of the Automation Builder as the draft version of the Automation. As you chat with the Automation Builder Agent or edit properties, Airbyte saves your changes automatically, and the header's **Saving…** / **Saved** indicator confirms each save.
 
 - **Test runs** always execute against the current draft. Use them to verify a change before letting a schedule pick it up.
 - **Live runs** (scheduled or webhook) also run against the current saved state. After you edit an Automation, the next live run uses the new version.

--- a/docs/ai-agents/interfaces/ui/readme.md
+++ b/docs/ai-agents/interfaces/ui/readme.md
@@ -19,10 +19,10 @@ Every Chat and Automation runs against the connectors you've authenticated in yo
 
 ## Set up connectors and context
 
-Administrators can add connectors and configure the context store from the web app.
+Administrators can add connectors and configure the Context Store from the web app.
 
 - [**Add a connector**](./add-connector): Authenticate data sources so agents in Chats, Automations, and every other interface can use them.
-- [**Context store**](../../concepts/context-store): Configure the searchable replica of select entities from your connected data sources that powers grounded answers and large-scale analytics.
+- [**Context Store**](../../concepts/context-store): Configure the searchable replica of select entities from your connected data sources that powers grounded answers and large-scale analytics.
 
 ## Related administration
 


### PR DESCRIPTION
This PR targets the following PR:
- airbytehq/airbyte#76936

---

## What

Applies the Vale rules introduced in airbytehq/airbyte#76936 to the existing AI Agents docs. Every mis-cased `context store` becomes `Context Store`, every mis-cased `Automation builder`/`automation builder` becomes `Automation Builder`, and every bare `Builder` that refers to the Automation Builder (things like `the Builder`, `Builder header`, `Builder chat`) is rewritten to `Automation Builder`.

Scope is intentionally limited to `docs/ai-agents/` per review feedback on the rule PR: we enforce the rule globally but only apply text fixes inside the AI Agents section for now.

## How

Mechanical find-and-replace pass:

- `sed` to rewrite `context store` / `Context store` to `Context Store` in concept and interface pages.
- `perl -pe` with negative lookbehinds to rewrite bare `Builder` (not preceded by `Connector ` or `Automation `) to `Automation Builder`.
- Manual review of each changed line to make sure the replacement reads correctly.

## Review guide

1. `docs/ai-agents/concepts/context-store.md` — most of the `Context Store` fixes live here.
2. `docs/ai-agents/interfaces/ui/automations.md` — bulk of the bare-`Builder` rewrites.
3. `docs/ai-agents/interfaces/ui/add-connector.md`, `interfaces/ui/readme.md`, `interfaces/api/execute.md`, `interfaces/mcp/readme.md`, `get-started/skills/readme.md` — smaller fixes.

Verified locally: `vale ../docs/ai-agents/` with the rules from airbytehq/airbyte#76936 returns zero `airbyte-agents.*` alerts on this branch.

## User Impact

No functional changes — reads the same, just with consistent product-name capitalization. Once merged, the AI Agents docs lint cleanly against the new Vale rules.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

Link to Devin session: https://app.devin.ai/sessions/20ce3272782940cf8a10244e60408eed
Requested by: @ian-at-airbyte