### PR TITLE
feat(source-smoke-test): Bump to 0.2.0 for incremental sync support

### DIFF
--- a/airbyte-integrations/connectors/source-smoke-test/metadata.yaml
+++ b/airbyte-integrations/connectors/source-smoke-test/metadata.yaml
@@ -9,7 +9,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 4eb59af1-e69b-4849-84f0-5d81cc5ce490
-  dockerImageTag: 0.1.0
+  dockerImageTag: 0.2.0
   dockerRepository: airbyte/source-smoke-test
   documentationUrl: https://docs.airbyte.com/integrations/sources/smoke-test
   githubIssueLabel: source-smoke-test

--- a/airbyte-integrations/connectors/source-smoke-test/pyproject.toml
+++ b/airbyte-integrations/connectors/source-smoke-test/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "0.1.0"
+version = "0.2.0"
 name = "source-smoke-test"
 description = "Smoke test source for destination regression testing, backed by PyAirbyte."
 authors = ["Airbyte <contact@airbyte.io>"]
@@ -18,7 +18,7 @@ include = "source_smoke_test"
 
 [tool.poetry.dependencies]
 python = ">=3.10,<3.13"
-airbyte = ">=0.41.0"
+airbyte = ">=0.45.0"
 airbyte-cdk = ">=6.0.0"
 
 [tool.poetry.group.dev.dependencies]

--- a/airbyte-integrations/connectors/source-smoke-test/pyproject.toml
+++ b/airbyte-integrations/connectors/source-smoke-test/pyproject.toml
@@ -18,7 +18,7 @@ include = "source_smoke_test"
 
 [tool.poetry.dependencies]
 python = ">=3.10,<3.13"
-airbyte = ">=0.45.0"
+airbyte = ">=0.41.0"
 airbyte-cdk = ">=6.0.0"
 
 [tool.poetry.group.dev.dependencies]

--- a/docs/integrations/sources/smoke-test.md
+++ b/docs/integrations/sources/smoke-test.md
@@ -64,7 +64,7 @@ To enable slow streams, set **All Slow Streams** to `true`, or include `large_ba
 | Feature | Supported |
 | :--- | :--- |
 | Full Refresh Sync | Yes |
-| Incremental Sync | No |
+| Incremental Sync | Yes (opt-in via `incremental_batch_stream`) |
 | Namespaces | No |
 
 ## Changelog
@@ -74,6 +74,7 @@ To enable slow streams, set **All Slow Streams** to `true`, or include `large_ba
 
 | Version | Date | Pull Request | Subject |
 | :--- | :--- | :--- | :--- |
+| 0.2.0 | 2026-04-24 | [airbytehq/PyAirbyte#1016](https://github.com/airbytehq/PyAirbyte/pull/1016) | Add optional incremental sync scenario (`incremental_batch_stream`) with configurable state checkpoints via `batch_size`, `batch_count`, `partition_by`, `start_date`, and `cursor_step` |
 | 0.1.0 | 2026-03-19 | [75181](https://github.com/airbytehq/airbyte/pull/75181) | Initial release: smoke test source for destination regression testing |
 
 </details>


### PR DESCRIPTION
## What

Bumps `source-smoke-test` to `0.2.0` so the published connector image ships the incremental sync scenario added upstream in PyAirbyte: [airbytehq/PyAirbyte#1016](https://github.com/airbytehq/PyAirbyte/pull/1016).

The connector itself is a thin `launch(SourceSmokeTest(), …)` shim — all the real logic lives in PyAirbyte. This PR is purely:
- a connector version bump so the published `airbyte/source-smoke-test:0.2.0` image exists
- doc updates for users

## How

- `airbyte-integrations/connectors/source-smoke-test/metadata.yaml`: `dockerImageTag: 0.1.0` → `0.2.0`.
- `airbyte-integrations/connectors/source-smoke-test/pyproject.toml`: `version = "0.1.0"` → `"0.2.0"`.
- `docs/integrations/sources/smoke-test.md`:
  - Features: `Incremental Sync: No` → `Yes (opt-in via incremental_batch_stream)`
  - Changelog: add `0.2.0` entry pointing to airbytehq/PyAirbyte#1016

Leaving the `airbyte` (PyAirbyte) floor at `>=0.41.0`. The image build picks up the latest PyAirbyte from PyPI at build time, so once airbytehq/PyAirbyte#1016 ships the new scenario is automatically available in `0.2.0`. I initially bumped the floor to `>=0.45.0` to pin intent, but PyAirbyte 0.45.0 isn't released yet and Poetry can't resolve against a nonexistent version, which broke CI.

No connector code changes here — see the PyAirbyte PR for the actual implementation, tests, and the new `start_date` / `batch_size` / `batch_count` / `partition_by` / `cursor_step` config fields.

## Review guide

1. `airbyte-integrations/connectors/source-smoke-test/metadata.yaml`
2. `airbyte-integrations/connectors/source-smoke-test/pyproject.toml`
3. `docs/integrations/sources/smoke-test.md`

## User Impact

- Existing users see no behavior change: the pre-existing scenarios remain full-refresh-only.
- New opt-in scenario `incremental_batch_stream` advertises `incremental` sync mode, emits an `updated_at` cursor, and force-emits STATE at configurable `batch_size` / `partition_by` boundaries. Covered end-to-end by the 51 unit tests in airbytehq/PyAirbyte#1016.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌

## Gated on

- [ ] airbytehq/PyAirbyte#1016 merges and PyAirbyte cuts a release containing it, before this wrapper is merged/published. (The floor is loose at `>=0.41.0`; the `0.2.0` image will simply pick up whichever latest PyAirbyte is on PyPI at image-build time.)

---
Requested by @aaronsteers.

Link to Devin session: https://app.devin.ai/sessions/aed4dcdceb4e444c98be17b2bfcd2602