### PR TITLE
feat(source-snapchat-marketing): re-enable api_budget at 100/10s with concurrency 4 for tuning iteration 5

### DIFF
--- a/airbyte-integrations/connectors/source-snapchat-marketing/manifest.yaml
+++ b/airbyte-integrations/connectors/source-snapchat-marketing/manifest.yaml
@@ -10693,16 +10693,16 @@ schemas:
           - number
         description: Total time viewers spend on viewing content in milliseconds.
 
-# api_budget:
-#   type: HTTPAPIBudget
-#   policies:
-#     - type: MovingWindowCallRatePolicy
-#       rates:
-#         - limit: 100
-#           interval: PT10S
-#       matchers: []
-#   status_codes_for_ratelimit_hit:
-#     - 429
+api_budget:
+  type: HTTPAPIBudget
+  policies:
+    - type: MovingWindowCallRatePolicy
+      rates:
+        - limit: 100
+          interval: PT10S
+      matchers: []
+  status_codes_for_ratelimit_hit:
+    - 429
 
 concurrency_level:
   type: ConcurrencyLevel

--- a/airbyte-integrations/connectors/source-snapchat-marketing/metadata.yaml
+++ b/airbyte-integrations/connectors/source-snapchat-marketing/metadata.yaml
@@ -8,7 +8,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 200330b2-ea62-4d11-ac6d-cfe3e3f8ab2b
-  dockerImageTag: 1.5.33-rc.4
+  dockerImageTag: 1.5.33-rc.5
   dockerRepository: airbyte/source-snapchat-marketing
   githubIssueLabel: source-snapchat-marketing
   icon: snapchat.svg

--- a/docs/integrations/sources/snapchat-marketing.md
+++ b/docs/integrations/sources/snapchat-marketing.md
@@ -143,7 +143,7 @@ Syncing data with an hourly granularity often generates large data volumes and c
 
 | Version    | Date       | Pull Request                                             | Subject                                                                        |
 |:-----------|:-----------|:---------------------------------------------------------|:-------------------------------------------------------------------------------|
-| 1.5.33-rc.5 | 2026-04-23 | [TBD](https://github.com/airbytehq/airbyte/pull/TBD) | Re-enable api_budget at 100/10s with concurrency 4 for tuning iteration 5 |
+| 1.5.33-rc.5 | 2026-04-23 | [76950](https://github.com/airbytehq/airbyte/pull/76950) | Re-enable api_budget at 100/10s with concurrency 4 for tuning iteration 5 |
 | 1.5.33-rc.4 | 2026-04-21 | [76875](https://github.com/airbytehq/airbyte/pull/76875) | Revert to concurrency 4 without api_budget for tuning iteration 4 |
 | 1.5.33-rc.3 | 2026-04-16 | [76416](https://github.com/airbytehq/airbyte/pull/76416) | Increase api_budget from 80 to 100 calls per 10s for tuning iteration 3 |
 | 1.5.33-rc.2 | 2026-04-13 | [76255](https://github.com/airbytehq/airbyte/pull/76255) | Increase default_concurrency to 5 for tuning iteration 2 |

--- a/docs/integrations/sources/snapchat-marketing.md
+++ b/docs/integrations/sources/snapchat-marketing.md
@@ -143,6 +143,7 @@ Syncing data with an hourly granularity often generates large data volumes and c
 
 | Version    | Date       | Pull Request                                             | Subject                                                                        |
 |:-----------|:-----------|:---------------------------------------------------------|:-------------------------------------------------------------------------------|
+| 1.5.33-rc.5 | 2026-04-23 | [TBD](https://github.com/airbytehq/airbyte/pull/TBD) | Re-enable api_budget at 100/10s with concurrency 4 for tuning iteration 5 |
 | 1.5.33-rc.4 | 2026-04-21 | [76875](https://github.com/airbytehq/airbyte/pull/76875) | Revert to concurrency 4 without api_budget for tuning iteration 4 |
 | 1.5.33-rc.3 | 2026-04-16 | [76416](https://github.com/airbytehq/airbyte/pull/76416) | Increase api_budget from 80 to 100 calls per 10s for tuning iteration 3 |
 | 1.5.33-rc.2 | 2026-04-13 | [76255](https://github.com/airbytehq/airbyte/pull/76255) | Increase default_concurrency to 5 for tuning iteration 2 |


### PR DESCRIPTION
## What

Part of the concurrency tuning progressive rollout for `source-snapchat-marketing` ([internal issue #15313](https://github.com/airbytehq/airbyte-internal-issues/issues/15313)).

Re-enables the `api_budget` (100 calls / 10s) alongside `default_concurrency=4` for tuning iteration 5. The previous iteration (rc.4) ran concurrency=4 with budget **disabled** (commented out); this iteration re-enables the budget to isolate its effect at the lower concurrency level.

**Tuning history for context:**
| RC | Concurrency | Budget | Result |
|----|-------------|--------|--------|
| rc.1 | 4 | 80/10s | +10% vs stable |
| rc.2 | 5 | 80/10s | +7% vs stable (best) |
| rc.3 | 5 | 100/10s | +30% vs stable (regression) |
| rc.4 | 4 | disabled | +11% vs stable |
| **rc.5** | **4** | **100/10s** | **this PR — to be measured** |

## How

1. **`manifest.yaml`**: Uncomments the previously commented-out `api_budget` block (MovingWindowCallRatePolicy, 100 calls per 10s window). `concurrency_level` remains unchanged at `default_concurrency: 4`.
2. **`metadata.yaml`**: Bumps `dockerImageTag` from `1.5.33-rc.4` → `1.5.33-rc.5`.
3. **`snapchat-marketing.md`**: Adds changelog entry for rc.5.

## Review guide

1. `manifest.yaml` (lines ~10696–10710) — verify the uncommented YAML is valid and matches the intended `limit: 100` / `interval: PT10S` config.
2. `metadata.yaml` — version bump only.
3. `docs/integrations/sources/snapchat-marketing.md` — changelog entry. **Note:** PR number is `[TBD]` and should be updated post-merge.

**Key risk to watch during monitoring:** The 100/10s budget is the same rate that caused a +21% regression in rc.3 — but rc.3 ran at concurrency=5. The hypothesis is that concurrency=4 generates fewer concurrent requests, so the budget won't over-throttle. This will be validated during the 24h monitoring window after rollout.

## User Impact

No user-facing impact. This is an RC version deployed only to pinned test actors during progressive rollout tuning.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/9239df45723948cd8dfdb91b65b84593
Requested by: @sophiecuiy