### PR TITLE
docs(ai-agents): populate Core Concepts landing page

### DIFF
--- a/docs/ai-agents/concepts/readme.md
+++ b/docs/ai-agents/concepts/readme.md
@@ -4,6 +4,14 @@ sidebar_position: 3
 
 # Core concepts
 
-- Core concepts home page
-- Brief overview
-- Route to sub-pages to learn more
+This section covers the building blocks of Airbyte Agents: the models, resources, and platform behaviors you work with across every interface.
+
+- [**Connect, Unify, Act**](connect-unify-act) — The three-layer model at the heart of the platform. Connect agents to any system through managed connectors, unify data from every source into one searchable layer, and let agents act on that data in real time.
+- [**Agent operations**](agent-operations) — The unit of work in Airbyte Agents. Learn how tool calls and token usage combine into agent operations, and how AOs relate to your plan's billing.
+- [**Context Store**](context-store) — A managed, searchable replica of your connector data. The Context Store gives agents fast, indexed access to business data without live API crawls.
+- [**System architecture**](architecture) — How the platform is organized. Covers the four interfaces, the resource hierarchy of organizations, workspaces, and connectors, and the execution model that routes agent requests.
+- [**Time zones**](time-zones) — How Airbyte Agents stores, displays, and schedules dates and times across the web app, API, SDK, and MCP server.
+
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />


### PR DESCRIPTION
## What

Populates the AI Agents > Core Concepts home page with a brief section overview and linked descriptions of each subpage. The subpages have already been written; this PR adds the landing page content that introduces them as the main building blocks of the Airbyte Agents experience.

Requested by @ian-at-airbyte.

## How

Replaced the placeholder bullet list in `docs/ai-agents/concepts/readme.md` with:
- A one-line intro framing the section as the building blocks of Airbyte Agents.
- A linked summary for each subpage: Connect, Unify, Act; Agent operations; Context Store; System architecture; Time zones.
- A `<DocCardList />` component for automatic card navigation, consistent with other section landing pages like Interfaces.

## Review guide

1. `docs/ai-agents/concepts/readme.md`

## User Impact

Users visiting the Core Concepts section now see a clear overview of what each concept page covers and can navigate to the relevant subpage directly.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/0e67e0042332441baa066eee4d13c66d