### PR TITLE
Add Segments stream to Klaviyo source connector

### DIFF
--- a/airbyte-integrations/connectors/source-klaviyo/integration_tests/abnormal_state.json
+++ b/airbyte-integrations/connectors/source-klaviyo/integration_tests/abnormal_state.json
@@ -243,5 +243,16 @@
         "name": "email_templates"
       }
     }
+  },
+  {
+    "type": "STREAM",
+    "stream": {
+      "stream_state": {
+        "updated": "2120-10-10T00:00:00+00:00"
+      },
+      "stream_descriptor": {
+        "name": "segments"
+      }
+    }
   }
 ]

--- a/airbyte-integrations/connectors/source-klaviyo/integration_tests/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-klaviyo/integration_tests/configured_catalog.json
@@ -149,6 +149,21 @@
       "cursor_field": ["updated"],
       "destination_sync_mode": "append",
       "primary_key": [["id"]]
+    },
+    {
+      "stream": {
+        "name": "segments",
+        "json_schema": {},
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "source_defined_cursor": true,
+        "default_cursor_field": ["updated"],
+        "source_defined_primary_key": [["id"]],
+        "namespace": null
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["updated"],
+      "destination_sync_mode": "append",
+      "primary_key": [["id"]]
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-klaviyo/manifest.yaml
+++ b/airbyte-integrations/connectors/source-klaviyo/manifest.yaml
@@ -977,6 +977,70 @@ definitions:
         type: InlineSchemaLoader
         schema:
           $ref: "#/schemas/lists_detailed"
+    segments:
+      type: DeclarativeStream
+      name: segments
+      primary_key:
+        - id
+      retriever:
+        type: SimpleRetriever
+        requester:
+          $ref: "#/definitions/base_requester"
+          path: segments
+          http_method: GET
+          request_headers:
+            Accept: application/json
+            Revision: "2024-10-15"
+          error_handler:
+            type: CustomErrorHandler
+            class_name: >-
+              source_declarative_manifest.components.KlaviyoErrorHandler
+            backoff_strategies:
+              - type: WaitTimeFromHeader
+                header: Retry-After
+            response_filters:
+              - type: HttpResponseFilter
+                action: RATE_LIMITED
+                http_codes:
+                  - 429
+              - type: HttpResponseFilter
+                action: FAIL
+                http_codes:
+                  - 401
+                  - 403
+                failure_type: config_error
+                error_message: >-
+                  Please provide a valid API key and make sure it has
+                  permissions to read specified streams.
+        record_selector:
+          type: RecordSelector
+          extractor:
+            type: DpathExtractor
+            field_path:
+              - data
+        paginator:
+          type: DefaultPaginator
+          page_token_option:
+            type: RequestPath
+          pagination_strategy:
+            type: CursorPagination
+            cursor_value: "{{ response.get('links', {}).get('next') }}"
+      incremental_sync:
+        type: DatetimeBasedCursor
+        cursor_field: updated
+        datetime_format: "%Y-%m-%dT%H:%M:%S%z"
+        start_datetime: "{{ config.get('start_date', '2012-01-01T00:00:00Z') }}"
+        is_client_side_incremental: true
+      transformations:
+        - type: AddFields
+          fields:
+            - path:
+                - updated
+              value: "{{ record.get('attributes', {}).get('updated') }}"
+      schema_loader:
+        type: InlineSchemaLoader
+        schema:
+          $ref: "#/schemas/segments"
     flow_series_reports:
       type: DeclarativeStream
       name: flow_series_reports
@@ -1278,6 +1342,7 @@ streams:
   - $ref: "#/definitions/streams/metrics"
   - $ref: "#/definitions/streams/lists"
   - $ref: "#/definitions/streams/lists_detailed"
+  - $ref: "#/definitions/streams/segments"
   # Analytics streams
   - $ref: "#/definitions/streams/flow_series_reports"
   - $ref: "#/definitions/streams/campaign_values_reports"
@@ -1384,6 +1449,7 @@ metadata:
     metrics: false
     lists: false
     lists_detailed: false
+    segments: false
     flow_series_reports: false
     campaign_values_reports: false
   yamlComponents:
@@ -1413,6 +1479,9 @@ metadata:
         - errorHandler
         - incrementalSync
       lists_detailed:
+        - errorHandler
+        - incrementalSync
+      segments:
         - errorHandler
         - incrementalSync
       flow_series_reports:
@@ -3748,6 +3817,152 @@ schemas:
           - "null"
           - string
         format: date-time
+  segments:
+    type: object
+    $schema: http://json-schema.org/draft-07/schema#
+    additionalProperties: true
+    properties:
+      type:
+        type: string
+      attributes:
+        type:
+          - "null"
+          - object
+        properties:
+          name:
+            type:
+              - "null"
+              - string
+          definition:
+            type:
+              - "null"
+              - object
+            additionalProperties: true
+            properties:
+              condition_groups:
+                type:
+                  - "null"
+                  - array
+                items:
+                  type:
+                    - "null"
+                    - object
+                  additionalProperties: true
+          created:
+            type:
+              - "null"
+              - string
+            format: date-time
+          updated:
+            type:
+              - "null"
+              - string
+            format: date-time
+          is_active:
+            type:
+              - "null"
+              - boolean
+          is_processing:
+            type:
+              - "null"
+              - boolean
+          is_starred:
+            type:
+              - "null"
+              - boolean
+      id:
+        type: string
+      links:
+        type:
+          - "null"
+          - object
+        additionalProperties: true
+        properties:
+          self:
+            type: string
+      relationships:
+        type:
+          - "null"
+          - object
+        additionalProperties: true
+        properties:
+          flow-triggers:
+            type:
+              - "null"
+              - object
+            properties:
+              data:
+                type: array
+                items:
+                  type:
+                    - "null"
+                    - object
+                  properties:
+                    type:
+                      type:
+                        - "null"
+                        - string
+                    id:
+                      type:
+                        - "null"
+                        - string
+              links:
+                type:
+                  - "null"
+                  - object
+                properties:
+                  related:
+                    type:
+                      - "null"
+                      - string
+                  self:
+                    type:
+                      - "null"
+                      - string
+          profiles:
+            type:
+              - "null"
+              - object
+            properties:
+              links:
+                type:
+                  - "null"
+                  - object
+                properties:
+                  related:
+                    type: string
+                  self:
+                    type: string
+          tags:
+            type:
+              - "null"
+              - object
+            properties:
+              data:
+                type: array
+                items:
+                  type:
+                    - "null"
+                    - object
+                  properties:
+                    type:
+                      type: string
+                    id:
+                      type: string
+              links:
+                type:
+                  - "null"
+                  - object
+                properties:
+                  related:
+                    type: string
+                  self:
+                    type: string
+      updated:
+        type:
+          - "null"
+          - string
+        format: date-time
   flow_series_reports:
     type: object
     $schema: http://json-schema.org/draft-07/schema#
@@ -4265,6 +4480,16 @@ api_budget:
           url_path_pattern: "^/api/lists/" # matches any path beginning with '/lists/' (e.g. '/lists/123')
           params:
             "additional-fields[list]": "profile_count"
+    # Segments
+    - type: MovingWindowCallRatePolicy
+      rates:
+        - limit: 75 # burst: 75 calls per second
+          interval: PT1S
+        - limit: 750 # steady: 750 calls per minute
+          interval: PT1M
+      matchers:
+        - method: GET
+          url_path_pattern: "^/api/segments($|/)"
     # Flow Series Reports (XS tier)
     - type: MovingWindowCallRatePolicy
       rates:
@@ -4306,7 +4531,8 @@ api_budget:
 #| metrics           | https://developers.klaviyo.com/en/reference/get_metrics              | M                       | None                               | No as `step` is not defined in `incremental_sync` | 1                                                                | None                                                                            |
 #| lists             | https://developers.klaviyo.com/en/reference/get_lists                | L                       | Yes, shared with lists_detailed    | No as `step` is not defined in `incremental_sync` | 2                                                                | With other streams (lists_detailed), not within stream as `step` not defined    |
 #| lists_detailed    | https://developers.klaviyo.com/en/reference/get_lists                | 1/s                     | Yes, shared with lists             | No as `step` is not defined in `incremental_sync` | 1                                                                | With other streams (lists), not within stream as `step` not defined             |
-# Note: As of 2024-11-11, `metrics`, `lists` and `lists_detailed` are not supported by the Concurrent CDK as they do client side-filtering.
+#| segments          | https://developers.klaviyo.com/en/reference/get_segments             | L                       | None                               | No as `step` is not defined in `incremental_sync` | 1                                                                | None                                                                            |
+# Note: As of 2024-11-11, `metrics`, `lists`, `lists_detailed` and `segments` are not supported by the Concurrent CDK as they do client side-filtering.
 
 # Based on the above, the only threads that allow for slicing and hence might perform more concurrent HTTP requests are `events` and `events_detailed`. There are no slicing for the others and hence the concurrency is limited by the number of streams querying the same endpoint. Given that the event endpoint is XL, we will set a default concurrency to 10.
 

--- a/airbyte-integrations/connectors/source-klaviyo/unit_tests/mock_server/request_builder.py
+++ b/airbyte-integrations/connectors/source-klaviyo/unit_tests/mock_server/request_builder.py
@@ -62,6 +62,11 @@ class KlaviyoRequestBuilder:
         return cls("lists", api_key)
 
     @classmethod
+    def segments_endpoint(cls, api_key: str) -> "KlaviyoRequestBuilder":
+        """Create a request builder for the /segments endpoint."""
+        return cls("segments", api_key)
+
+    @classmethod
     def lists_detailed_endpoint(cls, api_key: str, list_id: str) -> "KlaviyoRequestBuilder":
         """Create a request builder for the /lists/{list_id} endpoint."""
         return cls(f"lists/{list_id}", api_key)

--- a/airbyte-integrations/connectors/source-klaviyo/unit_tests/mock_server/test_segments.py
+++ b/airbyte-integrations/connectors/source-klaviyo/unit_tests/mock_server/test_segments.py
@@ -1,0 +1,393 @@
+# Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+
+import json
+from datetime import datetime, timezone
+from unittest import TestCase
+
+import freezegun
+from unit_tests.conftest import get_source
+
+from airbyte_cdk.models import SyncMode
+from airbyte_cdk.test.catalog_builder import CatalogBuilder
+from airbyte_cdk.test.entrypoint_wrapper import read
+from airbyte_cdk.test.mock_http import HttpMocker, HttpResponse
+from airbyte_cdk.test.state_builder import StateBuilder
+from mock_server.config import ConfigBuilder
+from mock_server.request_builder import KlaviyoRequestBuilder
+from mock_server.response_builder import KlaviyoPaginatedResponseBuilder
+
+
+_NOW = datetime(2024, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+_STREAM_NAME = "segments"
+_API_KEY = "test_api_key_abc123"
+
+
+def _segment_record(segment_id: str, name: str, updated: str, created: str = "2024-01-01T10:00:00+00:00", is_active: bool = True):
+    return {
+        "type": "segment",
+        "id": segment_id,
+        "attributes": {
+            "name": name,
+            "definition": {
+                "condition_groups": [
+                    {
+                        "conditions": [
+                            {
+                                "type": "profile-group-membership",
+                                "is_member": True,
+                                "group_ids": ["group_abc"],
+                            }
+                        ]
+                    }
+                ]
+            },
+            "created": created,
+            "updated": updated,
+            "is_active": is_active,
+            "is_processing": False,
+            "is_starred": False,
+        },
+        "links": {"self": f"https://a.klaviyo.com/api/segments/{segment_id}"},
+        "relationships": {
+            "profiles": {
+                "links": {
+                    "self": f"https://a.klaviyo.com/api/segments/{segment_id}/relationships/profiles",
+                    "related": f"https://a.klaviyo.com/api/segments/{segment_id}/profiles",
+                }
+            },
+            "tags": {"data": [], "links": {"self": f"https://a.klaviyo.com/api/segments/{segment_id}/relationships/tags", "related": f"https://a.klaviyo.com/api/segments/{segment_id}/tags"}},
+            "flow-triggers": {"data": [], "links": {"self": f"https://a.klaviyo.com/api/segments/{segment_id}/relationships/flow-triggers", "related": f"https://a.klaviyo.com/api/segments/{segment_id}/flow-triggers"}},
+        },
+    }
+
+
+@freezegun.freeze_time(_NOW.isoformat())
+class TestSegmentsStream(TestCase):
+    """
+    Tests for the Klaviyo 'segments' stream.
+
+    Stream configuration from manifest.yaml:
+    - Client-side incremental sync (is_client_side_incremental: true)
+    - DatetimeBasedCursor on 'updated' field
+    - Pagination: CursorPagination via links.next
+    - Error handling: 429 RATE_LIMITED, 401/403 FAIL
+    - Transformations: AddFields to extract 'updated' from attributes
+    """
+
+    @HttpMocker()
+    def test_full_refresh_single_page(self, http_mocker: HttpMocker):
+        """
+        Given: A configured Klaviyo connector
+        When: Running a full refresh sync for the segments stream
+        Then: The connector should make the correct API request and return all records
+        """
+        config = ConfigBuilder().with_api_key(_API_KEY).with_start_date(datetime(2024, 5, 31, tzinfo=timezone.utc)).build()
+
+        http_mocker.get(
+            KlaviyoRequestBuilder.segments_endpoint(_API_KEY).build(),
+            HttpResponse(
+                body=json.dumps(
+                    {
+                        "data": [_segment_record("segment_001", "Repeat Purchasers", "2024-05-31T12:30:00+00:00")],
+                        "links": {"self": "https://a.klaviyo.com/api/segments", "next": None},
+                    }
+                ),
+                status_code=200,
+            ),
+        )
+
+        source = get_source(config=config)
+        catalog = CatalogBuilder().with_stream(_STREAM_NAME, SyncMode.full_refresh).build()
+        output = read(source, config=config, catalog=catalog)
+
+        assert len(output.records) == 1
+        record = output.records[0].record.data
+        assert record["id"] == "segment_001"
+        assert record["attributes"]["name"] == "Repeat Purchasers"
+
+    @HttpMocker()
+    def test_pagination_multiple_pages(self, http_mocker: HttpMocker):
+        """
+        Given: An API that returns multiple pages of segments
+        When: Running a full refresh sync
+        Then: The connector should follow pagination links and return all records
+        """
+        config = ConfigBuilder().with_api_key(_API_KEY).with_start_date(datetime(2024, 5, 31, tzinfo=timezone.utc)).build()
+
+        http_mocker.get(
+            KlaviyoRequestBuilder.segments_endpoint(_API_KEY).build(),
+            [
+                KlaviyoPaginatedResponseBuilder()
+                .with_records([_segment_record("segment_001", "Segment 1", "2024-05-31T10:00:00+00:00")])
+                .with_next_page_link("https://a.klaviyo.com/api/segments?page[cursor]=abc123")
+                .build(),
+                KlaviyoPaginatedResponseBuilder()
+                .with_records([_segment_record("segment_002", "Segment 2", "2024-05-31T11:00:00+00:00")])
+                .build(),
+            ],
+        )
+
+        source = get_source(config=config)
+        catalog = CatalogBuilder().with_stream(_STREAM_NAME, SyncMode.full_refresh).build()
+        output = read(source, config=config, catalog=catalog)
+
+        assert len(output.records) == 2
+        assert output.records[0].record.data["id"] == "segment_001"
+        assert output.records[1].record.data["id"] == "segment_002"
+
+    @HttpMocker()
+    def test_client_side_incremental_first_sync_no_state(self, http_mocker: HttpMocker):
+        """
+        Given: No previous state (first sync)
+        When: Running an incremental sync
+        Then: The connector should fetch all records and emit state message
+        """
+        config = ConfigBuilder().with_api_key(_API_KEY).with_start_date(datetime(2024, 5, 31, tzinfo=timezone.utc)).build()
+
+        http_mocker.get(
+            KlaviyoRequestBuilder.segments_endpoint(_API_KEY).build(),
+            HttpResponse(
+                body=json.dumps(
+                    {
+                        "data": [_segment_record("segment_001", "Test Segment", "2024-05-31T12:30:00+00:00")],
+                        "links": {"self": "https://a.klaviyo.com/api/segments", "next": None},
+                    }
+                ),
+                status_code=200,
+            ),
+        )
+
+        source = get_source(config=config)
+        catalog = CatalogBuilder().with_stream(_STREAM_NAME, SyncMode.incremental).build()
+        output = read(source, config=config, catalog=catalog)
+
+        assert len(output.records) == 1
+        assert output.records[0].record.data["id"] == "segment_001"
+
+        assert len(output.state_messages) > 0
+        latest_state = output.most_recent_state.stream_state.__dict__
+        assert "updated" in latest_state
+
+    @HttpMocker()
+    def test_client_side_incremental_with_prior_state(self, http_mocker: HttpMocker):
+        """
+        For client-side incremental streams (is_client_side_incremental: true), the connector
+        fetches all records from the API but filters them client-side based on the state.
+
+        Given: A previous sync state with an updated cursor value
+        When: Running an incremental sync
+        Then: The connector should filter records client-side and only return new/updated records
+        """
+        config = ConfigBuilder().with_api_key(_API_KEY).with_start_date(datetime(2024, 1, 1, tzinfo=timezone.utc)).build()
+        state = StateBuilder().with_stream_state(_STREAM_NAME, {"updated": "2024-03-01T00:00:00+0000"}).build()
+
+        http_mocker.get(
+            KlaviyoRequestBuilder.segments_endpoint(_API_KEY).build(),
+            HttpResponse(
+                body=json.dumps(
+                    {
+                        "data": [
+                            _segment_record("segment_old", "Old Segment", "2024-02-15T10:00:00+00:00"),
+                            _segment_record("segment_new", "New Segment", "2024-03-15T10:00:00+00:00", created="2024-03-10T10:00:00+00:00"),
+                        ],
+                        "links": {"self": "https://a.klaviyo.com/api/segments", "next": None},
+                    }
+                ),
+                status_code=200,
+            ),
+        )
+
+        source = get_source(config=config, state=state)
+        catalog = CatalogBuilder().with_stream(_STREAM_NAME, SyncMode.incremental).build()
+        output = read(source, config=config, catalog=catalog, state=state)
+
+        assert len(output.records) == 1
+        assert output.records[0].record.data["id"] == "segment_new"
+
+        assert len(output.state_messages) > 0
+        latest_state = output.most_recent_state.stream_state.__dict__
+        assert latest_state["updated"] == "2024-03-15T10:00:00+0000"
+
+    @HttpMocker()
+    def test_data_feed_stops_pagination_on_old_records(self, http_mocker: HttpMocker):
+        """
+        Given: A state with a cursor value and API returning old records
+        When: Running an incremental sync
+        Then: The connector should stop pagination when old records are detected
+        """
+        config = ConfigBuilder().with_api_key(_API_KEY).with_start_date(datetime(2024, 1, 1, tzinfo=timezone.utc)).build()
+        state = StateBuilder().with_stream_state(_STREAM_NAME, {"updated": "2024-03-01T00:00:00+0000"}).build()
+
+        http_mocker.get(
+            KlaviyoRequestBuilder.segments_endpoint(_API_KEY).build(),
+            HttpResponse(
+                body=json.dumps(
+                    {
+                        "data": [_segment_record("segment_old", "Old Segment", "2024-02-01T10:00:00+00:00")],
+                        "links": {"self": "https://a.klaviyo.com/api/segments", "next": None},
+                    }
+                ),
+                status_code=200,
+            ),
+        )
+
+        source = get_source(config=config, state=state)
+        catalog = CatalogBuilder().with_stream(_STREAM_NAME, SyncMode.incremental).build()
+        output = read(source, config=config, catalog=catalog, state=state)
+
+        assert len(output.records) == 0
+
+    @HttpMocker()
+    def test_transformation_adds_updated_field(self, http_mocker: HttpMocker):
+        """
+        Given: A segment record with updated in attributes
+        When: Running a sync
+        Then: The 'updated' field should be added at the root level of the record
+        """
+        config = ConfigBuilder().with_api_key(_API_KEY).with_start_date(datetime(2024, 5, 31, tzinfo=timezone.utc)).build()
+
+        http_mocker.get(
+            KlaviyoRequestBuilder.segments_endpoint(_API_KEY).build(),
+            HttpResponse(
+                body=json.dumps(
+                    {
+                        "data": [_segment_record("segment_transform", "Transform Test", "2024-05-31T14:45:00+00:00")],
+                        "links": {"self": "https://a.klaviyo.com/api/segments", "next": None},
+                    }
+                ),
+                status_code=200,
+            ),
+        )
+
+        source = get_source(config=config)
+        catalog = CatalogBuilder().with_stream(_STREAM_NAME, SyncMode.full_refresh).build()
+        output = read(source, config=config, catalog=catalog)
+
+        assert len(output.records) == 1
+        record = output.records[0].record.data
+        assert "updated" in record
+        assert record["updated"] == "2024-05-31T14:45:00+00:00"
+
+    @HttpMocker()
+    def test_rate_limit_429_handling(self, http_mocker: HttpMocker):
+        """
+        Given: An API that returns a 429 rate limit error
+        When: Making an API request
+        Then: The connector should respect the Retry-After header and retry
+        """
+        config = ConfigBuilder().with_api_key(_API_KEY).with_start_date(datetime(2024, 5, 31, tzinfo=timezone.utc)).build()
+
+        http_mocker.get(
+            KlaviyoRequestBuilder.segments_endpoint(_API_KEY).build(),
+            [
+                HttpResponse(
+                    body=json.dumps({"errors": [{"detail": "Rate limit exceeded"}]}),
+                    status_code=429,
+                    headers={"Retry-After": "1"},
+                ),
+                HttpResponse(
+                    body=json.dumps(
+                        {
+                            "data": [_segment_record("segment_after_retry", "After Retry", "2024-05-31T10:00:00+00:00")],
+                            "links": {"self": "https://a.klaviyo.com/api/segments", "next": None},
+                        }
+                    ),
+                    status_code=200,
+                ),
+            ],
+        )
+
+        source = get_source(config=config)
+        catalog = CatalogBuilder().with_stream(_STREAM_NAME, SyncMode.full_refresh).build()
+        output = read(source, config=config, catalog=catalog)
+
+        assert len(output.records) == 1
+        assert output.records[0].record.data["id"] == "segment_after_retry"
+
+        log_messages = [log.log.message for log in output.logs]
+        assert any(
+            "Backing off" in msg and "UserDefinedBackoffException" in msg and "429" in msg for msg in log_messages
+        ), "Expected backoff log message for 429 rate limit"
+        assert any(
+            "Sleeping for" in msg and "seconds" in msg for msg in log_messages
+        ), "Expected retry sleeping log message for 429 rate limit"
+
+    @HttpMocker()
+    def test_unauthorized_401_error_fails(self, http_mocker: HttpMocker):
+        """
+        Given: Invalid API credentials
+        When: Making an API request that returns 401
+        Then: The connector should fail with a config error
+        """
+        config = ConfigBuilder().with_api_key("invalid_key").with_start_date(datetime(2024, 5, 31, tzinfo=timezone.utc)).build()
+
+        http_mocker.get(
+            KlaviyoRequestBuilder.segments_endpoint("invalid_key").build(),
+            HttpResponse(
+                body=json.dumps({"errors": [{"detail": "Invalid API key"}]}),
+                status_code=401,
+            ),
+        )
+
+        source = get_source(config=config)
+        catalog = CatalogBuilder().with_stream(_STREAM_NAME, SyncMode.full_refresh).build()
+        output = read(source, config=config, catalog=catalog, expecting_exception=True)
+
+        assert len(output.records) == 0
+        expected_error_message = "Please provide a valid API key and make sure it has permissions to read specified streams."
+        log_messages = [log.log.message for log in output.logs]
+        assert any(
+            expected_error_message in msg for msg in log_messages
+        ), f"Expected error message '{expected_error_message}' in logs for 401 authentication failure"
+
+    @HttpMocker()
+    def test_forbidden_403_error_fails(self, http_mocker: HttpMocker):
+        """
+        Given: API credentials with insufficient permissions
+        When: Making an API request that returns 403
+        Then: The connector should fail with a config error
+        """
+        config = ConfigBuilder().with_api_key(_API_KEY).with_start_date(datetime(2024, 5, 31, tzinfo=timezone.utc)).build()
+
+        http_mocker.get(
+            KlaviyoRequestBuilder.segments_endpoint(_API_KEY).build(),
+            HttpResponse(
+                body=json.dumps({"errors": [{"detail": "Forbidden - insufficient permissions"}]}),
+                status_code=403,
+            ),
+        )
+
+        source = get_source(config=config)
+        catalog = CatalogBuilder().with_stream(_STREAM_NAME, SyncMode.full_refresh).build()
+        output = read(source, config=config, catalog=catalog, expecting_exception=True)
+
+        assert len(output.records) == 0
+        expected_error_message = "Please provide a valid API key and make sure it has permissions to read specified streams."
+        log_messages = [log.log.message for log in output.logs]
+        assert any(
+            expected_error_message in msg for msg in log_messages
+        ), f"Expected error message '{expected_error_message}' in logs for 403 permission failure"
+
+    @HttpMocker()
+    def test_empty_results(self, http_mocker: HttpMocker):
+        """
+        Given: An API that returns no segments
+        When: Running a full refresh sync
+        Then: The connector should return zero records without errors
+        """
+        config = ConfigBuilder().with_api_key(_API_KEY).with_start_date(datetime(2024, 5, 31, tzinfo=timezone.utc)).build()
+
+        http_mocker.get(
+            KlaviyoRequestBuilder.segments_endpoint(_API_KEY).build(),
+            HttpResponse(
+                body=json.dumps({"data": [], "links": {"self": "https://a.klaviyo.com/api/segments", "next": None}}),
+                status_code=200,
+            ),
+        )
+
+        source = get_source(config=config)
+        catalog = CatalogBuilder().with_stream(_STREAM_NAME, SyncMode.full_refresh).build()
+        output = read(source, config=config, catalog=catalog)
+
+        assert len(output.records) == 0
+        assert not any(log.log.level == "ERROR" for log in output.logs)

--- a/airbyte-integrations/connectors/source-klaviyo/unit_tests/resource/http/response/segments.json
+++ b/airbyte-integrations/connectors/source-klaviyo/unit_tests/resource/http/response/segments.json
@@ -1,0 +1,52 @@
+[
+  {
+    "type": "segment",
+    "id": "segment_001",
+    "attributes": {
+      "name": "Repeat Purchasers",
+      "definition": {
+        "condition_groups": [
+          {
+            "conditions": [
+              {
+                "type": "profile-group-membership",
+                "is_member": true,
+                "group_ids": ["group_abc"]
+              }
+            ]
+          }
+        ]
+      },
+      "created": "2024-01-01T10:00:00+00:00",
+      "updated": "2024-01-15T12:30:00+00:00",
+      "is_active": true,
+      "is_processing": false,
+      "is_starred": false
+    },
+    "links": {
+      "self": "https://a.klaviyo.com/api/segments/segment_001"
+    },
+    "relationships": {
+      "profiles": {
+        "links": {
+          "self": "https://a.klaviyo.com/api/segments/segment_001/relationships/profiles",
+          "related": "https://a.klaviyo.com/api/segments/segment_001/profiles"
+        }
+      },
+      "tags": {
+        "data": [],
+        "links": {
+          "self": "https://a.klaviyo.com/api/segments/segment_001/relationships/tags",
+          "related": "https://a.klaviyo.com/api/segments/segment_001/tags"
+        }
+      },
+      "flow-triggers": {
+        "data": [],
+        "links": {
+          "self": "https://a.klaviyo.com/api/segments/segment_001/relationships/flow-triggers",
+          "related": "https://a.klaviyo.com/api/segments/segment_001/flow-triggers"
+        }
+      }
+    }
+  }
+]


### PR DESCRIPTION
## What

- Add a new segments stream to the Klaviyo source connector, backed by the [GET /api/segments](https://developers.klaviyo.com/en/reference/get_segments) endpoint
- The stream is semi-incremental (client-side filtering on the updated cursor field), matching the pattern used by lists and metrics
- Includes cursor-based pagination via links.next, standard error handling (429 retry, 401/403 config error), and an AddFields transformation to surface updated at the record root
- Adds L-tier rate limiting (75/s burst, 750/m steady) per Klaviyo's API documentation


## How
- New segments stream definition under definitions.streams
- Stream ref added to the root streams list
- Inline JSON schema under schemas.segments covering all response fields (name, definition, created, updated, is_active, is_processing, is_starred, relationships, links)
- Metadata entries (autoImportSchema, yamlComponents)
- Rate limit policy in api_budget
- unit_tests/mock_server/test_segments.py (new)

- 10 test cases: full refresh, pagination, incremental with/without state, client-side filtering, updated field transformation, 429/401/403 error handling, empty results
- unit_tests/mock_server/request_builder.py

- Added segments_endpoint() factory method
unit_tests/resource/http/response/segments.json (new)

- Mock segment response fixture
integration_tests/configured_catalog.json

- Added segments stream entry
integration_tests/abnormal_state.json

- Added segments far-future state entry

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
