### PR TITLE
chore(source-zendesk-talk): add subscription_tier config and dynamic tier-based HTTPAPIBudget for tuning iteration 5

### DIFF
--- a/airbyte-integrations/connectors/source-zendesk-talk/manifest.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-talk/manifest.yaml
@@ -563,39 +563,29 @@ streams:
 # Tuning iteration 2: decreased to 9 after Phase 1 showed +6% duration regression
 # Tuning iteration 3: decreased to 6 after rc.2 showed persistent heartbeat_timeout failures on high-volume connections
 # Tuning iteration 4: decreased to 4 and commented out HTTPAPIBudget to isolate concurrency effect
+# Tuning iteration 5: re-enabled HTTPAPIBudget as dynamic tier-based budget using MovingWindowCallRatePolicy
 # Ref: https://developer.zendesk.com/api-reference/voice/talk-api/rate_limits/
 concurrency_level:
   type: ConcurrencyLevel
   default_concurrency: 4
   max_concurrency: 16
 
-# HTTP API Budget: throttle requests per Zendesk Talk API rate limits
-# Commented out for tuning iteration 4 to isolate whether budget throttling contributes to heartbeat_timeout
-# Ref: https://developer.zendesk.com/api-reference/voice/talk-api/rate_limits/
-# api_budget:
-#   type: HTTPAPIBudget
-#   policies:
-#     # Incremental Exports (calls, call_legs): 10 requests per minute
-#     - type: FixedWindowCallRatePolicy
-#       period: "PT1M"
-#       call_limit: 10
-#       matchers:
-#         - method: GET
-#           url_path_pattern: "/stats/incremental/"
-#     # Current Queue Activity: 2,500 requests per 5 minutes
-#     - type: FixedWindowCallRatePolicy
-#       period: "PT5M"
-#       call_limit: 2500
-#       matchers:
-#         - method: GET
-#           url_path_pattern: "/stats/current_queue_activity"
-#     # All Talk API endpoints (catch-all): 15,000 requests per 5 minutes
-#     - type: FixedWindowCallRatePolicy
-#       period: "PT5M"
-#       call_limit: 15000
-#       matchers: []
-#   ratelimit_reset_header: "Retry-After"
-#   status_codes_for_ratelimit_hit: [429]
+# HTTP API Budget: dynamic rate limiting based on Zendesk subscription tier.
+# Uses MovingWindowCallRatePolicy (supports config interpolation) instead of FixedWindowCallRatePolicy.
+# Tier-based limits (req/min): Team=200, Growth=400, Professional=400, Enterprise=700, Enterprise Plus=2500.
+# Previous static budget with per-endpoint limits (e.g. 10 req/min for incremental exports) caused
+# heartbeat_timeout on high-volume connections (confirmed in rc.4 experiment). The tier-based catch-all
+# approach avoids over-throttling individual endpoints while still respecting overall API rate limits.
+# Server-side 429 handling via Retry-After header provides per-endpoint enforcement.
+api_budget:
+  type: HTTPAPIBudget
+  policies:
+    - type: MovingWindowCallRatePolicy
+      rates:
+        - limit: "{{ {'team': 200, 'growth': 400, 'professional': 400, 'enterprise': 700, 'enterprise_plus': 2500}.get(config.get('subscription_tier', 'team'), 200) }}"
+          interval: PT1M
+      matchers: []
+  status_codes_for_ratelimit_hit: [429]
 
 spec:
   type: Spec
@@ -736,6 +726,21 @@ spec:
         pattern: ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$
         examples:
           - "2020-10-15T00:00:00Z"
+      subscription_tier:
+        type: string
+        title: Subscription Plan/Tier
+        description: >-
+          Your Zendesk subscription plan tier. This controls API rate limiting
+          behavior — higher tiers have higher rate limits. If unsure, leave as
+          the default (Team) for the most conservative rate limiting.
+        enum:
+          - team
+          - growth
+          - professional
+          - enterprise
+          - enterprise_plus
+        default: team
+        order: 3
     additionalProperties: true
   advanced_auth:
     auth_flow_type: oauth2.0

--- a/airbyte-integrations/connectors/source-zendesk-talk/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-talk/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: c8630570-086d-4a40-99ae-ea5b18673071
-  dockerImageTag: 2.0.11-rc.4
+  dockerImageTag: 2.0.11-rc.5
   dockerRepository: airbyte/source-zendesk-talk
   documentationUrl: https://docs.airbyte.com/integrations/sources/zendesk-talk
   externalDocumentationUrls:

--- a/docs/integrations/sources/zendesk-talk.md
+++ b/docs/integrations/sources/zendesk-talk.md
@@ -79,7 +79,8 @@ The Zendesk connector should not run into Zendesk API limitations under normal u
 
 | Version | Date       | Pull Request                                             | Subject                                                                     |
 |:--------|:-----------|:---------------------------------------------------------|:----------------------------------------------------------------------------|
-| 2.0.11-rc.4 | 2026-04-21 | [](https://github.com/airbytehq/airbyte/pull/) | Decrease default_concurrency from 6 to 4 and remove HTTPAPIBudget for tuning iteration 4 |
+| 2.0.11-rc.5 | 2026-04-24 | [](https://github.com/airbytehq/airbyte/pull/) | Add subscription_tier config field and re-enable HTTPAPIBudget as dynamic tier-based budget for tuning iteration 5 |
+| 2.0.11-rc.4 | 2026-04-21 | [76872](https://github.com/airbytehq/airbyte/pull/76872) | Decrease default_concurrency from 6 to 4 and comment out HTTPAPIBudget for tuning iteration 4 |
 | 2.0.11-rc.3 | 2026-04-17 | [76449](https://github.com/airbytehq/airbyte/pull/76449) | Decrease default_concurrency from 9 to 6 for tuning iteration 3 |
 | 2.0.11-rc.2 | 2026-04-13 | [76266](https://github.com/airbytehq/airbyte/pull/76266) | Decrease default_concurrency from 12 to 9 for tuning iteration 2 |
 | 2.0.11-rc.1 | 2026-04-09 | [76203](https://github.com/airbytehq/airbyte/pull/76203) | Add concurrency support with default_concurrency of 12 |


### PR DESCRIPTION
## What

Tuning iteration 5 for source-zendesk-talk concurrency tuning ([internal issue](https://github.com/airbytehq/airbyte-internal-issues/issues/15316)).

In rc.4 (#76872), the `HTTPAPIBudget` was commented out to isolate whether budget throttling was causing `heartbeat_timeout` failures on a high-volume blocker connection (`dbf5ce4a`). **Result: confirmed.** With the budget removed, the blocker connection succeeded (662s, 212k rows) after failing on every prior RC (rc.1–rc.3) with 20 exhausted attempts each.

This PR re-enables the budget but redesigns it:
1. Adds a `subscription_tier` config field so the budget adapts to the customer's actual Zendesk plan.
2. Replaces the static per-endpoint `FixedWindowCallRatePolicy` policies with a single dynamic `MovingWindowCallRatePolicy` catch-all.

## How

**`manifest.yaml`:**
- **New spec field** `subscription_tier`: enum (`team`/`growth`/`professional`/`enterprise`/`enterprise_plus`), defaults to `team` (most conservative).
- **New `api_budget`**: single `MovingWindowCallRatePolicy` with a Jinja-interpolated `limit` that maps the tier to its req/min rate limit (Team=200, Growth=400, Professional=400, Enterprise=700, Enterprise Plus=2500).
- `MovingWindowCallRatePolicy` is used instead of `FixedWindowCallRatePolicy` because `call_limit` in `FixedWindowCallRatePolicy` [does not support config interpolation](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connectors/source-freshdesk/manifest.yaml#L3752-L3755). This pattern is proven in [source-stripe](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connectors/source-stripe/manifest.yaml#L2054) and [source-intercom](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connectors/source-intercom/manifest.yaml#L1088).
- The old per-endpoint sub-policies (10 req/min for `/stats/incremental/`, 2500/5min for `/stats/current_queue_activity`) are removed. The 10 req/min incremental limit was the root cause of the heartbeat_timeout. Per-endpoint enforcement is now handled server-side via 429 + `Retry-After` (the connector already has `WaitTimeFromHeader` backoff on every requester).

**`metadata.yaml`:** Bump `dockerImageTag` to `2.0.11-rc.5`.

**`zendesk-talk.md`:** Add rc.5 changelog entry, backfill rc.4 PR link.

## Review guide

1. `manifest.yaml` — the Jinja expression in `limit` (line ~585) is the most important thing to review. Verify the dict lookup + double fallback is correct and the tier values match [Zendesk's documented rate limits](https://developer.zendesk.com/api-reference/ticketing/account-configuration/usage_limits/).
2. `manifest.yaml` — the `subscription_tier` spec field (lines ~729-743). Verify enum values, default, and description are appropriate.
3. `metadata.yaml` — version bump only.
4. `zendesk-talk.md` — changelog only.

## User Impact

- Users will see a new optional **"Subscription Plan/Tier"** dropdown in the connector configuration UI. If left unset, it defaults to `team` (most conservative rate limiting).
- Higher-tier customers can select their plan to unlock faster sync throughput.
- No breaking change — existing connections will continue to work with the default `team` tier.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/a8b7ef49ffb0424c93226baac20ab5e3
Requested by: @sophiecuiy