### PR TITLE
ci: update doc sync workflow to reference airbyte-agent-sdk

### DIFF
--- a/.github/workflows/sync-ai-connector-docs.yml
+++ b/.github/workflows/sync-ai-connector-docs.yml
@@ -12,10 +12,10 @@ jobs:
       - name: Checkout airbyte repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Checkout airbyte-agent-connectors
+      - name: Checkout airbyte-agent-sdk
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          repository: airbytehq/airbyte-agent-connectors
+          repository: airbytehq/airbyte-agent-sdk
           path: agent-connectors-source
 
       - name: Sync connector docs
@@ -60,12 +60,12 @@ jobs:
         uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         with:
           token: ${{ steps.get-app-token.outputs.token }}
-          commit-message: "docs: sync agent connector docs from airbyte-agent-connectors repo"
+          commit-message: "docs: sync agent connector docs from airbyte-agent-sdk repo"
           branch: auto-sync-ai-connector-docs
           delete-branch: true
-          title: "docs: sync agent connector docs from airbyte-agent-connectors repo"
+          title: "docs: sync agent connector docs from airbyte-agent-sdk repo"
           body: |
-            Automated sync of agent connector docs from airbyte-agent-connectors.
+            Automated sync of agent connector docs from airbyte-agent-sdk.
 
             This PR was automatically created by the sync-agent-connector-docs workflow.
           labels: |


### PR DESCRIPTION
## What

The `sync-ai-connector-docs.yml` workflow still references the old repository name `airbytehq/airbyte-agent-connectors`, which was renamed to `airbytehq/airbyte-agent-sdk`. GitHub's 301 redirect keeps it functional, but the workflow should use the canonical name.

Requested by @ian-at-airbyte.

## How

Updated all occurrences of `airbyte-agent-connectors` to `airbyte-agent-sdk` in `.github/workflows/sync-ai-connector-docs.yml`:
- Checkout step name
- `repository` field
- Commit message template
- PR title template
- PR body template

## Review guide

1. `.github/workflows/sync-ai-connector-docs.yml` — the only file changed

## User Impact

No user-facing impact. The workflow will reference the correct repo name instead of relying on GitHub's redirect.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---
[Devin session](https://app.devin.ai/sessions/5ef97da741d746a79705681407e1ee7f)