### PR TITLE
feat(destination-clickhouse): support Replicated database engine

### DIFF
--- a/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: ce0d828e-1dc4-496c-b122-2da42e637e48
-  dockerImageTag: 2.1.23
+  dockerImageTag: 2.1.24
   dockerRepository: airbyte/destination-clickhouse
   githubIssueLabel: destination-clickhouse
   icon: clickhouse.svg

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseSqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseSqlGenerator.kt
@@ -13,11 +13,14 @@ import io.airbyte.cdk.load.message.Meta.Companion.COLUMN_NAME_AB_META
 import io.airbyte.cdk.load.message.Meta.Companion.COLUMN_NAME_AB_RAW_ID
 import io.airbyte.cdk.load.schema.model.StreamTableSchema
 import io.airbyte.cdk.load.schema.model.TableName
+import io.airbyte.integrations.destination.clickhouse.spec.ClickhouseConfiguration
 import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.inject.Singleton
 
 @Singleton
-class ClickhouseSqlGenerator {
+class ClickhouseSqlGenerator(
+    private val config: ClickhouseConfiguration,
+) {
     private val log = KotlinLogging.logger {}
 
     fun createNamespace(namespace: String): String {
@@ -48,6 +51,10 @@ class ClickhouseSqlGenerator {
                 }
             }
 
+        // When the target database uses the Replicated engine, ClickHouse auto-manages the
+        // zookeeper path and replica name for Replicated*MergeTree tables. Passing them
+        // explicitly is rejected, so the engine is emitted path-less.
+        val replicatedPrefix = if (config.useReplicatedTables) "Replicated" else ""
         val engine =
             when (tableSchema.importType) {
                 is Dedupe -> {
@@ -65,9 +72,9 @@ class ClickhouseSqlGenerator {
                             // is invalid
                             COLUMN_NAME_AB_EXTRACTED_AT
                         }
-                    "ReplacingMergeTree($versionColumn)"
+                    "${replicatedPrefix}ReplacingMergeTree($versionColumn)"
                 }
-                else -> "MergeTree()"
+                else -> "${replicatedPrefix}MergeTree()"
             }
 
         return """

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/spec/ClickhouseConfiguration.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/spec/ClickhouseConfiguration.kt
@@ -18,6 +18,7 @@ data class ClickhouseConfiguration(
     val username: String,
     val password: String,
     val enableJson: Boolean,
+    val useReplicatedTables: Boolean,
     val tunnelConfig: SshTunnelMethodConfiguration,
     val recordWindowSize: Long?,
 ) : DestinationConfiguration() {
@@ -51,6 +52,7 @@ class ClickhouseConfigurationFactory :
             username = pojo.username,
             password = pojo.password,
             enableJson = pojo.enableJson ?: false,
+            useReplicatedTables = pojo.useReplicatedTables ?: false,
             tunnelConfig = pojo.getTunnelMethodValue() ?: SshNoTunnelMethod,
             recordWindowSize = pojo.recordWindowSize,
         )
@@ -75,6 +77,10 @@ class ClickhouseConfigurationFactory :
             username = overrides.getOrDefault("username", spec.username),
             enableJson =
                 overrides.getOrDefault("enable_json", spec.enableJson.toString()).toBoolean(),
+            useReplicatedTables =
+                overrides
+                    .getOrDefault("use_replicated_tables", spec.useReplicatedTables.toString())
+                    .toBoolean(),
             tunnelConfig = spec.getTunnelMethodValue() ?: SshNoTunnelMethod,
             recordWindowSize = spec.recordWindowSize,
         )

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/spec/ClickhouseSpecification.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/spec/ClickhouseSpecification.kt
@@ -31,6 +31,7 @@ sealed class ClickhouseSpecification : ConfigurationSpecification() {
     abstract val username: String
     abstract val password: String
     abstract val enableJson: Boolean?
+    abstract val useReplicatedTables: Boolean?
     abstract fun getTunnelMethodValue(): SshTunnelMethodConfiguration?
     abstract val recordWindowSize: Long?
 }
@@ -81,6 +82,19 @@ class ClickhouseSpecificationOss : ClickhouseSpecification() {
     @get:JsonProperty("enable_json")
     @get:JsonSchemaInject(json = """{"order": 6, "default": false}""")
     override val enableJson: Boolean? = false
+
+    @get:JsonSchemaTitle("Use Replicated Tables")
+    @get:JsonPropertyDescription(
+        "Create tables using ClickHouse's Replicated engines (ReplicatedMergeTree / " +
+            "ReplicatedReplacingMergeTree) with no explicit ZooKeeper path or replica name. " +
+            "Enable this when the target database uses the <code>Replicated</code> database " +
+            "engine — ClickHouse will manage the path and replica macros automatically. Leave " +
+            "disabled for single-node servers, ClickHouse Cloud, or databases that don't use " +
+            "the Replicated engine."
+    )
+    @get:JsonProperty("use_replicated_tables")
+    @get:JsonSchemaInject(json = """{"order": 7, "default": false, "group": "advanced"}""")
+    override val useReplicatedTables: Boolean? = false
 
     @JsonIgnore
     @ConfigurationBuilder(configurationPrefix = "tunnel_method")
@@ -158,6 +172,11 @@ open class ClickhouseSpecificationCloud : ClickhouseSpecification() {
     @get:JsonProperty("enable_json")
     @get:JsonSchemaInject(json = """{"order": 6, "default": false}""")
     override val enableJson: Boolean? = false
+
+    // ClickHouse Cloud manages replication via SharedMergeTree — hidden and fixed to false.
+    @get:JsonProperty("use_replicated_tables")
+    @get:JsonSchemaInject(json = """{"default": false, "airbyte_hidden": true}""")
+    override val useReplicatedTables: Boolean? = false
 
     @JsonIgnore
     @ConfigurationBuilder(configurationPrefix = "tunnel_method")

--- a/airbyte-integrations/connectors/destination-clickhouse/src/test/kotlin/io/airbyte/integrations/destination/clickhouse/check/ClickhouseCheckerTest.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/test/kotlin/io/airbyte/integrations/destination/clickhouse/check/ClickhouseCheckerTest.kt
@@ -154,6 +154,7 @@ class ClickhouseCheckerTest {
                 username = username,
                 password = password,
                 enableJson = enableJson,
+                useReplicatedTables = false,
                 tunnelConfig = SshNoTunnelMethod,
                 recordWindowSize = recordWindow,
             )

--- a/airbyte-integrations/connectors/destination-clickhouse/src/test/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseSqlGeneratorTest.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/test/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseSqlGeneratorTest.kt
@@ -6,10 +6,17 @@ package io.airbyte.integrations.destination.clickhouse.client
 
 import com.github.vertical_blank.sqlformatter.SqlFormatter
 import com.github.vertical_blank.sqlformatter.languages.Dialect
+import io.airbyte.cdk.load.command.Append
+import io.airbyte.cdk.load.command.Dedupe
 import io.airbyte.cdk.load.component.ColumnChangeset
 import io.airbyte.cdk.load.component.ColumnType
 import io.airbyte.cdk.load.component.ColumnTypeChange
+import io.airbyte.cdk.load.schema.model.StreamTableSchema
 import io.airbyte.cdk.load.schema.model.TableName
+import io.airbyte.cdk.ssh.SshNoTunnelMethod
+import io.airbyte.integrations.destination.clickhouse.spec.ClickhouseConfiguration
+import io.mockk.every
+import io.mockk.mockk
 import kotlin.test.assertTrue
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
@@ -20,7 +27,54 @@ import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 
 class ClickhouseSqlGeneratorTest {
-    private val clickhouseSqlGenerator = ClickhouseSqlGenerator()
+    private val clickhouseSqlGenerator = ClickhouseSqlGenerator(testConfig())
+
+    private fun testConfig(useReplicatedTables: Boolean = false) =
+        ClickhouseConfiguration(
+            hostname = "localhost",
+            port = "8123",
+            protocol = "http",
+            database = "default",
+            username = "default",
+            password = "",
+            enableJson = false,
+            useReplicatedTables = useReplicatedTables,
+            tunnelConfig = SshNoTunnelMethod,
+            recordWindowSize = null,
+        )
+
+    private fun mockSchema(importType: io.airbyte.cdk.load.command.ImportType): StreamTableSchema =
+        mockk(relaxed = true) {
+            every { columnSchema } returns
+                mockk(relaxed = true) {
+                    every { finalSchema } returns LinkedHashMap.newLinkedHashMap(0)
+                }
+            every { this@mockk.importType } returns importType
+            every { getPrimaryKey() } returns emptyList()
+            every { getCursor() } returns emptyList()
+        }
+
+    @Test
+    fun `createTable uses plain engines when useReplicatedTables is false`() {
+        val gen = ClickhouseSqlGenerator(testConfig(useReplicatedTables = false))
+        val appendSql = gen.createTable(TableName("ns", "t"), mockSchema(Append), replace = false)
+        val dedupeSql = gen.createTable(TableName("ns", "t"), mockSchema(mockk<Dedupe>(relaxed = true)), replace = false)
+        assertTrue(appendSql.contains("ENGINE = MergeTree()"), appendSql)
+        assertTrue(dedupeSql.contains("ENGINE = ReplacingMergeTree("), dedupeSql)
+        assertTrue(!appendSql.contains("Replicated"))
+        assertTrue(!dedupeSql.contains("Replicated"))
+    }
+
+    @Test
+    fun `createTable uses Replicated engines when useReplicatedTables is true`() {
+        val gen = ClickhouseSqlGenerator(testConfig(useReplicatedTables = true))
+        val appendSql = gen.createTable(TableName("ns", "t"), mockSchema(Append), replace = false)
+        val dedupeSql = gen.createTable(TableName("ns", "t"), mockSchema(mockk<Dedupe>(relaxed = true)), replace = false)
+        assertTrue(appendSql.contains("ENGINE = ReplicatedMergeTree()"), appendSql)
+        assertTrue(dedupeSql.contains("ENGINE = ReplicatedReplacingMergeTree("), dedupeSql)
+        assertTrue(!appendSql.contains("/clickhouse/"), "path-less: $appendSql")
+        assertTrue(!appendSql.contains("{replica}"), "no replica arg: $appendSql")
+    }
 
     @Test
     fun testCreateNamespace() {

--- a/docs/integrations/destinations/clickhouse.md
+++ b/docs/integrations/destinations/clickhouse.md
@@ -179,6 +179,7 @@ This destination supports [namespaces](https://docs.airbyte.com/platform/using-a
 
 | Version    | Date       | Pull Request                                               | Subject                                                                        |
 |:-----------|:-----------|:-----------------------------------------------------------|:-------------------------------------------------------------------------------|
+| 2.1.24     | 2026-04-20 | [TBD](https://github.com/airbytehq/airbyte/pull/TBD)       | Add `use_replicated_tables` option for databases using the Replicated engine.  |
 | 2.1.23     | 2026-02-04 | [72857](https://github.com/airbytehq/airbyte/pull/72857)   | No user-facing changes (Upgrade CDK to 0.2.8)                    |
 | 2.1.22     | 2026-01-26 | [71784](https://github.com/airbytehq/airbyte/pull/71784)   | No user-facing changes (internal refactor SSH tunnel logic)                    |
 | 2.1.21     | 2026-01-20 | [72294](https://github.com/airbytehq/airbyte/pull/72294)   | Upgrade CDK to 0.2.0                                                           |


### PR DESCRIPTION
 ## What
  The destination currently hardcodes `MergeTree` / `ReplacingMergeTree`. Inside a database created with `ENGINE = Replicated(...)` this replicates metadata only — table data is not replicated. Adds an opt-in flag to emit `Replicated*MergeTree()` engines so ClickHouse auto-manages
  the ZooKeeper path and replica macros.

  ## How
  - New `use_replicated_tables` boolean on the OSS spec (default `false`, in the `advanced` group).
  - Hidden and pinned to `false` on the Cloud spec — SharedMergeTree handles replication there.
  - `ClickhouseSqlGenerator` prefixes `Replicated` to the emitted engine when the flag is on, using the path-less form required inside a Replicated database.
  - `dockerImageTag` bumped to `2.1.24` + changelog entry.

  ## Review guide
  1. `spec/ClickhouseSpecification.kt` — OSS flag + hidden Cloud override
  2. `client/ClickhouseSqlGenerator.kt` — engine emission
  3. `spec/ClickhouseConfiguration.kt` — plumbing

  ## User Impact
  No change by default. Users whose target database uses the Replicated engine can enable the new advanced option to get properly replicated tables.

  ## Can this PR be safely reverted and rolled back?
  - [x] YES 💚