### PR TITLE
chore(source-freshdesk): add subscription_tier spec field with dynamic plan-based rate limiting (3.2.16)

### DIFF
--- a/airbyte-integrations/connectors/source-freshdesk/manifest.yaml
+++ b/airbyte-integrations/connectors/source-freshdesk/manifest.yaml
@@ -1690,11 +1690,10 @@ spec:
         title: Subscription Plan/Tier
         description: Your API subscription tier (affects rate limits)
         enum:
-          - free
           - growth
           - pro
           - enterprise
-        default: free
+        default: growth
         order: 5
       num_workers:
         type: integer

--- a/airbyte-integrations/connectors/source-freshdesk/manifest.yaml
+++ b/airbyte-integrations/connectors/source-freshdesk/manifest.yaml
@@ -1685,6 +1685,17 @@ spec:
         order: 4
         title: Lookback Window
         default: 14
+      subscription_tier:
+        type: string
+        title: Subscription Plan/Tier
+        description: Your API subscription tier (affects rate limits)
+        enum:
+          - free
+          - growth
+          - pro
+          - enterprise
+        default: free
+        order: 5
       num_workers:
         type: integer
         title: Number of Concurrent Threads
@@ -1695,7 +1706,7 @@ spec:
         default: 5
         minimum: 2
         maximum: 16
-        order: 5
+        order: 6
     additionalProperties: true
 
 metadata:

--- a/airbyte-integrations/connectors/source-freshdesk/manifest.yaml
+++ b/airbyte-integrations/connectors/source-freshdesk/manifest.yaml
@@ -3755,13 +3755,10 @@ concurrency_level:
 api_budget:
   type: HTTPAPIBudget
   policies:
-    - type: FixedWindowCallRatePolicy
-      period: "PT1M"
-      # due to lack for support for interpolated string for the call_limit field, this has been
-      # hardcoded to 50 which is the default rate for free plan
-      # in the near term use "{{ config.get('requests_per_minute')}}"
-      # long term is to utilize the `rate_limit_plan` field in config and specifying for each endpoint
-      call_limit: 50
+    - type: MovingWindowCallRatePolicy
+      rates:
+        - limit: "{{ {'growth': 200, 'pro': 400, 'enterprise': 700}.get(config.get('subscription_tier', 'growth'), 200) }}"
+          interval: "PT1M"
       matchers:
         - method: GET
           url_base: "https://{{ config['domain'] }}/api/v2/"

--- a/airbyte-integrations/connectors/source-freshdesk/metadata.yaml
+++ b/airbyte-integrations/connectors/source-freshdesk/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: ec4b9503-13cb-48ab-a4ab-6ade4be46567
-  dockerImageTag: 3.2.16-rc.1
+  dockerImageTag: 3.2.16
   dockerRepository: airbyte/source-freshdesk
   documentationUrl: https://docs.airbyte.com/integrations/sources/freshdesk
   externalDocumentationUrls:
@@ -33,7 +33,7 @@ data:
       enabled: true
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: true
+      enableProgressiveRollout: false
   releaseStage: generally_available
   suggestedStreams:
     streams:

--- a/airbyte-integrations/connectors/source-freshdesk/metadata.yaml
+++ b/airbyte-integrations/connectors/source-freshdesk/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: ec4b9503-13cb-48ab-a4ab-6ade4be46567
-  dockerImageTag: 3.2.15
+  dockerImageTag: 3.2.16-rc.1
   dockerRepository: airbyte/source-freshdesk
   documentationUrl: https://docs.airbyte.com/integrations/sources/freshdesk
   externalDocumentationUrls:
@@ -33,7 +33,7 @@ data:
       enabled: true
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
   releaseStage: generally_available
   suggestedStreams:
     streams:

--- a/docs/integrations/sources/freshdesk.md
+++ b/docs/integrations/sources/freshdesk.md
@@ -72,6 +72,7 @@ If you don't use the start date Freshdesk will retrieve only the last 30 days. M
 
 | Version | Date       | Pull Request                                             | Subject                                                                               |
 | :------ | :--------- | :------------------------------------------------------- | :------------------------------------------------------------------------------------ |
+| 3.2.16-rc.1 | 2026-04-24 | | Add subscription_tier spec field for plan-based rate limiting |
 | 3.2.15 | 2026-04-24 | [76979](https://github.com/airbytehq/airbyte/pull/76979) | Update source-declarative-manifest base image to 7.17.4 |
 | 3.2.14 | 2026-04-23 | [76957](https://github.com/airbytehq/airbyte/pull/76957) | Promoted release candidate to GA |
 | 3.2.14-rc.5 | 2026-04-22 | | Re-enable HTTPAPIBudget, keep c=5 for Full Tier 2 rollout |

--- a/docs/integrations/sources/freshdesk.md
+++ b/docs/integrations/sources/freshdesk.md
@@ -72,7 +72,7 @@ If you don't use the start date Freshdesk will retrieve only the last 30 days. M
 
 | Version | Date       | Pull Request                                             | Subject                                                                               |
 | :------ | :--------- | :------------------------------------------------------- | :------------------------------------------------------------------------------------ |
-| 3.2.16-rc.1 | 2026-04-24 | | Add subscription_tier spec field for plan-based rate limiting |
+| 3.2.16 | 2026-04-24 | | Add subscription_tier spec field with dynamic plan-based rate limiting |
 | 3.2.15 | 2026-04-24 | [76979](https://github.com/airbytehq/airbyte/pull/76979) | Update source-declarative-manifest base image to 7.17.4 |
 | 3.2.14 | 2026-04-23 | [76957](https://github.com/airbytehq/airbyte/pull/76957) | Promoted release candidate to GA |
 | 3.2.14-rc.5 | 2026-04-22 | | Re-enable HTTPAPIBudget, keep c=5 for Full Tier 2 rollout |


### PR DESCRIPTION
## What
Adds a new `subscription_tier` configuration field to the source-freshdesk connector spec and wires it to dynamically adjust the HTTPAPIBudget based on the user's Freshdesk plan tier.

Previously, the API budget was hardcoded to 50 calls/min (free plan rate). Now, the budget adjusts dynamically:
- **growth**: 200 req/min (new default)
- **pro**: 400 req/min
- **enterprise**: 700 req/min

## How
- Added `subscription_tier` enum field to `spec.connection_specification.properties` in `manifest.yaml` with `default: growth`
- Enum values: `growth`, `pro`, `enterprise` (free tier excluded per requirements)
- Bumped `num_workers` order from 5 → 6 to accommodate the new field's order position
- Switched `api_budget` from `FixedWindowCallRatePolicy` (hardcoded `call_limit: 50`) to `MovingWindowCallRatePolicy` with a `Rate` object whose `limit` uses Jinja interpolation: maps `subscription_tier` config value → plan-specific rate limit
  - This switch was necessary because `FixedWindowCallRatePolicy.call_limit` is typed as `int` (no interpolation support), while `Rate.limit` supports `Union[int, str]` with Jinja interpolation ([CDK PR #353](https://github.com/airbytehq/airbyte-python-cdk/pull/353))
- Bumped version to `3.2.16` (GA, no progressive rollout)
- Added changelog entry

## Review guide
1. `manifest.yaml` — new spec field definition (~lines 1688–1697) and dynamic api_budget wiring (~lines 3755–3764)
2. `metadata.yaml` — version bump to 3.2.16
3. `docs/integrations/sources/freshdesk.md` — changelog entry

### Reviewer checklist
- [ ] Confirm the Jinja expression `{{ {'growth': 200, 'pro': 400, 'enterprise': 700}.get(config.get('subscription_tier', 'growth'), 200) }}` evaluates correctly in the CDK runtime
- [ ] Confirm switching from `FixedWindowCallRatePolicy` to `MovingWindowCallRatePolicy` is acceptable (moving window vs fixed window is a behavioral difference in how rate limits reset)
- [ ] Confirm the **4x default budget increase** (50 → 200 calls/min) is intentional — existing users who don't set `subscription_tier` will default to `growth` (200/min) instead of the previous hardcoded 50/min
- [ ] Confirm excluding `free` from the enum and defaulting to `growth` is correct
- [ ] Note: the existing `rate_limit_plan` oneOf object (lines 1559–1670) still includes a "Free Plan" option and is not connected to this new logic. Consider whether `subscription_tier` should eventually replace `rate_limit_plan`

## User Impact
Users will see a new "Subscription Plan/Tier" dropdown in the connector configuration UI (defaults to "growth"). The API budget will now dynamically adjust based on the selected tier. Existing users who don't configure this field will see their effective rate limit increase from 50 to 200 calls/min.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/f5e7f185cbaf4e49b5d1ff5af45e3749
Requested by: @sophiecuiy