### PR TITLE
Prevent jdbc_url_params from spoofing resolved auth identity

### DIFF
--- a/airbyte-integrations/connectors/source-mssql/src/main/kotlin/io/airbyte/integrations/source/mssql/MsSqlServerSourceConfiguration.kt
+++ b/airbyte-integrations/connectors/source-mssql/src/main/kotlin/io/airbyte/integrations/source/mssql/MsSqlServerSourceConfiguration.kt
@@ -322,9 +322,11 @@ constructor(
                 }
             }
 
-        // Parse JDBC URL parameters
+        // Parse JDBC URL parameters. Operator-supplied jdbc_url_params is treated as the base
+        // layer; trusted resolved auth and the explicit encryption settings are layered on top
+        // so a stray (or malicious) jdbc_url_params=user=...&password=...&authentication=... can
+        // never override the resolved auth identity/mode. Mirrors the CDC path's exclusion set.
         val jdbcProperties = mutableMapOf<String, String>()
-        jdbcProperties.putAll(resolvedAuth.toJdbcProperties())
 
         // Parse URL parameters from jdbcUrlParams
         val pattern = "^([^=]+)=(.*)$".toRegex()
@@ -341,6 +343,7 @@ constructor(
                 jdbcProperties[key] = URLDecoder.decode(urlEncodedValue, StandardCharsets.UTF_8)
             }
         }
+        jdbcProperties.putAll(resolvedAuth.toJdbcProperties())
         jdbcProperties.putAll(jdbcEncryption)
 
         // Validate and process configuration values

--- a/airbyte-integrations/connectors/source-mssql/src/test/kotlin/io/airbyte/integrations/source/mssql/MsSqlServerEntraIdAuthTest.kt
+++ b/airbyte-integrations/connectors/source-mssql/src/test/kotlin/io/airbyte/integrations/source/mssql/MsSqlServerEntraIdAuthTest.kt
@@ -198,6 +198,43 @@ class MsSqlServerEntraIdAuthTest {
         Assertions.assertEquals("false", config.jdbcProperties["encrypt"])
     }
 
+    @Test
+    fun jdbcUrlParamsCannotSpoofResolvedEntraIdAuth() {
+        // Defense-in-depth: a jdbc_url_params string attempting to override the resolved Entra ID
+        // service-principal auth with a SqlPassword identity must NOT take effect on the JDBC
+        // session path. The trusted resolved auth wins.
+        val pojo = baseEncryptedPojo()
+        pojo.clientId = "client-uuid"
+        pojo.clientSecret = "secret-value"
+        pojo.jdbcUrlParams =
+            "user=attacker&password=pwned&authentication=SqlPassword&applicationIntent=ReadOnly"
+
+        val config = MsSqlServerSourceConfigurationFactory().make(pojo)
+        Assertions.assertEquals("client-uuid", config.jdbcProperties["user"])
+        Assertions.assertEquals("secret-value", config.jdbcProperties["password"])
+        Assertions.assertEquals(
+            "ActiveDirectoryServicePrincipal",
+            config.jdbcProperties["authentication"],
+        )
+        // Unrelated operator-supplied params still pass through.
+        Assertions.assertEquals("ReadOnly", config.jdbcProperties["applicationIntent"])
+    }
+
+    @Test
+    fun jdbcUrlParamsCannotSpoofResolvedSqlPasswordAuth() {
+        // Same guarantee for the legacy SQL password path: jdbc_url_params cannot swap in a
+        // different user/password/auth mode.
+        val pojo = baseEncryptedPojo()
+        pojo.username = "legit"
+        pojo.password = "legit-pw"
+        pojo.jdbcUrlParams = "user=attacker&password=pwned&authentication=ActiveDirectoryPassword"
+
+        val config = MsSqlServerSourceConfigurationFactory().make(pojo)
+        Assertions.assertEquals("legit", config.jdbcProperties["user"])
+        Assertions.assertEquals("legit-pw", config.jdbcProperties["password"])
+        Assertions.assertEquals("SqlPassword", config.jdbcProperties["authentication"])
+    }
+
     // --- fixtures ---
 
     private fun baseEncryptedPojo(): MsSqlServerSourceConfigurationSpecification =


### PR DESCRIPTION
## What
Fixes a security vulnerability where operator-supplied `jdbc_url_params` could override the resolved authentication identity and mode for MSSQL connections. This ensures that trusted resolved auth (Entra ID service principal or SQL password) cannot be spoofed by malicious or accidental `jdbc_url_params` values.

## How
Reordered the JDBC properties assembly in `MsSqlServerSourceConfiguration.kt` to apply resolved auth settings **after** parsing `jdbc_url_params`, ensuring they take precedence. This mirrors the defense-in-depth approach already used in the CDC path.

The change:
1. Parses `jdbc_url_params` into a mutable map first (allowing operator-supplied parameters like `applicationIntent`)
2. Overlays resolved auth properties (`user`, `password`, `authentication`) on top, making them immutable
3. Applies encryption settings last

Added two comprehensive test cases in `MsSqlServerEntraIdAuthTest.kt`:
- `jdbcUrlParamsCannotSpoofResolvedEntraIdAuth()`: Verifies Entra ID service principal auth cannot be overridden
- `jdbcUrlParamsCannotSpoofResolvedSqlPasswordAuth()`: Verifies SQL password auth cannot be overridden

Both tests confirm that unrelated operator-supplied parameters still pass through correctly.

## Review guide
1. `MsSqlServerSourceConfiguration.kt` - Verify the reordering of `putAll()` calls ensures resolved auth wins
2. `MsSqlServerEntraIdAuthTest.kt` - Review the two new test cases for comprehensive coverage of both auth paths

## User Impact
Users will no longer be able to accidentally or maliciously override their configured authentication method via `jdbc_url_params`. The resolved authentication identity (whether Entra ID or SQL password) is now guaranteed to be used for the JDBC session, while other operator-supplied parameters continue to work as expected.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚

https://claude.ai/code/session_01VQe3FcDsdZwDCYZqRiyJ1b