### PR TITLE
docs(ai-agents): remove widget tokens from Interfaces > API

### DIFF
--- a/docs/ai-agents/interfaces/api/add-connector.md
+++ b/docs/ai-agents/interfaces/api/add-connector.md
@@ -107,10 +107,10 @@ The `workspace_name` field identifies which [workspace](./workspaces) the connec
 
 <!--
 AGENTIC-1140: create-connector doesn't autocreate workspaces (404s when
-the workspace_name is new), while scoped-token and widget-token mint do
-autocreate. Readers following the default narrative on this page stay on
-"default", so they never encounter this. Revisit when autocreate is
-consistent across endpoints.
+the workspace_name is new), while scoped-token mint does autocreate.
+Readers following the default narrative on this page stay on "default",
+so they never encounter this. Revisit when autocreate is consistent
+across endpoints.
 -->
 
 ## List connectors

--- a/docs/ai-agents/interfaces/api/authentication/readme.md
+++ b/docs/ai-agents/interfaces/api/authentication/readme.md
@@ -16,11 +16,10 @@ If you're building a Python app, the [SDK](../../sdk/authenticate) handles token
 
 The Airbyte Agent API uses a hierarchical token system. Each token type has a different scope and is designed for specific use cases.
 
-| Token type        | Use case                                                                                     | Scope                                |
-| ----------------- | -------------------------------------------------------------------------------------------- | ------------------------------------ |
-| Application token | Organization management, generating scoped and widget tokens, executing connector operations | Organization-wide                    |
-| Scoped token      | Workspace-scoped access                                                                      | Single workspace                     |
-| Widget token      | Embedding the authentication module in your app                                              | Single workspace with CORS protection |
+| Token type        | Use case                                                                          | Scope             |
+| ----------------- | --------------------------------------------------------------------------------- | ----------------- |
+| Application token | Organization management, generating scoped tokens, executing connector operations | Organization-wide |
+| Scoped token      | Workspace-scoped access                                                           | Single workspace  |
 
 ### Application token
 
@@ -48,7 +47,7 @@ The response contains your application token:
 }
 ```
 
-Application tokens are short-lived — `expires_in` is 900 seconds (15 minutes) by design, because they carry organization-wide privileges. Request a new token when yours expires. [Scoped tokens](#scoped-token) and [widget tokens](#widget-token) live longer (20 minutes) because they're already limited to a single workspace and their exposure is lower. If you're building a long-running app, cache the current token and refresh it just before `expires_in` elapses.
+Application tokens are short-lived — `expires_in` is 900 seconds (15 minutes) by design, because they carry organization-wide privileges. Request a new token when yours expires. [Scoped tokens](#scoped-token) live longer (20 minutes) because they're already limited to a single workspace and their exposure is lower. If you're building a long-running app, cache the current token and refresh it just before `expires_in` elapses.
 
 ### Scoped token
 
@@ -73,28 +72,6 @@ The response carries the scoped token as a single `token` field:
 
 If the workspace doesn't exist, Airbyte creates it automatically. Scoped tokens expire after 20 minutes.
 
-### Widget token
-
-Widget tokens are specialized tokens used by the embeddable authentication module. They include all features of scoped tokens plus origin validation for CORS protection.
-
-```bash title="Request"
-curl -X POST https://api.airbyte.ai/api/v1/account/applications/widget-token \
-  -H 'Authorization: Bearer <your_application_token>' \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "workspace_name": "default",
-    "allowed_origin": "https://yourapp.com"
-  }'
-```
-
-The widget token response also has a `token` field. The value is a JWT that wraps both a scoped token and the widget URL. The embedded authentication widget decodes this itself — your backend just forwards the `token` string to the frontend.
-
-```json title="Response"
-{
-  "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
-}
-```
-
 ## Authentication flow
 
 A typical flow for getting connected and executing an operation looks like this:
@@ -112,5 +89,3 @@ When using hosted authentication, follow these best practices:
 - **Never expose tokens in client-side code.** These tokens provide organization-wide or workspace-level access and should only be used in your backend. Ensure your frontend calls your backend instead of the API's authentication endpoints directly.
 
 - **Handle token expiration.** Application tokens expire after 15 minutes and scoped tokens expire after 20 minutes. The Python SDK handles token refresh automatically, but API users must request new tokens when the current token expires.
-
-- **Validate the `allowed_origin`** when using widget tokens to ensure requests only come from your app.

--- a/docs/ai-agents/interfaces/api/readme.md
+++ b/docs/ai-agents/interfaces/api/readme.md
@@ -24,7 +24,7 @@ If your account belongs to multiple organizations, generate your application tok
 
 The four pages in this section are designed to map one-to-one with the [SDK](../sdk) section so the same mental model works in either environment.
 
-1. **[Authentication](./authentication)**: Get an application token (and, when needed, scoped and widget tokens). This is how every subsequent call is authorized.
+1. **[Authentication](./authentication)**: Get an application token (and, when needed, a scoped token). This is how every subsequent call is authorized.
 
 2. **[Add a connector](./add-connector)**: Create a connector from a `definition_id` plus the credentials for the third-party service.
 

--- a/docs/ai-agents/interfaces/api/workspaces.md
+++ b/docs/ai-agents/interfaces/api/workspaces.md
@@ -21,24 +21,24 @@ Persist each workspace's UUID in your backend when it's created, and reference i
 
 <!--
 AGENTIC-1140: renaming a workspace makes name-keyed reads 404 while
-scoped-token/widget-token mint silently autocreates a brand-new empty
-workspace under the old name with a new UUID. The "persist the UUID"
-guidance above is the safe path for readers; we don't surface the mint
-behavior publicly. Revisit when autocreate is consistent across endpoints
-and/or rename rejects reuse of the old name.
+scoped-token mint silently autocreates a brand-new empty workspace
+under the old name with a new UUID. The "persist the UUID" guidance
+above is the safe path for readers; we don't surface the mint behavior
+publicly. Revisit when autocreate is consistent across endpoints and/or
+rename rejects reuse of the old name.
 -->
 
 
 ## Create a new workspace
 
-You don't create workspaces directly. Airbyte creates one automatically the first time you mint a [scoped token](./authentication#scoped-token) or [widget token](./authentication#widget-token) against a new `workspace_name`. Use any stable string that makes sense in your app — for example, an internal tenant ID or team slug.
+You don't create workspaces directly. Airbyte creates one automatically the first time you mint a [scoped token](./authentication#scoped-token) against a new `workspace_name`. Use any stable string that makes sense in your app — for example, an internal tenant ID or team slug.
 
 <!--
 AGENTIC-1140: create-connector doesn't autocreate a workspace — it 404s
-when the workspace_name is new. Minting a scoped or widget token against
-that name is the canonical way to create a workspace, and the paragraph
-above already routes readers through that path, so we don't need to call
-out the asymmetry publicly. Revisit when autocreate is consistent.
+when the workspace_name is new. Minting a scoped token against that name
+is the canonical way to create a workspace, and the paragraph above
+already routes readers through that path, so we don't need to call out
+the asymmetry publicly. Revisit when autocreate is consistent.
 -->
 
 


### PR DESCRIPTION
## What

Stacked on top of `docs-airbyte-agents`. Removes widget-token coverage from the Interfaces > API section so the direct-API narrative no longer exposes a concept that only applies to Airbyte Embedded (the authentication module).

Requested by @ian-at-airbyte in Slack: "branch off the docs-airbyte-agents integration branch and create a stacked PR. Remove discussion of widget tokens in Interface > API."

## How

Edits four pages under `docs/ai-agents/interfaces/api/`:

1. `authentication/readme.md`
   - Drops the "Widget token" row from the token types table.
   - Removes the entire "Widget token" section (endpoint, request/response example, explanatory paragraph).
   - Drops the "Scoped tokens and widget tokens live longer (20 minutes)" clause so only scoped tokens are mentioned.
   - Removes the `allowed_origin` bullet from "Security considerations".

2. `readme.md`
   - "How the pieces fit together": "Get an application token (and, when needed, scoped and widget tokens)" → "… (and, when needed, a scoped token)".

3. `workspaces.md`
   - "Create a new workspace": the sentence pointing readers at minting either a scoped or widget token to auto-create a workspace now only mentions scoped tokens, which is the canonical API path for non-Embedded consumers.
   - Updates the two hidden `AGENTIC-1140` HTML comments to match.

4. `add-connector.md`
   - Updates the hidden `AGENTIC-1140` HTML comment in "About `workspace_name`" to reference only scoped-token mint.

Verified no published API call example in `docs/ai-agents/interfaces/api/` still requires a widget token — all remaining `Bearer` references are `<application_token>` or `<scoped_token>`. The only remaining `widget` mentions in that tree are inside `authentication-module.md`, which has `draft: true` and isn't rendered.

## Review guide

1. `docs/ai-agents/interfaces/api/authentication/readme.md` — primary surface area, where the "Widget token" concept is fully removed.
2. `docs/ai-agents/interfaces/api/readme.md` — one-line wording tweak in the overview.
3. `docs/ai-agents/interfaces/api/workspaces.md` — "Create a new workspace" copy and hidden comment.
4. `docs/ai-agents/interfaces/api/add-connector.md` — hidden comment only.

## User Impact

Readers following the direct-API path no longer see references to widget tokens, which are specific to Airbyte Embedded and aren't reachable through the narrative these pages teach. Widget-token coverage will continue to live in the (draft) Authentication module page once that ships.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

Link to Devin session: https://app.devin.ai/sessions/4ea1f23610cf422fa78073e121460f0c