### PR TITLE
docs(ai-agents): populate Agent Operations concept page, refactor billing

### DIFF
--- a/docs/ai-agents/admin/billing.md
+++ b/docs/ai-agents/admin/billing.md
@@ -4,13 +4,7 @@ plan: all
 
 # Billing and pricing
 
-Airbyte Agents bills you based on a unit of measurement called agent operations (AOs). All plans come with a specific number of free AOs, and most plans allow you to exceed this limit for an additional cost.
-
-## What's an agent operation?
-
-An agent operation represents the processing intensity of a prompt and how much work the agent does to answer it. Airbyte derives AOs from a combination of tool calls and token usage. Simple tasks typically make fewer tool calls and use fewer tokens, so they consume fewer AOs. Complex reasoning tasks typically make more tool calls and use more tokens, so they consume more AOs.
-
-Each time your agent works for you, it consumes AOs. Your plan determines:
+Airbyte Agents bills you based on a unit of measurement called [agent operations (AOs)](../concepts/agent-operations.md). All plans come with a specific number of free AOs, and most plans allow you to exceed this limit for an additional cost. Your plan determines:
 
 - How many free AOs you have each month.
 - Whether you can exceed that limit and how much overage costs.

--- a/docs/ai-agents/admin/sessions.md
+++ b/docs/ai-agents/admin/sessions.md
@@ -1,6 +1,6 @@
 # Review sessions
 
-The Sessions page shows a read-only history of every agent interaction in your workspace, along with token usage and the tools each interaction used. Use it to audit what your agents did, troubleshoot unexpected results, and understand what's driving your [agent operations (AOs)](./billing.md).
+The Sessions page shows a read-only history of every agent interaction in your workspace, along with token usage and the tools each interaction used. Use it to audit what your agents did, troubleshoot unexpected results, and understand what's driving your [agent operations (AOs)](../concepts/agent-operations.md).
 
 ## What sessions are
 

--- a/docs/ai-agents/admin/tool-calls.md
+++ b/docs/ai-agents/admin/tool-calls.md
@@ -13,7 +13,7 @@ Airbyte classifies tool calls as one of the following types:
 - **Direct**: A real-time request to a third-party API. Airbyte routes the call through the connector and returns the live response to the agent. Direct tool calls are useful for operational queries, real-time lookups, and actions that change state, like creating a ticket or sending a message.
 - **Search**: A query against data Airbyte has already replicated into the Context Store. Airbyte answers the call from the cache without contacting the upstream API, which makes search tool calls fast and cost-efficient.
 
-Tool calls are the billable unit that most directly reflects the work your agents do. Airbyte combines tool calls with token usage to calculate agent operations (AOs). For more information, see [Billing and pricing](./billing.md).
+Tool calls are the billable unit that most directly reflects the work your agents do. Airbyte combines tool calls with token usage to calculate [agent operations (AOs)](../concepts/agent-operations.md). For billing details, see [Billing and pricing](./billing.md).
 
 Tool calls can originate from any interface: Chat, Automations, the Automation Builder chat, MCP, the API, and the SDK. The Tool Calls page shows activity from all sources.
 

--- a/docs/ai-agents/concepts/agent-operations.md
+++ b/docs/ai-agents/concepts/agent-operations.md
@@ -6,12 +6,9 @@ sidebar_position: 1
 
 An agent operation (AO) is the unit of work in Airbyte Agents. Every time an agent processes a prompt, reasons about data, or calls a tool, it consumes AOs. AOs measure the processing intensity of a task, not just the number of requests.
 
-Airbyte derives AOs from a combination of two factors:
+Airbyte derives AOs primarily from tool calls. Each action an agent takes against a connector counts as a tool call. Listing records, fetching a single record, searching the Context Store, and writing data back to a source are all tool calls.
 
-- **Tool calls.** Each action an agent takes against a connector counts as a tool call. Listing records, fetching a single record, searching the Context Store, and writing data back to a source are all tool calls.
-- **Token usage.** The input and output tokens an agent consumes while reasoning about your prompt contribute to the AO count.
-
-Simple tasks typically make fewer tool calls and use fewer tokens, so they consume fewer AOs. Complex reasoning tasks that span multiple connectors, require iterative lookups, or produce long responses consume more.
+Simple tasks typically make fewer tool calls, so they consume fewer AOs. Complex tasks that span multiple connectors, require iterative lookups, or produce long responses consume more.
 
 ## What produces agent operations
 
@@ -26,7 +23,7 @@ Any interaction with an agent consumes AOs. The source of the interaction determ
 | **API** | Direct calls to the Airbyte Agents API. | No |
 | **SDK** | Calls from an agent built with the Airbyte Agents SDK. | No |
 
-Sources tracked as sessions appear on the [Sessions](../admin/sessions.md) page, where you can review the full conversation, tool calls, and token usage. Sources that aren't tracked as sessions still consume AOs and appear in the [Usage panel](../admin/billing.md#monitor-usage) on the Billing page.
+Sources tracked as sessions appear on the [Sessions](../admin/sessions.md) page, where you can review the full conversation and tool calls. Sources that aren't tracked as sessions still consume AOs and appear in the [Usage panel](../admin/billing.md#monitor-usage) on the Billing page.
 
 ## How AOs relate to billing
 

--- a/docs/ai-agents/concepts/agent-operations.md
+++ b/docs/ai-agents/concepts/agent-operations.md
@@ -6,9 +6,12 @@ sidebar_position: 1
 
 An agent operation (AO) is the unit of work in Airbyte Agents. Every time an agent processes a prompt, reasons about data, or calls a tool, it consumes AOs. AOs measure the processing intensity of a task, not just the number of requests.
 
-Airbyte derives AOs primarily from tool calls. Each action an agent takes against a connector counts as a tool call. Listing records, fetching a single record, searching the Context Store, and writing data back to a source are all tool calls.
+Airbyte derives AOs from a combination of two factors:
 
-Simple tasks typically make fewer tool calls, so they consume fewer AOs. Complex tasks that span multiple connectors, require iterative lookups, or produce long responses consume more.
+- **Tool calls.** Each action an agent takes against a connector counts as a tool call. Listing records, fetching a single record, searching the Context Store, and writing data back to a source are all tool calls.
+- **Token usage.** The input and output tokens an agent consumes while reasoning about your prompt contribute to the AO count.
+
+Simple tasks typically make fewer tool calls and use fewer tokens, so they consume fewer AOs. Complex reasoning tasks that span multiple connectors, require iterative lookups, or produce long responses consume more.
 
 ## What produces agent operations
 

--- a/docs/ai-agents/concepts/agent-operations.md
+++ b/docs/ai-agents/concepts/agent-operations.md
@@ -4,6 +4,36 @@ sidebar_position: 1
 
 # Agent operations
 
-- What are agent operations
-- How we will (link to billing)
-- What else to say here?
+An agent operation (AO) is the unit of work in Airbyte Agents. Every time an agent processes a prompt, reasons about data, or calls a tool, it consumes AOs. AOs measure the processing intensity of a task, not just the number of requests.
+
+Airbyte derives AOs from a combination of two factors:
+
+- **Tool calls.** Each action an agent takes against a connector counts as a tool call. Listing records, fetching a single record, searching the Context Store, and writing data back to a source are all tool calls.
+- **Token usage.** The input and output tokens an agent consumes while reasoning about your prompt contribute to the AO count.
+
+Simple tasks typically make fewer tool calls and use fewer tokens, so they consume fewer AOs. Complex reasoning tasks that span multiple connectors, require iterative lookups, or produce long responses consume more.
+
+## What produces agent operations
+
+Any interaction with an agent consumes AOs. The source of the interaction determines how Airbyte tracks it.
+
+| Source | Description | Tracked as a session? |
+|---|---|---|
+| **Chat** | A conversation with an agent in the web app. | Yes |
+| **Automation** | A single run of a scheduled, webhook-triggered, or manually triggered automation. | Yes |
+| **Automation Builder Chat** | A conversation inside the Automation Builder while designing an automation. | Yes |
+| **MCP** | Tool calls from agents connected through the Model Context Protocol. | No |
+| **API** | Direct calls to the Airbyte Agents API. | No |
+| **SDK** | Calls from an agent built with the Airbyte Agents SDK. | No |
+
+Sources tracked as sessions appear on the [Sessions](../admin/sessions.md) page, where you can review the full conversation, tool calls, and token usage. Sources that aren't tracked as sessions still consume AOs and appear in the [Usage panel](../admin/billing.md#monitor-usage) on the Billing page.
+
+## How AOs relate to billing
+
+Your plan determines how many AOs you receive each month, whether you can exceed that allowance, and how much overage costs. For plan details, usage monitoring, and payment management, see [Billing and pricing](../admin/billing.md).
+
+## Related topics
+
+- [Billing and pricing](../admin/billing.md) -- Plan allowances, overage, invoices, and usage monitoring.
+- [Review sessions](../admin/sessions.md) -- Audit what your agents did and how many AOs each session consumed.
+- [Review tool calls](../admin/tool-calls.md) -- Inspect individual tool calls across all sources.

--- a/docs/ai-agents/concepts/agent-operations.md
+++ b/docs/ai-agents/concepts/agent-operations.md
@@ -18,7 +18,7 @@ Simple tasks typically make fewer tool calls and use fewer tokens, so they consu
 Any interaction with an agent consumes AOs. The source of the interaction determines how Airbyte tracks it.
 
 | Source | Description | Tracked as a session? |
-|---|---|---|
+| --- | --- | --- |
 | **Chat** | A conversation with an agent in the web app. | Yes |
 | **Automation** | A single run of a scheduled, webhook-triggered, or manually triggered automation. | Yes |
 | **Automation Builder Chat** | A conversation inside the Automation Builder while designing an automation. | Yes |


### PR DESCRIPTION
## What

Populates the Core Concepts > Agent Operations page with a conceptual definition of agent operations (AOs), and refactors billing.md so that the conceptual content lives in Core Concepts while billing stays focused on billing concerns.

Requested by @ian-at-airbyte.

## How

1. **New content in `docs/ai-agents/concepts/agent-operations.md`**: Replaces the stub with a conceptual definition of AOs, a table of the six sources that produce them (Chat, Automation, Automation Builder Chat, MCP, API, SDK) and whether each is tracked as a session, a short section linking AOs to billing, and a Related Topics section.
2. **Refactored `docs/ai-agents/admin/billing.md`**: Removed the "What's an agent operation?" H2 section (definition + explanation paragraph). The opening paragraph now links to the concept page as the canonical definition. The plan-determines bullet list is preserved.
3. **Updated cross-references in `sessions.md` and `tool-calls.md`**: Changed the `[agent operations (AOs)]` links from `./billing.md` to `../concepts/agent-operations.md` so the concept page is the canonical target.

## Review guide

1. `docs/ai-agents/concepts/agent-operations.md` -- the new concept page
2. `docs/ai-agents/admin/billing.md` -- removed conceptual section, added link to concept page
3. `docs/ai-agents/admin/sessions.md` -- updated AO link target
4. `docs/ai-agents/admin/tool-calls.md` -- updated AO link target

## User Impact

Readers of Core Concepts get a dedicated page explaining what agent operations are and what produces them. The billing page stays focused on payments, plans, and usage monitoring. Cross-references across the docs now point to the concept page as the canonical AO definition.

## Can this PR be safely reverted and rolled back?

- [x] YES

---
[Devin session](https://app.devin.ai/sessions/c9aa6fcabec7403696c123ab32fb47b4)