### PR TITLE
docs(ai-agents): populate System Architecture section under Core Concepts

### DIFF
--- a/docs/ai-agents/concepts/architecture/connectors-and-credentials.md
+++ b/docs/ai-agents/concepts/architecture/connectors-and-credentials.md
@@ -36,7 +36,7 @@ A typical connector lifecycle looks like this:
 
 1. **Add credentials** — Provide the third-party service's credentials through the [web app](../../interfaces/ui/add-connector), [API](../../interfaces/api/add-connector), or [SDK](../../interfaces/sdk/add-connector). Airbyte stores the credentials and returns a connector ID.
 2. **Execute operations** — Make tool calls against the connector. Each call targets an entity and an action. See [Execute operations (API)](../../interfaces/api/execute) or [Execute operations (SDK)](../../interfaces/sdk/execute).
-3. **Enable the Context Store** — Optionally turn on the [Context Store](../context-store) to replicate and index a subset of your connector data. This enables fast search operations without hitting the upstream API.
+3. **Use the Context Store** — The [Context Store](../context-store) is enabled by default and replicates and indexes a subset of your connector data. This powers fast search operations without hitting the upstream API.
 
 ## Entities and actions {#entities-and-actions}
 
@@ -53,7 +53,7 @@ Airbyte Agents uses a two-layer credential model.
 
 ### Platform credentials
 
-Platform credentials authenticate your app with Airbyte. Every organization has a `client_id`, `client_secret`, and `organization_id` on the [Profile page](../../admin/profile). The platform uses these to issue short-lived tokens.
+Platform credentials identify your organization with Airbyte. When you sign in to the web app, Airbyte authenticates you behind the scenes. For programmatic access through the API, SDK, or MCP server, your organization's `client_id`, `client_secret`, and `organization_id` — available on the [Profile page](../../admin/profile) — serve the same purpose. The platform uses these to issue short-lived tokens.
 
 | Token type | Scope | Lifetime | Use case |
 | --- | --- | --- | --- |
@@ -74,10 +74,6 @@ Airbyte stores all connector credentials securely. You provide them once, and Ai
 ### Add once, use everywhere
 
 Credentials you add through one interface are available to all of them. A connector configured in the web app works through the API, SDK, or MCP server without re-entering credentials. This applies to every interface in the platform.
-
-### Collecting end-user credentials
-
-If you're building a multi-tenant app and need your end users to connect their own data sources, the authentication module (Airbyte Embedded) is a pre-built UI component you embed in your app. It handles connector selection, credential input, and validation so you don't have to build a custom credential collection flow.
 
 ## Security
 

--- a/docs/ai-agents/concepts/architecture/connectors-and-credentials.md
+++ b/docs/ai-agents/concepts/architecture/connectors-and-credentials.md
@@ -77,7 +77,7 @@ Credentials you add through one interface are available to all of them. A connec
 
 ### Collecting end-user credentials
 
-If you're building a multi-tenant app and need your end users to connect their own data sources, the [authentication module](../../interfaces/api/authentication-module) is a pre-built UI component you embed in your app. It handles connector selection, credential input, and validation so you don't have to build a custom credential collection flow.
+If you're building a multi-tenant app and need your end users to connect their own data sources, the authentication module (Airbyte Embedded) is a pre-built UI component you embed in your app. It handles connector selection, credential input, and validation so you don't have to build a custom credential collection flow.
 
 ## Security
 
@@ -91,5 +91,4 @@ If you're building a multi-tenant app and need your end users to connect their o
 - [Agent connectors](../../connectors) — Browse the connector catalog.
 - [Authentication (API)](../../interfaces/api/authentication) — Token types and the authentication flow.
 - [Authentication (SDK)](../../interfaces/sdk/authenticate) — Credential configuration for Python apps.
-- [Authentication module](../../interfaces/api/authentication-module) — Embed credential collection in your app.
 - [Context Store](../context-store) — The searchable replica powered by your connectors.

--- a/docs/ai-agents/concepts/architecture/connectors-and-credentials.md
+++ b/docs/ai-agents/concepts/architecture/connectors-and-credentials.md
@@ -38,7 +38,7 @@ A typical connector lifecycle looks like this:
 2. **Execute operations** — Make tool calls against the connector. Each call targets an entity and an action. See [Execute operations (API)](../../interfaces/api/execute) or [Execute operations (SDK)](../../interfaces/sdk/execute).
 3. **Enable the Context Store** — Optionally turn on the [Context Store](../context-store) to replicate and index a subset of your connector data. This enables fast search operations without hitting the upstream API.
 
-## Entities and actions
+## Entities and actions {#entities-and-actions}
 
 Each connector exposes a set of entities and actions that define what agents can do with that service.
 

--- a/docs/ai-agents/concepts/architecture/connectors-and-credentials.md
+++ b/docs/ai-agents/concepts/architecture/connectors-and-credentials.md
@@ -1,0 +1,95 @@
+---
+sidebar_position: 3
+---
+
+# Connectors and credentials
+
+A connector in Airbyte Agents is a stored credential and configuration for a third-party service. Connectors are what agents use to read, search, and write data in external systems. Each connector lives inside a [workspace](./workspaces) and is available to every [interface](../../interfaces) that can access that workspace.
+
+## What a connector includes
+
+When you add a connector, Airbyte stores:
+
+- **Connector type** — Which third-party service the connector targets, identified by a `definition_id`. Browse the full catalog in [Agent connectors](../../connectors).
+- **Credentials** — The API key, OAuth tokens, or other secrets needed to authenticate with the service.
+- **Configuration** — Any non-credential settings the connector needs, like a list of repositories for GitHub or an account ID for an ad platform.
+
+Airbyte validates credentials at execution time and handles OAuth token refresh automatically.
+
+## Two ways to run connectors
+
+Airbyte agent connectors support two operating modes.
+
+### Hosted mode
+
+Airbyte stores your credentials securely in the cloud and manages token refresh. Authenticate with your platform credentials, add connectors through any interface, and execute operations without managing secrets yourself. This is the default mode and the recommended starting point.
+
+### Open source mode
+
+Each agent connector is also an open source Python package you can install and run independently. In open source mode, you provide API credentials directly to the connector in your code. No Airbyte account is required. Use this mode when you want to manage credentials yourself or run connectors in an air-gapped environment.
+
+For installation and usage in open source mode, see each connector's page in [Agent connectors](../../connectors).
+
+## Connector lifecycle
+
+A typical connector lifecycle looks like this:
+
+1. **Add credentials** — Provide the third-party service's credentials through the [web app](../../interfaces/ui/add-connector), [API](../../interfaces/api/add-connector), or [SDK](../../interfaces/sdk/add-connector). Airbyte stores the credentials and returns a connector ID.
+2. **Execute operations** — Make tool calls against the connector. Each call targets an entity and an action. See [Execute operations (API)](../../interfaces/api/execute) or [Execute operations (SDK)](../../interfaces/sdk/execute).
+3. **Enable the Context Store** — Optionally turn on the [Context Store](../context-store) to replicate and index a subset of your connector data. This enables fast search operations without hitting the upstream API.
+
+## Entities and actions
+
+Each connector exposes a set of entities and actions that define what agents can do with that service.
+
+- **Entities** are the resources the connector can access, like `contacts`, `issues`, `orders`, or `messages`.
+- **Actions** describe what the agent can do with each entity. Common actions include `list`, `get`, `search`, `create`, and `download`.
+
+The exact entities and actions vary by connector. See the connector's page in [Agent connectors](../../connectors) for the full list.
+
+## Credential management
+
+Airbyte Agents uses a two-layer credential model.
+
+### Platform credentials
+
+Platform credentials authenticate your app with Airbyte. Every organization has a `client_id`, `client_secret`, and `organization_id` on the [Profile page](../../admin/profile). The platform uses these to issue short-lived tokens.
+
+| Token type | Scope | Lifetime | Use case |
+| --- | --- | --- | --- |
+| Application token | Organization-wide | 15 minutes | Managing connectors, generating scoped tokens, executing operations |
+| Scoped token | Single workspace | 20 minutes | Workspace-isolated access for multi-tenant apps |
+
+For details, see [Authentication](../../interfaces/api/authentication).
+
+### Connector credentials
+
+Connector credentials authenticate with each third-party service. The credential shape depends on the service:
+
+- **API key or personal access token** — A single secret. GitHub uses `personal_access_token`, Linear uses `api_key`, Notion uses `token`.
+- **OAuth** — A `client_id`, `client_secret`, and `refresh_token`. Airbyte rotates access tokens automatically at execution time.
+
+Airbyte stores all connector credentials securely. You provide them once, and Airbyte injects them into every execution request.
+
+### Add once, use everywhere
+
+Credentials you add through one interface are available to all of them. A connector configured in the web app works through the API, SDK, or MCP server without re-entering credentials. This applies to every interface in the platform.
+
+### Collecting end-user credentials
+
+If you're building a multi-tenant app and need your end users to connect their own data sources, the [authentication module](../../interfaces/api/authentication-module) is a pre-built UI component you embed in your app. It handles connector selection, credential input, and validation so you don't have to build a custom credential collection flow.
+
+## Security
+
+- Platform tokens are short-lived by design. Application tokens expire after 15 minutes; scoped tokens expire after 20 minutes.
+- Airbyte stores connector credentials server-side and never returns them in API responses after creation.
+- Never expose platform credentials or tokens in client-side code. Keep them in your backend.
+- Rotate platform credentials periodically from the [Profile page](https://app.airbyte.ai/profile).
+
+## Related topics
+
+- [Agent connectors](../../connectors) — Browse the connector catalog.
+- [Authentication (API)](../../interfaces/api/authentication) — Token types and the authentication flow.
+- [Authentication (SDK)](../../interfaces/sdk/authenticate) — Credential configuration for Python apps.
+- [Authentication module](../../interfaces/api/authentication-module) — Embed credential collection in your app.
+- [Context Store](../context-store) — The searchable replica powered by your connectors.

--- a/docs/ai-agents/concepts/architecture/organizations.md
+++ b/docs/ai-agents/concepts/architecture/organizations.md
@@ -1,1 +1,36 @@
+---
+sidebar_position: 1
+---
+
 # Organizations
+
+An organization is the top-level container in Airbyte Agents. It represents a single account, maps to one billing subscription, and owns every workspace, connector, and credential beneath it.
+
+## What an organization contains
+
+Each organization has:
+
+- **Platform API credentials** — A `client_id`, `client_secret`, and `organization_id` that authenticate programmatic access through the [API](../../interfaces/api), [SDK](../../interfaces/sdk), and [MCP server](../../interfaces/mcp). Find these on the [Profile page](https://app.airbyte.ai/profile).
+- **Workspaces** — One or more [workspaces](./workspaces), each holding its own set of connectors and credentials. Every organization starts with a `default` workspace.
+- **Context Store configuration** — The [Context Store](../context-store) is an organization-level setting. Administrators can turn it on or off for the entire organization from the Credentials page.
+- **Billing** — Plans, payment methods, usage limits, and invoices live at the organization level. See [Billing and pricing](../../admin/billing).
+- **Users** — People who can sign in and interact with the organization through the [web app](../../interfaces/ui).
+
+## One organization per account
+
+When you sign up at [app.airbyte.ai](https://app.airbyte.ai), Airbyte creates an organization for you automatically. Your account belongs to that organization. If you need to work across multiple organizations, your Airbyte account can be associated with more than one — pass the `organization_id` to the SDK or API to target a specific organization. See [Multiple organizations](../../interfaces/sdk/authenticate#multiple-organizations).
+
+## Who can administer an organization
+
+Organization administrators can:
+
+- Rename the organization from the [Profile page](../../admin/profile).
+- Manage [billing](../../admin/billing), including payment methods, spending caps, and plan changes.
+- Turn the [Context Store](../context-store) on or off.
+- View [sessions](../../admin/sessions) and [tool calls](../../admin/tool-calls) for the entire organization.
+
+## Related topics
+
+- [Profile](../../admin/profile) — View and copy API credentials, rename the organization.
+- [Billing and pricing](../../admin/billing) — Plans, usage, invoices.
+- [Workspaces](./workspaces) — The isolation layer within an organization.

--- a/docs/ai-agents/concepts/architecture/organizations.md
+++ b/docs/ai-agents/concepts/architecture/organizations.md
@@ -11,23 +11,14 @@ An organization is the top-level container in Airbyte Agents. It represents a si
 Each organization has:
 
 - **Platform API credentials** — A `client_id`, `client_secret`, and `organization_id` that authenticate programmatic access through the [API](../../interfaces/api), [SDK](../../interfaces/sdk), and [MCP server](../../interfaces/mcp). Find these on the [Profile page](https://app.airbyte.ai/profile).
-- **Workspaces** — One or more [workspaces](./workspaces), each holding its own set of connectors and credentials. Every organization starts with a `default` workspace.
-- **Context Store configuration** — The [Context Store](../context-store) is an organization-level setting. Administrators can turn it on or off for the entire organization from the Credentials page.
+- **Workspaces** — Every organization starts with a `default` [workspace](./workspaces), which is all most people need. If you need to isolate credentials across tenants or teams, you can create additional workspaces.
+- **Context Store configuration** — The [Context Store](../context-store) is enabled by default and operates at the organization level. You can turn it on or off from the Credentials page.
 - **Billing** — Plans, payment methods, usage limits, and invoices live at the organization level. See [Billing and pricing](../../admin/billing).
 - **Users** — People who can sign in and interact with the organization through the [web app](../../interfaces/ui).
 
 ## One organization per account
 
 When you sign up at [app.airbyte.ai](https://app.airbyte.ai), Airbyte creates an organization for you automatically. Your account belongs to that organization. If you need to work across multiple organizations, your Airbyte account can be associated with more than one — pass the `organization_id` to the SDK or API to target a specific organization. See [Multiple organizations](../../interfaces/sdk/authenticate#multiple-organizations).
-
-## Who can administer an organization
-
-Organization administrators can:
-
-- Rename the organization from the [Profile page](../../admin/profile).
-- Manage [billing](../../admin/billing), including payment methods, spending caps, and plan changes.
-- Turn the [Context Store](../context-store) on or off.
-- View [sessions](../../admin/sessions) and [tool calls](../../admin/tool-calls) for the entire organization.
 
 ## Related topics
 

--- a/docs/ai-agents/concepts/architecture/readme.md
+++ b/docs/ai-agents/concepts/architecture/readme.md
@@ -4,8 +4,89 @@ sidebar_position: 3
 
 # System architecture
 
-- Organizations
-- Workspaces
-- How we manage credentials
-- Add credentials once, use them anywhere (UI, API, SDK, MCP) - any interface
-- What else do we need to say?
+Airbyte Agents is a cloud platform that gives AI agents authenticated, structured access to third-party SaaS data. It stores credentials, manages token refresh, and exposes a uniform execution interface so agents can read, search, and write data across dozens of services.
+
+Four interfaces share the same backend. Credentials you configure through one interface are available to all of them.
+
+- [**Web app**](../../interfaces/ui) at [app.airbyte.ai](https://app.airbyte.ai) — Talk to an Airbyte-hosted agent in Chats, or define Automations that run on a schedule or webhook.
+- [**API**](../../interfaces/api) — HTTP endpoints for managing connectors, tokens, and executing operations from any language.
+- [**SDK**](../../interfaces/sdk) — Python SDK for building agents that authenticate, connect, and execute operations in your own code.
+- [**MCP server**](../../interfaces/mcp) — A remote Model Context Protocol server that connects MCP-capable agents like Claude, Cursor, and ChatGPT to your data.
+
+```mermaid
+flowchart TB
+    subgraph interfaces["Interfaces"]
+        direction LR
+        UI["Web app"]
+        API["API"]
+        SDK["SDK"]
+        MCP["MCP server"]
+    end
+
+    subgraph platform["Airbyte Agents Platform"]
+        AUTH["Authentication\n& token management"]
+        EXEC["Execution engine"]
+        CS["Context Store"]
+    end
+
+    subgraph services["Third-party services"]
+        direction LR
+        SVC1["CRM"]
+        SVC2["Support desk"]
+        SVC3["Analytics"]
+        SVC4["..."]
+    end
+
+    interfaces --> AUTH
+    AUTH --> EXEC
+    EXEC -- "Direct" --> services
+    EXEC -- "Search" --> CS
+    CS -. "replicates from" .-> services
+```
+
+## Resource hierarchy
+
+Every Airbyte Agents account is organized into a three-level hierarchy.
+
+```mermaid
+flowchart TB
+    ORG["Organization"]
+    ORG --> WS1["Workspace (default)"]
+    ORG --> WS2["Workspace (tenant-a)"]
+    ORG --> WS3["Workspace (tenant-b)"]
+    WS1 --> C1["Connector (GitHub)"]
+    WS1 --> C2["Connector (Salesforce)"]
+    WS2 --> C3["Connector (HubSpot)"]
+    WS3 --> C4["Connector (Stripe)"]
+    WS3 --> C5["Connector (Zendesk)"]
+```
+
+- **[Organization](./organizations)** — The top-level container. Maps to a single billing account and a set of platform API credentials. All workspaces, users, and billing settings live here.
+- **[Workspace](./workspaces)** — An isolation boundary within an organization. Each workspace holds its own set of connectors and credentials. A token scoped to one workspace cannot access another.
+- **[Connector](./connectors-and-credentials)** — A stored credential and configuration for a third-party service. Connectors are the building blocks agents use to interact with external APIs.
+
+## Credential management
+
+Airbyte Agents uses a two-layer credential model.
+
+- **Platform credentials** authenticate your app with Airbyte. Your organization's `client_id` and `client_secret` are on the [Profile page](https://app.airbyte.ai/profile). The platform uses these to issue short-lived tokens for API, SDK, and MCP access.
+- **Connector credentials** authenticate with each third-party service. When you add a connector, you provide the service's API key, OAuth tokens, or other credentials. Airbyte stores them securely and handles token refresh at execution time.
+
+Add credentials once through any interface and every other interface can use them. For details, see [Connectors and credentials](./connectors-and-credentials).
+
+## Execution model
+
+When an agent interacts with a connector, it makes **tool calls**. Each tool call targets an entity and an action — for example, `issues.list` or `contacts.search`. Airbyte classifies tool calls into two types.
+
+- **Direct** — A real-time request to the third-party API. Airbyte routes the call through the connector, and returns the live response. Use direct calls for real-time look-ups and actions that change state, like creating a ticket or sending a message.
+- **Search** — A query against the [Context Store](../context-store), a managed, pre-indexed replica of your connector data. Airbyte answers the call from its own storage without contacting the upstream API, which makes search calls fast and cost-efficient. Use search calls for filtered look-ups across large datasets.
+
+For details on reviewing tool call activity, see [Review tool calls](../../admin/tool-calls).
+
+## Billing
+
+Airbyte Agents bills based on **agent operations (AOs)**, a unit derived from a combination of tool calls and token usage. Each plan includes a monthly allowance of AOs. For details, see [Billing and pricing](../../admin/billing).
+
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />

--- a/docs/ai-agents/concepts/architecture/readme.md
+++ b/docs/ai-agents/concepts/architecture/readme.md
@@ -6,7 +6,7 @@ sidebar_position: 3
 
 Airbyte Agents is a cloud platform that gives AI agents authenticated, structured access to third-party SaaS data. It stores credentials, manages token refresh, and exposes a uniform execution interface so agents can read, search, and write data across dozens of services.
 
-Four interfaces share the same backend. Credentials you configure through one interface are available to all of them.
+You can interact with the platform through four interfaces. They all connect to the same service, so credentials you configure through one interface are available to all of them.
 
 - [**Web app**](../../interfaces/ui) at [app.airbyte.ai](https://app.airbyte.ai) — Talk to an Airbyte-hosted agent in Chats, or define Automations that run on a schedule or webhook.
 - [**API**](../../interfaces/api) — HTTP endpoints for managing connectors, tokens, and executing operations from any language.
@@ -69,7 +69,7 @@ flowchart TB
 
 Airbyte Agents uses a two-layer credential model.
 
-- **Platform credentials** authenticate your app with Airbyte. Your organization's `client_id` and `client_secret` are on the [Profile page](https://app.airbyte.ai/profile). The platform uses these to issue short-lived tokens for API, SDK, and MCP access.
+- **Platform credentials** identify your organization with Airbyte. When you sign in to the web app, Airbyte authenticates you behind the scenes. For the API, SDK, and MCP server, your organization's `client_id` and `client_secret` — available on the [Profile page](https://app.airbyte.ai/profile) — serve the same purpose.
 - **Connector credentials** authenticate with each third-party service. When you add a connector, you provide the service's API key, OAuth tokens, or other credentials. Airbyte stores them securely and handles token refresh at execution time.
 
 Add credentials once through any interface and every other interface can use them. For details, see [Connectors and credentials](./connectors-and-credentials).

--- a/docs/ai-agents/concepts/architecture/workspaces.md
+++ b/docs/ai-agents/concepts/architecture/workspaces.md
@@ -8,7 +8,7 @@ A workspace is an isolation boundary within an [organization](./organizations). 
 
 ## The default workspace
 
-Every organization starts with a workspace named `default`. Most apps use this single workspace and never need to create additional ones. The [SDK](../../interfaces/sdk), [API](../../interfaces/api), and [MCP server](../../interfaces/mcp) all target the `default` workspace unless you specify otherwise.
+Every organization starts with a workspace named `default`. Most people use this single workspace and never need to create additional ones. The web app, SDK, API, and MCP server all target the `default` workspace unless you specify otherwise.
 
 ## When to create additional workspaces
 
@@ -31,11 +31,11 @@ The UUID is the durable identifier. The name is a convenience for routing.
 
 ## Create a workspace
 
-Workspaces are created automatically. The first time you mint a [scoped token](../../interfaces/api/authentication#scoped-token) against a new `workspace_name`, Airbyte creates the workspace for you. Use any stable string that makes sense in your app — for example, an internal tenant ID or team slug.
+Workspaces are created programmatically through the API or SDK — they can't be created through the web app. The first time you mint a [scoped token](../../interfaces/api/authentication#scoped-token) against a new `workspace_name`, Airbyte creates the workspace for you. Use any stable string that makes sense in your app — for example, an internal tenant ID or team slug.
 
 ## Scoped tokens
 
-A scoped token limits access to a single workspace. Most apps that use the `default` workspace can skip scoped tokens entirely and authenticate with an [application token](../../interfaces/api/authentication#application-token). Generate a scoped token when you need to hand a token to a component that should only see one workspace's connectors.
+A scoped token limits access to a single workspace. If you just use the `default` workspace (most cases), you can skip scoped tokens entirely and authenticate with an [application token](../../interfaces/api/authentication#application-token). Generate a scoped token when you need to hand a token to a component that should only see one workspace's connectors.
 
 For details on generating and using scoped tokens, see [Authentication](../../interfaces/api/authentication#scoped-token).
 

--- a/docs/ai-agents/concepts/architecture/workspaces.md
+++ b/docs/ai-agents/concepts/architecture/workspaces.md
@@ -1,1 +1,53 @@
+---
+sidebar_position: 2
+---
+
 # Workspaces
+
+A workspace is an isolation boundary within an [organization](./organizations). Each workspace holds its own set of connectors and credentials. A token scoped to one workspace cannot access connectors in another.
+
+## The default workspace
+
+Every organization starts with a workspace named `default`. Most apps use this single workspace and never need to create additional ones. The [SDK](../../interfaces/sdk), [API](../../interfaces/api), and [MCP server](../../interfaces/mcp) all target the `default` workspace unless you specify otherwise.
+
+## When to create additional workspaces
+
+Create additional workspaces when you need to isolate credentials across distinct boundaries. Common scenarios include:
+
+- **Multi-tenant SaaS** — Give each of your customers their own workspace so their credentials and data stay separate.
+- **Team isolation** — Separate engineering, sales, and support connectors into their own workspaces.
+- **Environment separation** — Use different workspaces for development, staging, and production.
+
+If none of these apply, the `default` workspace is all you need.
+
+## Workspace identifiers
+
+Every workspace has two identifiers:
+
+- **UUID** (`id`) — An Airbyte-assigned identifier that never changes. Persist this in your backend and use it for any operation that accepts a `workspace_id`.
+- **Name** (`workspace_name`) — A human-readable label you choose when the workspace is created. Routing endpoints like scoped-token minting and connector creation accept the name as a lookup key.
+
+The UUID is the durable identifier. The name is a convenience for routing.
+
+## Create a workspace
+
+Workspaces are created automatically. The first time you mint a [scoped token](../../interfaces/api/authentication#scoped-token) against a new `workspace_name`, Airbyte creates the workspace for you. Use any stable string that makes sense in your app — for example, an internal tenant ID or team slug.
+
+## Scoped tokens
+
+A scoped token limits access to a single workspace. Most apps that use the `default` workspace can skip scoped tokens entirely and authenticate with an [application token](../../interfaces/api/authentication#application-token). Generate a scoped token when you need to hand a token to a component that should only see one workspace's connectors.
+
+For details on generating and using scoped tokens, see [Authentication](../../interfaces/api/authentication#scoped-token).
+
+## Manage workspaces
+
+Workspace management — listing, updating, and deleting workspaces — is available through the API. The SDK `Workspace` class covers day-to-day operations like listing connectors and executing operations.
+
+- [Manage workspaces (API)](../../interfaces/api/workspaces) — List, update, and delete workspaces.
+- [Manage workspaces (SDK)](../../interfaces/sdk/workspaces) — Target a workspace, list connectors, and execute operations.
+
+## Related topics
+
+- [Organizations](./organizations) — The parent container for all workspaces.
+- [Connectors and credentials](./connectors-and-credentials) — What lives inside a workspace.
+- [Authentication](../../interfaces/api/authentication) — Application tokens, scoped tokens, and the token hierarchy.


### PR DESCRIPTION
## What

Populates the **Airbyte Agents > Core Concepts > System Architecture** section with four documentation pages explaining platform structure, resource hierarchy, credential management, and execution model.

## How

Four markdown files in `docs/ai-agents/concepts/architecture/`:

| File | Content |
|------|---------|
| `readme.md` | Platform overview, two mermaid diagrams (architecture layers + resource hierarchy), credential management, execution model (Direct vs Search), billing summary |
| `organizations.md` | Top-level container, org-level resources, one-org-per-account |
| `workspaces.md` | Isolation boundary, default workspace, when to create more, identifiers, scoped tokens |
| `connectors-and-credentials.md` | Connector structure, hosted vs open source modes, lifecycle, entities/actions, two-layer credential model, "add once use everywhere", security |

## Review guide

1. `docs/ai-agents/concepts/architecture/readme.md` — Start here for the overall architecture overview
2. `docs/ai-agents/concepts/architecture/organizations.md`
3. `docs/ai-agents/concepts/architecture/workspaces.md`
4. `docs/ai-agents/concepts/architecture/connectors-and-credentials.md`

## User Impact

New documentation pages for Airbyte Agents users. No code changes.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

## Notes

- Spaced em-dashes trigger Vale `Google.EmDash` errors but are the established pattern across all existing ai-agents docs. Left as-is.
- The `authentication-module.md` page has `draft: true`, so links to it were omitted. Restore when that page is published.

Requested by @ian-at-airbyte.

Link to Devin session: https://app.devin.ai/sessions/a7e16b50c039440ea294f7518d1f7a64