### PR TITLE
chore: update base in load cdk.

### DIFF
--- a/airbyte-cdk/bulk/core/load/build.gradle
+++ b/airbyte-cdk/bulk/core/load/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     api("com.github.f4b6a3:uuid-creator:6.1.1")
     implementation 'commons-codec:commons-codec:1.16.0'
 
-    api "io.airbyte.bulk-cdk:bulk-cdk-core-base:1.0.1"
+    api "io.airbyte.bulk-cdk:bulk-cdk-core-base:1.0.3"
     implementation 'org.apache.commons:commons-lang3:3.17.0'
     implementation 'com.ethlo.time:itu:1.14.0'
 

--- a/airbyte-cdk/bulk/core/load/changelog.md
+++ b/airbyte-cdk/bulk/core/load/changelog.md
@@ -7,19 +7,19 @@ The Load CDK provides functionality for destination connectors including stream-
 <details>
   <summary>Expand to review</summary>
 
-| Version | Date       | Pull Request | Subject                                                                                         |
-|---------|------------|--------------|-------------------------------------------------------------------------------------------------|
-| 1.0.10  | 2026-04-23 | | Bump bulk-cdk-core-base from 1.0.1 to 1.0.3: picks up fix to use AIRBYTE_EDITION env var instead of DEPLOYMENT_MODE for cloud feature flag (base 1.0.3). |
-| 1.0.9   | 2026-04-15 | [#76246](https://github.com/airbytehq/airbyte/pull/76246) | Perf: fix timestamp coercion using exception-as-control-flow. Use ethlo/itu for ISO-8601 fast path (~25x faster), JDK TemporalQueries fallback for exotic formats. Eliminates ~56% destination CPU on timestamp-heavy workloads. |
-| 1.0.8   | 2026-04-14 | [#74728](https://github.com/airbytehq/airbyte/pull/74728) | Fix OAuthAuthenticator to track token expiry via `expires_in` and refresh expired tokens. |
-| 1.0.7   | 2026-03-27 | | Fix: update Iceberg sort order before schema evolution to prevent ValidationException when deleting columns referenced by the sort order. Handles Dedupe-to-Append mode switches and PK changes. |
-| 1.0.6   | 2026-03-12 | [#74715](https://github.com/airbytehq/airbyte/pull/74715) | Fix: drop temp table after successful upsert to prevent duplicate records across syncs. |
-| 1.0.5   | 2026-03-10 | [#74723](https://github.com/airbytehq/airbyte/pull/74723) | Fix schema evolution: defer identifier field update when replacing columns to avoid Iceberg conflict. |
-| 1.0.4   | 2026-03-05 | [#74328](https://github.com/airbytehq/airbyte/pull/74328) | Fix iceberg dedup: map PK NumberType to StringType instead of DecimalType for identifier field compatibility. |
-| 1.0.3   | 2026-03-05 | [#74272](https://github.com/airbytehq/airbyte/pull/74272) | Fix iceberg dedup.                                                                              |
-| 1.0.2   | 2026-02-24 | | Bump bulk-cdk-core-base to 1.0.1 to pick up CVE fixes (CVE-2021-47621, CVE-2022-36944).         |
-| 1.0.1   | 2026-02-09 | [#72959](https://github.com/airbytehq/airbyte/pull/72959) | Fix: CVE-2026-25526 (Jinjava dependency bump).                                                  |
-| 1.0.0   | 2026-02-02 | [#72376](https://github.com/airbytehq/airbyte/pull/72376) | Initial independent release of bulk-cdk-core-load. Separate versioning for load package begins. |
+| Version | Date       | Pull Request                                                   | Subject                                                                                         |
+|---------|------------|----------------------------------------------------------------|-------------------------------------------------------------------------------------------------|
+| 1.0.10  | 2026-04-23 | [#76966](https://github.com/airbytehq/airbyte/pull/76966/)     | Bump bulk-cdk-core-base from 1.0.1 to 1.0.3: picks up fix to use AIRBYTE_EDITION env var instead of DEPLOYMENT_MODE for cloud feature flag (base 1.0.3). |
+| 1.0.9   | 2026-04-15 | [#76246](https://github.com/airbytehq/airbyte/pull/76246)      | Perf: fix timestamp coercion using exception-as-control-flow. Use ethlo/itu for ISO-8601 fast path (~25x faster), JDK TemporalQueries fallback for exotic formats. Eliminates ~56% destination CPU on timestamp-heavy workloads. |
+| 1.0.8   | 2026-04-14 | [#74728](https://github.com/airbytehq/airbyte/pull/74728)      | Fix OAuthAuthenticator to track token expiry via `expires_in` and refresh expired tokens. |
+| 1.0.7   | 2026-03-27 |                                                                | Fix: update Iceberg sort order before schema evolution to prevent ValidationException when deleting columns referenced by the sort order. Handles Dedupe-to-Append mode switches and PK changes. |
+| 1.0.6   | 2026-03-12 | [#74715](https://github.com/airbytehq/airbyte/pull/74715)      | Fix: drop temp table after successful upsert to prevent duplicate records across syncs. |
+| 1.0.5   | 2026-03-10 | [#74723](https://github.com/airbytehq/airbyte/pull/74723)      | Fix schema evolution: defer identifier field update when replacing columns to avoid Iceberg conflict. |
+| 1.0.4   | 2026-03-05 | [#74328](https://github.com/airbytehq/airbyte/pull/74328)      | Fix iceberg dedup: map PK NumberType to StringType instead of DecimalType for identifier field compatibility. |
+| 1.0.3   | 2026-03-05 | [#74272](https://github.com/airbytehq/airbyte/pull/74272)      | Fix iceberg dedup.                                                                              |
+| 1.0.2   | 2026-02-24 |                                                                | Bump bulk-cdk-core-base to 1.0.1 to pick up CVE fixes (CVE-2021-47621, CVE-2022-36944).         |
+| 1.0.1   | 2026-02-09 | [#72959](https://github.com/airbytehq/airbyte/pull/72959)      | Fix: CVE-2026-25526 (Jinjava dependency bump).                                                  |
+| 1.0.0   | 2026-02-02 | [#72376](https://github.com/airbytehq/airbyte/pull/72376)      | Initial independent release of bulk-cdk-core-load. Separate versioning for load package begins. |
 
 </details>
 

--- a/airbyte-cdk/bulk/core/load/changelog.md
+++ b/airbyte-cdk/bulk/core/load/changelog.md
@@ -9,6 +9,7 @@ The Load CDK provides functionality for destination connectors including stream-
 
 | Version | Date       | Pull Request | Subject                                                                                         |
 |---------|------------|--------------|-------------------------------------------------------------------------------------------------|
+| 1.0.10  | 2026-04-23 | | Bump bulk-cdk-core-base from 1.0.1 to 1.0.3: picks up fix to use AIRBYTE_EDITION env var instead of DEPLOYMENT_MODE for cloud feature flag (base 1.0.3). |
 | 1.0.9   | 2026-04-15 | [#76246](https://github.com/airbytehq/airbyte/pull/76246) | Perf: fix timestamp coercion using exception-as-control-flow. Use ethlo/itu for ISO-8601 fast path (~25x faster), JDK TemporalQueries fallback for exotic formats. Eliminates ~56% destination CPU on timestamp-heavy workloads. |
 | 1.0.8   | 2026-04-14 | [#74728](https://github.com/airbytehq/airbyte/pull/74728) | Fix OAuthAuthenticator to track token expiry via `expires_in` and refresh expired tokens. |
 | 1.0.7   | 2026-03-27 | | Fix: update Iceberg sort order before schema evolution to prevent ValidationException when deleting columns referenced by the sort order. Handles Dedupe-to-Append mode switches and PK changes. |

--- a/airbyte-cdk/bulk/core/load/version.properties
+++ b/airbyte-cdk/bulk/core/load/version.properties
@@ -1,1 +1,1 @@
-version=1.0.9
+version=1.0.10


### PR DESCRIPTION
## What
Bump the `bulk-cdk-core-base` dependency in the load CDK from 1.0.1 to 1.0.3 and cut a new load CDK release (1.0.10).
## How
- Updated `bulk-cdk-core-base` pinned version from `1.0.1` to `1.0.3` in `core/load/build.gradle`, picking up the `AIRBYTE_EDITION` env var fix for cloud feature flag detection (base 1.0.3)
## Recommended reading order
1. build.gradle
## User Impact
Destination connectors that depend on the load CDK will correctly detect Airbyte Cloud deployments via the `AIRBYTE_EDITION` environment variable. Only `destination-mssql` would be affected, but it's on the legacy toolkit so nothing will actually be affected. 
## Can this PR be safely reverted and rolled back?
- [x] YES
- [ ] NO