### PR TITLE
docs(ai-agents): prefer uv over pip in SDK install sample

### DIFF
--- a/docs/ai-agents/interfaces/sdk/readme.md
+++ b/docs/ai-agents/interfaces/sdk/readme.md
@@ -21,9 +21,13 @@ Log in or sign up at [app.airbyte.ai](https://app.airbyte.ai/).
 
 ## Install
 
+Add the SDK to a [uv](https://docs.astral.sh/uv/)-managed project:
+
 ```bash
-pip install airbyte-agent-sdk
+uv add airbyte-agent-sdk
 ```
+
+To install into an existing virtual environment instead, run `uv pip install airbyte-agent-sdk`.
 
 The install name uses dashes. The Python import name uses underscores: `from airbyte_agent_sdk import Workspace, connect`.
 


### PR DESCRIPTION
This PR targets the following PR:
- #76447

---

## What

The SDK interface page shows a bare `pip install airbyte-agent-sdk` command. The rest of the `docs/ai-agents` Python install samples already prefer [uv](https://docs.astral.sh/uv/) — the quickstart tutorials use `uv init` + `uv add`, and every connector README uses `uv pip install`. Update the SDK interface page so its install sample uses uv as well.

## How

Replaces the single `pip install airbyte-agent-sdk` block in <ref_file file="/home/ubuntu/repos/airbyte/docs/ai-agents/interfaces/sdk/readme.md" /> with a `uv add airbyte-agent-sdk` block, plus a one-line fallback pointing at `uv pip install airbyte-agent-sdk` for users installing into an existing virtual environment.

## Review guide

1. `docs/ai-agents/interfaces/sdk/readme.md`

## User Impact

Docs-only. Readers following the SDK interface page land on the uv-native install path that matches the quickstart tutorials, with a pip-compatible fallback for existing environments.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

Requested by @ian-at-airbyte in Slack.

Link to Devin session: https://app.devin.ai/sessions/dbfd30b34ae84239abe6796da2cb06a5