### PR TITLE
chore(source-amazon-seller-partner): concurrency tuning iteration 1 (5.7.4-rc.1)

### DIFF
--- a/airbyte-integrations/connectors/source-amazon-seller-partner/manifest.yaml
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/manifest.yaml
@@ -285,7 +285,7 @@ spec:
         title: Number of Workers
         description: The number of workers to use for the connector when syncing concurrently.
         type: integer
-        default: 2
+        default: 4
         minimum: 2
         maximum: 10
         order: 14
@@ -3186,68 +3186,68 @@ definitions:
           - path: ["dataEndTime"]
             value: "{{ format_datetime(stream_slice['end_time'], '%Y-%m-%d') }}"
 
-api_budget:
-  type: HTTPAPIBudget
-  policies:
-    - type: MovingWindowCallRatePolicy
-      rates:
-        - limit: 1 # burst: 0.0167 calls per second
-          interval: PT1M
-      matchers:
-        - method: GET
-          url_path_pattern: "orders/v0/orders(\\?.*)?$" # matches '/orders' (exact or with trailing slash/extra)
-    - type: MovingWindowCallRatePolicy
-      rates:
-        - limit: 1 # burst: 0.5 call per second
-          interval: PT2S
-      matchers:
-        - method: GET
-          url_path_pattern: "orders/v0/orders/[^/]+/orderItems(\\?.*)?$" # matches /orderItems
-
-    # SP-API Reports v2021-06-30
-
-    # 1) Create report  (POST /reports/2021-06-30/reports)
-    #   Default: ~0.0167 rps (≈1/min), burst 15
-    - type: MovingWindowCallRatePolicy
-      rates:
-        - limit: 1
-          interval: PT1M
-      matchers:
-        - method: POST
-          url_path_pattern: "reports/2021-06-30/reports$"
-
-    # 2) Poll report status  (GET /reports/2021-06-30/reports/{reportId})
-    #   Default: 2 rps, burst 15
-    - type: MovingWindowCallRatePolicy
-      rates:
-        - limit: 2
-          interval: PT1S
-      matchers:
-        - method: GET
-          url_path_pattern: "reports/2021-06-30/reports/[^/]+$"
-
-    # 3) Get report document metadata  (GET /reports/2021-06-30/documents/{documentId})
-    #   Default: ~0.0167 rps (≈1/min), burst 15
-    - type: MovingWindowCallRatePolicy
-      rates:
-        - limit: 1
-          interval: PT1M
-      matchers:
-        - method: GET
-          url_path_pattern: "reports/2021-06-30/documents/[^/]+$"
-
-    # SP-API Finances v0
-    # ListFinancialEvents: Rate 0.5 rps, Burst 30
-    - type: MovingWindowCallRatePolicy
-      rates:
-        - limit: 1
-          interval: PT2S
-      matchers:
-        - method: GET
-          url_path_pattern: "finances/v0/financialEvents(\\?.*)?$"
-
-  # Other API budget settings:
-  status_codes_for_ratelimit_hit: [429]
+# api_budget:
+#   type: HTTPAPIBudget
+#   policies:
+#     - type: MovingWindowCallRatePolicy
+#       rates:
+#         - limit: 1 # burst: 0.0167 calls per second
+#           interval: PT1M
+#       matchers:
+#         - method: GET
+#           url_path_pattern: "orders/v0/orders(\\?.*)?$" # matches '/orders' (exact or with trailing slash/extra)
+#     - type: MovingWindowCallRatePolicy
+#       rates:
+#         - limit: 1 # burst: 0.5 call per second
+#           interval: PT2S
+#       matchers:
+#         - method: GET
+#           url_path_pattern: "orders/v0/orders/[^/]+/orderItems(\\?.*)?$" # matches /orderItems
+#
+#     # SP-API Reports v2021-06-30
+#
+#     # 1) Create report  (POST /reports/2021-06-30/reports)
+#     #   Default: ~0.0167 rps (≈1/min), burst 15
+#     - type: MovingWindowCallRatePolicy
+#       rates:
+#         - limit: 1
+#           interval: PT1M
+#       matchers:
+#         - method: POST
+#           url_path_pattern: "reports/2021-06-30/reports$"
+#
+#     # 2) Poll report status  (GET /reports/2021-06-30/reports/{reportId})
+#     #   Default: 2 rps, burst 15
+#     - type: MovingWindowCallRatePolicy
+#       rates:
+#         - limit: 2
+#           interval: PT1S
+#       matchers:
+#         - method: GET
+#           url_path_pattern: "reports/2021-06-30/reports/[^/]+$"
+#
+#     # 3) Get report document metadata  (GET /reports/2021-06-30/documents/{documentId})
+#     #   Default: ~0.0167 rps (≈1/min), burst 15
+#     - type: MovingWindowCallRatePolicy
+#       rates:
+#         - limit: 1
+#           interval: PT1M
+#       matchers:
+#         - method: GET
+#           url_path_pattern: "reports/2021-06-30/documents/[^/]+$"
+#
+#     # SP-API Finances v0
+#     # ListFinancialEvents: Rate 0.5 rps, Burst 30
+#     - type: MovingWindowCallRatePolicy
+#       rates:
+#         - limit: 1
+#           interval: PT2S
+#       matchers:
+#         - method: GET
+#           url_path_pattern: "finances/v0/financialEvents(\\?.*)?$"
+#
+#   # Other API budget settings:
+#   status_codes_for_ratelimit_hit: [429]
 
 streams:
   # REST Streams
@@ -3311,7 +3311,7 @@ streams:
 
 concurrency_level:
   type: ConcurrencyLevel
-  default_concurrency: "{{ config.get('num_workers', 2) }}"
+  default_concurrency: "{{ config.get('num_workers', 4) }}"
   max_concurrency: 10
 max_concurrent_async_job_count: "{{ config.get('max_async_job_count', 2) }}"
 

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/manifest.yaml
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/manifest.yaml
@@ -3186,68 +3186,68 @@ definitions:
           - path: ["dataEndTime"]
             value: "{{ format_datetime(stream_slice['end_time'], '%Y-%m-%d') }}"
 
-# api_budget:
-#   type: HTTPAPIBudget
-#   policies:
-#     - type: MovingWindowCallRatePolicy
-#       rates:
-#         - limit: 1 # burst: 0.0167 calls per second
-#           interval: PT1M
-#       matchers:
-#         - method: GET
-#           url_path_pattern: "orders/v0/orders(\\?.*)?$" # matches '/orders' (exact or with trailing slash/extra)
-#     - type: MovingWindowCallRatePolicy
-#       rates:
-#         - limit: 1 # burst: 0.5 call per second
-#           interval: PT2S
-#       matchers:
-#         - method: GET
-#           url_path_pattern: "orders/v0/orders/[^/]+/orderItems(\\?.*)?$" # matches /orderItems
-#
-#     # SP-API Reports v2021-06-30
-#
-#     # 1) Create report  (POST /reports/2021-06-30/reports)
-#     #   Default: ~0.0167 rps (≈1/min), burst 15
-#     - type: MovingWindowCallRatePolicy
-#       rates:
-#         - limit: 1
-#           interval: PT1M
-#       matchers:
-#         - method: POST
-#           url_path_pattern: "reports/2021-06-30/reports$"
-#
-#     # 2) Poll report status  (GET /reports/2021-06-30/reports/{reportId})
-#     #   Default: 2 rps, burst 15
-#     - type: MovingWindowCallRatePolicy
-#       rates:
-#         - limit: 2
-#           interval: PT1S
-#       matchers:
-#         - method: GET
-#           url_path_pattern: "reports/2021-06-30/reports/[^/]+$"
-#
-#     # 3) Get report document metadata  (GET /reports/2021-06-30/documents/{documentId})
-#     #   Default: ~0.0167 rps (≈1/min), burst 15
-#     - type: MovingWindowCallRatePolicy
-#       rates:
-#         - limit: 1
-#           interval: PT1M
-#       matchers:
-#         - method: GET
-#           url_path_pattern: "reports/2021-06-30/documents/[^/]+$"
-#
-#     # SP-API Finances v0
-#     # ListFinancialEvents: Rate 0.5 rps, Burst 30
-#     - type: MovingWindowCallRatePolicy
-#       rates:
-#         - limit: 1
-#           interval: PT2S
-#       matchers:
-#         - method: GET
-#           url_path_pattern: "finances/v0/financialEvents(\\?.*)?$"
-#
-#   # Other API budget settings:
-#   status_codes_for_ratelimit_hit: [429]
+api_budget:
+  type: HTTPAPIBudget
+  policies:
+    - type: MovingWindowCallRatePolicy
+      rates:
+        - limit: 1 # burst: 0.0167 calls per second
+          interval: PT1M
+      matchers:
+        - method: GET
+          url_path_pattern: "orders/v0/orders(\\?.*)?$" # matches '/orders' (exact or with trailing slash/extra)
+    - type: MovingWindowCallRatePolicy
+      rates:
+        - limit: 1 # burst: 0.5 call per second
+          interval: PT2S
+      matchers:
+        - method: GET
+          url_path_pattern: "orders/v0/orders/[^/]+/orderItems(\\?.*)?$" # matches /orderItems
+
+    # SP-API Reports v2021-06-30
+
+    # 1) Create report  (POST /reports/2021-06-30/reports)
+    #   Default: ~0.0167 rps (≈1/min), burst 15
+    - type: MovingWindowCallRatePolicy
+      rates:
+        - limit: 1
+          interval: PT1M
+      matchers:
+        - method: POST
+          url_path_pattern: "reports/2021-06-30/reports$"
+
+    # 2) Poll report status  (GET /reports/2021-06-30/reports/{reportId})
+    #   Default: 2 rps, burst 15
+    - type: MovingWindowCallRatePolicy
+      rates:
+        - limit: 2
+          interval: PT1S
+      matchers:
+        - method: GET
+          url_path_pattern: "reports/2021-06-30/reports/[^/]+$"
+
+    # 3) Get report document metadata  (GET /reports/2021-06-30/documents/{documentId})
+    #   Default: ~0.0167 rps (≈1/min), burst 15
+    - type: MovingWindowCallRatePolicy
+      rates:
+        - limit: 1
+          interval: PT1M
+      matchers:
+        - method: GET
+          url_path_pattern: "reports/2021-06-30/documents/[^/]+$"
+
+    # SP-API Finances v0
+    # ListFinancialEvents: Rate 0.5 rps, Burst 30
+    - type: MovingWindowCallRatePolicy
+      rates:
+        - limit: 1
+          interval: PT2S
+      matchers:
+        - method: GET
+          url_path_pattern: "finances/v0/financialEvents(\\?.*)?$"
+
+  # Other API budget settings:
+  status_codes_for_ratelimit_hit: [429]
 
 streams:
   # REST Streams

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/manifest.yaml
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/manifest.yaml
@@ -3186,68 +3186,68 @@ definitions:
           - path: ["dataEndTime"]
             value: "{{ format_datetime(stream_slice['end_time'], '%Y-%m-%d') }}"
 
-api_budget:
-  type: HTTPAPIBudget
-  policies:
-    - type: MovingWindowCallRatePolicy
-      rates:
-        - limit: 1 # burst: 0.0167 calls per second
-          interval: PT1M
-      matchers:
-        - method: GET
-          url_path_pattern: "orders/v0/orders(\\?.*)?$" # matches '/orders' (exact or with trailing slash/extra)
-    - type: MovingWindowCallRatePolicy
-      rates:
-        - limit: 1 # burst: 0.5 call per second
-          interval: PT2S
-      matchers:
-        - method: GET
-          url_path_pattern: "orders/v0/orders/[^/]+/orderItems(\\?.*)?$" # matches /orderItems
-
-    # SP-API Reports v2021-06-30
-
-    # 1) Create report  (POST /reports/2021-06-30/reports)
-    #   Default: ~0.0167 rps (≈1/min), burst 15
-    - type: MovingWindowCallRatePolicy
-      rates:
-        - limit: 1
-          interval: PT1M
-      matchers:
-        - method: POST
-          url_path_pattern: "reports/2021-06-30/reports$"
-
-    # 2) Poll report status  (GET /reports/2021-06-30/reports/{reportId})
-    #   Default: 2 rps, burst 15
-    - type: MovingWindowCallRatePolicy
-      rates:
-        - limit: 2
-          interval: PT1S
-      matchers:
-        - method: GET
-          url_path_pattern: "reports/2021-06-30/reports/[^/]+$"
-
-    # 3) Get report document metadata  (GET /reports/2021-06-30/documents/{documentId})
-    #   Default: ~0.0167 rps (≈1/min), burst 15
-    - type: MovingWindowCallRatePolicy
-      rates:
-        - limit: 1
-          interval: PT1M
-      matchers:
-        - method: GET
-          url_path_pattern: "reports/2021-06-30/documents/[^/]+$"
-
-    # SP-API Finances v0
-    # ListFinancialEvents: Rate 0.5 rps, Burst 30
-    - type: MovingWindowCallRatePolicy
-      rates:
-        - limit: 1
-          interval: PT2S
-      matchers:
-        - method: GET
-          url_path_pattern: "finances/v0/financialEvents(\\?.*)?$"
-
-  # Other API budget settings:
-  status_codes_for_ratelimit_hit: [429]
+# api_budget:
+#   type: HTTPAPIBudget
+#   policies:
+#     - type: MovingWindowCallRatePolicy
+#       rates:
+#         - limit: 1 # burst: 0.0167 calls per second
+#           interval: PT1M
+#       matchers:
+#         - method: GET
+#           url_path_pattern: "orders/v0/orders(\\?.*)?$" # matches '/orders' (exact or with trailing slash/extra)
+#     - type: MovingWindowCallRatePolicy
+#       rates:
+#         - limit: 1 # burst: 0.5 call per second
+#           interval: PT2S
+#       matchers:
+#         - method: GET
+#           url_path_pattern: "orders/v0/orders/[^/]+/orderItems(\\?.*)?$" # matches /orderItems
+#
+#     # SP-API Reports v2021-06-30
+#
+#     # 1) Create report  (POST /reports/2021-06-30/reports)
+#     #   Default: ~0.0167 rps (≈1/min), burst 15
+#     - type: MovingWindowCallRatePolicy
+#       rates:
+#         - limit: 1
+#           interval: PT1M
+#       matchers:
+#         - method: POST
+#           url_path_pattern: "reports/2021-06-30/reports$"
+#
+#     # 2) Poll report status  (GET /reports/2021-06-30/reports/{reportId})
+#     #   Default: 2 rps, burst 15
+#     - type: MovingWindowCallRatePolicy
+#       rates:
+#         - limit: 2
+#           interval: PT1S
+#       matchers:
+#         - method: GET
+#           url_path_pattern: "reports/2021-06-30/reports/[^/]+$"
+#
+#     # 3) Get report document metadata  (GET /reports/2021-06-30/documents/{documentId})
+#     #   Default: ~0.0167 rps (≈1/min), burst 15
+#     - type: MovingWindowCallRatePolicy
+#       rates:
+#         - limit: 1
+#           interval: PT1M
+#       matchers:
+#         - method: GET
+#           url_path_pattern: "reports/2021-06-30/documents/[^/]+$"
+#
+#     # SP-API Finances v0
+#     # ListFinancialEvents: Rate 0.5 rps, Burst 30
+#     - type: MovingWindowCallRatePolicy
+#       rates:
+#         - limit: 1
+#           interval: PT2S
+#       matchers:
+#         - method: GET
+#           url_path_pattern: "finances/v0/financialEvents(\\?.*)?$"
+#
+#   # Other API budget settings:
+#   status_codes_for_ratelimit_hit: [429]
 
 streams:
   # REST Streams

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/metadata.yaml
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/metadata.yaml
@@ -15,7 +15,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: e55879a8-0ef8-4557-abcf-ab34c53ec460
-  dockerImageTag: 5.7.3
+  dockerImageTag: 5.7.4-rc.1
   dockerRepository: airbyte/source-amazon-seller-partner
   documentationUrl: https://docs.airbyte.com/integrations/sources/amazon-seller-partner
   erdUrl: https://dbdocs.io/airbyteio/source-amazon-seller-partner?view=relationships
@@ -42,7 +42,7 @@ data:
       - ListFinancialEventGroups
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
     breakingChanges:
       2.0.0:
         message: "Deprecated FBA reports will be removed permanently from Cloud and Brand Analytics Reports will be removed temporarily. Updates on Brand Analytics Reports can be tracked here: [#32353](https://github.com/airbytehq/airbyte/issues/32353)"

--- a/docs/integrations/sources/amazon-seller-partner.md
+++ b/docs/integrations/sources/amazon-seller-partner.md
@@ -306,7 +306,7 @@ You may also combine this with a smaller **Financial Events Step Size** (e.g., 1
 
 | Version    | Date       | Pull Request                                              | Subject                                                                                                                                                                             |
 |:-----------|:-----------|:----------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 5.7.4-rc.1 | 2026-04-23 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Concurrency tuning iteration 1: bump default_concurrency from 2 to 4. Existing HTTPAPIBudget retained. |
+| 5.7.4-rc.1 | 2026-04-23 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Concurrency tuning iteration 1: bump default_concurrency from 2 to 4 and temporarily comment out HTTPAPIBudget to measure empirical concurrency ceiling. |
 | 5.7.3 | 2026-04-21 | [76494](https://github.com/airbytehq/airbyte/pull/76494) | Update dependencies |
 | 5.7.2 | 2026-04-13 | [75143](https://github.com/airbytehq/airbyte/pull/75143) | Fix incorrect URL path for GET_V2_SETTLEMENT_REPORT_DATA_FLAT_FILE stream — add missing `/reports/` segment |
 | 5.7.1 | 2026-04-02 | [76031](https://github.com/airbytehq/airbyte/pull/76031) | Deprecate non-functional `wait_to_avoid_fatal_errors` config option (hidden from UI) |

--- a/docs/integrations/sources/amazon-seller-partner.md
+++ b/docs/integrations/sources/amazon-seller-partner.md
@@ -306,7 +306,7 @@ You may also combine this with a smaller **Financial Events Step Size** (e.g., 1
 
 | Version    | Date       | Pull Request                                              | Subject                                                                                                                                                                             |
 |:-----------|:-----------|:----------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 5.7.4-rc.1 | 2026-04-23 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Concurrency tuning iteration 1: bump default_concurrency from 2 to 4 and temporarily comment out HTTPAPIBudget to measure empirical concurrency ceiling. |
+| 5.7.4-rc.1 | 2026-04-23 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Concurrency tuning iteration 1: bump default_concurrency from 2 to 4. Existing HTTPAPIBudget retained. |
 | 5.7.3 | 2026-04-21 | [76494](https://github.com/airbytehq/airbyte/pull/76494) | Update dependencies |
 | 5.7.2 | 2026-04-13 | [75143](https://github.com/airbytehq/airbyte/pull/75143) | Fix incorrect URL path for GET_V2_SETTLEMENT_REPORT_DATA_FLAT_FILE stream — add missing `/reports/` segment |
 | 5.7.1 | 2026-04-02 | [76031](https://github.com/airbytehq/airbyte/pull/76031) | Deprecate non-functional `wait_to_avoid_fatal_errors` config option (hidden from UI) |

--- a/docs/integrations/sources/amazon-seller-partner.md
+++ b/docs/integrations/sources/amazon-seller-partner.md
@@ -306,6 +306,7 @@ You may also combine this with a smaller **Financial Events Step Size** (e.g., 1
 
 | Version    | Date       | Pull Request                                              | Subject                                                                                                                                                                             |
 |:-----------|:-----------|:----------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 5.7.4-rc.1 | 2026-04-23 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Concurrency tuning iteration 1: bump default_concurrency from 2 to 4 and temporarily comment out HTTPAPIBudget to measure empirical concurrency ceiling. |
 | 5.7.3 | 2026-04-21 | [76494](https://github.com/airbytehq/airbyte/pull/76494) | Update dependencies |
 | 5.7.2 | 2026-04-13 | [75143](https://github.com/airbytehq/airbyte/pull/75143) | Fix incorrect URL path for GET_V2_SETTLEMENT_REPORT_DATA_FLAT_FILE stream — add missing `/reports/` segment |
 | 5.7.1 | 2026-04-02 | [76031](https://github.com/airbytehq/airbyte/pull/76031) | Deprecate non-functional `wait_to_avoid_fatal_errors` config option (hidden from UI) |


### PR DESCRIPTION
## What

Connector Concurrency Tuning & Rollout playbook — iteration 1 for `source-amazon-seller-partner`.

This RC starts the empirical concurrency tuning loop from the current GA `5.7.3` (which has `default_concurrency=2` via `num_workers` and an active HTTPAPIBudget).

**Path:** A (single-tier rate limits — Amazon SP-API has per-operation limits but no documented plan tiers; dynamic per-seller adjustments do not define discrete tiers). Rate-limit research: https://developer-docs.amazon.com/sp-api/docs/usage-plans-and-rate-limits

**Starting concurrency math:**
- `max_rate_limit` = `0.0167` rps (lowest documented limit across used endpoints: `getOrders`, `createReport`, `getReportDocument`)
- `floor(0.0167 / 4)` = `0` → triggers low-rate-limit special case
- `starting_concurrency` = `4`, `step` = `1`

## How

- `manifest.yaml`:
  - `num_workers` spec default: `2` → `4` (minimum stays `2`, maximum stays `10`)
  - `concurrency_level.default_concurrency` Jinja fallback: `{{ config.get('num_workers', 2) }}` → `{{ config.get('num_workers', 4) }}`
  - Comment out (do not delete) the `api_budget` / `HTTPAPIBudget` block covering orders, order items, reports, report documents, and financial events. Values preserved in place for restoration after tuning.
- `metadata.yaml`:
  - `dockerImageTag`: `5.7.3` → `5.7.4-rc.1`
  - `releases.rolloutConfiguration.enableProgressiveRollout`: `false` → `true`
- `docs/integrations/sources/amazon-seller-partner.md`:
  - Changelog entry for `5.7.4-rc.1`.

## Review guide

1. `airbyte-integrations/connectors/source-amazon-seller-partner/manifest.yaml` — verify the commented-out HTTPAPIBudget preserves all original policies and `num_workers` default bumped to `4`.
2. `airbyte-integrations/connectors/source-amazon-seller-partner/metadata.yaml` — version bump + progressive rollout enabled.
3. `docs/integrations/sources/amazon-seller-partner.md` — changelog.

## User Impact

No behavior change for users on GA `5.7.3`. This RC will be pinned to a small cohort of 17 Tier-2 actors with daily-or-more-frequent schedules. Pinned actors will run with `default_concurrency=4` and without the proactive client-side rate-limit throttling, relying on server-side 429 retry to surface any concurrency ceiling.

Once tuning converges, a follow-up PR will restore an updated `HTTPAPIBudget` sized to the measured concurrency and promote to GA.

**Cohort (17 actors):** pinning all eligible TIER_2 daily-or-more-frequent actors (< 20 → Phase 0 Step 8.2 limitation clause). Airbyte-internal org: 0 actors in this cohort.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

Yes — this PR only modifies `manifest.yaml`, `metadata.yaml`, and the changelog. Reverting restores `5.7.3` behavior exactly (the HTTPAPIBudget block is commented out, not deleted). During the rollout, any pinned actor can be immediately unpinned to fall back to `5.7.3`.

---
[Devin session](https://app.devin.ai/sessions/eb2ea3f67f5f4abea5dfa13d12e77ad2)

Requested by: @sophiecuiy