### PR TITLE
ci(auto-merge): native auto-merge, pre-check statuses, job summaries, upgrade github-script v8

### DIFF
--- a/.github/workflows/auto-merge-cron.yml
+++ b/.github/workflows/auto-merge-cron.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Fetch required checks for master branch
         id: required-checks
         if: fromJSON(steps.normal-prs.outputs.normal-count) > 0
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ steps.get-hoard-token.outputs.token }}
           script: |
@@ -88,6 +88,79 @@ jobs:
             }
             core.info(`Required checks (${checks.length}): ${JSON.stringify(checks)}`);
             core.setOutput('checks', JSON.stringify(checks));
+
+      # ---------- Write candidate summary ----------
+      - name: Write candidate summary
+        env:
+          FORCE_JSON: ${{ steps.force-prs.outputs.force-matrix }}
+          NORMAL_JSON: ${{ steps.normal-prs.outputs.normal-matrix }}
+        run: |
+          {
+            echo "## Auto-Merge Candidate Summary"
+            echo ""
+
+            force_count=$(echo "$FORCE_JSON" | jq length)
+            normal_count=$(echo "$NORMAL_JSON" | jq length)
+            total=$((force_count + normal_count))
+            echo "**Total PRs discovered:** ${total} (${normal_count} normal, ${force_count} force-merge)"
+            echo ""
+
+            if [ "$force_count" -gt 0 ]; then
+              echo "### Force-Merge PRs (bypass CI checks)"
+              echo ""
+              echo "$FORCE_JSON" | jq -r '.[] | "- [#\(.number)](https://github.com/airbytehq/airbyte/pull/\(.number)): \(.title)"'
+              echo ""
+            fi
+
+            if [ "$normal_count" -gt 0 ]; then
+              # Classify normal PRs by title prefix
+              docs=$(echo "$NORMAL_JSON" | jq '[.[] | select(.title | test("^docs[:(]"; "i"))]')
+              deps=$(echo "$NORMAL_JSON" | jq '[.[] | select(.title | test("^deps[:(]"; "i"))]')
+              other=$(echo "$NORMAL_JSON" | jq --argjson docs "$docs" --argjson deps "$deps" \
+                '[.[] | select(.number as $n | ($docs + $deps) | map(.number) | index($n) | not)]')
+
+              docs_count=$(echo "$docs" | jq length)
+              deps_count=$(echo "$deps" | jq length)
+              other_count=$(echo "$other" | jq length)
+
+              echo "### Normal-Merge PRs by Type"
+              echo ""
+              echo "| Type | Count |"
+              echo "|------|-------|"
+              echo "| docs | ${docs_count} |"
+              echo "| deps | ${deps_count} |"
+              echo "| other | ${other_count} |"
+              echo ""
+
+              if [ "$docs_count" -gt 0 ]; then
+                echo "<details><summary>Docs PRs (${docs_count})</summary>"
+                echo ""
+                echo "$docs" | jq -r '.[] | "- [#\(.number)](https://github.com/airbytehq/airbyte/pull/\(.number)): \(.title)"'
+                echo ""
+                echo "</details>"
+                echo ""
+              fi
+
+              if [ "$deps_count" -gt 0 ]; then
+                echo "<details><summary>Deps PRs (${deps_count})</summary>"
+                echo ""
+                echo "$deps" | jq -r '.[] | "- [#\(.number)](https://github.com/airbytehq/airbyte/pull/\(.number)): \(.title)"'
+                echo ""
+                echo "</details>"
+                echo ""
+              fi
+
+              if [ "$other_count" -gt 0 ]; then
+                echo "<details><summary>Other PRs (${other_count})</summary>"
+                echo ""
+                echo "$other" | jq -r '.[] | "- [#\(.number)](https://github.com/airbytehq/airbyte/pull/\(.number)): \(.title)"'
+                echo ""
+                echo "</details>"
+                echo ""
+              fi
+            fi
+          } | tee -a "$GITHUB_STEP_SUMMARY"
+
     outputs:
       normal-matrix: ${{ steps.normal-prs.outputs.normal-matrix }}
       normal-count: ${{ steps.normal-prs.outputs.normal-count }}
@@ -153,7 +226,7 @@ jobs:
       - name: Verify required status checks pass
         if: steps.check-open.outputs.state == 'OPEN' && steps.validate-paths.outputs.valid == 'true'
         id: verify-checks
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           REQUIRED_CHECKS_JSON: ${{ needs.list-candidates.outputs.required-checks }}
         with:
@@ -192,9 +265,11 @@ jobs:
             if (missing.length > 0) {
               core.info(`Missing checks: ${missing.join(', ')}`);
               core.setOutput('ready', 'false');
+              core.setOutput('missing', missing.join(', '));
             } else {
               core.info('All required checks passing');
               core.setOutput('ready', 'true');
+              core.setOutput('missing', '');
             }
 
       # ---------- Eligibility gate ----------
@@ -263,6 +338,38 @@ jobs:
       - name: Dry-run notice
         if: steps.eligible.outputs.result == 'true' && vars.ENABLE_CONNECTOR_AUTO_MERGE != 'true'
         run: echo "::notice::DRY RUN -- would merge PR ${PR_NUMBER}"
+
+      # ---------- Per-PR summary ----------
+      - name: Write per-PR summary
+        if: always()
+        env:
+          STATE: ${{ steps.check-open.outputs.state }}
+          VALID_PATHS: ${{ steps.validate-paths.outputs.valid }}
+          CHECKS_READY: ${{ steps.verify-checks.outputs.ready }}
+          MISSING_CHECKS: ${{ steps.verify-checks.outputs.missing }}
+          ELIGIBLE: ${{ steps.eligible.outputs.result }}
+          DRY_RUN: ${{ vars.ENABLE_CONNECTOR_AUTO_MERGE != 'true' }}
+        run: |
+          link="[#${PR_NUMBER}](https://github.com/airbytehq/airbyte/pull/${PR_NUMBER})"
+          if [ "$ELIGIBLE" = "true" ]; then
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "| ${link} | ${PR_TITLE} | :yellow_circle: Would merge (dry-run) |" >> "$GITHUB_STEP_SUMMARY"
+            else
+              echo "| ${link} | ${PR_TITLE} | :green_circle: Merged |" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          else
+            reason=""
+            if [ "$STATE" != "OPEN" ]; then
+              reason="PR not open (${STATE})"
+            elif [ "$VALID_PATHS" != "true" ]; then
+              reason="Non-connector files changed"
+            elif [ "$CHECKS_READY" != "true" ]; then
+              reason="Missing checks: ${MISSING_CHECKS}"
+            else
+              reason="Unknown"
+            fi
+            echo "| ${link} | ${PR_TITLE} | :red_circle: Blocked — ${reason} |" >> "$GITHUB_STEP_SUMMARY"
+          fi
 
   # ---------- Job 3: Force merge (bypass CI checks) ----------
   force-merge:
@@ -384,3 +491,31 @@ jobs:
       - name: Dry-run notice
         if: steps.eligible.outputs.result == 'true' && vars.ENABLE_CONNECTOR_AUTO_MERGE != 'true'
         run: echo "::notice::DRY RUN -- would force-merge PR ${PR_NUMBER}"
+
+      # ---------- Per-PR summary ----------
+      - name: Write per-PR summary
+        if: always()
+        env:
+          STATE: ${{ steps.check-open.outputs.state }}
+          VALID_PATHS: ${{ steps.validate-paths.outputs.valid }}
+          ELIGIBLE: ${{ steps.eligible.outputs.result }}
+          DRY_RUN: ${{ vars.ENABLE_CONNECTOR_AUTO_MERGE != 'true' }}
+        run: |
+          link="[#${PR_NUMBER}](https://github.com/airbytehq/airbyte/pull/${PR_NUMBER})"
+          if [ "$ELIGIBLE" = "true" ]; then
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "| ${link} | ${PR_TITLE} | :yellow_circle: Would force-merge (dry-run) |" >> "$GITHUB_STEP_SUMMARY"
+            else
+              echo "| ${link} | ${PR_TITLE} | :green_circle: Force-merged |" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          else
+            reason=""
+            if [ "$STATE" != "OPEN" ]; then
+              reason="PR not open (${STATE})"
+            elif [ "$VALID_PATHS" != "true" ]; then
+              reason="Non-connector files changed"
+            else
+              reason="Unknown"
+            fi
+            echo "| ${link} | ${PR_TITLE} | :red_circle: Blocked — ${reason} |" >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/auto-merge-cron.yml
+++ b/.github/workflows/auto-merge-cron.yml
@@ -1,7 +1,10 @@
 name: Auto merge connector PRs Cron
-# Dry-run mode is controlled by the org-level variable ENABLE_CONNECTOR_AUTO_MERGE.
-# Set to "true" to enable real merges; any other value (or unset) runs in dry-run mode.
-# In dry-run mode, PRs are still approved and promoted from draft, but merges are skipped.
+# Normal-merge PRs always have native auto-merge enabled and bot approval applied.
+# GitHub waits for required CI checks to pass before merging.
+#
+# Force-merge PRs bypass CI checks and are gated by the org-level variable
+# ENABLE_CONNECTOR_AUTO_MERGE. Set to "true" to enable force-merges;
+# any other value (or unset) runs in dry-run mode for force-merges only.
 # Manage at: https://github.com/organizations/airbytehq/settings/variables/actions
 
 on:
@@ -89,11 +92,77 @@ jobs:
             core.info(`Required checks (${checks.length}): ${JSON.stringify(checks)}`);
             core.setOutput('checks', JSON.stringify(checks));
 
+      # ---------- Pre-check: query check statuses for all normal PRs ----------
+      - name: Pre-check required statuses for all normal PRs
+        id: pre-check
+        if: fromJSON(steps.normal-prs.outputs.normal-count) > 0
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ steps.get-hoard-token.outputs.token }}
+          script: |
+            const prs = JSON.parse(process.env.NORMAL_JSON || '[]');
+            const requiredChecks = new Set(JSON.parse(process.env.REQUIRED_CHECKS_JSON || '[]'));
+            const results = [];
+
+            for (const pr of prs) {
+              try {
+                const { data: prData } = await github.rest.pulls.get({
+                  owner: 'airbytehq', repo: 'airbyte', pull_number: pr.number,
+                });
+                const sha = prData.head.sha;
+
+                const statuses = await github.paginate(
+                  github.rest.repos.listCommitStatusesForRef,
+                  { owner: 'airbytehq', repo: 'airbyte', ref: sha, per_page: 100 }
+                );
+                const successStatuses = new Set(
+                  statuses.filter(s => s.state === 'success').map(s => s.context)
+                );
+
+                const checkRuns = await github.paginate(
+                  github.rest.checks.listForRef,
+                  { owner: 'airbytehq', repo: 'airbyte', ref: sha, per_page: 100 },
+                  (response) => response.data
+                );
+                const successChecks = new Set(
+                  checkRuns
+                    .filter(cr => cr.conclusion === 'success' || cr.conclusion === 'skipped')
+                    .map(cr => cr.name)
+                );
+
+                const allPassing = new Set([...successStatuses, ...successChecks]);
+                const missing = [...requiredChecks].filter(c => !allPassing.has(c));
+
+                results.push({
+                  number: pr.number,
+                  title: pr.title,
+                  ready: missing.length === 0,
+                  missing: missing,
+                });
+              } catch (err) {
+                core.warning(`Failed to check PR #${pr.number}: ${err.message}`);
+                results.push({
+                  number: pr.number,
+                  title: pr.title,
+                  ready: false,
+                  missing: ['(check query failed)'],
+                });
+              }
+            }
+
+            const readyCount = results.filter(r => r.ready).length;
+            core.info(`Pre-check complete: ${readyCount}/${results.length} PRs have all checks passing`);
+            core.setOutput('results', JSON.stringify(results));
+        env:
+          NORMAL_JSON: ${{ steps.normal-prs.outputs.normal-matrix }}
+          REQUIRED_CHECKS_JSON: ${{ steps.required-checks.outputs.checks }}
+
       # ---------- Write candidate summary ----------
       - name: Write candidate summary
         env:
           FORCE_JSON: ${{ steps.force-prs.outputs.force-matrix }}
           NORMAL_JSON: ${{ steps.normal-prs.outputs.normal-matrix }}
+          PRECHECK_JSON: ${{ steps.pre-check.outputs.results }}
         run: |
           {
             echo "## Auto-Merge Candidate Summary"
@@ -123,6 +192,14 @@ jobs:
               deps_count=$(echo "$deps" | jq length)
               other_count=$(echo "$other" | jq length)
 
+              # Count ready vs waiting from pre-check
+              ready_count=0
+              waiting_count=0
+              if [ -n "$PRECHECK_JSON" ] && [ "$PRECHECK_JSON" != "null" ]; then
+                ready_count=$(echo "$PRECHECK_JSON" | jq '[.[] | select(.ready == true)] | length')
+                waiting_count=$(echo "$PRECHECK_JSON" | jq '[.[] | select(.ready == false)] | length')
+              fi
+
               echo "### Normal-Merge PRs by Type"
               echo ""
               echo "| Type | Count |"
@@ -131,7 +208,30 @@ jobs:
               echo "| deps | ${deps_count} |"
               echo "| other | ${other_count} |"
               echo ""
+              echo "**Check status:** ${ready_count} ready, ${waiting_count} waiting on checks"
+              echo ""
 
+              # Show PRs with all checks passing
+              if [ "$ready_count" -gt 0 ]; then
+                echo "<details><summary>:green_circle: Ready to merge (${ready_count})</summary>"
+                echo ""
+                echo "$PRECHECK_JSON" | jq -r '.[] | select(.ready == true) | "- [#\(.number)](https://github.com/airbytehq/airbyte/pull/\(.number)): \(.title)"'
+                echo ""
+                echo "</details>"
+                echo ""
+              fi
+
+              # Show PRs waiting on checks
+              if [ "$waiting_count" -gt 0 ]; then
+                echo "<details><summary>:yellow_circle: Waiting on checks (${waiting_count})</summary>"
+                echo ""
+                echo "$PRECHECK_JSON" | jq -r '.[] | select(.ready == false) | "- [#\(.number)](https://github.com/airbytehq/airbyte/pull/\(.number)): \(.title) — missing: \(.missing | join(", "))"'
+                echo ""
+                echo "</details>"
+                echo ""
+              fi
+
+              # Type breakdown details
               if [ "$docs_count" -gt 0 ]; then
                 echo "<details><summary>Docs PRs (${docs_count})</summary>"
                 echo ""
@@ -168,7 +268,7 @@ jobs:
       force-count: ${{ steps.force-prs.outputs.force-count }}
       required-checks: ${{ steps.required-checks.outputs.checks }}
 
-  # ---------- Job 2: Normal merge (verify CI first) ----------
+  # ---------- Job 2: Normal merge (auto-merge + approve) ----------
   normal-merge:
     name: "Merge #${{ matrix.pr.number }}"
     needs: list-candidates
@@ -279,7 +379,6 @@ jobs:
           echo "result=${{
             steps.check-open.outputs.state == 'OPEN'
             && steps.validate-paths.outputs.valid == 'true'
-            && steps.verify-checks.outputs.ready == 'true'
           }}" | tee -a $GITHUB_OUTPUT
 
       # ---------- Prepare PR for merge ----------
@@ -298,7 +397,13 @@ jobs:
           GH_TOKEN: ${{ steps.get-hoard-token.outputs.token }}
         run: gh pr ready "$PR_NUMBER" --repo airbytehq/airbyte
 
-      # ---------- Approve and merge ----------
+      # ---------- Enable auto-merge and approve ----------
+      - name: Enable auto-merge on PR
+        if: steps.eligible.outputs.result == 'true'
+        env:
+          GH_TOKEN: ${{ steps.get-hoard-token.outputs.token }}
+        run: gh pr merge "$PR_NUMBER" --repo airbytehq/airbyte --squash --auto
+
       - name: Authenticate as 'octavia-bot-admin' GitHub App
         if: steps.eligible.outputs.result == 'true'
         uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
@@ -309,8 +414,9 @@ jobs:
           app-id: ${{ secrets.OCTAVIA_BOT_ADMIN_APP_ID }}
           private-key: ${{ secrets.OCTAVIA_BOT_ADMIN_PRIVATE_KEY }}
 
-      - name: Approve PR with admin bot
+      - name: Apply bot approval
         if: steps.eligible.outputs.result == 'true'
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ steps.get-admin-token.outputs.token }}
         run: >
@@ -318,26 +424,6 @@ jobs:
           --repo airbytehq/airbyte
           --approve
           --body "Auto-approved by auto-merge workflow."
-
-      - name: Squash merge PR
-        if: steps.eligible.outputs.result == 'true' && vars.ENABLE_CONNECTOR_AUTO_MERGE == 'true'
-        env:
-          GH_TOKEN: ${{ steps.get-hoard-token.outputs.token }}
-        run: |
-          for attempt in 1 2 3; do
-            if gh pr merge "$PR_NUMBER" --repo airbytehq/airbyte --squash; then
-              echo "::notice::Merged PR ${PR_NUMBER}: ${PR_TITLE}"
-              exit 0
-            fi
-            echo "::warning::Merge attempt $attempt/3 failed, retrying in 60s..."
-            sleep 60
-          done
-          echo "::error::Failed to merge PR #$PR_NUMBER after 3 attempts"
-          exit 1
-
-      - name: Dry-run notice
-        if: steps.eligible.outputs.result == 'true' && vars.ENABLE_CONNECTOR_AUTO_MERGE != 'true'
-        run: echo "::notice::DRY RUN -- would merge PR ${PR_NUMBER}"
 
       # ---------- Per-PR summary ----------
       - name: Write per-PR summary
@@ -348,27 +434,26 @@ jobs:
           CHECKS_READY: ${{ steps.verify-checks.outputs.ready }}
           MISSING_CHECKS: ${{ steps.verify-checks.outputs.missing }}
           ELIGIBLE: ${{ steps.eligible.outputs.result }}
-          DRY_RUN: ${{ vars.ENABLE_CONNECTOR_AUTO_MERGE != 'true' }}
         run: |
           link="[#${PR_NUMBER}](https://github.com/airbytehq/airbyte/pull/${PR_NUMBER})"
           if [ "$ELIGIBLE" = "true" ]; then
-            if [ "$DRY_RUN" = "true" ]; then
-              echo "| ${link} | ${PR_TITLE} | :yellow_circle: Would merge (dry-run) |" >> "$GITHUB_STEP_SUMMARY"
-            else
-              echo "| ${link} | ${PR_TITLE} | :green_circle: Merged |" >> "$GITHUB_STEP_SUMMARY"
+            checks_note=""
+            if [ "$CHECKS_READY" = "true" ]; then
+              checks_note="all checks passing"
+            elif [ -n "$MISSING_CHECKS" ]; then
+              checks_note="waiting on: ${MISSING_CHECKS}"
             fi
+            echo "| ${link} | ${PR_TITLE} | :green_circle: Auto-merge enabled | ${checks_note} |" >> "$GITHUB_STEP_SUMMARY"
           else
             reason=""
             if [ "$STATE" != "OPEN" ]; then
               reason="PR not open (${STATE})"
             elif [ "$VALID_PATHS" != "true" ]; then
               reason="Non-connector files changed"
-            elif [ "$CHECKS_READY" != "true" ]; then
-              reason="Missing checks: ${MISSING_CHECKS}"
             else
               reason="Unknown"
             fi
-            echo "| ${link} | ${PR_TITLE} | :red_circle: Blocked — ${reason} |" >> "$GITHUB_STEP_SUMMARY"
+            echo "| ${link} | ${PR_TITLE} | :red_circle: Skipped — ${reason} | |" >> "$GITHUB_STEP_SUMMARY"
           fi
 
   # ---------- Job 3: Force merge (bypass CI checks) ----------
@@ -462,8 +547,9 @@ jobs:
           app-id: ${{ secrets.OCTAVIA_BOT_ADMIN_APP_ID }}
           private-key: ${{ secrets.OCTAVIA_BOT_ADMIN_PRIVATE_KEY }}
 
-      - name: Approve PR with admin bot
+      - name: Apply bot approval
         if: steps.eligible.outputs.result == 'true'
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ steps.get-admin-token.outputs.token }}
         run: >

--- a/.github/workflows/auto-merge-cron.yml
+++ b/.github/workflows/auto-merge-cron.yml
@@ -326,6 +326,7 @@ jobs:
       - name: Verify required status checks pass
         if: steps.check-open.outputs.state == 'OPEN' && steps.validate-paths.outputs.valid == 'true'
         id: verify-checks
+        continue-on-error: true
         uses: actions/github-script@v8
         env:
           REQUIRED_CHECKS_JSON: ${{ needs.list-candidates.outputs.required-checks }}
@@ -559,6 +560,7 @@ jobs:
           --body "Auto-approved by auto-merge workflow (bypass-ci)."
 
       - name: Force squash merge PR
+        id: force-merge-pr
         if: steps.eligible.outputs.result == 'true' && vars.ENABLE_CONNECTOR_AUTO_MERGE == 'true'
         env:
           GH_TOKEN: ${{ steps.get-hoard-token.outputs.token }}
@@ -586,13 +588,16 @@ jobs:
           VALID_PATHS: ${{ steps.validate-paths.outputs.valid }}
           ELIGIBLE: ${{ steps.eligible.outputs.result }}
           DRY_RUN: ${{ vars.ENABLE_CONNECTOR_AUTO_MERGE != 'true' }}
+          MERGE_OUTCOME: ${{ steps.force-merge-pr.outcome }}
         run: |
           link="[#${PR_NUMBER}](https://github.com/airbytehq/airbyte/pull/${PR_NUMBER})"
           if [ "$ELIGIBLE" = "true" ]; then
             if [ "$DRY_RUN" = "true" ]; then
               echo "| ${link} | ${PR_TITLE} | :yellow_circle: Would force-merge (dry-run) |" >> "$GITHUB_STEP_SUMMARY"
-            else
+            elif [ "$MERGE_OUTCOME" = "success" ]; then
               echo "| ${link} | ${PR_TITLE} | :green_circle: Force-merged |" >> "$GITHUB_STEP_SUMMARY"
+            else
+              echo "| ${link} | ${PR_TITLE} | :red_circle: Force-merge failed |" >> "$GITHUB_STEP_SUMMARY"
             fi
           else
             reason=""


### PR DESCRIPTION
## What

Refactor the auto-merge cron workflow to use native GitHub auto-merge for normal PRs, add comprehensive job summaries, and resolve Node.js deprecation warnings.

Requested by @aaronsteers.

## How

1. **Normal-merge: native auto-merge + bot approval (always-on)**
   - Replaces direct `gh pr merge --squash` with `gh pr merge --squash --auto` — GitHub natively waits for required checks to pass before merging.
   - Bot approval applied via `octavia-bot-admin` (separate identity from the hoard bot that enables auto-merge, following the `connectors-up-to-date` pipeline pattern).
   - `ENABLE_CONNECTOR_AUTO_MERGE` variable no longer gates normal merges.

2. **Force-merge: gated on `ENABLE_CONNECTOR_AUTO_MERGE`**
   - The org-level variable now exclusively controls force-merge behavior (bypass-ci-checks).
   - Force-merge still uses direct `gh pr merge --squash` with retry loop.

3. **Pre-check step in `list-candidates`**
   - New `github-script` step queries required check statuses for all normal PRs in a single job.
   - Results feed into the candidate summary (ready vs waiting breakdown with missing check names).

4. **Job summaries**
   - `list-candidates`: PR classification by type (docs/deps/other), check status breakdown, collapsible PR lists with links.
   - `normal-merge` per-PR: shows auto-merge enabled + which checks are still pending.
   - `force-merge` per-PR: shows merge/dry-run status.

5. **`actions/github-script@v7` → `@v8`** (all 3 usages) — resolves Node.js 20 deprecation warnings.

## Review guide

1. `.github/workflows/auto-merge-cron.yml` — single file changed

## User Impact

- Normal-merge PRs now get auto-merge + approval immediately; GitHub handles waiting for CI. No manual variable toggle needed.
- Force-merge PRs remain gated behind `ENABLE_CONNECTOR_AUTO_MERGE` for safety.
- Workflow run summaries provide clear visibility into PR classification, check status, and merge outcomes.
- Node.js 20 deprecation warnings eliminated.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---
[Devin session](https://app.devin.ai/sessions/fecaa0be182447db939b8ec09b0a5394)